### PR TITLE
docs: refactor documentation routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Use these entry points before substantive work:
 - `docs/design.md`: canonical product architecture and behavior model.
 - `docs/compatibility.md`: supported Argo CD behavior and runtime-boundary
   status.
+- `docs/source-acquisition.md`: Git, Helm, remote Kustomize, cache, and auth
+  behavior.
 - `docs/reports/live-integration-design-gate.md`: required before
   proposing live runtime, server-side diff, defaulting, admission, or
   managed-fields work.
@@ -107,10 +109,10 @@ Use `rg` first, then read the smallest relevant files.
 | CLI flags, output, exit codes | `internal/cli`, `internal/requestopts` |
 | Public Go API | `pkg/drydock`, then matching `internal/app` request types |
 | Discovery and Argo settings | `internal/discovery`, `internal/config` |
-| ApplicationSet generation | `internal/appset` |
+| ApplicationSet generation | `docs/applicationsets.md`, then `internal/appset` |
 | Application planning and orchestration | `internal/app` |
 | Kustomize, Helm, directory rendering | `internal/render` |
-| Git, chart, remote acquisition | `internal/source`, `internal/chart`, `internal/remote`, `internal/acquisition` |
+| Git, chart, remote acquisition | `docs/source-acquisition.md`, then `internal/source`, `internal/chart`, `internal/remote`, `internal/acquisition` |
 | Manifest diffs and image extraction | `internal/diff`, `internal/manifest` |
 | Cache lifecycle and cache events | `internal/cache`, `internal/cacheevent`, `internal/cli/cache.go` |
 | Path containment and symlink rules | `internal/pathsafety`, then caller-specific checks |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ drydock discovers and renders local Argo CD desired state, including:
 - Cache lifecycle commands for Git, chart, and remote Kustomize caches.
 
 See [`docs/compatibility.md`](docs/compatibility.md) for the detailed Argo CD
-support matrix.
+support matrix. See [`docs/applicationsets.md`](docs/applicationsets.md) for
+ApplicationSet details and [`docs/source-acquisition.md`](docs/source-acquisition.md)
+for remote source, cache, and auth behavior.
 
 ## Offline Runtime Model
 
@@ -229,8 +231,12 @@ Join the home-operations Discord at <https://discord.gg/home-operations>.
 ## Documentation
 
 - [`docs/README.md`](docs/README.md): documentation ownership and routing.
-- [`docs/usage.md`](docs/usage.md): CLI examples, flags, outputs, cache
-  behavior, and optional smoke tests.
+- [`docs/usage.md`](docs/usage.md): operator CLI workflows and high-value
+  command examples.
+- [`docs/applicationsets.md`](docs/applicationsets.md): ApplicationSet
+  generator behavior, fixture schema, and template parameters.
+- [`docs/source-acquisition.md`](docs/source-acquisition.md): Git, Helm,
+  remote Kustomize, cache, and auth behavior.
 - [`docs/compatibility.md`](docs/compatibility.md): supported Argo CD behavior
   and intentional runtime boundaries.
 - [`docs/release.md`](docs/release.md): release and Argo CD dependency upgrade

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,9 @@ copying the same rule into multiple files.
 | `AGENTS.md` | Mandatory agent operating rules and hard constraints. |
 | `docs/agent-reference.md` | Task-specific agent constraints and code-area notes. |
 | `docs/design.md` | Product architecture and behavior model. |
-| `docs/usage.md` | CLI examples, flags, outputs, and user workflows. |
+| `docs/usage.md` | Operator CLI workflows and high-value command examples. |
+| `docs/applicationsets.md` | ApplicationSet generator behavior, fixture schema, and template parameters. |
+| `docs/source-acquisition.md` | Git, Helm, remote Kustomize, cache, and auth behavior. |
 | `docs/compatibility.md` | Supported Argo CD behavior and runtime-boundary status. |
 | `docs/release.md` | Release and Argo CD dependency upgrade notes. |
 | `docs/logo/` | Project logo assets. |
@@ -23,7 +25,10 @@ copying the same rule into multiple files.
   closed plans and audits.
 - Keep `docs/reports` for active design gates only.
 - Put durable product behavior in `docs/design.md`, `docs/usage.md`,
-  or `docs/compatibility.md`, depending on ownership above.
+  `docs/applicationsets.md`, `docs/source-acquisition.md`, or
+  `docs/compatibility.md`, depending on ownership above.
+- Split a focused reference page only when it removes dense detail from
+  `docs/usage.md` or `docs/design.md`.
 - Keep `README.md`, `AGENTS.md`, and `docs/agent-reference.md` as routing
   surfaces; link to canonical docs instead of duplicating long explanations.
 - Update this file when adding, deleting, or changing ownership of docs.

--- a/docs/applicationsets.md
+++ b/docs/applicationsets.md
@@ -1,0 +1,181 @@
+# ApplicationSet Reference
+
+`drydock` expands a deterministic local subset of Argo CD `ApplicationSet`
+generators. Unsupported generators emit diagnostics; non-strict commands keep
+supported generated Applications, while `--strict` promotes those diagnostics
+to errors.
+
+Provider-backed generators are fixture-backed only. The CLI never contacts
+Kubernetes, Argo CD, SCM provider, pull-request, cloud, or plugin-service APIs
+for ApplicationSet generation.
+
+## Supported Generators
+
+Supported local generators:
+
+- Git directories
+- Git files
+- List, including `elementsYaml`
+- Matrix
+- Merge
+- Fixture-backed provider generators for clusters, clusterDecisionResource,
+  SCM provider, pull requests, and plugin generators
+
+Supported template behavior:
+
+- `spec.goTemplate: true`
+- `spec.goTemplateOptions`, including `missingkey=error`
+- Sprig-compatible functions used by Argo CD, including `regexReplaceAll`
+- generator-level selectors
+- generator-level template overrides
+- generated `Application.metadata.namespace` set to the ApplicationSet
+  namespace
+- Argo CD's default generated Application finalizer where applicable
+- multiple supported top-level generators evaluated independently and
+  concatenated in manifest order
+
+## Git Generators
+
+Git directories and Git files matches are sorted by normalized relative path.
+Include and exclude patterns are deterministic, and `exclude: true` removes a
+path even when another pattern includes it.
+
+Git files must remain under the repository root and must not traverse symlinks.
+YAML and JSON files must decode to non-empty mapping documents. Arrays,
+scalars, invalid YAML/JSON, and empty files produce diagnostics.
+
+Git files `values` use the same `values.*` and `.values.*` behavior as Git
+directories. `pathParamPrefix` applies to all path-related params. For example,
+`pathParamPrefix: myRepo` produces `.myRepo.path.path` in Go templates and
+`myRepo.path` in non-Go-template mode.
+
+In PR diff mode, mapped repository URLs use the local `--path` or
+`--path-orig` trees for directory discovery and rendering, even when the
+ApplicationSet declares `revision: master`.
+
+## List, Matrix, And Merge
+
+List generators support `elements` and `elementsYaml`.
+
+Matrix generators combine exactly two child generators and interpolate the
+second child from first-child params, including templated `elementsYaml`.
+
+Merge generators overlay two or more child generators by `mergeKeys` in base
+generator order.
+
+Matrix and merge children may use list, Git directories, Git files,
+fixture-backed provider generators, and nested matrix/merge combinations where
+the Argo CD v3 nested JSON API permits them.
+
+## Provider Fixtures
+
+Provider-backed generators use explicit local fixture files supplied with the
+repeatable `--appset-provider-fixture` flag:
+
+```bash
+drydock get apps --path . --appset-provider-fixture fixtures/appset-providers.yaml
+drydock diff apps --path . --path-orig ../base --appset-provider-fixture fixtures/appset-providers.yaml
+```
+
+Fixture files are strict YAML or JSON documents. Unknown fields, duplicate
+identities, URL-like fixture paths, and malformed files produce
+`appset.provider-fixture-invalid`. If fixtures are supplied but no entries
+match a provider generator, drydock emits `appset.provider-no-match`. Filters
+that cannot be evaluated from fixture data fail closed with
+`appset.provider-unsupported-filter`.
+
+### Fixture Schema
+
+```yaml
+clusters:
+  - name: prod-a
+    server: https://prod-a.example.invalid
+    project: platform
+    labels:
+      environment: prod
+    annotations:
+      owner: platform
+    values:
+      region: home
+
+clusterDecisions:
+  - configMapRef: placement-config
+    resourceName: placement-a
+    labels:
+      placement: edge
+    matchKey: clusterName
+    statusListKey: clusters
+    decisions:
+      - clusterName: prod-a
+        placement: edge
+    values:
+      tier: edge
+
+scmRepositories:
+  - provider: github
+    organization: example-org
+    repository: example-repo
+    repositoryID: repo-123
+    branch: main
+    sha: abcdef1234567890
+    url: https://github.com/example-org/example-repo
+    labels:
+      - ops
+    paths:
+      - deploy/app.yaml
+    values:
+      tier: ops
+
+pullRequests:
+  - provider: github
+    organization: example-org
+    repository: example-repo
+    number: 42
+    title: Update chart
+    branch: renovate/chart
+    targetBranch: main
+    headSHA: abcdef1234567890
+    author: renovate
+    labels:
+      - dependencies
+    values:
+      kind: renovate
+
+plugins:
+  - configMapRef: generator-plugin
+    outputs:
+      - environment: prod
+        cluster:
+          name: prod-a
+    values:
+      source: fixture
+```
+
+Additional provider-specific fixture fields are available where Argo provider
+configuration needs scope data that should not alter emitted template params.
+SCM repositories accept `project`, `region`, and `tags`; pull requests accept
+`project` and `state`. For example, Azure DevOps uses `organization` plus
+`project`, AWS CodeCommit requires explicit `region` and can evaluate
+`tagFilters` from `tags`, and GitLab `pullRequestState` is evaluated from
+`state`.
+
+## Template Parameters
+
+Provider fixtures emit the same stable template parameter names that Argo CD
+uses for each supported provider family:
+
+| Generator | Stable template parameters |
+| --- | --- |
+| `clusters` | `name`, `nameNormalized`, `server`, `project`, metadata labels/annotations, `values` |
+| `clusterDecisionResource` | `name`, `server`, decision fields, `values` |
+| `scmProvider` | `organization`, `repository`, `repository_id`, `url`, `branch`, `branchNormalized`, `sha`, `short_sha`, `short_sha_7`, `labels`, `values` |
+| `pullRequest` | `number`, `title`, `branch`, `branch_slug`, `target_branch`, `target_branch_slug`, `head_sha`, `head_short_sha`, `head_short_sha_7`, `author`, `labels`, `values` |
+| `plugin` | fixture output fields, `generator.input.parameters`, `values` |
+
+For non-Go-template ApplicationSets, nested maps are flattened with dot
+notation, including `metadata.labels.<key>`, `metadata.annotations.<key>`, and
+`values.<key>`.
+
+For Go-template ApplicationSets, nested values remain available as maps or
+arrays, such as `.metadata.labels`, `.metadata.annotations`, `.labels`, and
+`.values`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,234 +1,213 @@
 # Argo CD Compatibility Notes
 
-`drydock` tracks Argo CD compatibility for offline desired-state analysis:
-Application discovery, rendering, render tests, diagnostics, image inspection,
-cache-backed source acquisition, and desired-vs-desired diffs. Default commands
-run offline from live Argo CD and Kubernetes runtime and may fetch declared
-sources into explicit caches unless `--offline` is set.
+`drydock` tracks Argo CD compatibility for offline-runtime desired-state
+analysis. Default commands discover, render, test, diff, inspect images, and
+diagnose local Argo CD desired state without contacting live Argo CD or
+Kubernetes runtime. Declared sources may be fetched into explicit caches unless
+`--offline` is set.
 
-Supported today:
+## Runtime Model
 
