### PR TITLE
feat: detect exact image fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ drydock diff apps --path . --path-orig ../baseline --offline
 | Goal | Command |
 | --- | --- |
 | List Applications | `drydock get apps --path .` |
-| List rendered workload images | `drydock get images --path . -o name` |
+| List rendered image references | `drydock get images --path . -o name` |
 | Render all Applications | `drydock build apps --path .` |
 | Render one Application | `drydock build app renovate --path .` |
 | Test renderability | `drydock test apps --path .` |
 | Diff rendered manifests | `drydock diff apps --path . --path-orig ../baseline` |
 | Diff one Application | `drydock diff app renovate --path . --path-orig ../baseline` |
-| Diff workload images | `drydock diff images --path . --path-orig ../baseline -o json` |
+| Diff rendered image references | `drydock diff images --path . --path-orig ../baseline -o json` |
 | Inspect repository diagnostics | `drydock diag --path .` |
 | Inspect redacted settings | `drydock diag --path . --settings -o json` |
 | Inspect cache roots | `drydock cache path` |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -81,7 +81,7 @@ Supported today:
 - `get apps` structured table, name, JSON, and YAML output with Kubernetes
   label selector filtering on Application metadata labels
 - `get images` structured table, name, JSON, and YAML output using the same
-  conservative workload image extraction as `diff images`
+  rendered image reference extraction as `diff images`
 - `build app` rendering for one Application by `NAME` or `NAMESPACE/NAME`
 - Partial build results for embedding callers when some selected Applications
   fail to render
@@ -115,7 +115,7 @@ Supported today:
   `resource.exclusions` and `resource.inclusions`
 - Explicit rendered-resource filters through `--skip-kind`, `--skip-crds`, and
   `--skip-secrets`
-- `diff images` conservative workload image diffs
+- `diff images` rendered image reference diffs
 - Repeated-resource last-wins behavior inside one Application
 - Public Go API in `pkg/drydock` for Application listing, rendering,
   manifest diffs, image diffs, injectable Git/chart/remote-resource

--- a/docs/design.md
+++ b/docs/design.md
@@ -448,9 +448,11 @@ Supported formats:
 `get images`; diff commands reject it. `diff images -o json|yaml` emits
 structured `added`, `removed`, and `unchanged` image lists.
 
-Image diff defaults to Argo-style workload image extraction. A future
-`--images all-strings` mode can provide broader heuristic extraction for CRDs
-and CI pull-test workflows.
+Image diff extracts PodSpec container images and scalar rendered manifest
+fields whose key is exactly `image`. It skips Secret manifests, top-level
+metadata/status, ConfigMap data payloads, and arbitrary string scanning so CI
+pull-test workflows catch CRD image fields without treating every string as an
+image reference.
 
 ## Diagnostics
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ syntax to match `Application.metadata.labels`:
 drydock get apps --path . -l 'env in (prod,stage),tier!=test'
 ```
 
-List conservative workload container images from rendered Applications:
+List rendered image references from Applications:
 
 ```bash
 drydock get images --path . -o name
@@ -610,16 +610,17 @@ drydock diff apps \
 
 ## Image Diffs
 
-Diff conservative workload container images from rendered manifests:
+Diff rendered image references from rendered manifests:
 
 ```bash
 drydock diff images --path ./current --path-orig ../base
 ```
 
