### PR TITLE
ci: serialize release source checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,45 @@ jobs:
           experimental: true
           install_args: --locked
 
-      - name: Run source CI
-        run: mise run ci
+      - name: Verify dependencies
+        run: mise run mod-verify
+
+      - name: Check go.mod tidiness
+        run: mise run mod-tidy-check
+
+      - name: Test
+        run: mise run test
+
+      - name: Vet
+        run: mise run vet
+
+      - name: Lint Go
+        run: mise run lint
+
+      - name: Lint Markdown
+        run: mise run markdownlint
+
+      - name: Lint GitHub Actions
+        run: mise run actionlint
+
+      - name: Audit GitHub Actions security
+        run: mise run zizmor
+
+      - name: Diff check
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --check "${{ github.event.pull_request.base.sha }}...HEAD"
+          else
+            before="${{ github.event.before }}"
+            empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            if [ "$before" = "0000000000000000000000000000000000000000" ] || \
+              ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+              git diff --check "$empty_tree" HEAD
+            else
+              git diff --check "$before..HEAD"
+            fi
+          fi
 
   binaries:
     needs:


### PR DESCRIPTION
## Summary
- Replace the release workflow single concurrent source gate with sequential checks matching normal CI.
- Avoid golangci-lint competing with cold-cache Go test and vet work during release publishing.
- Keep committed-range whitespace checking in the release workflow.

## Verification
- mise run actionlint
- mise run zizmor
- git diff --check origin/main...HEAD
- review agent approved