-- Direct `Application` CRs
-- Git-directory, Git-files, list, matrix, merge, and fixture-backed provider
-  `ApplicationSet` CR expansion
-- ApplicationSet list `elementsYaml`, including matrix-interpolated
-  `elementsYaml`
-- ApplicationSet generator selectors and generator template overrides for
-  supported generators
-- Matrix interpolation for supported local children
-- Deterministic merge-key overlays for supported local children
-- Nested ApplicationSet matrix/merge combinations where the Argo CD v3 nested
-  JSON API permits them
-- Explicit local YAML/JSON fixtures for cluster, clusterDecisionResource, SCM
-  provider, pull-request, and plugin ApplicationSet generators, including
-  nested matrix/merge children
-- Fail-closed fixture diagnostics for invalid provider fixtures, no provider
-  matches, and unsupported provider filters
-- Single-source and multi-source planning for supported source types
-- Kustomize and directory rendering, including repo-root-local Kustomize
-  references
-- Argo CD `kustomize.buildOptions` support for `--enable-helm`,
-  `--helm-api-versions`, and
-  `--load-restrictor=LoadRestrictionsRootOnly|LoadRestrictionsNone`
-- Kustomize `helmCharts` rendered through the shared Go-library Helm path
-- Kustomize Helm `valuesFile` and `additionalValuesFiles` entries may point
-  outside the kustomization directory when the resolved file remains inside
-  the repository root
-- Default discovery skips Helm chart template files and only discovers Argo CD
-  objects from real manifests, not raw Go-template YAML
-- Directory rendering ignores values-like YAML documents only when both
-  `apiVersion` and `kind` are absent, and fails clearly when exactly one of
-  those fields is present
-- Remote Kustomize HTTP(S) file refs and Git refs rendered through the remote
-  resource cache
-- HTTP(S) Kustomize refs as single YAML/JSON files, with directory-shaped refs
-  such as bases and components requiring Git refs to Kustomization directories
-- Remote Kustomize `resources`, `bases`, `components`, `patches.path`,
-  `patchesJson6902.path`, non-inline `patchesStrategicMerge`, `generators`,
-  `transformers`, `validators`, `configurations`, `crds`, `openapi.path`,
-  `replacements.path`, and generator file/env refs
-- Local Helm chart rendering
-- Chart-only remote Helm sources for public HTTP/S and OCI repositories
-- Public Helm chart fetching by default for render and diff chart dependencies
-- User chart cache entries for acquired charts
-- User remote-resource cache entries for acquired Kustomize resources
-- Optional cache event API/reporting for Git, Helm, and remote Kustomize
-  acquisition, with redacted targets and errors
-- `--repo-map URL=PATH` path-source resolution for local external checkouts
-- Default Git clone/fetch into the Git cache for unmapped path sources missing
-  from the local tree
-- User Git repository cache entries for fetched path sources
-- Explicit Git HTTPS bearer/basic auth and SSH key-file auth
-- Explicit HTTP(S) Helm bearer/basic auth
-- Explicit HTTP(S) remote Kustomize bearer/basic auth, with Kustomize Git refs
-  reusing explicit Git credentials
-- Explicit Helm OCI registry config path plumbing
-- `diag --path` repository diagnostics through the render validation path
-- Stable diagnostic codes in structured CLI and public API diagnostic output
-- `diag -o json` and `diag -o yaml` structured diagnostic reports
-- `diag --cache-events` optional cache acquisition event reporting in
-  structured diagnostic reports
-- `diag --settings -o json|yaml` CLI-only redacted settings summaries for
-  parsed Argo CD settings metadata. Lua/action bodies and secret-looking
-  strings embedded in Lua are not printed.
-- Custom health Lua validation in `test apps` and `test app`, executed offline
-  against rendered desired manifests. This catches Lua script and return
-  contract failures, but is not live Argo CD health aggregation because no
-  cluster state is read.
-- `cache path`, `cache list`, `cache prune`, and `cache delete` local source
-  cache lifecycle commands for recognized Git, chart, and remote Kustomize
-  cache layouts
-- `get apps` structured table, name, JSON, and YAML output with Kubernetes
-  label selector filtering on Application metadata labels
-- `get images` structured table, name, JSON, and YAML output using the same
-  rendered image reference extraction as `diff images`
-- `build app` rendering for one Application by `NAME` or `NAMESPACE/NAME`
+Supported:
+
+- Direct `Application` CRs.
+- Single-source and multi-source Applications.
+- Desired-vs-desired manifest and image diffs.
+- Render tests with per-Application `PASS`, `FAIL`, and `SKIPPED` status.
+- Structured JSON and YAML outputs for list, test, diagnostic, and diff
+  commands where supported.
+- Stable diagnostic codes in CLI and public API output.
+- Render concurrency with deterministic output ordering.
 - Partial build results for embedding callers when some selected Applications
-  fail to render
-- `test apps` and `test app` per-Application PASS/FAIL/SKIPPED render status
-  output, including JSON and YAML formats
-- `diff apps` desired-vs-desired manifest diffs
-- `diff app` desired-vs-desired diffs for one Application, including
-  add/delete diffs when the Application exists on only one side
-- `diff apps` and `diff app` structured JSON and YAML output
-- `diff apps`, `diff app`, and `diff images` against local Git refs through
-  temporary local snapshots, without `git` shellouts or checkout mutation
-- `--strip-attr KEY` diff normalization for metadata label and annotation keys
-- Default diff ignores for common Helm chart/version labels and pod-template
-  `checksum/*` annotations, plus `--show-ignored-fields` to include those
-  drydock-default ignored fields in manifest diffs
-- Application-level `spec.ignoreDifferences[]` `jsonPointers`,
-  `jqPathExpressions`, and `managedFieldsManagers` for rendered manifest diffs
-- Global `resource.customizations.ignoreDifferences.*` `jsonPointers`,
-  `jqPathExpressions`, and `managedFieldsManagers` from discovered `argocd-cm`
-  and Argo CD Helm values `configs.cm`
-- Global `resource.customizations.knownTypeFields.*` normalization for
-  desired-vs-desired manifest diffs
-- Global `resource.customizations.ignoreResourceUpdates.*` parsing and
-  diagnostics, without applying them to desired-vs-desired diffs
-- Health and action customization parsing and diagnostics, including
-  `useOpenLibs`/Lua metadata and redacted SHA-256 summaries. Resource action
-  Lua is not executed offline.
-- Discovered `resource.compareoptions.ignoreResourceStatusField` and
-  `resource.compareoptions.ignoreAggregatedRoles`
-- Argo CD core resource exclusions plus discovered global
-  `resource.exclusions` and `resource.inclusions`
-- Explicit rendered-resource filters through `--skip-kind`, `--skip-crds`, and
-  `--skip-secrets`
-- `diff images` rendered image reference diffs
-- Repeated-resource last-wins behavior inside one Application
-- Public Go API in `pkg/drydock` for Application listing, rendering,
-  manifest diffs, image diffs, injectable Git/chart/remote-resource
-  acquisition, injectable config management plugin rendering, named in-process
-  plugin renderer registry dispatch, and plugin renderer timeout controls
-- Config management plugin source detection with fail-closed diagnostics in
-  the CLI and default Go client when no plugin renderer is injected
-- Local `AppProject` manifest discovery
-- Offline diagnostics for Application source repository, destination
-  server/name/namespace, and source namespace validation from local
-  `AppProject` manifests. Name-only destinations are accepted when the
-  AppProject permits `server: "*"` for the target namespace; exact
-  server-only allowlists still require `destination.server` because drydock
-  does not parse cluster Secret metadata.
-- AppProject RBAC role and policy parsing as reported metadata, without
-  simulating authorization
-- `permitOnlyProjectScopedClusters` reporting as deferred metadata, without
-  offline project-scoped cluster Secret enforcement
-- Repository credential matching diagnostics based on discovered repository
-  Secret metadata only, without reading secret credential fields
-- Benchmarks for repeated local Application rendering and ApplicationSet
-  expansion
-- Render concurrency through `--parallelism N`, bounded automatic defaults for
-  multi-Application test/diff commands, and `drydock.Config.Parallelism`, with
-  deterministic output ordering, cache-backed source snapshots, and lock-held
-  local graph copies for remote Kustomize Git refs
-- CI documentation for local, library-backed verification without cluster,
-  server, or renderer CLI dependencies
-- Release and upgrade documentation for static binary/module releases, Argo CD
-  dependency upgrades, cache compatibility, and an optional explicit-version
-  install Action
-
-Network and cache behavior:
-
-- `--offline` disables Git, Helm chart, and remote Kustomize resource network
-  fetching. It requires cache hits, repo maps, or local chart availability.
-- `--refresh-charts` refreshes cached immutable chart entries.
-- `--chart-cache-dir PATH` overrides the default user cache directory.
-- `--repo-map URL=PATH` maps a Git repo URL to a local checkout and takes
-  precedence over local fallback and network fetching.
-- `--git-cache-dir PATH` overrides the default Git repository cache directory.
-- `--refresh-git` fetches cached Git repositories before rendering.
-- `--git-bearer-token` takes precedence over `--git-username` and
-  `--git-password` for Git HTTPS auth.
-- Git SSH auth requires `--git-ssh-key-file` and `--git-known-hosts-file`.
-  `ssh://host/...` defaults the SSH user to `git`.
-- Kustomize Git remote refs reuse the explicit `--git-*` credentials, but use
-  `--remote-cache-dir`, `--refresh-remotes`, and `--offline` for cache and
-  network behavior.
-- Top-level `--repo` for Git ref diffs supports local repository paths only.
-  Remote repository URLs are deferred; clone locally before using `--ref` or
-  `--ref-orig`.
-- `--helm-bearer-token` takes precedence over `--helm-username` and
-  `--helm-password` for HTTP(S) Helm repository auth.
-- `--registry-config PATH` is the only OCI registry credential source used by
-  this slice; ambient Helm and Docker registry config is not read.
-- `--appset-provider-fixture PATH` supplies local-only provider generator data
-  and does not enable Kubernetes, Argo CD, SCM, pull-request, cloud, or plugin
-  service API access.
-- `--refresh-remotes` refreshes cached remote Kustomize resources.
-- `--remote-cache-dir PATH` overrides the default remote resource cache
-  directory.
-- `--remote-bearer-token` takes precedence over `--remote-username` and
-  `--remote-password` for HTTP(S) remote Kustomize resource auth.
-- Git, chart, and remote-resource caches must stay outside the current working
-  directory, selected repository roots, Git repository trees, and
-  symlink-resolved equivalents.
-- Cache lifecycle commands are local filesystem operations only. They do not
-  render Applications, clone/fetch Git repositories, fetch Helm charts, fetch
-  remote Kustomize resources, read credential flags, or retry failed
-  network/auth acquisitions.
-- New cache entries include hidden `.drydock-cache/metadata.json` sidecars
-  with redacted target metadata. Older hash-only entries are listed as legacy
-  entries when their filesystem layout is recognized.
-- Non-dry-run `cache prune` and `cache delete` operations require `--yes`;
-  dry-runs do not require confirmation.
-- Offline render/build/diff commands require existing cache hits or local chart
-  availability. Populate caches with a prior non-offline render using the
-  relevant auth, cache-dir, and refresh flags.
+  fail to render.
 
 Not reproduced offline:
 
-- Kubernetes API defaulting
-- Admission mutation
-- Live server-side apply field ownership prediction
-- Live Argo CD server-side diff
-- Managed-fields ignores when ownership data exists only on the live cluster
-- Applying `ignoreResourceUpdates` to desired-vs-desired diffs
-- Any live runtime behavior that has not passed the live runtime boundary gate
-- Resource action Lua execution
-- Live Argo CD Application health aggregation
-- Live destination cluster existence checks
-- Sync window enforcement
-- Source integrity signature verification
-- Project-scoped cluster Secret enforcement
-- Full Argo CD RBAC/Casbin authorization simulation
-- CLI config management plugin execution, shellout plugin adapters, Argo CD
-  repo-server sidecar plugin discovery, ambient plugin configuration, ambient
-  plugin environment loading, and plugin credential injection
-- Live provider API calls for cluster, clusterDecisionResource, SCM provider,
-  pull-request, and plugin ApplicationSet generators. Only explicit local
-  fixtures are supported.
-- Live cluster and Argo CD API sources
+- Kubernetes API defaulting.
+- Admission mutation.
+- Live Argo CD server-side diff.
+- Live server-side apply field ownership prediction.
+- Managed-fields ignores when ownership data exists only on the live cluster.
+- Live Argo CD Application health aggregation.
+- Live destination cluster existence checks.
+- Sync window enforcement.
+- Source integrity signature verification.
+- Project-scoped cluster Secret enforcement.
+- Full Argo CD RBAC/Casbin authorization simulation.
 
-These live-state behaviors must stay explicit out-of-boundary results in
-offline-runtime workflows. Do not approximate them silently in
-desired-vs-desired diffs. Any implementation must pass the live runtime
-boundary gate and preserve the default library-backed render/diff path.
+These live-state behaviors must stay explicit runtime-boundary diagnostics, not
+silent approximations.
 
-Live runtime access is design-gated in
-`docs/reports/live-integration-design-gate.md`. Future live work
-must stay explicitly opt-in and must not change `--offline` cache-only behavior
-or the default offline-runtime render/diff contract.
+## Applications And ApplicationSets
 