-This projection is intentionally conservative and does not report arbitrary
-`image` keys from ConfigMaps or CRDs. Use `-o json` or `-o yaml` for
-machine-readable `added`, `removed`, and `unchanged` image lists. Diagnostics
-remain on stderr so stdout stays valid JSON or YAML.
+This projection includes PodSpec container images plus scalar manifest fields
+whose key is exactly `image`. It does not scan arbitrary string content, Secret
+manifests, top-level metadata/status, or ConfigMap data payloads. Use `-o json`
+or `-o yaml` for machine-readable `added`, `removed`, and `unchanged` image
+lists. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
 
 ## Diagnostics
 

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -86,7 +86,7 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 	imagesFlags.parallelism = defaultRenderAppsParallelism()
 	images := &cobra.Command{
 		Use:   "images",
-		Short: "Diff rendered container images",
+		Short: "Diff rendered image references",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			output, err := parseDiffOutput(imagesFlags.output, "diff images")

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -66,7 +66,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 	imagesFlags.output = string(cliformat.OutputTable)
 	images := &cobra.Command{
 		Use:   "images",
-		Short: "List rendered container images",
+		Short: "List rendered image references",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			output, err := cliformat.ParseOutput(imagesFlags.output)

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -328,6 +328,25 @@ func TestGetImagesNameOutput(t *testing.T) {
 	}
 }
 
+func TestGetImagesIncludesExactImageKey(t *testing.T) {
+	root := t.TempDir()
+	writeExactImageKeyAppForCLI(t, root, "renovate/renovate:43.195.6@sha256:72d184865d505d5badc5c3b32a48410096e0d9d7e0d875dae28ee97832178f47")
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"get", "images", "--path", root, "-o", "name"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	want := "renovate/renovate:43.195.6@sha256:72d184865d505d5badc5c3b32a48410096e0d9d7e0d875dae28ee97832178f47\n"
+	if got := out.String(); got != want {
+		t.Fatalf("get images -o name output = %q, want %q", got, want)
+	}
+}
+
 func TestGetImagesSkipKindOmitsFilteredWorkloads(t *testing.T) {
 	root := t.TempDir()
 	writeImageAppForCLI(t, root, "ghcr.io/example/demo:v1")
@@ -484,5 +503,30 @@ metadata:
   name: `+appName+`
 data:
   value: `+appName+`
+`)
+}
+
+func writeExactImageKeyAppForCLI(t *testing.T, root, image string) {
+	t.Helper()
+	writeCLITestFile(t, filepath.Join(root, "apps", "renovate.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: renovate
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/renovate
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: renovate
+`)
+	writeCLITestFile(t, filepath.Join(root, "manifests", "renovate", "renovatejob.yaml"), `apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: renovate
+spec:
+  image: `+image+`
 `)
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -941,6 +941,83 @@ data:
 	}
 }
 
