### PR TITLE
ci: mark published release as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,7 +509,8 @@ jobs:
             --method PATCH \
             "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
             -F body=@release-notes.md \
-            -f draft=false
+            -f draft=false \
+            -f make_latest=true
 
           published_sha="$(git ls-remote --tags origin "refs/tags/${TAG}" | awk 'NR == 1 { print $1 }')"
           if [[ "${published_sha}" != "${GITHUB_SHA}" ]]; then


### PR DESCRIPTION
## Summary
- mark the existing v0.1.2 release as latest
- update the release workflow to set make_latest=true when publishing staged draft releases

## Verification
- mise run actionlint
- mise run zizmor
- git diff --check