-The tool pins Argo CD dependencies. Upgrade Argo CD dependencies deliberately
-and update compatibility tests in the same change.
+Supported:
+
+- Direct Application discovery from repository manifests.
+- ApplicationSet Git directories, Git files, list, matrix, and merge
+  generators.
+- ApplicationSet list `elementsYaml`, including matrix-interpolated
+  `elementsYaml`.
+- Generator selectors and generator template overrides for supported
+  generators.
+- Nested matrix/merge combinations where the Argo CD v3 nested JSON API
+  permits them.
+- Explicit local YAML/JSON fixtures for cluster, clusterDecisionResource, SCM
+  provider, pull-request, and plugin ApplicationSet generators.
+- Fail-closed fixture diagnostics for invalid provider fixtures, no provider
+  matches, and unsupported provider filters.
+
+Not supported:
+
+- Live Kubernetes, Argo CD, SCM provider, pull-request, cloud, or plugin
+  service API calls for ApplicationSet generation.
+- Unsupported generators without diagnostics.
+
+See `docs/applicationsets.md` for generator details and fixture schema.
+
+## Sources And Acquisition
+
+Supported:
+
+- Kustomize, directory, local Helm chart, and chart-only remote Helm sources.
+- HTTP(S) and OCI Helm chart fetching by default for declared chart
+  dependencies.
+- Kustomize `helmCharts` rendered through the shared Go-library Helm path.
+- Helm `$ref/...` external value files from Git sources.
+- Remote Kustomize HTTP(S) file refs and Git refs through the remote-resource
+  cache.
+- Default Git clone/fetch into the Git cache for unmapped path sources missing
+  from the local tree.
+- `--repo-map URL=PATH` path-source resolution for local external checkouts.
+- Explicit Git HTTPS bearer/basic auth and SSH key-file auth.
+- Explicit HTTP(S) Helm bearer/basic auth.
+- Explicit HTTP(S) remote Kustomize bearer/basic auth.
+- Explicit Helm OCI registry config path plumbing.
+- Cache event API/reporting for Git, Helm, and remote Kustomize acquisition,
+  with redacted targets and errors.
+- Local cache lifecycle commands for recognized Git, chart, and remote
+  Kustomize cache layouts.
+
+Important boundaries:
+
+- `--offline` disables Git, Helm chart, and remote Kustomize resource network
+  fetching and requires cache hits, repo maps, local files, or local chart
+  availability.
+- `--repo-map` takes precedence over local fallback and network fetching.
+- Top-level `--repo` for Git ref diffs supports local repository paths only.
+- Ambient Git credential helpers, ambient Helm registry config, and secret
+  credential fields from discovered repository Secrets are not read.
+- Cache lifecycle commands are local filesystem operations only; they do not
+  render, fetch, read credential flags, or retry failed acquisitions.
+
+See `docs/source-acquisition.md` for cache, auth, and remote source details.
+
+## Rendering
+
+Supported:
+
+- Directory rendering that skips values-like YAML documents only when both
+  `apiVersion` and `kind` are absent, and fails clearly when exactly one is
+  present.
+- Local Kustomize rendering with supported `kustomize.buildOptions`:
+  `--enable-helm`, `--helm-api-versions`, and
+  `--load-restrictor=LoadRestrictionsRootOnly|LoadRestrictionsNone`.
+- Kustomize Helm `valuesFile` and `additionalValuesFiles` entries outside the
+  kustomization directory when the resolved file remains inside the repository
+  root.
+- Remote Kustomize refs in `resources`, `bases`, `components`,
+  `patches.path`, `patchesJson6902.path`, non-inline
+  `patchesStrategicMerge`, `generators`, `transformers`, `validators`,
+  `configurations`, `crds`, `openapi.path`, `replacements.path`, and generator
+  file/env refs.
+- Config management plugin source detection with fail-closed diagnostics in
+  the CLI and default Go client.
+- Injectable in-process plugin renderers, named plugin registry dispatch, and
+  plugin timeout controls for embedding callers.
+
+Not supported:
+
+- CLI config management plugin execution.
+- Shellout plugin adapters.
+- Argo CD repo-server sidecar plugin discovery.
+- Ambient plugin configuration or environment loading.
+- Plugin credential injection.
+
+## Diff, Images, And Output
+
+Supported:
+
+- `diff apps` desired-vs-desired manifest diffs.
+- `diff app` desired-vs-desired diffs for one Application, including
+  add/delete diffs when the Application exists on only one side.
+- `diff apps`, `diff app`, and `diff images` against local Git refs through
+  temporary local snapshots, without `git` shellouts or checkout mutation.
+- Changed-only Application selection with safe render-all fallback and strict
+  failure mode.
+- Default diff ignores for common Helm chart/version labels and pod-template
+  `checksum/*` annotations.
+- `--show-ignored-fields` to include drydock-default ignored fields while
+  keeping Argo CD diff customizations active.
+- `--strip-attr KEY` normalization for metadata label and annotation keys.
+- Application-level `spec.ignoreDifferences[]` `jsonPointers`,
+  `jqPathExpressions`, and `managedFieldsManagers`.
+- Global `resource.customizations.ignoreDifferences.*`,
+  `knownTypeFields.*`, selected compare options, resource exclusions, and
+  resource inclusions.
+- Repeated-resource last-wins behavior inside one Application, with a
+  diagnostic.
+- `get images` and `diff images` rendered image reference extraction from
+  PodSpec container images and scalar fields whose key is exactly `image`.
+
+Not supported:
+
+- Applying `ignoreResourceUpdates` to desired-vs-desired diffs.
+- Managed-fields prediction from live state.
+- Arbitrary string scanning for image references.
+
+## Diagnostics, Projects, And Settings
+
+Supported:
+
+- `diag --path` repository diagnostics through the render validation path.
+- `diag -o json|yaml` structured diagnostic reports.
+- `diag --cache-events` optional cache acquisition event reporting.
+- `diag --settings -o json|yaml` redacted settings summaries for parsed Argo
+  CD settings metadata.
+- Local AppProject manifest discovery.
+- Offline diagnostics for Application source repository, destination
+  server/name/namespace, and source namespace validation from local AppProject
+  manifests.
+- AppProject RBAC role and policy parsing as reported metadata, without
+  simulating authorization.
+- Repository credential matching diagnostics based on discovered repository
+  Secret metadata only, without reading secret credential fields.
+- Cluster Secret metadata parsing for offline named-cluster destination
+  diagnostics.
+- Custom health Lua validation in `test apps` and `test app`, executed offline
+  against rendered desired manifests.
+- Health and action customization parsing and diagnostics, including
+  `useOpenLibs` metadata and redacted SHA-256 Lua summaries.
+
+Not supported:
+
+- Raw Lua body output in structured settings summaries.
+- Resource action Lua execution.
+- Live Argo CD health aggregation.
+- Live AppProject authorization decisions.
+
+## Public API And Releases
+
+Supported:
+
+- Public Go API in `pkg/drydock` for Application listing, rendering, manifest
+  diffs, image diffs, source acquisition hooks, plugin renderer hooks, and
+  stable diagnostics.
+- `cache path`, `cache list`, `cache prune`, and `cache delete` local cache
+  lifecycle commands.
+- Benchmarks for repeated local Application rendering and ApplicationSet
+  expansion.
+- Static binary, setup-action, and GHCR container release shape documented in
+  `docs/release.md`.
+
+The module pins Argo CD dependencies. Upgrade Argo CD deliberately and update
+compatibility tests and this document in the same change.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,613 +1,219 @@
 # drydock Design
 
-Date: 2026-05-22
+`drydock` is an independent Go CLI and embeddable library for Argo CD GitOps
+repository analysis. It discovers Argo CD Applications, renders desired
+manifests, validates renderability, inspects images and diagnostics, and
+compares current and baseline desired state for pull request diffs.
 
-## Purpose
+The core design target is offline-runtime analysis: default workflows require
+no running Kubernetes cluster, Argo CD instance, `kubectl`, `argocd`, Helm CLI,
+Kustomize CLI, repo-server, or external render service. Declared Git, HTTP
+Helm, OCI Helm, and remote Kustomize sources may be fetched into explicit
+drydock caches unless `--offline` is set.
 
-`drydock` is an independent Go CLI for Argo CD GitOps repository analysis that
-runs offline from live Argo CD and Kubernetes runtime. It performs offline
-desired-state analysis: discover Argo CD Applications, render desired
-manifests, validate renderability, inspect images and diagnostics, and compare
-current and baseline trees for desired-vs-desired pull request diffs.
+## Runtime Boundary
 
-The tool is intentionally not a live-cluster diff. It does not contact the
-Kubernetes API server, does not run Argo CD controllers, and does not claim to
-reproduce server-side apply prediction, admission mutation, or managed-fields
-ownership. This is a product boundary, not a missing default integration.
+drydock is not a live-cluster diff. It does not query Kubernetes or Argo CD,
+run Argo CD controllers, or silently approximate live-only behavior. These are
+intentional product boundaries:
 
-Default render, diff, image, and diagnostic workflows are offline-runtime
-desired-vs-desired analysis. They may fetch declared Git, HTTP Helm, OCI Helm,
-and remote Kustomize sources into explicit caches unless `--offline` is set.
-Live-cluster diffing, Argo CD server-side diff parity, Kubernetes defaulting,
-admission mutation, and live-only managed-fields ownership prediction are not
-approximated silently. Any future exception to that boundary must first update
-the live runtime boundary document and keep the default path independent of a
-Kubernetes cluster, Argo CD server, `kubectl`, `argocd`, Helm/Kustomize
-command-line tools, and external render services.
+- Kubernetes API defaulting and admission mutation.
+- Argo CD server-side diff.
+- Live server-side apply field ownership prediction.
+- Live Argo CD Application health aggregation.
+- Full Argo CD RBAC authorization.
+- CLI config management plugin execution and repo-server sidecar discovery.
+- Live provider APIs for ApplicationSet generators.
 
-## Repository
-
-The canonical module and repository identity is:
-
-```text
-github.com/sholdee/drydock
-```
-
-Local checkout paths are operator-specific and may lag the repository rename
-until the external rename checklist is completed.
-
-The repository is licensed Apache-2.0. Releases include a root `LICENSE` and
-third-party notices for redistributed source, copied fixtures, binary/container
-distributions, and imported Apache-2.0 components as needed.
-
-## Scope
-
-Supported:
-
-- Direct `Application` CRs.
-- `ApplicationSet` Git directories, Git files, list, matrix, and merge
-  generators with Go templates.
-- Single-source and multi-source Applications.
-- Git path sources rendered as Kustomize or directory manifests.
-- Helm chart sources from HTTP and OCI repositories.
-- Helm `$ref/...` external value files from Git sources.
-- Repository URL to local path mappings.
-- Default Git cache acquisition for unmapped external repositories unless
-  `--offline` is set.
-- Explicit Git HTTPS bearer/basic auth, Git SSH key-file auth, HTTP(S) Helm
-  bearer/basic auth, and explicit OCI Helm registry config path plumbing.
-- Config management plugin source detection with fail-closed diagnostics in
-  the CLI/default path, plus injectable Go API plugin renderers, named
-  in-process plugin registry dispatch, and plugin renderer timeout controls
-  for embedders that provide deterministic local plugin rendering.
-- Cluster, clusterDecisionResource, SCM provider, pull-request, and plugin
-  ApplicationSet generators through explicit local fixtures.
-- Render, test, get, diagnostic, cache, manifest diff, and image diff commands.
-- Changed-only rendering with safe fallback.
-
-Outside the core runtime contract:
-
-- Live-cluster diff.
-- Argo CD API/server integration, Argo CD server-side diff parity,
-  Kubernetes defaulting, admission mutation, and live-only managed-fields
-  ownership prediction.
-- CLI config management plugin execution, shellout plugin adapters, Argo CD
-  repo-server sidecar plugin discovery, ambient plugin configuration, ambient
-  plugin environment loading, and plugin credential injection.
-- Full Argo CD project/RBAC/destination validation.
-- Live health aggregation and richer health diagnostics beyond offline custom
-  health Lua validation.
+Future live-runtime work must remain explicitly opt-in and pass the design gate
+in `docs/reports/live-integration-design-gate.md`.
 
 ## Architecture
 
-The default architecture is a native local engine with Argo CD types and
-decoupled helpers. The tool imports Argo CD API types and selected reusable
-normalization/diff helpers, but owns local orchestration and rendering.
+The production path is a native local engine using Argo CD API types and
+selected reusable helpers where they are decoupled from live runtime services.
+drydock owns discovery, source planning, cache use, rendering orchestration,
+diagnostics, and output shaping.
+
+```mermaid
+flowchart LR
+  Repo[Checked-out repository] --> Discover[Discover Applications, ApplicationSets, settings]
+  Discover --> Plan[Plan sources and inputs]
+  Plan --> Acquire[Acquire declared sources into caches]
+  Acquire --> Render[Render desired manifests with Go libraries]
+  Render --> Normalize[Apply Argo-aware normalization]
+  Normalize --> Diffs[Manifest diffs]
+  Normalize --> Images[Image diffs and inventory]
+  Render --> Tests[Render tests and Lua health validation]
+  Render --> Diag[Diagnostics]
+```
 
 Primary packages:
 
 - `cmd/drydock`: Cobra CLI and exit-code handling.
-- `internal/config`: canonical `ArgoSettings` model loaded from CLI flags,
-  `argocd-cm`, Argo CD Helm values, repository secrets, and defaults.
-- `internal/discovery`: scans repository trees for `Application`,
-  `ApplicationSet`, Argo CD settings, and repository metadata.
-- `internal/appset`: local ApplicationSet Git directories, Git files, list,
-  matrix, and merge generators with Go-template support.
-- `internal/source`: repository URL normalization, local repo maps, source
-  checkout, and cache management.
-- `internal/render`: renderer interface plus Helm, Kustomize, and directory
-  renderers.
-- `internal/app`: Application normalization, single/multi-source planning,
-  `$ref` resolution, repeated-resource warnings, and per-Application rendered
-  output.
+- `pkg/drydock`: public embedding API.
+- `internal/config`: Argo CD settings model and provenance.
+- `internal/discovery`: repository scanning for Applications, ApplicationSets,
+  settings, projects, repository metadata, and cluster metadata.
+- `internal/appset`: deterministic local ApplicationSet expansion.
+- `internal/source`, `internal/chart`, `internal/remote`,
+  `internal/acquisition`: Git, Helm, remote Kustomize, cache, and credential
+  plumbing.
+- `internal/render`: Helm, Kustomize, directory, and plugin renderer
+  interfaces.
+- `internal/app`: Application normalization, source planning, `$ref`
+  resolution, repeated-resource handling, and orchestration.
 - `internal/change`: changed-file detection and Application input indexing.