+func TestExtractImagesIncludesExactImageKeysFromCRDs(t *testing.T) {
+	docs := []Document{
+		{Body: `
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: renovate
+spec:
+  image: renovate/renovate:43.195.6@sha256:72d184865d505d5badc5c3b32a48410096e0d9d7e0d875dae28ee97832178f47
+`},
+		{Body: `
+apiVersion: example.test/v1
+kind: ExampleApp
+metadata:
+  name: nested
+spec:
+  components:
+    - name: api
+      image: ghcr.io/example/api:v1
+    - name: worker
+      template:
+        image: ghcr.io/example/worker:v1
+`},
+	}
+
+	images := ExtractImages(docs)
+	want := []string{
+		"ghcr.io/example/api:v1",
+		"ghcr.io/example/worker:v1",
+		"renovate/renovate:43.195.6@sha256:72d184865d505d5badc5c3b32a48410096e0d9d7e0d875dae28ee97832178f47",
+	}
+	if !reflect.DeepEqual(images, want) {
+		t.Fatalf("ExtractImages() = %#v, want %#v", images, want)
+	}
+}
+
+func TestExtractImagesIgnoresNonDeployableExactImageKeys(t *testing.T) {
+	docs := []Document{
+		{Body: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+spec:
+  image: ghcr.io/example/secret:v1
+`},
+		{Body: `
+apiVersion: example.test/v1
+kind: ExampleApp
+metadata:
+  name: metadata
+  labels:
+    image: ghcr.io/example/metadata:v1
+status:
+  image: ghcr.io/example/status:v1
+spec:
+  containerImage: ghcr.io/example/container-image:v1
+  description: ghcr.io/example/description:v1
+`},
+		{Body: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  image: ghcr.io/example/configmap-data:v1
+binaryData:
+  image: Z2hjci5pby9leGFtcGxlL2NvbmZpZ21hcC1iaW5hcnk6djE=
+`},
+	}
+
+	images := ExtractImages(docs)
+	if len(images) != 0 {
+		t.Fatalf("ExtractImages() = %#v, want no images", images)
+	}
+}
+
 func configMapDocument(value string, pointers []string) Document {
 	return Document{
 		Parent: testParent(),

--- a/internal/diff/images.go
+++ b/internal/diff/images.go
@@ -15,6 +15,7 @@ func ExtractImages(docs []Document) []string {
 			continue
 		}
 		collectWorkloadImages(value, images)
+		collectExactImageFields(value, images)
 	}
 
 	out := make([]string, 0, len(images))
@@ -23,6 +24,56 @@ func ExtractImages(docs []Document) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func collectExactImageFields(value any, images map[string]struct{}) {
+	kind, _ := stringField(value, "kind")
+	if kind == "Secret" {
+		return
+	}
+	collectExactImageFieldsAt(value, images, kind, nil)
+}
+
+func collectExactImageFieldsAt(value any, images map[string]struct{}, kind string, path []string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			collectExactImageFieldChild(key, child, images, kind, path)
+		}
+	case map[any]any:
+		for key, child := range typed {
+			stringKey, ok := key.(string)
+			if !ok {
+				continue
+			}
+			collectExactImageFieldChild(stringKey, child, images, kind, path)
+		}
+	case []any:
+		for _, child := range typed {
+			collectExactImageFieldsAt(child, images, kind, path)
+		}
+	}
+}
+
+func collectExactImageFieldChild(key string, value any, images map[string]struct{}, kind string, path []string) {
+	if skipExactImageFieldPath(kind, path, key) {
+		return
+	}
+	if key == "image" {
+		addImage(value, images)
+		return
+	}
+	collectExactImageFieldsAt(value, images, kind, append(path, key))
+}
+
+func skipExactImageFieldPath(kind string, path []string, key string) bool {
+	if len(path) != 0 {
+		return false
+	}
+	if key == "metadata" || key == "status" {
+		return true
+	}
+	return kind == "ConfigMap" && (key == "data" || key == "binaryData")
 }
 
 func collectWorkloadImages(value any, images map[string]struct{}) {

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -134,12 +134,12 @@ func (client *Client) DiffApplications(ctx context.Context) (DiffApplicationsRes
 	}, err
 }
 
-// DiffImages compares container images between config.PathOrig and config.Path.
+// DiffImages compares image references between config.PathOrig and config.Path.
 func DiffImages(ctx context.Context, config Config) (ImageDiffResult, error) {
 	return NewClient(config).DiffImages(ctx)
 }
 
-// DiffImages compares container images between the client's PathOrig and Path.
+// DiffImages compares image references between the client's PathOrig and Path.
 func (client *Client) DiffImages(ctx context.Context) (ImageDiffResult, error) {
 	result, err := client.orchestrator.DiffImages(ctx, client.diffRequest())
 	return ImageDiffResult{


### PR DESCRIPTION
## Summary
- extend rendered image extraction beyond PodSpecs to scalar fields keyed exactly as `image`
- skip Secrets, top-level metadata/status, ConfigMap data payloads, and arbitrary string scanning
- update get/diff image wording and docs from workload-only images to rendered image references

## Verification
- go test ./internal/diff -run 'TestExtractImages'
- go test ./internal/cli -run 'TestGetImages'
- go test ./...
- mise run markdownlint
- mise run lint
- git diff --check
- go run ./cmd/drydock diff images --repo /Users/ethan.shold/git/home-ops --ref origin/pr-3046 --ref-orig d530c79239fdcdb578faf7a6475eb3f268dd720f --skip-secrets --output json --exit-code=false

## Review
- spec review: APPROVED
- quality review: APPROVED
- final delta review: APPROVED