### PR TITLE
ci: install go for renovate post-upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,9 @@
   postUpdateOptions: ['gomodTidy'],
   postUpgradeTasks: {
     commands: ['go run ./scripts/sync-argocd-gitops-engine.go'],
+    installTools: {
+      golang: {},
+    },
     dataFileTemplate:
       '[{{#each upgrades}}{"depName":"{{{depName}}}","packageName":"{{{packageName}}}","manager":"{{{manager}}}","newValue":"{{{newValue}}}","newVersion":"{{{newVersion}}}"}{{#unless @last}},{{/unless}}{{/each}}]',
     executionMode: 'branch',


### PR DESCRIPTION
## Summary
- declare golang as a Renovate post-upgrade task tool for drydock
- fixes Renovate artifact failures where go run ./scripts/sync-argocd-gitops-engine.go failed with spawn go ENOENT

## Verification
- git diff --check
- go run ./scripts/sync-argocd-gitops-engine.go