-- `internal/diff`: parent-aware desired-vs-desired diffs and image diffs.
-- `internal/diagnostic`: warnings, provenance, unsupported-feature reporting,
-  and strict-mode escalation.
+- `internal/diff` and `internal/manifest`: manifest normalization, resource
+  diffs, and image extraction.
+- `internal/diagnostic`: stable diagnostics, provenance, and strict-mode
+  escalation.
 
 The repo-server wrapper approach is not the default architecture. Argo CD
-repo-server internals can be used as compatibility references or test oracles,
-but the production path should not depend on repo-server service/cache/gRPC
-plumbing.
-
-The shellout approach is also not the default architecture. The product goal is
-a single binary with no required `helm`, `kustomize`, `kubectl`, or `argocd`
-executables on `PATH`. A future optional compatibility backend may be added
-behind the renderer interface if needed.
-
-Config management plugin execution follows the same boundary. The default CLI
-and package-level API do not execute plugin commands or discover repo-server
-sidecars. Embedders may inject deterministic in-process plugin renderers through
-`pkg/drydock`; those renderers receive explicit Application source metadata and
-return manifests and diagnostics in-process. The named registry helper dispatches
-only by explicit `plugin.name`. Timeouts are caller-configured through the public
-API and are reported as plugin failures without converting caller cancellation
-into plugin timeout diagnostics.
-
-## Argo CD Versioning
-
-The Go module pins Argo CD dependencies deliberately. Initial dependency
-selection followed the Argo CD checkout used during project bootstrap, and
-future changes should happen through explicit upgrade PRs.
-
-`drydock version` prints:
-
-- `drydock` version.
-- Embedded Argo CD API/diff dependency versions.
-- Go version.
-
-Argo CD dependency upgrades are explicit PRs with compatibility test updates.
-The project does not float Argo CD dependencies to `latest`.
+repo-server internals can be compatibility references or test oracles, but the
+runtime path must stay a self-contained Go binary.
 
 ## Settings Model
 
-All runtime settings are normalized into a canonical `ArgoSettings` structure.
-Providers feed this model, and every discovered value carries provenance.
-
-Example model:
-
-```go
-type ArgoSettings struct {
-    KustomizeBuildOptions []string
-    HelmRepositories map[string]RepositorySettings
-    ResourceCustomizations map[string]ResourceCustomization
-    ResourceExclusions []ResourceExclusion
-    TrackingMethod string
-    InstanceLabelKey string
-}
-```
+Runtime settings are normalized into `ArgoSettings`. Every discovered value
+carries provenance so diagnostics can explain where behavior came from.
 
 Provider precedence:
 
-1. Explicit CLI flags, including `--argocd-cm`, `--argocd-values`,
+1. Explicit CLI flags such as `--argocd-cm`, `--argocd-values`,
    `--repo-secret`, and `--kustomize-build-option`.
 2. Rendered Argo CD ConfigMap candidates, especially `argocd-cm`.
-3. Argo CD Helm chart values candidates, including `configs.cm`.
-4. Repository secrets labeled `argocd.argoproj.io/secret-type: repository`,
-   using only non-sensitive fields such as `url`, `type`, `enableOCI`, `name`,
-   and `project`.
+3. Argo CD Helm values candidates, including `configs.cm`.
+4. Repository Secrets labeled
+   `argocd.argoproj.io/secret-type: repository`, using only non-sensitive
+   metadata.
 5. Built-in Argo CD defaults.
 
-Discovery is generic and not specific to any one repository. Common paths may
-be scanned, but conflicting discovered settings fail closed and require an
-explicit CLI selection. Missing settings use defaults with a warning.
+Rendering and diff-affecting settings are enforced. Resource action Lua is
+parsed as metadata only. Custom health Lua is validated offline during render
+tests against rendered desired manifests; it is not live Argo CD health
+aggregation.
 
-Example diagnostic:
+## Discovery And ApplicationSets
 
-```text
-kustomize.buildOptions:
-  value: --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard
-  source: apps/argocd/manifests/values.yaml:configs.cm.kustomize.buildOptions
-```
+Discovery scans the selected repository tree for direct `Application` CRs,
+supported generated `ApplicationSet` Applications, Argo CD settings,
+AppProjects, repository metadata, and cluster Secret metadata. Generated and
+direct Applications share the same downstream planning, rendering, test, and
+diff path.
 
-Health customizations, RBAC, and resource exclusions are recorded when found.
-Rendering/diff-affecting settings are enforced during render and diff.
-`drydock test apps` validates configured custom Argo CD health Lua offline by
-default against rendered desired manifests, not live Argo CD Application
-health aggregation. Valid returned health states such as `Healthy`,
-`Progressing`, or `Degraded` do not fail Applications; Lua compile, runtime,
-invalid-return, invalid-status, and ambiguous-customization failures do.
-Resource action Lua remains metadata-only and is not executed offline.
-`diag --settings -o json|yaml` exposes a CLI-only redacted summary for
-operators, including names, booleans, and SHA-256 hashes of trimmed Lua
-bodies. Raw Lua bodies and secret-looking strings embedded in Lua are not part
-of the structured summary.
+ApplicationSet support is deterministic and local. Git, list, matrix, merge,
+and fixture-backed provider generators are documented in
+`docs/applicationsets.md`.
 
-## Application Discovery
+Unsupported generators or unsupported fields produce diagnostics. Non-strict
+commands keep supported Applications where possible; `--strict` promotes those
+diagnostics to errors.
 
-The default command behavior scans the provided tree for Argo CD entrypoints:
+## Source Planning And Acquisition
 
-```bash
-drydock get apps --path ./repo
-drydock build app --path ./repo monitoring
-drydock diff apps --path ./repo --path-orig ../repo-base
-```
+Applications follow Argo CD source precedence:
 
-Diff commands may also compare local Git refs. A ref side is materialized as a
-temporary local snapshot, then the existing path-based planning and rendering
-pipeline is reused:
+- `spec.sources` wins when non-empty.
+- `spec.source` is used otherwise.
 
-```bash
-drydock diff apps --path ./repo --ref-orig main
-drydock diff apps --repo ./repo --ref feature --ref-orig main
-```
+Each source renders independently in source array order. Ref-only sources
+render no manifests. `$ref/...` Helm value files resolve from the referenced
+source root, not from the referenced source `path`. If multiple sources emit
+the same resource identity inside one Application, the later source wins and a
+repeated-resource diagnostic is emitted.
 
-`--ref-orig` replaces `--path-orig`; `--ref` replaces `--path`; `--repo`
-defaults to `--path` and must be a local repository path. Top-level remote
-repository URLs are deferred.
+Repository resolution and cache behavior are documented in
+`docs/source-acquisition.md`. Important invariants:
 
-Optional narrowing flags include:
-
-- `--app-manifests <path>`
-- `--namespace <namespace>`
-- `--project <project>`
-- `--selector <label-selector>`
-- `--app <name>`
-
-The scanner identifies direct `Application` CRs and supported
-`ApplicationSet` CRs. Generated Applications and direct Applications share the
-same downstream planning, rendering, and diff path.
-
-## ApplicationSet Support
-
-The supported local ApplicationSet subset includes the Git directories
-generator, Git files generator, and list generator.
-
-Supported behavior:
-
-- `spec.goTemplate: true`
-- `spec.goTemplateOptions`, including `missingkey=error`
-- Sprig-compatible template functions used by Argo CD, including
-  `regexReplaceAll`
-- directory include/exclude filtering
-- git-files include/exclude filtering
-- `.path.path`
-- `.path.basename`
-- `.path.basenameNormalized`
-- `.path.filename` for git-files
-- `.path.filenameNormalized` for git-files
-- `.path.segments`
-- generated `Application.metadata.namespace` set to the ApplicationSet
-  namespace
-- Argo CD's default generated Application finalizer where applicable
-- multiple supported top-level generators evaluated independently and
-  concatenated in manifest order
-
-Unsupported generators or unsupported ApplicationSet fields produce diagnostics.
-In non-strict mode, unsupported ApplicationSets are skipped with warnings. In
-strict mode, they are errors.
-
-Git files generator matches are sorted by normalized relative path. Traversal is
-contained to the repository root: symlinks, absolute paths, and `..` escapes are
-not followed. YAML/JSON mapping documents become template params. Go-template
-mode preserves nested maps such as `.cluster.name`; non-Go-template mode
-flattens nested keys such as `cluster.name` and converts scalar values to
-strings. Arrays, scalars, invalid YAML/JSON, and empty files produce
-diagnostics.
-
-Git files `values` use the same `values.*` and `.values.*` behavior as Git
-directories. Git files `exclude: true` excludes a file even when another
-pattern includes it.
-
-`pathParamPrefix` applies to all path-related params. For example,
-`pathParamPrefix: myRepo` produces `.myRepo.path.path` in Go templates and
-`myRepo.path` in non-Go-template mode.
-
-In PR diff mode, mapped repository URLs use the local `--path` or `--path-orig`
-trees for directory discovery and rendering, even when the ApplicationSet
-declares `revision: master`.
-
-## Source Planning
-
-Applications are planned using Argo CD source precedence:
-
-- If `spec.sources` is non-empty, it wins and `spec.source` is ignored.
-- Otherwise, `spec.source` is used.
-
-Multi-source support is included for supported source types.
-
-Supported multi-source semantics:
-
-- Each source renders independently in source array order.
-- Ref-only sources are allowed and render no manifests.
-- `ref: values` creates a `$values` root for Helm value files.
-- `$ref/...` value file paths resolve from the referenced source root, not
-  from its `path`.
-- Duplicate refs are errors.
-- Invalid ref keys are errors.
-- Sources with `ref` and `chart` are rejected for external value usage.
-- If multiple sources emit the same resource identity within one Application,
-  the later source wins and a repeated-resource warning is emitted.
-
-Repository resolution:
-
-- `--repo-map <url>=<path>` maps normalized repository URLs to local trees.
-- `--path` and `--path-orig` are authoritative for mapped PR repositories and
-  override declared revisions.
-- Unmapped external repositories fetch into the Git cache by default and require
-  another repo map or cache hit when `--offline` is set.
-- Git HTTPS auth is explicit via bearer token or username/password, with bearer
-  token taking precedence.
-- Git SSH auth is explicit via key file, passphrase when required, and
-  known-hosts file. SSH auth fails closed before network access if the key file
-  or known-hosts file is missing.
-- Supported SSH URL forms are `ssh://git@host/org/repo.git`,
-  `git@host:org/repo.git`, and `ssh://host/org/repo.git`. Missing usernames
-  default to `git`.
-- HTTP(S) Helm auth is explicit via bearer token or username/password, with
-  bearer token taking precedence.
-- OCI Helm auth is explicit via a `--registry-config` path.
-- The tool never prompts for credentials, never reads ambient Git credential
-  helpers, and never reads ambient Helm registry config in this slice.
-- Passwords, bearer tokens, SSH private keys, SSH passphrases, and registry
-  credential values are never printed in diagnostics or formatted errors.
-
-## Cache Model
-
-Source caches are explicit operator-managed roots for Git repositories, Helm
-charts, and remote Kustomize resources. Entries keep their current hash-based
-layout and include hidden `.drydock-cache/metadata.json` sidecars with redacted
-target metadata. Metadata writes are atomic and preserve original creation
-time across cache hits.
-
-`cache list`, `cache prune`, and `cache delete` only operate on recognized
-entry roots. Prune/delete remain explicit filesystem lifecycle commands,
-guarded by protected-root checks, age/key/source filters, dry-run support, and
-`--yes` for destructive execution.
-
-A shared content-addressed store with ref tables, leases, and mark-sweep
-collection is intentionally deferred. It would be useful only after drydock has
-multiple cache surfaces sharing the same immutable blobs; until then, it would
-add deletion semantics that need stronger live-reference protection than the
-current one-entry-per-acquisition layout requires.
+- `--repo-map URL=PATH` wins over local source fallback and network fetching.
+- PR diff roots are authoritative for mapped repositories.
+- Unmapped external Git repositories fetch into the Git cache by default and
+  require cache hits or repo maps under `--offline`.
+- Credential use is explicit, non-interactive, and redacted.
+- Caches must stay outside selected repository trees and symlink-resolved
+  equivalents.
 
 ## Rendering
 
-All renderers implement:
+All renderers implement an internal renderer interface and return manifests,
+diagnostics, and errors without writing generated output into the source tree.
 
-```go
-type Renderer interface {
-    Render(ctx context.Context, source ResolvedSource, opts RenderOptions) ([]Manifest, Diagnostics, error)
-}
-```
+Supported render paths:
 
