### PR TITLE
ci: ignore renovate fixture paths

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'helpers:pinGitHubActionDigests',
   ],
   platformAutomerge: true,
+  ignorePaths: ['testdata/**'],
   postUpdateOptions: ['gomodTidy'],
   packageRules: [
     {


### PR DESCRIPTION
Exclude `testdata` fixtures from Renovate dependency discovery.

The affected files contain intentionally fake Docker images, Helm chart names,
OCI registries, and GitHub tag sources used to exercise drydock behavior.
Renovate should not try to look them up as real dependencies.

Validated with:

- `mise run whitespace`
- `mise run actionlint`
- `npx --yes --package renovate@43.150.0 -- renovate-config-validator --strict`
