### PR TITLE
ci: skip generated changelog markdown lint

### DIFF
--- a/.gomarklint.json
+++ b/.gomarklint.json
@@ -5,7 +5,7 @@
     "heading-level": false,
     "max-line-length": { "enabled": false }
   },
-  "include": ["README.md", "CHANGELOG.md", "AGENTS.md", "docs"],
+  "include": ["README.md", "AGENTS.md", "docs"],
   "ignore": [".worktrees"],
   "output": "text"
 }


### PR DESCRIPTION
Exclude generated release-please CHANGELOG.md output from gomarklint. Human-authored Markdown remains covered by README.md, AGENTS.md, and docs/.