-Supported renderers:
+- Directory manifests.
+- Kustomize sources using Go libraries and supported Argo CD build options.
+- Local Helm charts.
+- Kustomize `helmCharts` through the shared Helm library path.
+- Remote Helm chart sources from HTTP(S) and OCI repositories.
+- Remote Kustomize HTTP(S) files and Git refs.
+- Deterministic in-process plugin renderers supplied by embedding callers.
 
-- Helm renderer: supports HTTP and OCI chart sources, target revision,
-  release name, destination namespace, `valuesObject`, `values`, value files,
-  file parameters, `ignoreMissingValueFiles`, and `$ref/...` external value
-  files.
-- Kustomize renderer: supports local Kustomize builds with Argo settings build
-  options, especially `--enable-helm` and Helm API versions. App-level
-  Kustomize overrides are supported where Go libraries make this practical.
-- Directory renderer: parses plain YAML/JSON manifests, flattens `List`
-  resources, skips irrelevant files, and errors on invalid manifest content.
-
-The default render path does not shell out. Renderers should use Go libraries
-and isolated temp/cache directories.
+The default CLI and default Go client fail closed for config management plugin
+sources unless an embedding caller injects a plugin renderer.
 
 ## Diff Semantics
 
-The primary diff is desired-vs-desired. It answers: "What rendered desired
-manifests changed between the base tree and current tree?"
+Manifest diffs are desired-vs-desired. They answer: "What rendered desired
+manifests changed between the baseline tree and current tree?"
 
-Offline-safe behavior:
+Diff behavior:
 
-- Render both sides using the same planning and settings model.
-- Normalize obvious generated noise. By default this removes common Helm
-  chart/version labels from resource metadata and pod-template metadata, plus
-  pod-template `checksum/*` annotations. `--show-ignored-fields` disables only
-  this drydock-default filtering and leaves Argo CD diff customizations active.
-- Apply Argo CD `ignoreDifferences` where possible without live managed fields.
-- Apply JSON pointer and jq path ignores through reusable Argo CD normalizers
-  where decoupled.
-- Treat `ServerSideDiff=true` and `ServerSideApply=true` as diagnostics, not
-  executable behavior.
+- Render both sides with the same planning and settings model.
+- Apply Argo CD `ignoreDifferences`, known type fields, resource exclusions,
+  inclusions, and supported compare options where possible without live state.
+- Hide common Helm chart/version label noise and pod-template `checksum/*`
+  annotations by default.
+- Preserve the ability to show drydock-default ignored fields with
+  `--show-ignored-fields`.
+- Treat server-side diff/apply settings as diagnostics, not executable live
+  behavior.
 - Resolve `--ref` and `--ref-orig` through temporary local snapshots without
   shelling out to `git` or mutating the operator checkout.
 
-The tool does not claim to reproduce:
+Changed-only mode is on by default for multi-Application PR diffs. It indexes
+Application manifest files, source paths, `$ref` value files, and supported
+`argocd.argoproj.io/manifest-generate-paths` inputs. If every changed path can
+be mapped, only affected Applications render. If any path is unowned,
+non-strict mode warns and renders all Applications; `--strict-changed-only`
+fails instead.
 
-- Kubernetes API defaulting.
-- Server-side apply field ownership.
-- Admission webhooks.
-- Managed-fields-manager ignores.
-- Live Argo CD server-side diff.
+Argo CD permits overlapping Applications, so drydock keeps every affected
+Application instead of collapsing ownership to one most-specific owner.
 
-## Changed-Only Mode
+## Output And Diagnostics
 
-Changed-only mode is on by default for PR diffs.
+Structured outputs keep stdout machine-parseable. Diagnostics and failure
+summaries go to stderr unless status text is the primary output.
 
-Algorithm:
+Exit codes:
 
-1. Compute changed paths between `--path-orig` and `--path`. For local Git ref
-   diffs, compute changed paths from Git refs and tracked worktree files so
-   ignored or untracked local output does not force a full render.
-2. Build an Application input index from discovered direct and generated
-   Applications.
-3. Match changed files to every Application whose inputs intersect the change.
-4. Include Application manifest files, source paths, `$ref` value-file inputs,
-   and `argocd.argoproj.io/manifest-generate-paths` where supported.
-5. Render only affected Applications when every changed path is owned.
-6. If any changed path is unowned, render all Applications and report the
-   unowned paths.
-7. `--strict-changed-only` fails on unowned paths instead.
-8. `--changed-only=false` renders all Applications.
-
-Unlike Flux-oriented ownership, Argo CD changed-only mode does not choose a
-single most-specific owner. Overlapping Applications are valid, so all affected
-Applications are kept.
-
-## Output
-
-Default unified diff headers include parent Application, source, and child
-resource identity:
-
-```diff
---- Application: argocd/monitoring Source: 0 apps/monitoring Deployment: monitoring/foo
-+++ Application: argocd/monitoring Source: 0 apps/monitoring Deployment: monitoring/foo
-@@ ...
-```
-
-Structured output includes:
-
-- parent Application kind, namespace, and name
-- source index, source name, and source path/chart
-- resource group, kind, namespace, and name
-- change type
-- warnings
-- diff body
-
-Supported formats:
-
-- `diff`
-- `json`
-- `yaml`
-
-`-o name` is reserved for list-style commands such as `get apps` and
-`get images`; diff commands reject it. `diff images -o json|yaml` emits
-structured `added`, `removed`, and `unchanged` image lists.
-
-Image diff extracts PodSpec container images and scalar rendered manifest
-fields whose key is exactly `image`. It skips Secret manifests, top-level
-metadata/status, ConfigMap data payloads, and arbitrary string scanning so CI
-pull-test workflows catch CRD image fields without treating every string as an
-image reference.
-
-## Diagnostics
-
-Diagnostics are explicit and provenance-based.
-
-Required diagnostics:
-
-- settings provenance
-- conflicting settings candidates
-- unsupported ApplicationSet fields/generators
-- unsupported source types
-- server-side diff/apply offline limitations
-- repeated resources per Application
-- unowned changed files and render-all fallback
-- strict-mode escalations
-
-Secrets are never printed. Repository secrets only contribute non-sensitive
-metadata.
-
-## Exit Codes
-
-Diff-style commands use:
-
-- `0`: command succeeded and no diff was found.
-- `1`: command succeeded and a diff was found.
+- `0`: success and no diff for diff-style commands.
+- `1`: success with a diff for diff-style commands.
 - `2`: tool, configuration, discovery, or render error.
 
-`--exit-code=false` makes diffs exit `0` for local inspection.
+Diagnostics are provenance-based and redact secrets. Repository Secrets only
+contribute non-sensitive metadata. Required diagnostic surfaces include
+settings provenance, conflicting settings candidates, unsupported
+ApplicationSet behavior, unsupported source types, offline runtime limitations,
+repeated resources, unowned changed files, strict-mode escalations, source
+repository checks, destination checks, and cache acquisition events.
 
-Warnings do not change exit code unless strict mode promotes them to errors.
+## Public API
 
-## CLI Shape
+`pkg/drydock` exposes Application listing, rendering, manifest diffs, image
+diffs, source acquisition hooks, plugin renderer hooks, stable diagnostics, and
+partial build results. Public APIs must not expose `internal/...` types.
 
-Initial command surface:
+Embedding callers can inject deterministic Git, chart, remote-resource, and
+plugin renderers for tests or controlled environments. The package-level API
+uses the same default network, cache, and runtime-boundary behavior as the CLI.
 
-```bash
-drydock get apps --path .
-drydock build app <name> --path .
-drydock build apps --path .
-drydock diff app <name> --path . --path-orig ../base
-drydock diff apps --path . --path-orig ../base
-drydock diff images --path . --path-orig ../base -o json
-drydock diag --path .
-drydock version
-```
+## Versioning
 
-Important flags:
+The module pins Argo CD dependencies deliberately. Argo CD upgrades are explicit
+PRs with compatibility test updates and `docs/compatibility.md` updates.
 
-- `--path`
-- `--path-orig`
-- `--repo-map <url>=<path>`
-- `--changed-only`
-- `--strict-changed-only`
-- `--strict`
-- `--exit-code`
-- `--unified`
-- `--limit-bytes`
-- `-o diff|json|yaml` for diff commands
-- `-o table|json|yaml|name` for list commands
-- `--argocd-cm`
-- `--argocd-values`
-- `--repo-secret`
-- `--kustomize-build-option`
-- `--app-manifests`
-- `--namespace`
-- `--project`
-- `--selector`
-
-## Linting And Formatting
-
-The repository includes linting from the start.
-
-`.golangci.yml` keeps the strict Go lint profile selected during project
-bootstrap:
-
-- golangci-lint config version `2`
-- 5 minute timeout
-- strict linters including `bodyclose`, `copyloopvar`, `durationcheck`,
-  `errcheck`, `errorlint`, `exhaustive`, `gocritic`, `gocyclo`, `govet`,
-  `ineffassign`, `intrange`, `misspell`, `nakedret`, `nilerr`, `nilnil`,
-  `nolintlint`, `prealloc`, `staticcheck`, `unconvert`, `unused`,
-  `wastedassign`, and `whitespace`
-- `gocyclo` threshold 15
-- `nolintlint` requires explanations and specific linters
-- `errcheck` checks type assertions
-- standard error-handling exclusions
-- `gofmt` formatter with simplify enabled
-
-`.gomarklint.json` keeps the Go-native Markdown lint profile selected during
-project bootstrap:
-
-- disable line length
-- allow top-level document headings
-- keep list spacing compatible with dense reference docs
-
-## Agent Guidance
-
-`AGENTS.md` owns mandatory agent operating rules and hard constraints.
-`docs/README.md` owns documentation routing. Update those files when a design
-change alters agent rules, package routing, validation expectations, or
-documentation ownership.
-
-## Validation
-
-Baseline validation commands:
-
-```bash
-go test ./...
-go vet ./...
-golangci-lint run
-go run github.com/shinagawa-web/gomarklint/v3@v3.0.5
-```
-
-Compatibility and regression tests cover:
-
-- ApplicationSet Git directories rendering.
-- ApplicationSet Go-template behavior and missing-key errors.
-- Multi-source precedence.
-- Ref validation.
-- Helm `$ref` external value files.
-- Helm `valuesObject` precedence.
-- OCI Helm repository metadata.
-- Kustomize build options from settings discovery.
-- Repeated-resource last-wins warnings.
-- Changed-only mapping.
-- Unowned changed-file fallback and strict failure.
-- Exit-code behavior.
-
-Home-ops-oriented tests use minimal fixtures adapted for the behavior under
-test, not a wholesale copy of the operational repository.
-
-## Open Risks
-
-- Pure-Go Kustomize with Helm chart support may expose compatibility gaps
-  against Argo CD's shellout behavior.
-- Pure-Go Helm OCI handling must match Argo CD chart-source semantics closely
-  enough for common repos.
-- Argo CD internal packages may change across versions, so imports must stay
-  conservative and pinned.
-- Offline normalization cannot know all cluster-scoped CRDs without discovery
-  data, so unknown GVK namespace handling must be documented and configurable
-  over time.
-- Network-off default requires clear diagnostics for missing external sources.
-
-## Acceptance Criteria
-
-- New repository is Apache-2.0 licensed.
-- No required shellouts for default render/diff workflows.
-- Direct Applications and supported ApplicationSets are discovered from repo
-  trees.
-- Multi-source Applications work for supported source types.
-- Local repo maps override declared revisions in PR diff mode.
-- Argo CD settings discovery is generic, provenance-based, and conflict-aware.
-- Changed-only mode is safe by default and strict when requested.
-- Diff output is parent-aware.
-- Exit codes are CI-friendly.
-- Linting configs mirror the referenced Go and Markdown lint settings.
-- AGENTS.md is created early and maintained alongside implementation changes.
+`drydock version` prints the drydock version, embedded Argo CD dependency
+versions, and Go version. Release binaries receive their version from release
+build metadata.

--- a/docs/release.md
+++ b/docs/release.md
@@ -80,17 +80,24 @@ Release tags use true SemVer with a leading `v`, such as `v0.1.0`. Release PRs
 are managed by release-please using conventional commits and
 `release-please-config.json`.
 
-The first public release is bootstrapped from `.release-please-manifest.json`
-version `0.0.0` and `initial-version: 0.1.0`. The release-readiness commit uses
-`Release-As: 0.1.0` so release-please should open the first release PR for
-`v0.1.0`. Do not publish a different first release tag.
-
 Release automation is split by ownership:
 
 - The `Release Please` workflow manages changelog/version release PRs only.
   It must not create GitHub Releases or release tags.
 - The `Release` workflow publishes an unreleased version from
   `.release-please-manifest.json` after the release PR is merged.
+
+```mermaid
+flowchart TD
+  ReleasePR[Release Please PR] --> Merge[Merge release PR to main]
+  Merge --> Version[Read manifest version]
+  Version --> Checks[Run source checks]
+  Checks --> Build[Build archives and container]
+  Build --> Draft[Create draft immutable GitHub Release]
+  Draft --> PushImage[Push and sign GHCR image tags]
+  PushImage --> Publish[Publish release and mark latest]
+  Publish --> Verify[Verify tag target and artifacts]
+```
 
 This preserves the normal operator workflow of marking the release PR ready,
 waiting for CI, and merging it. The publishing workflow then builds, signs, and

--- a/docs/source-acquisition.md
+++ b/docs/source-acquisition.md
@@ -1,0 +1,131 @@
+# Source Acquisition
+
+`drydock` renders from local files and explicit source caches. Declared Git,
+HTTP Helm, OCI Helm, and remote Kustomize sources may be fetched into those
+caches unless `--offline` is set. The tool does not read ambient Git
+credential helpers, ambient Helm registry config, or live Argo CD repository
+state.
+
+## Resolution Model
+
+Repository source resolution is deterministic:
+
+1. Explicit `--repo-map URL=PATH`.
+2. Existing local source path under the selected repository tree.
+3. Declared Git cache/fetch behavior for unmapped external repositories.
+4. Clear failure when a source cannot be resolved.
+
+`--repo-map` wins over local source-path fallback and network fetching.
+`--path` and `--path-orig` are authoritative for mapped pull-request
+repositories and override declared revisions.
+
+Ref-only sources are allowed and render no manifests. `$ref/...` Helm value
+files resolve from the referenced source root, not from its `path`.
+
+## Kustomize Sources
+
+For local Kustomize sources, drydock applies the supported subset of Argo CD
+`kustomize.buildOptions` discovered from `argocd-cm` or Argo CD Helm values:
+
+- `--enable-helm`
+- `--helm-api-versions`
+- `--load-restrictor=LoadRestrictionsRootOnly`
+- `--load-restrictor=LoadRestrictionsNone`
+
+Unsupported build options fail explicitly instead of being ignored.
+
+Supported Kustomize remote refs include:
+
+- `https://github.com/org/repo//path?ref=v1`
+- `git::https://github.com/org/repo.git//path?ref=v1`
+- `ssh://git@github.com/org/repo.git//path?ref=v1`
+- `git@github.com:org/repo.git//path?ref=v1`
+
+Remote Kustomize refs are supported in `resources`, `bases`, `components`,
+`patches.path`, `patchesJson6902.path`, non-inline `patchesStrategicMerge`,
+`generators`, `transformers`, `validators`, `configurations`, `crds`,
+`openapi.path`, `replacements.path`, and ConfigMap/Secret generator `files`,
+`envs`, and `env` entries.
+
+HTTP(S) refs are treated as single YAML/JSON files. Directory-shaped fields,
+including remote bases and components, must use Git refs that resolve to
+Kustomization directories. The renderer copies acquired content into a
+temporary workspace under generated `.drydock` paths and does not write
+generated manifests into the source tree.
+
+## Network And Cache Flags
+
+| Flag | Behavior |
+| --- | --- |
+| `--offline` | Disable Git, Helm chart, and remote Kustomize network fetching. |
+| `--repo-map URL=PATH` | Map a source repository URL to a local checkout. |
+| `--refresh-git` | Fetch cached Git repositories before rendering. |
+| `--git-cache-dir PATH` | Override the default Git repository cache root. |
+| `--refresh-charts` | Refresh cached immutable chart entries before rendering. |
+| `--chart-cache-dir PATH` | Override the default chart cache root. |
+| `--refresh-remotes` | Refresh cached remote Kustomize resources before rendering. |
+| `--remote-cache-dir PATH` | Override the default remote-resource cache root. |
+| `--registry-config PATH` | Supply the only Helm OCI registry credentials. |
+
+Offline render/build/diff commands require cache hits, repo maps, local files,
+or local chart availability. Populate caches with a prior non-offline render
+using the relevant auth, cache-dir, and refresh flags.
+
+Caches must stay outside Git repository trees. Cache entries include hidden
+`.drydock-cache/metadata.json` sidecars with redacted target metadata. Older
+hash-only entries are listed as legacy entries when their filesystem layout is
+recognized.
+
+## Credentials
+
+Authenticated source handling is explicit and non-interactive:
+
+- Git HTTPS auth supports bearer and basic auth; bearer wins.
+- Git SSH auth requires explicit key and known-hosts files.
+- HTTP(S) Helm auth supports bearer and basic auth; bearer wins.
+- HTTP(S) remote Kustomize auth supports bearer and basic auth; bearer wins.
+- OCI Helm auth is provided only through `--registry-config`.
+
+Credential flags:
+
+| Source | Flags |
+| --- | --- |
+| Git HTTPS bearer | `--git-bearer-token TOKEN` |
+| Git HTTPS basic | `--git-username USER`, `--git-password PASS` |
+| Git SSH | `--git-ssh-key-file PATH`, `--git-known-hosts-file PATH`, `--git-ssh-passphrase PASSPHRASE` |
+| HTTP(S) Helm bearer | `--helm-bearer-token TOKEN` |
+| HTTP(S) Helm basic | `--helm-username USER`, `--helm-password PASS` |
+| HTTP(S) remote Kustomize bearer | `--remote-bearer-token TOKEN` |
+| HTTP(S) remote Kustomize basic | `--remote-username USER`, `--remote-password PASS` |
+
+Kustomize Git remote refs reuse the explicit `--git-*` credentials, but use
+the remote Kustomize cache and `--offline`/`--refresh-remotes` behavior.
+
+Supported SSH URL forms are `ssh://git@host/org/repo.git`,
+`git@host:org/repo.git`, and `ssh://host/org/repo.git`. Missing usernames
+default to `git`.
+
+Passwords, bearer tokens, SSH private keys, SSH passphrases, registry
+credential values, and credential-bearing URLs are never printed in diagnostics
+or formatted errors.
+
+## Cache Lifecycle Boundary
+
+Cache lifecycle commands are local filesystem operations only. They do not:
+
+- render Applications
+- clone or fetch Git repositories
+- fetch Helm charts
+- fetch remote Kustomize resources
+- read credential flags
+- retry failed network or authentication acquisitions
+
+`cache prune` and `cache delete` operate only on recognized drydock cache entry
+roots. They reject cache roots that resolve inside the current working
+directory, selected repository roots, Git repository trees, or symlink-resolved
+equivalents. Non-dry-run deletion requires `--yes`; dry-runs never require
+confirmation.
+
+A shared content-addressed store with ref tables, leases, and mark-sweep
+collection is intentionally deferred. It would be useful only after drydock has
+multiple cache surfaces sharing immutable blobs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,22 +1,18 @@
 # Usage
 
-`drydock` currently wires Application discovery, rendered image listing,
-all-Application and named-Application build, all-Application and
-named-Application render tests, named-Application manifest diffs, image diffs,
-repository diagnostics, and local source-cache lifecycle commands.
+`drydock` is an offline-runtime CLI for Argo CD GitOps repositories. Default
+commands render and compare desired state from checked-out files plus explicit
+local caches. They do not contact a Kubernetes cluster or Argo CD server, and
+they do not require `kubectl`, `argocd`, Helm CLI, or Kustomize CLI.
 
-Default commands are desired-vs-desired workflows that run offline from live
-Argo CD and Kubernetes runtime. They may fetch declared Git, HTTP Helm, OCI
-Helm, and remote Kustomize sources into explicit caches unless `--offline` is
-set. They do not contact a Kubernetes cluster or Argo CD server, do not shell
-out to `kubectl`, `argocd`, Helm CLI, or Kustomize CLI, and do not silently
-approximate Kubernetes defaulting, admission mutation, Argo CD server-side
-diff, or live-only managed fields.
+Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources may be fetched
+into drydock caches unless `--offline` is set. Use `--offline` when the command
+must be cache-only.
 
 ## Application Discovery
 
-List discovered direct `Application` CRs and supported generated
-`ApplicationSet` Applications:
+List direct `Application` CRs and supported generated `ApplicationSet`
+Applications:
 
 ```bash
 drydock get apps --path .
@@ -36,144 +32,19 @@ List rendered image references from Applications:
 drydock get images --path . -o name
 ```
 
-`get images` supports the same structured output formats as `get apps`.
-Diagnostics are printed to stderr for both commands.
+`get images` uses the same output formats as `get apps`. Diagnostics are
+printed to stderr for both commands.
 
 Supported local `ApplicationSet` generators are Git directories, Git files,
-list, matrix, merge, and explicit fixture-backed provider generators. Multiple
-supported top-level generators are expanded independently and concatenated in
-manifest order. Unsupported generators emit diagnostics; non-strict commands
-keep supported generated Applications, while `--strict` promotes those
-diagnostics to errors.
+list, matrix, merge, and explicit fixture-backed provider generators.
+Unsupported generators emit diagnostics; non-strict commands keep supported
+Applications, while `--strict` promotes the diagnostics to errors.
 
-Git files generator matches are sorted by normalized relative path. Include
-and exclude patterns are evaluated deterministically, and `exclude: true`
-removes a file even if another pattern includes it. Files must stay under the
-repository root and must not traverse symlinks. YAML and JSON files must decode
-to non-empty mapping documents.
+For generator details, fixture schemas, and stable template parameters, see
+[`applicationsets.md`](applicationsets.md).
 
-List generators support `elements` and `elementsYaml`. Supported generators
-honor generator-level selectors and generator-level template overrides.
-Selectors match flattened parameter keys, including nested Go-template maps.
-Matrix generators combine exactly two child generators and interpolate the
-second child from first-child params, including templated `elementsYaml`.
-Merge generators overlay two or more child generators by `mergeKeys` in base
-generator order. Matrix and merge children may use list, Git directories, Git
-files, fixture-backed provider generators, and nested matrix/merge combinations
-where the Argo CD v3 nested JSON API permits them.
-
-Provider-backed `ApplicationSet` generators are supported only from explicit
-local fixture files. The CLI never contacts Kubernetes, Argo CD, SCM provider,
-pull-request, cloud, or plugin-service APIs for these generators. Supply one
-or more fixtures with the repeatable flag:
-
-```bash
-drydock get apps --path . --appset-provider-fixture fixtures/appset-providers.yaml
-drydock diff apps --path . --path-orig ../base --appset-provider-fixture fixtures/appset-providers.yaml
-```
-
-Fixture files are strict YAML or JSON documents. Unknown fields, duplicate
-identities, URL-like fixture paths, and malformed files produce
-`appset.provider-fixture-invalid`. If fixtures are supplied but no entries
-match a provider generator, drydock emits `appset.provider-no-match`. Filters
-that cannot be evaluated from fixture data fail closed with
-`appset.provider-unsupported-filter`.
-
-Fixture schema:
-
-```yaml
-clusters:
-  - name: prod-a
-    server: https://prod-a.example.invalid
-    project: platform
-    labels:
-      environment: prod
-    annotations:
-      owner: platform
-    values:
-      region: home
-
-clusterDecisions:
-  - configMapRef: placement-config
-    resourceName: placement-a
-    labels:
-      placement: edge
-    matchKey: clusterName
-    statusListKey: clusters
-    decisions:
-      - clusterName: prod-a
-        placement: edge
-    values:
-      tier: edge
-
-scmRepositories:
-  - provider: github
-    organization: example-org
-    repository: example-repo
-    repositoryID: repo-123
-    branch: main
-    sha: abcdef1234567890
-    url: https://github.com/example-org/example-repo
-    labels:
-      - ops
-    paths:
-      - deploy/app.yaml
-    values:
-      tier: ops
-
-pullRequests:
-  - provider: github
-    organization: example-org
-    repository: example-repo
-    number: 42
-    title: Update chart
-    branch: renovate/chart
-    targetBranch: main
-    headSHA: abcdef1234567890
-    author: renovate
-    labels:
-      - dependencies
-    values:
-      kind: renovate
-
-plugins:
-  - configMapRef: generator-plugin
-    outputs:
-      - environment: prod
-        cluster:
-          name: prod-a
-    values:
-      source: fixture
-```
-
-Additional provider-specific fixture fields are available where Argo provider
-configuration needs scope data that should not alter emitted template params:
-SCM repositories accept `project`, `region`, and `tags`; pull requests accept
-`project` and `state`. For example, Azure DevOps uses `organization` plus
-`project` for matching, AWS CodeCommit requires explicit `region` and can
-evaluate `tagFilters` from `tags`, and GitLab `pullRequestState` is evaluated
-from `state`.
-
-Provider fixtures emit the same stable template parameter names that Argo CD
-uses for each supported provider family:
-
-| Generator | Stable template parameters |
-| --- | --- |
-| `clusters` | `name`, `nameNormalized`, `server`, `project`, metadata labels/annotations, `values` |
-| `clusterDecisionResource` | `name`, `server`, decision fields, `values` |
-| `scmProvider` | `organization`, `repository`, `repository_id`, `url`, `branch`, `branchNormalized`, `sha`, `short_sha`, `short_sha_7`, `labels`, `values` |
-| `pullRequest` | `number`, `title`, `branch`, `branch_slug`, `target_branch`, `target_branch_slug`, `head_sha`, `head_short_sha`, `head_short_sha_7`, `author`, `labels`, `values` |
-| `plugin` | fixture output fields, `generator.input.parameters`, `values` |
-
-For non-Go-template ApplicationSets, nested maps are flattened with dot
-notation, including `metadata.labels.<key>`, `metadata.annotations.<key>`, and
-`values.<key>`. For Go-template ApplicationSets, nested values remain available
-as maps or arrays, such as `.metadata.labels`, `.metadata.annotations`,
-`.labels`, and `.values`.
-
-Local `AppProject` manifests are also discovered. They are used for offline
-diagnostics only; discovery does not contact a Kubernetes cluster or Argo CD
-server.
+Local `AppProject` manifests are discovered for offline diagnostics only.
+Discovery does not contact a Kubernetes cluster or Argo CD server.
 
 ## Rendering
 
@@ -183,7 +54,7 @@ Build every discovered Application:
 drydock build apps --path .
 ```
 
-Build exactly one discovered Application by `metadata.name`:
+Build exactly one Application by `metadata.name`:
 
 ```bash
 drydock build app renovate --path .
@@ -200,108 +71,28 @@ drydock build app argocd/my-app --path .
 
 When one selected Application fails to render, embedding callers receive a
 partial `BuildResult` containing successful manifests, diagnostics, and
-per-Application statuses. CLI `build` commands keep stdout parseable; on render
-failure they print diagnostics to stderr and do not mix invalid partial manifest
-streams into stdout.
+per-Application statuses. CLI `build` commands keep stdout parseable: on render
+failure, diagnostics go to stderr and invalid partial manifest streams are not
+mixed into stdout.
 
 Use `--parallelism N` on render-backed commands to render up to `N`
-Applications concurrently. `drydock test apps`, `drydock diff apps`, and
-`drydock diff images` default to bounded host CPU parallelism; single-Application
-commands default to `1`. Parallel rendering preserves selected Application
-order for manifests, statuses, diagnostics, cache events, and structured
-output. Cache-backed chart, Git source, and remote HTTP resources are
-snapshot-protected before render reads. Remote Kustomize Git
-refs hold the cache lock only long enough to collect and copy the local
-Kustomize graph into the temporary workspace, avoiding full repository
-snapshots while preserving same-process cache safety.
+Applications concurrently. Multi-Application `test` and `diff` commands default
+to bounded host CPU parallelism; single-Application commands default to `1`.
+Parallel rendering preserves selected Application order for manifests,
+statuses, diagnostics, cache events, and structured output.
 
 Rendering supports directory sources, Kustomize sources, local Helm charts,
-Kustomize `helmCharts`, remote Kustomize HTTP(S) files and Git refs, and
-Argo CD chart-only remote Helm sources. Declared Git, chart, and remote
-Kustomize fetching is enabled by default when a render needs remote content.
-Path-based Git sources use the local `--path` tree when the source path exists
-there. Use `--repo-map URL=PATH` to force a source repo URL to a local checkout.
+Kustomize `helmCharts`, remote Kustomize HTTP(S) files and Git refs, and Argo CD
+chart-only remote Helm sources. Path-based Git sources use the local `--path`
+tree when the source path exists there. Use `--repo-map URL=PATH` to force a
+source repository URL to a local checkout.
 
 Repositories tagged with `argocd` or `gitops` are not always Argo CD
 Application fleet repositories. `drydock test apps` reports zero applications
 when no `Application` or supported `ApplicationSet` objects are discovered.
 
-For local Kustomize sources, drydock applies the supported subset of Argo CD
-`kustomize.buildOptions` discovered from `argocd-cm` or Argo CD Helm values:
-`--enable-helm`, `--helm-api-versions`, and
-`--load-restrictor=LoadRestrictionsRootOnly|LoadRestrictionsNone`.
-Unsupported build options fail explicitly instead of being ignored.
-
-Supported Kustomize remote refs include:
-
-- `https://github.com/org/repo//path?ref=v1`
-- `git::https://github.com/org/repo.git//path?ref=v1`
-- `ssh://git@github.com/org/repo.git//path?ref=v1`
-- `git@github.com:org/repo.git//path?ref=v1`
-
-Remote Kustomize refs are supported in `resources`, `bases`, `components`,
-`patches.path`, `patchesJson6902.path`, non-inline `patchesStrategicMerge`,
-`generators`, `transformers`, `validators`, `configurations`, `crds`,
-`openapi.path`, `replacements.path`, and ConfigMap/Secret generator
-`files`, `envs`, and `env` entries. HTTP(S) refs are treated as single
-YAML/JSON files. Directory-shaped fields, including remote bases and
-components, must use Git refs that resolve to Kustomization directories. The
-renderer copies acquired content into a temporary workspace under generated
-`.drydock` paths and does not write generated manifests into the source
-tree.
-
-Network and cache flags:
-
-- `--offline` disables Git, Helm chart, and remote Kustomize network fetching.
-  It requires local files, repo maps, local charts, or existing cache entries.
-- `--refresh-charts` refreshes cached immutable chart entries before rendering.
-- `--chart-cache-dir PATH` overrides the default user cache directory for
-  acquired charts.
-- `--repo-map URL=PATH` maps a Git repository URL to a local checkout and wins
-  over local source-path fallback and network fetching.
-- `--git-cache-dir PATH` overrides the default user cache directory for cached
-  Git repositories.
-- `--refresh-git` fetches cached Git repositories before rendering.
-- `--git-bearer-token TOKEN` authenticates Git HTTPS clone/fetch requests with
-  bearer auth and takes precedence over basic auth.
-- `--git-username USER` and `--git-password PASS` authenticate Git HTTPS
-  clone/fetch requests with basic auth.
-- `--git-ssh-key-file PATH` authenticates Git SSH clone/fetch requests.
-  `--git-known-hosts-file PATH` is required for SSH in this slice; encrypted
-  keys can use `--git-ssh-passphrase PASSPHRASE`.
-- Kustomize Git remote refs reuse the explicit `--git-*` credentials, but use
-  the remote Kustomize cache and `--offline`/`--refresh-remotes` behavior.
-- `--helm-bearer-token TOKEN` authenticates HTTP Helm repository index and
-  archive requests with bearer auth and takes precedence over basic auth.
-- `--helm-username USER` and `--helm-password PASS` authenticate HTTP Helm
-  repository index and archive requests with basic auth.
-- `--registry-config PATH` supplies the only Helm OCI registry credentials used
-  by this slice. Ambient Helm and Docker registry config is not read.
-- `--refresh-remotes` refreshes cached remote Kustomize resources before
-  rendering.
-- `--remote-cache-dir PATH` overrides the default user cache directory for
-  cached remote Kustomize resources.
-- `--remote-bearer-token TOKEN` authenticates HTTP(S) remote Kustomize
-  resource requests with bearer auth and takes precedence over basic auth.
-- `--remote-username USER` and `--remote-password PASS` authenticate HTTP(S)
-  remote Kustomize resource requests with basic auth.
-- `--appset-provider-fixture PATH` supplies offline YAML/JSON data for
-  provider-backed ApplicationSet generators. The flag is repeatable and is
-  local-file only; it never enables live provider access.
-- `--skip-kind KIND` omits rendered resources with that Kubernetes kind from
-  build output, manifest diffs, image extraction, and render tests. The flag is
-  repeatable and matches kind only.
-- `--skip-crds` omits rendered `CustomResourceDefinition` resources.
-- `--skip-secrets` omits rendered `Secret` resources.
-- `--parallelism N` controls Application render concurrency for render-backed
-  commands while preserving deterministic output ordering.
-
-Caches must stay outside Git repository trees. New cache entries include
-hidden `.drydock-cache/metadata.json` sidecars with redacted target metadata,
-and older hash-only entries are listed as legacy entries when their filesystem
-layout is recognized. Offline render/build/diff commands require cache hits
-or local chart availability; populate caches with a prior non-offline render
-using the relevant auth, cache-dir, and refresh flags.
+For acquisition, cache, auth, and remote source details, see
+[`source-acquisition.md`](source-acquisition.md).
 
 ## Cache Lifecycle
 
@@ -332,34 +123,18 @@ drydock cache delete --source remote --all --dry-run
 ```
 
 `cache prune` and `cache delete` require `--yes` for non-dry-run deletion.
-Dry-runs never require confirmation and leave cache files in place. Cache
-commands accept `--git-cache-dir`, `--chart-cache-dir`, and
-`--remote-cache-dir`; `--path` and `--path-orig` are used only for safety
-checks, and `--path` defaults to the current directory. Render-time network
-and credential flags such as `--offline`, `--refresh-*`, and auth flags are
-not cache lifecycle behavior, except that cache commands resolve the same cache
-directories.
+Dry-runs never require confirmation and leave cache files in place.
 
-Cache lifecycle commands do not render Applications, clone/fetch Git
-repositories, fetch Helm charts, fetch remote Kustomize resources, or read
-credential flags. They operate only on recognized drydock cache entry roots
-and reject cache roots that resolve inside the current working directory, the
-selected `--path`/`--path-orig` protected roots, any Git repository tree, or
-symlink-resolved equivalents. They never retry failed network or
-authentication acquisitions; rerun the render/build/diff acquisition path with
-the relevant credentials or refresh flags to repopulate a missing or stale
-cache entry. Corrupt, mismatched, or unsupported metadata may hide descriptive
-metadata, but it must not make an unrecognized filesystem child deletable.
-
-The current cache model is one hash-addressed entry per acquired source.
-Content-addressed blob sharing, ref tables, leases, and mark-sweep garbage
-collection are deferred until the cache has enough shared-blob behavior to
-justify the extra lifecycle semantics.
+Cache lifecycle commands are local filesystem operations only. They do not
+render Applications, clone/fetch Git repositories, fetch Helm charts, fetch
+remote Kustomize resources, or read credential flags. They operate only on
+recognized drydock cache entry roots and reject cache roots that resolve inside
+the current working directory, selected repository roots, Git repository trees,
+or symlink-resolved equivalents.
 
 ## Go API
 
-Use `github.com/sholdee/drydock/pkg/drydock` when embedding
-the renderer directly:
+Use `github.com/sholdee/drydock/pkg/drydock` when embedding the renderer:
 
 ```go
 client := drydock.NewClient(drydock.Config{
@@ -373,39 +148,26 @@ result, err := client.Render(ctx)
 
 Package-level `Render`, `ListApplications`, `DiffApplications`, and
 `DiffImages` functions use the same default network and cache behavior as the
-CLI. `NewClient` accepts public Git, chart, and remote-resource acquirer
-interfaces so tests and embedding callers can provide fakes without importing
-internal packages or performing public network fetches.
+CLI. `NewClient` accepts public Git, chart, remote-resource, and plugin
+renderer interfaces so tests and embedding callers can provide deterministic
+fakes without importing internal packages.
 
 Public render results include Applications, manifests, diagnostics, and
 per-Application statuses. If one selected Application fails, `Render` returns
-the error and still returns the partial successful manifests, stable
-diagnostics, and statuses. Set `SkipKinds`, `SkipCRDs`, or `SkipSecrets` on
-`drydock.Config` to apply the same rendered-resource filters exposed by
-the CLI.
+the error and still returns partial successful manifests, stable diagnostics,
+and statuses. `SkipKinds`, `SkipCRDs`, and `SkipSecrets` apply the same
+rendered-resource filters exposed by the CLI.
 
-Config management plugin sources are explicit. The CLI and default Go client
-do not execute plugin commands; an Application source with `spec.source.plugin`
+Config management plugin sources are explicit. The CLI and default Go client do
+not execute plugin commands; an Application source with `spec.source.plugin`
 fails closed with `plugin.unsupported` unless an embedding caller supplies
 `drydock.Config.PluginRenderer`. Embedders can pass a renderer directly or use
 `drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to dispatch
-in-process renderers by `plugin.name`. Plugin names are trimmed for registry
-lookup, and unnamed plugin sources match only an explicitly registered empty
-name.
+in-process renderers by `plugin.name`.
 
-Set `drydock.Config.PluginTimeout` to bound each injected plugin renderer
-call. A plugin timeout emits `plugin.failed` while preserving partial render
-results from successful Applications. Renderer-supplied plugin diagnostics get
-stable codes; diagnostics without explicit plugin codes use the neutral
-`plugin.unspecified` fallback. Injected plugin renderer output participates in
-normal render, diff, image extraction, destination namespace defaulting, and
-resource filtering.
-
-Shellout plugin adapters, Argo CD repo-server sidecar plugin discovery,
-ambient plugin configuration, ambient plugin environment loading, and plugin
-credential injection are outside the default CLI/runtime contract. The default
-CLI path does not read ambient plugin credentials or execute external plugin
-commands.
+Shellout plugin adapters, Argo CD repo-server sidecar plugin discovery, ambient
+plugin configuration, ambient plugin environment loading, and plugin credential
+injection are outside the default CLI/runtime contract.
 
 ## Render Tests
 
@@ -415,15 +177,10 @@ Test every discovered Application without printing manifest bodies:
 drydock test apps --path .
 ```
 
-Test exactly one discovered Application by `metadata.name`:
+Test exactly one Application:
 
 ```bash
 drydock test app renovate --path .
-```
-
-Use `NAMESPACE/NAME` when a name appears in multiple namespaces:
-
-```bash
 drydock test app argocd/my-app --path .
 ```
 
@@ -436,19 +193,15 @@ SKIPPED argocd/skipped unsupported ApplicationSet generator ...
 ```
 
 Status values are `PASS` for Applications that rendered successfully, `FAIL`
-for render or planning failures, and `SKIPPED` when an earlier discovery or
-expansion precondition prevented safe rendering. `test apps` and `test app`
-return exit code `0` only when every selected Application passes; any `FAIL`,
-`SKIPPED`, or runtime failure returns exit code `2`.
+for render or planning failures, and `SKIPPED` when discovery or expansion
+preconditions prevented safe rendering. `test apps` and `test app` return exit
+code `0` only when every selected Application passes. Any `FAIL`, `SKIPPED`,
+or runtime failure returns exit code `2`.
 
 `drydock test apps` and `drydock test app` validate configured custom Argo CD
 health Lua by default. Validation is offline and runs against rendered desired
-manifests, not live Argo CD Application health aggregation. It catches Lua
-compile, runtime, invalid return, invalid status, and ambiguous customization
-failures. Valid health states do not make render tests fail because desired
-manifests often lack live `.status`.
-
-Use `--skip-lua-health` to isolate render failures or benchmark render-only
+manifests, not live Argo CD Application health aggregation. Use
+`--skip-lua-health` to isolate render failures or benchmark render-only
 behavior:
 
 ```bash
@@ -458,7 +211,8 @@ drydock test apps --path . --skip-lua-health
 When `test apps` writes text output to a terminal, statuses stream as each
 Application completes. Status labels are colored, a single stderr progress
 counter updates in place when stderr is also a terminal, and a final summary is
-printed after the status lines. Redirected text output stays plain and buffered.
+printed after the status lines. Redirected text output stays plain and
+buffered.
 
 Structured status output is available with `-o json` and `-o yaml`:
 
@@ -466,9 +220,6 @@ Structured status output is available with `-o json` and `-o yaml`:
 drydock test apps --path . -o json
 drydock test apps --path . -o yaml
 ```
-
-Structured test output contains only status records and diagnostics remain on
-stderr.
 
 ## Manifest Diffs
 
@@ -482,16 +233,17 @@ drydock diff apps --path ./current --path-orig ../base
 desired-vs-desired manifest diffs. It uses changed-only selection by default:
 if changed files can be mapped to Application inputs, only affected
 Applications render; if any changed file is unowned, non-strict mode warns and
-renders all Applications. Use `--changed-only=false` to render all
-Applications explicitly, or `--strict-changed-only` to fail on incomplete input
-ownership.
+renders all Applications.
 
-### Git ref diffs
+Use `--changed-only=false` to render all Applications explicitly, or
+`--strict-changed-only` to fail on incomplete input ownership.
+
+### Git Ref Diffs
 
 Diff commands can compare local Git refs without creating a separate baseline
 worktree. `--ref-orig` replaces `--path-orig` with a temporary snapshot of the
-baseline ref. `--ref` replaces `--path` with a temporary snapshot of the
-current ref. `--repo` selects the local Git repository used to resolve refs and
+baseline ref. `--ref` replaces `--path` with a temporary snapshot of the current
+ref. `--repo` selects the local Git repository used to resolve refs and
 defaults to `--path`.
 
 ```bash
@@ -500,16 +252,14 @@ drydock diff apps --repo . --ref feature --ref-orig main
 ```
 
 `--path . --ref-orig main` compares the current working tree, including tracked
-uncommitted changes, against committed `main`. Ref-based changed-only
-selection uses the local Git object graph and tracked worktree files instead of
-walking ignored or untracked output directories. `--repo . --ref feature
+uncommitted changes, against committed `main`. `--repo . --ref feature
 --ref-orig main` compares committed refs only. Top-level remote `--repo` URLs
 are not supported yet; clone the repository locally and pass the local path.
 
-Manifest diffs default to unified diff output. `diff apps` and `diff app`
-also support `-o json` and `-o yaml`, which serialize the structured
-`[]diff.Result` payload. Diagnostics remain on stderr so stdout stays valid
-JSON or YAML. `-o name` is not supported for manifest diffs.
+Manifest diffs default to unified diff output. `diff apps` and `diff app` also
+support `-o json` and `-o yaml`, which serialize the structured `[]diff.Result`
+payload. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
+`-o name` is not supported for manifest diffs.
 
 Manifest diffs hide common Helm-rendered metadata noise by default:
 
@@ -527,7 +277,7 @@ drydock-default ignored fields again. This flag does not disable Argo CD
 
 Use repeatable `--strip-attr KEY` to remove matching keys from
 `metadata.labels` and `metadata.annotations` before comparing rendered
-manifests and generating diffs:
+manifests:
 
 ```bash
 drydock diff apps \
@@ -537,42 +287,22 @@ drydock diff apps \
   --strip-attr app.kubernetes.io/version
 ```
 
-If stripped attributes are the only rendered difference for a resource, no diff
-result is emitted for that resource.
-
 Application-level `spec.ignoreDifferences[]` rules and global
-`resource.customizations.ignoreDifferences.*` settings from discovered
-`argocd-cm` or Helm values `configs.cm` are honored for rendered resource
-diffs. Supported ignore fields are `jsonPointers`, `jqPathExpressions`, and
-`managedFieldsManagers`. When a matching resource exists on both sides,
-`drydock` applies the union of matching Application-local and global
-settings from the baseline and current trees so a newly added ignore rule can
-suppress the intended PR noise immediately.
+`resource.customizations.ignoreDifferences.*` settings are honored for rendered
+resource diffs. Supported ignore fields are `jsonPointers`,
+`jqPathExpressions`, and `managedFieldsManagers`. `jqPathExpressions` are
+evaluated as Argo CD-style `del(<expression>)` delete filters. When a matching
+resource exists on both sides, drydock applies the union of matching
+Application-local and global settings from the baseline and current trees so a
+new ignore rule can suppress intended PR noise immediately.
 
-`jqPathExpressions` are evaluated as Argo CD-style `del(<expression>)` delete
-filters. Invalid expressions fail the diff so unsafe normalization does not hide
-changes. `managedFieldsManagers` is an offline approximation: it suppresses
-fields only when rendered desired manifests include matching
-`metadata.managedFields` ownership data.
-
-Global `resource.customizations.knownTypeFields.*` settings are also applied
-when normalizing rendered resources for desired-vs-desired diffs. Global
-`resource.customizations.ignoreResourceUpdates.*` settings are parsed and
-reported as diagnostics, but they are not applied as desired diff ignores.
-Custom health Lua validation belongs to `drydock test`; diff commands do not
-execute Lua. Resource action Lua remains metadata-only and is not executed
-offline. Structured `diag --settings` output can report redacted names,
-booleans, and SHA-256 hashes for these settings without printing raw Lua bodies
-or secret-looking strings embedded in Lua.
-
-Discovered `resource.compareoptions` settings are also honored for
-`ignoreResourceStatusField` and `ignoreAggregatedRoles`. By default status is
-ignored for all resources. Use `ignoreResourceStatusField: none`, `off`, or
-`false` when rendered status fields should remain visible in PR diffs.
+By default status is ignored for all resources. Use
+`ignoreResourceStatusField: none`, `off`, or `false` in discovered Argo CD
+compare options when rendered status fields should remain visible in PR diffs.
 
 Rendered-resource filters run before diff comparison. Argo CD core exclusions
 and discovered `resource.exclusions`/`resource.inclusions` are applied
-automatically. For example, omit CRDs and Secrets from a pull request diff with:
+automatically. Omit CRDs and Secrets from a pull request diff with:
 
 ```bash
 drydock diff apps \
@@ -586,18 +316,13 @@ Diff one requested Application by `metadata.name`:
 
 ```bash
 drydock diff app renovate --path-orig ../base --path .
-```
-
-Use `NAMESPACE/NAME` to disambiguate:
-
-```bash
 drydock diff app argocd/my-app --path-orig ../base --path .
 ```
 
 `diff app` selects the requested Application directly in each tree and does not
 use changed-only Git path filtering. If the Application exists only in current,
 the diff shows additions; if it exists only in baseline, the diff shows
-deletions. If it is absent from both trees, the command errors.
+deletions.
 
 For local inspection, keep the command successful even when a diff exists:
 
@@ -634,8 +359,6 @@ drydock diag --path .
 and render validation path as `build apps`. It prints diagnostics to stderr and
 returns an error when runtime failures or error-severity diagnostics are found.
 Use `--strict` to promote warnings to errors.
-When diagnostics are written to a terminal, warning severity labels are yellow
-and error severity labels are red.
 
 Structured diagnostic output can include a redacted settings summary:
 
@@ -647,19 +370,14 @@ drydock diag --path . --settings -o yaml
 The settings summary is CLI-only. It reports parsed resource-customization
 metadata such as action names, `useOpenLibs`, and SHA-256 hashes for
 health/action Lua. It does not print raw Lua bodies, embedded secret-looking
-strings, or any live-cluster state. It also does not change default render/diff
-behavior, which remains offline from live Argo CD and Kubernetes runtime and
-independent of `kubectl` or external renderer shellouts.
+strings, or any live-cluster state.
 
 When local `AppProject` manifests are present, `diag`, `build`, `test`, `diff`,
-and the Go API report source repository and destination server/name/namespace
-validation diagnostics from those manifests. They also report source namespace
-diagnostics when a project sets `spec.sourceNamespaces`. RBAC roles and
-policies are parsed and reported as metadata only; Argo CD authorization is not
-simulated. `permitOnlyProjectScopedClusters` is reported as deferred metadata,
-and project-scoped cluster Secret enforcement is not simulated offline.
-Repository credential matching diagnostics use discovered repository Secret
-metadata only and never read secret credential fields.
+and the Go API report source repository and destination validation diagnostics
+from those manifests. RBAC roles and policies are parsed and reported as
+metadata only; Argo CD authorization is not simulated. Repository credential
+matching diagnostics use discovered repository Secret metadata only and never
+read secret credential fields.
 
 ## Local Verification And Benchmarks
 
@@ -672,9 +390,8 @@ golangci-lint run --allow-parallel-runners
 git diff --check main..HEAD
 ```
 
-Run the render and ApplicationSet benchmarks when changing discovery,
-rendering, ApplicationSet expansion, cache event recording, or diagnostics on
-hot paths:
+Run render and ApplicationSet benchmarks when changing discovery, rendering,
+ApplicationSet expansion, cache event recording, or diagnostics on hot paths:
 
 ```bash
 go test ./internal/app -run '^$' -bench 'BenchmarkOrchestrator(BuildManyLocalApplications|ExpandApplicationSetList)' -benchmem -count=1
@@ -687,14 +404,17 @@ Benchmark numbers are trend signals, not hard pass/fail thresholds.
 These source paths are outside the current default runtime contract:
 
 - Live provider API calls for cluster, clusterDecisionResource, SCM provider,
-  pull-request, and plugin ApplicationSet generators. Use explicit local
-  `--appset-provider-fixture` data instead.
+  pull-request, and plugin ApplicationSet generators.
 - CLI config management plugin execution, shellout plugin adapters, Argo CD
   repo-server sidecar plugin discovery, ambient plugin configuration, ambient
   plugin environment loading, and plugin credential injection.
 - Live cluster and Argo CD API sources.
 - Live destination cluster existence, sync windows, source integrity
   verification, project-scoped cluster Secrets, and full RBAC simulation.
+
+See
+[`reports/live-integration-design-gate.md`](reports/live-integration-design-gate.md)
+before proposing live-runtime features.
 
 ## Optional Home-Ops Smoke
 
@@ -705,9 +425,7 @@ RENOVATE_CHART_TO=4.8.2 scripts/home-ops-renovate-smoke.sh
 ```
 
 The smoke script is optional, targets maintainers with a local `home-ops`
-checkout, uses temporary worktrees, and does not mutate the real checkout. It
-detects the current Renovate chart version from `apps/renovate/kustomization.yaml`
-and requires `RENOVATE_CHART_TO` to name the simulated target version.
+checkout, uses temporary worktrees, and does not mutate the real checkout.
 Committed tests and portable fixtures do not depend on `home-ops`.
 
 Run the optional home-ops pattern smoke:
@@ -717,6 +435,6 @@ scripts/home-ops-pattern-smoke.sh
 ```
 
 The pattern smoke applies small synthetic changes across representative
-`home-ops` app patterns in temporary worktrees. It is optional, may fetch
-public charts, and accepts `RENOVATE_CHART_TO` or `EXTERNAL_SECRETS_CHART_TO`
-when maintainers want to choose explicit chart target versions.
+`home-ops` app patterns in temporary worktrees. It is optional, may fetch public
+charts, and accepts `RENOVATE_CHART_TO` or `EXTERNAL_SECRETS_CHART_TO` when
+maintainers want to choose explicit chart target versions.


### PR DESCRIPTION
## Summary

- split dense ApplicationSet and source acquisition details into focused docs
- tightened design, compatibility, usage, and release docs around the offline-runtime contract
- updated README, docs index, and AGENTS routing to point at the new reference pages

## Verification

- `mise run markdownlint`
- `git diff --check`

## Review

- Spec review: APPROVED
- Quality/readability review: APPROVED
