### PR TITLE
feat: render native kustomize CMP sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ drydock discovers and renders local Argo CD desired state, including:
 - Single-source and multi-source Applications.
 - Directory, Kustomize, local Helm chart, remote Helm chart, and remote
   Kustomize sources.
+- Native-compatible Kustomize build config management plugin definitions,
+  rendered through drydock's Go-native Kustomize path without executing plugin
+  commands.
 - Declared Git, HTTP Helm, OCI Helm, and remote Kustomize source acquisition
   into local caches.
 - Repository maps with `--repo-map URL=PATH` for adjacent local checkouts.

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -48,9 +48,11 @@ Public API rules:
 - Stable diagnostic `Code` values are part of the CLI JSON/YAML and public API
   contract.
 
-Config management plugin sources fail closed by default. CLI/default paths do
-not execute plugins. Public API plugin rendering is allowed only through
-explicit in-process `Config.PluginRenderer` or registry injection. Preserve
+Config management plugin sources fail closed by default, except
+native-compatible Kustomize build CMP definitions discovered from Argo CD Helm
+values or rendered `argocd-cmp-cm` ConfigMaps. CLI/default paths do not execute
+plugin commands. Public API plugin rendering is allowed only through explicit
+in-process `Config.PluginRenderer` or registry injection. Preserve
 `plugin.unsupported`, `plugin.failed`, and `plugin.unspecified` diagnostics,
 and do not reclassify caller cancellation as plugin timeout.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -119,6 +119,11 @@ Supported:
   `patchesStrategicMerge`, `generators`, `transformers`, `validators`,
   `configurations`, `crds`, `openapi.path`, `replacements.path`, and generator
   file/env refs.
+- Native-compatible Kustomize build config management plugin definitions
+  discovered from Argo CD Helm values or rendered `argocd-cmp-cm` ConfigMaps.
+  drydock parses those definitions as metadata and renders matched
+  Applications through the Go-native Kustomize renderer without executing the
+  plugin command.
 - Config management plugin source detection with fail-closed diagnostics in
   the CLI and default Go client.
 - Injectable in-process plugin renderers, named plugin registry dispatch, and
@@ -126,8 +131,8 @@ Supported:
 
 Not supported:
 
-- CLI config management plugin execution.
-- Shellout plugin adapters.
+- Arbitrary CLI config management plugin execution.
+- Shellout plugin adapters or plugin command execution.
 - Argo CD repo-server sidecar plugin discovery.
 - Ambient plugin configuration or environment loading.
 - Plugin credential injection.

--- a/docs/design.md
+++ b/docs/design.md
@@ -147,10 +147,14 @@ Supported render paths:
 - Kustomize `helmCharts` through the shared Helm library path.
 - Remote Helm chart sources from HTTP(S) and OCI repositories.
 - Remote Kustomize HTTP(S) files and Git refs.
+- Native-compatible Kustomize build config management plugin definitions
+  discovered from Argo CD Helm values or rendered `argocd-cmp-cm` ConfigMaps,
+  rendered through the same Go-library Kustomize path without executing plugin
+  commands.
 - Deterministic in-process plugin renderers supplied by embedding callers.
 
-The default CLI and default Go client fail closed for config management plugin
-sources unless an embedding caller injects a plugin renderer.
+The default CLI and default Go client fail closed for other config management
+plugin sources unless an embedding caller injects a plugin renderer.
 
 ## Diff Semantics
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -159,8 +159,10 @@ and statuses. `SkipKinds`, `SkipCRDs`, and `SkipSecrets` apply the same
 rendered-resource filters exposed by the CLI.
 
 Config management plugin sources are explicit. The CLI and default Go client do
-not execute plugin commands; an Application source with `spec.source.plugin`
-fails closed with `plugin.unsupported` unless an embedding caller supplies
+not execute plugin commands. Native-compatible Kustomize build plugin
+definitions discovered from Argo CD Helm values or rendered `argocd-cmp-cm`
+ConfigMaps are rendered through drydock's Go-native Kustomize path; other
+plugin sources fail closed with `plugin.unsupported` unless an embedding caller supplies
 `drydock.Config.PluginRenderer`. Embedders can pass a renderer directly or use
 `drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to dispatch
 in-process renderers by `plugin.name`.
@@ -405,9 +407,9 @@ These source paths are outside the current default runtime contract:
 
 - Live provider API calls for cluster, clusterDecisionResource, SCM provider,
   pull-request, and plugin ApplicationSet generators.
-- CLI config management plugin execution, shellout plugin adapters, Argo CD
-  repo-server sidecar plugin discovery, ambient plugin configuration, ambient
-  plugin environment loading, and plugin credential injection.
+- Arbitrary CLI config management plugin execution, shellout plugin adapters,
+  Argo CD repo-server sidecar plugin discovery, ambient plugin configuration,
+  ambient plugin environment loading, and plugin credential injection.
 - Live cluster and Argo CD API sources.
 - Live destination cluster existence, sync windows, source integrity
   verification, project-scoped cluster Secrets, and full RBAC simulation.

--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -106,6 +106,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 		remoteResourceGitCredentials: session.request.RemoteResourceGitCredentials,
 		pluginTimeout:                session.request.PluginTimeout,
 		kustomizeBuildOptions:        settingsBuildOptions(result.Settings),
+		configManagementPlugins:      result.Settings.ConfigManagementPlugins,
 		cacheEvents:                  session.cacheRecorder,
 	}
 	snapshotRoot, err := os.MkdirTemp("", "drydock-cache-snapshots-*")

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/render"
@@ -36,6 +37,7 @@ type localProvider struct {
 	remoteResourceGitCredentials remote.GitCredentials
 	pluginTimeout                time.Duration
 	kustomizeBuildOptions        []string
+	configManagementPlugins      map[string]config.ConfigManagementPlugin
 	cacheEvents                  *cacheevent.Recorder
 	acquisition                  acquisition.Session
 }
@@ -63,7 +65,6 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 	opts.RemoteResourceCredentials = p.remoteResourceCredentials
 	opts.RemoteResourceGitCredentials = p.remoteResourceGitCredentials
 	opts.CacheEventRecorder = p.cacheEvents
-	opts.BuildOptions = append(opts.BuildOptions, p.kustomizeBuildOptions...)
 	anchoredRefRoots, err := anchorLocalRefRoots(sourceRoot, opts.RefRoots)
 	if err != nil {
 		return nil, nil, err
@@ -76,6 +77,7 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 	if opts.Plugin != nil {
 		return p.renderPluginSource(ctx, source, opts)
 	}
+	opts.BuildOptions = append(opts.BuildOptions, p.kustomizeBuildOptions...)
 	if source.Path != "" {
 		renderer, err := selectLocalRenderer(source)
 		if err != nil {

--- a/internal/app/local_provider_plugin.go
+++ b/internal/app/local_provider_plugin.go
@@ -13,6 +13,9 @@ import (
 
 func (p localProvider) renderPluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, error) {
 	if p.pluginRenderer == nil {
+		if manifests, diags, handled, err := p.renderNativeKustomizePluginSource(ctx, source, opts); handled {
+			return manifests, diags, err
+		}
 		message := fmt.Sprintf("config management plugin %s is not supported without an injected plugin renderer", pluginDisplayName(opts.Plugin.Name))
 		return nil, []diagnostic.Diagnostic{{
 			Code:     diagnostic.CodePluginUnsupported,

--- a/internal/app/native_kustomize_cmp.go
+++ b/internal/app/native_kustomize_cmp.go
@@ -1,0 +1,149 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+func (p localProvider) renderNativeKustomizePluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, bool, error) {
+	if opts.Plugin == nil {
+		return nil, nil, false, nil
+	}
+	plugin, ok := p.configManagementPlugins[strings.TrimSpace(opts.Plugin.Name)]
+	if !ok {
+		return nil, nil, false, nil
+	}
+	if source.Path == "" || source.Chart != "" || len(opts.Plugin.Env) != 0 || len(opts.Plugin.Parameters) != 0 {
+		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name)
+	}
+	buildOptions, err := nativeKustomizePluginBuildOptions(plugin)
+	if err != nil {
+		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name)
+	}
+	nativeOptions := opts
+	nativeOptions.Plugin = nil
+	nativeOptions.BuildOptions = append([]string(nil), buildOptions...)
+	manifests, diags, err := (render.KustomizeRenderer{}).Render(ctx, source, nativeOptions)
+	return manifests, diags, true, err
+}
+
+func nativeKustomizePluginBuildOptions(plugin config.ConfigManagementPlugin) ([]string, error) {
+	if plugin.HasInit {
+		return nil, fmt.Errorf("plugin init is unsupported")
+	}
+	tokens, err := nativeKustomizePluginTokens(plugin)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeNativeKustomizeBuildTokens(tokens)
+}
+
+func nativeKustomizePluginTokens(plugin config.ConfigManagementPlugin) ([]string, error) {
+	command := trimCommandTokens(plugin.GenerateCommand)
+	args := trimCommandTokens(plugin.GenerateArgs)
+	if isShellCommand(command) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("shell wrapper must provide exactly one command string")
+		}
+		return safeShellFields(args[0])
+	}
+	tokens := append(append([]string(nil), command...), args...)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("generate command is empty")
+	}
+	return tokens, nil
+}
+
+func trimCommandTokens(tokens []string) []string {
+	out := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token != "" {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+func isShellCommand(command []string) bool {
+	if len(command) != 2 {
+		return false
+	}
+	shell := filepath.Clean(command[0])
+	return (shell == "sh" || shell == "/bin/sh") && command[1] == "-c"
+}
+
+func safeShellFields(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, fmt.Errorf("shell command is empty")
+	}
+	if strings.ContainsAny(command, "\n\r|&;<>(){}[]*$`\"'!?\\") {
+		return nil, fmt.Errorf("shell command uses unsupported syntax")
+	}
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("shell command is empty")
+	}
+	return fields, nil
+}
+
+func normalizeNativeKustomizeBuildTokens(tokens []string) ([]string, error) {
+	if len(tokens) < 2 || filepath.Base(tokens[0]) != "kustomize" || tokens[1] != "build" {
+		return nil, fmt.Errorf("generate command is not kustomize build")
+	}
+	options := make([]string, 0, len(tokens)-2)
+	for i := 2; i < len(tokens); i++ {
+		token := strings.TrimSpace(tokens[i])
+		if token == "" || token == "." {
+			continue
+		}
+		switch {
+		case token == "--enable-helm",
+			strings.HasPrefix(token, "--helm-api-versions="),
+			strings.HasPrefix(token, "--load-restrictor="):
+			options = append(options, token)
+		case token == "--helm-api-versions" || token == "--load-restrictor":
+			if i+1 >= len(tokens) {
+				return nil, fmt.Errorf("kustomize build option requires a value")
+			}
+			i++
+			value := strings.TrimSpace(tokens[i])
+			if value == "" || strings.HasPrefix(value, "-") {
+				return nil, fmt.Errorf("kustomize build option requires a value")
+			}
+			options = append(options, token, value)
+		default:
+			return nil, fmt.Errorf("unsupported kustomize build command shape")
+		}
+	}
+	if err := render.ValidateKustomizeBuildOptions(options); err != nil {
+		return nil, fmt.Errorf("unsupported kustomize build option")
+	}
+	return options, nil
+}
+
+func unsupportedNativeKustomizePluginDiagnostic(name string) []diagnostic.Diagnostic {
+	message := unsupportedNativeKustomizePluginMessage(name)
+	return []diagnostic.Diagnostic{{
+		Code:     diagnostic.CodePluginUnsupported,
+		Severity: diagnostic.SeverityError,
+		Category: "plugin",
+		Message:  message,
+	}}
+}
+
+func unsupportedNativeKustomizePluginError(name string) error {
+	message := unsupportedNativeKustomizePluginMessage(name)
+	return fmt.Errorf("%s: %w", message, render.ErrUnsupportedPlugin)
+}
+
+func unsupportedNativeKustomizePluginMessage(name string) string {
+	return fmt.Sprintf("config management plugin %s is not supported by the native Kustomize adapter without an injected plugin renderer", pluginDisplayName(name))
+}

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -553,6 +553,8 @@ func loadSettingsFromDiscovery(root string, discovered discovery.Result) (config
 		switch candidate.Kind {
 		case "argocd-cm":
 			settings, nextDiags, err = config.LoadFromConfigMapDocument(path, candidate.DocumentIndex)
+		case "argocd-cmp-cm":
+			settings, nextDiags, err = config.LoadConfigManagementPluginConfigMapDocument(path, candidate.DocumentIndex)
 		case "argocd-values":
 			settings, nextDiags, err = config.LoadFromHelmValuesDocument(path, candidate.DocumentIndex)
 		case "repository-secret":

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"context"
+	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -112,6 +114,237 @@ spec:
 		})
 	}
 }
+
+func TestOrchestratorBuildRendersNativeKustomizePluginFromHelmValues(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm")
+	writeNativeKustomizeCMPHelmValues(t, root, "kustomize-build-with-helm", "", "sh, -c", "kustomize build --enable-helm")
+	writeNativeKustomizeSource(t, root, "plugin", "native")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, ok := manifestByName(result.Manifests, "native"); !ok {
+		t.Fatalf("Manifests = %#v, want native ConfigMap", result.Manifests)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "plugin", Status: ApplicationStatusPass},
+	})
+}
+
+func TestOrchestratorBuildRendersNativeKustomizePluginFromRawHelmValues(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm")
+	writeNativeKustomizeCMPRawHelmValues(t, root, "kustomize-build-with-helm", "", "kustomize, build", "--enable-helm")
+	writeNativeKustomizeSource(t, root, "plugin", "raw-helm-values")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, ok := manifestByName(result.Manifests, "raw-helm-values"); !ok {
+		t.Fatalf("Manifests = %#v, want ConfigMap from raw Helm values CMP", result.Manifests)
+	}
+}
+
+func TestOrchestratorBuildRendersNativeKustomizePluginFromRenderedConfigMap(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm")
+	writeNativeKustomizeCMPConfigMap(t, root, "kustomize-build-with-helm", "", "kustomize, build", "--enable-helm")
+	writeNativeKustomizeSource(t, root, "plugin", "rendered-cmp")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, ok := manifestByName(result.Manifests, "rendered-cmp"); !ok {
+		t.Fatalf("Manifests = %#v, want ConfigMap from rendered CMP ConfigMap", result.Manifests)
+	}
+}
+
+func TestOrchestratorBuildMatchesVersionedNativeKustomizePlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm-v2")
+	writeNativeKustomizeCMPHelmValues(t, root, "kustomize-build-with-helm", "v2", "kustomize, build", "., --enable-helm")
+	writeNativeKustomizeSource(t, root, "plugin", "versioned")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, ok := manifestByName(result.Manifests, "versioned"); !ok {
+		t.Fatalf("Manifests = %#v, want ConfigMap from versioned plugin", result.Manifests)
+	}
+}
+
+func TestOrchestratorBuildRejectsNativeKustomizePluginWithInit(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm")
+	writeTestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm:
+        init:
+          command: [sh, -c]
+          args: [echo preparing]
+        generate:
+          command: [sh, -c]
+          args: [kustomize build --enable-helm]
+`)
+	writeNativeKustomizeSource(t, root, "plugin", "native")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err == nil {
+		t.Fatal("Build() error = nil, want unsupported plugin error")
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
+		t.Fatalf("Diagnostics = %#v, want plugin.unsupported", result.Diagnostics)
+	}
+	if len(result.Manifests) != 0 {
+		t.Fatalf("Manifests = %#v, want none", result.Manifests)
+	}
+}
+
+func TestOrchestratorNativeKustomizePluginDoesNotInheritGlobalBuildOptions(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build")
+	writeTestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cm:
+    kustomize.buildOptions: --load-restrictor=LoadRestrictionsNone
+  cmp:
+    plugins:
+      kustomize-build:
+        generate:
+          command: [kustomize, build]
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../shared/cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "shared", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err == nil {
+		t.Fatal("Build() error = nil, want load-restrictor failure")
+	}
+	if !strings.Contains(result.Statuses[0].Message, "security") && !strings.Contains(result.Statuses[0].Message, "restrict") {
+		t.Fatalf("status message = %q, want root-only Kustomize restriction", result.Statuses[0].Message)
+	}
+}
+
+func TestOrchestratorInjectedPluginRendererOverridesNativeKustomizePlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-build-with-helm")
+	writeTestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm:
+        init:
+          command: [sh, -c]
+          args: [echo would-fail-native]
+        generate:
+          command: [sh, -c]
+          args: [kustomize build --enable-helm]
+`)
+
+	rendered := false
+	result, err := (Orchestrator{PluginRenderer: internalPluginRendererFunc(func(_ context.Context, request render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		rendered = true
+		if request.Plugin.Name != "kustomize-build-with-helm" {
+			t.Fatalf("Plugin.Name = %q, want kustomize-build-with-helm", request.Plugin.Name)
+		}
+		return nil, nil, nil
+	})}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !rendered {
+		t.Fatal("injected plugin renderer was not called")
+	}
+	if hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
+		t.Fatalf("Diagnostics = %#v, did not expect native unsupported diagnostic", result.Diagnostics)
+	}
+}
+
+func TestNativeKustomizePluginBuildOptionsFailClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugin  config.ConfigManagementPlugin
+		wantErr bool
+	}{
+		{
+			name: "direct argv with supported flags",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"kustomize", "build"},
+				GenerateArgs:    []string{".", "--enable-helm", "--helm-api-versions", "example.io/v1/Foo"},
+			},
+		},
+		{
+			name: "safe shell wrapper",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"sh", "-c"},
+				GenerateArgs:    []string{"kustomize build --enable-helm"},
+			},
+		},
+		{
+			name: "pipeline rejected",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"sh", "-c"},
+				GenerateArgs:    []string{"kustomize build --enable-helm | sed s/a/b/"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "remote operand rejected",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"kustomize", "build"},
+				GenerateArgs:    []string{"https://github.com/example/repo"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "init rejected",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"kustomize", "build"},
+				HasInit:         true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown option rejected",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"kustomize", "build"},
+				GenerateArgs:    []string{"--enable-alpha-plugins"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := nativeKustomizePluginBuildOptions(tt.plugin)
+			if tt.wantErr && err == nil {
+				t.Fatal("nativeKustomizePluginBuildOptions() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("nativeKustomizePluginBuildOptions() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestOrchestratorPluginTimeoutReturnsPartialStatus(t *testing.T) {
 	root := t.TempDir()
 	writeBuildApplication(t, root, "ok", "ok")
@@ -134,6 +367,80 @@ func TestOrchestratorPluginTimeoutReturnsPartialStatus(t *testing.T) {
 	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginFailed) {
 		t.Fatalf("Diagnostics = %#v, want plugin.failed", result.Diagnostics)
 	}
+}
+
+func writeNativeKustomizeCMPHelmValues(t *testing.T, root, name, version, command, args string) {
+	t.Helper()
+	versionBlock := ""
+	if version != "" {
+		versionBlock = "        version: " + version + "\n"
+	}
+	writeTestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cmp:
+    plugins:
+      `+name+`:
+`+versionBlock+`        generate:
+          command: [`+command+`]
+          args: [`+args+`]
+`)
+}
+
+func writeNativeKustomizeCMPRawHelmValues(t *testing.T, root, name, version, command, args string) {
+	t.Helper()
+	versionBlock := ""
+	if version != "" {
+		versionBlock = "          version: " + version + "\n"
+	}
+	writeTestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cmp:
+    plugins:
+      `+name+`.yaml: |
+        apiVersion: argoproj.io/v1alpha1
+        kind: ConfigManagementPlugin
+        metadata:
+          name: `+name+`
+        spec:
+`+versionBlock+`          generate:
+            command: [`+command+`]
+            args: [`+args+`]
+`)
+}
+
+func writeNativeKustomizeCMPConfigMap(t *testing.T, root, name, version, command, args string) {
+	t.Helper()
+	versionBlock := ""
+	if version != "" {
+		versionBlock = "      version: " + version + "\n"
+	}
+	writeTestFile(t, filepath.Join(root, "settings", "argocd-cmp-cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmp-cm
+data:
+  `+name+`.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: `+name+`
+    spec:
+`+versionBlock+`      generate:
+        command: [`+command+`]
+        args: [`+args+`]
+`)
+}
+
+func writeNativeKustomizeSource(t *testing.T, root, appName, configMapName string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "manifests", appName, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", appName, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+configMapName+`
+`)
 }
 func TestOrchestratorInjectedPluginRendererErrorPreservesDiagnostics(t *testing.T) {
 	root := t.TempDir()

--- a/internal/cli/diag_test.go
+++ b/internal/cli/diag_test.go
@@ -271,6 +271,40 @@ func TestDiagSettingsSummaryDoesNotLeakLuaBodies(t *testing.T) {
 	}
 }
 
+func TestDiagSettingsSummaryDoesNotLeakConfigManagementPluginCommands(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "ok")
+	writeCLITestFile(t, filepath.Join(root, "settings", "values.yaml"), `configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm:
+        generate:
+          command: [sh, -c]
+          args: [kustomize build --enable-helm --secret-token]
+`)
+
+	for _, output := range []string{"json", "yaml"} {
+		t.Run(output, func(t *testing.T) {
+			cmd := NewRootCommand(VersionInfo{})
+			cmd.SetArgs([]string{"diag", "--path", root, "-o", output, "--settings"})
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			}
+			combined := stdout.String() + stderr.String()
+			for _, forbidden := range []string{"kustomize build", "--secret-token", "ConfigManagementPlugins"} {
+				if strings.Contains(combined, forbidden) {
+					t.Fatalf("%s output leaked %q\nstdout:\n%s\nstderr:\n%s", output, forbidden, stdout.String(), stderr.String())
+				}
+			}
+		})
+	}
+}
+
 func TestDiagJSONOutputCanIncludeCacheEvents(t *testing.T) {
 	root := t.TempDir()
 	chartDir := filepath.Join(t.TempDir(), "demo")

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -18,6 +18,7 @@ func MergeDiscovered(candidates []ArgoSettings) (ArgoSettings, []diagnostic.Diag
 		diags = append(diags, mergeHelmRepositories(&merged, candidate)...)
 		diags = append(diags, mergeCompareOptions(&merged, candidate)...)
 		diags = append(diags, mergeIgnoreResourceUpdatesEnabled(&merged, candidate)...)
+		diags = append(diags, mergeConfigManagementPlugins(&merged, candidate)...)
 		merged.ResourceExclusions = append(merged.ResourceExclusions, candidate.ResourceExclusions...)
 		merged.ResourceInclusions = append(merged.ResourceInclusions, candidate.ResourceInclusions...)
 		diags = append(diags, mergeResourceCustomizations(&merged, candidate)...)
@@ -133,6 +134,25 @@ func mergeResourceCustomizations(merged *ArgoSettings, candidate ArgoSettings) [
 			continue
 		}
 		merged.ResourceCustomizations[key] = next
+	}
+	return diags
+}
+
+func mergeConfigManagementPlugins(merged *ArgoSettings, candidate ArgoSettings) []diagnostic.Diagnostic {
+	var diags []diagnostic.Diagnostic
+	for name, plugin := range candidate.ConfigManagementPlugins {
+		if name == "" {
+			continue
+		}
+		existing, ok := merged.ConfigManagementPlugins[name]
+		if ok && existing.commandFingerprint != plugin.commandFingerprint {
+			diags = append(diags, conflictDiagnostic(
+				fmt.Sprintf("conflicting config management plugin settings discovered for %q", name),
+				plugin.Provenance,
+			))
+			continue
+		}
+		merged.ConfigManagementPlugins[name] = plugin
 	}
 	return diags
 }

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"go.yaml.in/yaml/v4"
@@ -18,30 +19,32 @@ func LoadFromHelmValues(path string) (ArgoSettings, []diagnostic.Diagnostic, err
 		return settings, nil, err
 	}
 
-	var doc struct {
-		Configs struct {
-			CM map[string]string `yaml:"cm"`
-		} `yaml:"configs"`
-	}
+	var doc helmValuesSettingsDocument
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return settings, nil, fmt.Errorf("parse helm values %s: %w", path, err)
 	}
 
 	diags := applyCMMap(&settings, doc.Configs.CM, path, "configs.cm")
+	cmpDiags, err := applyCMPPlugins(&settings, doc.Configs.CMP.Plugins, path, "configs.cmp.plugins")
+	if err != nil {
+		return settings, diags, err
+	}
+	diags = append(diags, cmpDiags...)
 	return settings, diags, nil
 }
 
 func LoadFromHelmValuesDocument(path string, documentIndex int) (ArgoSettings, []diagnostic.Diagnostic, error) {
 	settings := DefaultSettings()
-	var doc struct {
-		Configs struct {
-			CM map[string]string `yaml:"cm"`
-		} `yaml:"configs"`
-	}
+	var doc helmValuesSettingsDocument
 	if err := decodeYAMLDocumentAt(path, documentIndex, &doc); err != nil {
 		return settings, nil, fmt.Errorf("parse helm values %s document %d: %w", path, documentIndex, err)
 	}
 	diags := applyCMMap(&settings, doc.Configs.CM, path, "configs.cm")
+	cmpDiags, err := applyCMPPlugins(&settings, doc.Configs.CMP.Plugins, path, "configs.cmp.plugins")
+	if err != nil {
+		return settings, diags, err
+	}
+	diags = append(diags, cmpDiags...)
 	return settings, diags, nil
 }
 
@@ -97,6 +100,49 @@ func LoadFromConfigMapDocument(path string, documentIndex int) (ArgoSettings, []
 	}
 	diags := applyCMMap(&settings, doc.Data, path, "data")
 	return settings, diags, nil
+}
+
+func LoadConfigManagementPluginConfigMapDocument(path string, documentIndex int) (ArgoSettings, []diagnostic.Diagnostic, error) {
+	settings := DefaultSettings()
+	var doc struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := decodeYAMLDocumentAt(path, documentIndex, &doc); err != nil {
+		return settings, nil, fmt.Errorf("parse config management plugin ConfigMap %s document %d: %w", path, documentIndex, err)
+	}
+	if doc.Kind != "ConfigMap" || doc.Metadata.Name != "argocd-cmp-cm" {
+		return settings, []diagnostic.Diagnostic{{
+			Severity:   diagnostic.SeverityWarning,
+			Category:   "settings",
+			Message:    "file document is not argocd-cmp-cm ConfigMap",
+			Provenance: diagnostic.Provenance{Path: path},
+		}}, nil
+	}
+
+	var diags []diagnostic.Diagnostic
+	for key, value := range doc.Data {
+		if !looksLikeConfigManagementPluginYAML(value) {
+			continue
+		}
+		plugins, err := configManagementPluginsFromYAML([]byte(value), path, "data."+key)
+		if err != nil {
+			return settings, nil, fmt.Errorf("parse config management plugin %s document %d data %q: %w", path, documentIndex, key, err)
+		}
+		for _, plugin := range plugins {
+			if diag := addConfigManagementPlugin(&settings, plugin); diag != nil {
+				diags = append(diags, *diag)
+			}
+		}
+	}
+	return settings, diags, nil
+}
+
+func looksLikeConfigManagementPluginYAML(value string) bool {
+	return strings.Contains(value, "ConfigManagementPlugin")
 }
 
 func LoadRepositorySecret(path string) (ArgoSettings, []diagnostic.Diagnostic, error) {
@@ -190,6 +236,143 @@ func decodeYAMLDocumentAt(path string, documentIndex int, out any) error {
 		}
 		return yaml.Unmarshal(data, out)
 	}
+}
+
+type helmValuesSettingsDocument struct {
+	Configs struct {
+		CM  map[string]string `yaml:"cm"`
+		CMP struct {
+			Plugins map[string]any `yaml:"plugins"`
+		} `yaml:"cmp"`
+	} `yaml:"configs"`
+}
+
+type cmpPluginSpec struct {
+	Version  string     `yaml:"version"`
+	Init     cmpCommand `yaml:"init"`
+	Generate cmpCommand `yaml:"generate"`
+}
+
+type cmpCommand struct {
+	Command []string `yaml:"command"`
+	Args    []string `yaml:"args"`
+}
+
+func applyCMPPlugins(settings *ArgoSettings, plugins map[string]any, path, pointer string) ([]diagnostic.Diagnostic, error) {
+	var diags []diagnostic.Diagnostic
+	for key, value := range plugins {
+		name := strings.TrimSpace(key)
+		if name == "" {
+			continue
+		}
+		plugins, err := configManagementPluginsFromHelmValue(name, value, path, pointer+"."+name)
+		if err != nil {
+			return diags, err
+		}
+		for _, plugin := range plugins {
+			if diag := addConfigManagementPlugin(settings, plugin); diag != nil {
+				diags = append(diags, *diag)
+			}
+		}
+	}
+	return diags, nil
+}
+
+func configManagementPluginsFromHelmValue(name string, value any, path, pointer string) ([]ConfigManagementPlugin, error) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if !looksLikeConfigManagementPluginYAML(typed) {
+			return nil, nil
+		}
+		return configManagementPluginsFromYAML([]byte(typed), path, pointer)
+	default:
+		data, err := yaml.Marshal(typed)
+		if err != nil {
+			return nil, fmt.Errorf("parse config management plugin %s: %w", pointer, err)
+		}
+		if looksLikeConfigManagementPluginYAML(string(data)) {
+			return configManagementPluginsFromYAML(data, path, pointer)
+		}
+		var spec cmpPluginSpec
+		if err := yaml.Unmarshal(data, &spec); err != nil {
+			return nil, fmt.Errorf("parse config management plugin %s: %w", pointer, err)
+		}
+		return []ConfigManagementPlugin{configManagementPluginFromSpec(name, spec, path, pointer)}, nil
+	}
+}
+
+func addConfigManagementPlugin(settings *ArgoSettings, plugin ConfigManagementPlugin) *diagnostic.Diagnostic {
+	name := plugin.EffectiveName()
+	if name == "" {
+		return nil
+	}
+	existing, ok := settings.ConfigManagementPlugins[name]
+	if ok && existing.commandFingerprint != plugin.commandFingerprint {
+		diag := conflictDiagnostic(
+			fmt.Sprintf("conflicting config management plugin settings discovered for %q", name),
+			plugin.Provenance,
+		)
+		return &diag
+	}
+	settings.ConfigManagementPlugins[name] = plugin
+	return nil
+}
+
+func configManagementPluginsFromYAML(data []byte, path, pointer string) ([]ConfigManagementPlugin, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var plugins []ConfigManagementPlugin
+	for index := 0; ; index++ {
+		var doc configManagementPluginDocument
+		if err := decoder.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if doc.Kind != "ConfigManagementPlugin" {
+			continue
+		}
+		name := strings.TrimSpace(doc.Metadata.Name)
+		if name == "" {
+			continue
+		}
+		plugin := configManagementPluginFromSpec(name, doc.Spec, path, fmt.Sprintf("%s#%d", pointer, index))
+		plugins = append(plugins, plugin)
+	}
+	return plugins, nil
+}
+
+type configManagementPluginDocument struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec cmpPluginSpec `yaml:"spec"`
+}
+
+func configManagementPluginFromSpec(name string, spec cmpPluginSpec, path, pointer string) ConfigManagementPlugin {
+	plugin := ConfigManagementPlugin{
+		Name:            name,
+		Version:         strings.TrimSpace(spec.Version),
+		GenerateCommand: append([]string(nil), spec.Generate.Command...),
+		GenerateArgs:    append([]string(nil), spec.Generate.Args...),
+		HasInit:         len(spec.Init.Command) > 0 || len(spec.Init.Args) > 0,
+		Provenance:      diagnostic.Provenance{Path: path, Pointer: pointer},
+	}
+	plugin.commandFingerprint = pluginCommandFingerprint(plugin)
+	return plugin
+}
+
+func pluginCommandFingerprint(plugin ConfigManagementPlugin) string {
+	return fmt.Sprintf("name=%s\x00version=%s\x00init=%t\x00command=%q\x00args=%q",
+		plugin.Name,
+		plugin.Version,
+		plugin.HasInit,
+		plugin.GenerateCommand,
+		plugin.GenerateArgs,
+	)
 }
 
 type repositorySecretDocument struct {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -72,22 +72,41 @@ type ResourceCustomization struct {
 	Provenance            Provenance             `json:"provenance,omitempty" yaml:"provenance,omitempty"`
 }
 
+type ConfigManagementPlugin struct {
+	Name               string     `json:"-" yaml:"-"`
+	Version            string     `json:"-" yaml:"-"`
+	GenerateCommand    []string   `json:"-" yaml:"-"`
+	GenerateArgs       []string   `json:"-" yaml:"-"`
+	HasInit            bool       `json:"-" yaml:"-"`
+	Provenance         Provenance `json:"-" yaml:"-"`
+	commandFingerprint string
+}
+
+func (plugin ConfigManagementPlugin) EffectiveName() string {
+	if plugin.Version == "" {
+		return plugin.Name
+	}
+	return plugin.Name + "-" + plugin.Version
+}
+
 type ArgoSettings struct {
-	KustomizeBuildOptions        []Value[string]                  `json:"kustomizeBuildOptions,omitempty" yaml:"kustomizeBuildOptions,omitempty"`
-	HelmRepositories             map[string]RepositorySettings    `json:"helmRepositories,omitempty" yaml:"helmRepositories,omitempty"`
-	TrackingMethod               Value[string]                    `json:"trackingMethod,omitempty" yaml:"trackingMethod,omitempty"`
-	InstanceLabelKey             Value[string]                    `json:"instanceLabelKey,omitempty" yaml:"instanceLabelKey,omitempty"`
-	ResourceExclusions           []ResourceFilterRule             `json:"resourceExclusions,omitempty" yaml:"resourceExclusions,omitempty"`
-	ResourceInclusions           []ResourceFilterRule             `json:"resourceInclusions,omitempty" yaml:"resourceInclusions,omitempty"`
-	CompareOptions               ResourceCompareOptions           `json:"compareOptions,omitempty" yaml:"compareOptions,omitempty"`
-	ResourceCustomizations       map[string]ResourceCustomization `json:"resourceCustomizations,omitempty" yaml:"resourceCustomizations,omitempty"`
-	IgnoreResourceUpdatesEnabled Value[bool]                      `json:"ignoreResourceUpdatesEnabled,omitempty" yaml:"ignoreResourceUpdatesEnabled,omitempty"`
+	KustomizeBuildOptions        []Value[string]                   `json:"kustomizeBuildOptions,omitempty" yaml:"kustomizeBuildOptions,omitempty"`
+	HelmRepositories             map[string]RepositorySettings     `json:"helmRepositories,omitempty" yaml:"helmRepositories,omitempty"`
+	TrackingMethod               Value[string]                     `json:"trackingMethod,omitempty" yaml:"trackingMethod,omitempty"`
+	InstanceLabelKey             Value[string]                     `json:"instanceLabelKey,omitempty" yaml:"instanceLabelKey,omitempty"`
+	ResourceExclusions           []ResourceFilterRule              `json:"resourceExclusions,omitempty" yaml:"resourceExclusions,omitempty"`
+	ResourceInclusions           []ResourceFilterRule              `json:"resourceInclusions,omitempty" yaml:"resourceInclusions,omitempty"`
+	CompareOptions               ResourceCompareOptions            `json:"compareOptions,omitempty" yaml:"compareOptions,omitempty"`
+	ResourceCustomizations       map[string]ResourceCustomization  `json:"resourceCustomizations,omitempty" yaml:"resourceCustomizations,omitempty"`
+	IgnoreResourceUpdatesEnabled Value[bool]                       `json:"ignoreResourceUpdatesEnabled,omitempty" yaml:"ignoreResourceUpdatesEnabled,omitempty"`
+	ConfigManagementPlugins      map[string]ConfigManagementPlugin `json:"-" yaml:"-"`
 }
 
 func DefaultSettings() ArgoSettings {
 	return ArgoSettings{
-		HelmRepositories:       map[string]RepositorySettings{},
-		ResourceCustomizations: map[string]ResourceCustomization{},
+		HelmRepositories:        map[string]RepositorySettings{},
+		ResourceCustomizations:  map[string]ResourceCustomization{},
+		ConfigManagementPlugins: map[string]ConfigManagementPlugin{},
 		CompareOptions: ResourceCompareOptions{
 			IgnoreResourceStatusField: "all",
 		},

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestLoadHelmValuesSettings(t *testing.T) {
@@ -28,6 +29,156 @@ func TestLoadHelmValuesSettings(t *testing.T) {
 	}
 	if settings.InstanceLabelKey.Provenance.Path == "" {
 		t.Fatalf("expected provenance")
+	}
+}
+
+func TestLoadHelmValuesConfigManagementPlugins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte(`configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm:
+        version: v1
+        generate:
+          command: [sh, -c]
+          args: [kustomize build --enable-helm]
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	settings, diags, err := LoadFromHelmValues(path)
+	if err != nil {
+		t.Fatalf("LoadFromHelmValues() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	plugin, ok := settings.ConfigManagementPlugins["kustomize-build-with-helm-v1"]
+	if !ok {
+		t.Fatalf("ConfigManagementPlugins = %#v, want versioned plugin key", settings.ConfigManagementPlugins)
+	}
+	if plugin.Name != "kustomize-build-with-helm" || plugin.Version != "v1" || plugin.EffectiveName() != "kustomize-build-with-helm-v1" {
+		t.Fatalf("plugin = %#v", plugin)
+	}
+	if got := strings.Join(append(plugin.GenerateCommand, plugin.GenerateArgs...), " "); got != "sh -c kustomize build --enable-helm" {
+		t.Fatalf("plugin command = %q", got)
+	}
+}
+
+func TestLoadHelmValuesRawConfigManagementPluginYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte(`configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm.yaml: |
+        apiVersion: argoproj.io/v1alpha1
+        kind: ConfigManagementPlugin
+        metadata:
+          name: kustomize-build-with-helm
+        spec:
+          version: v2
+          generate:
+            command: [kustomize, build]
+            args: [--enable-helm]
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	settings, diags, err := LoadFromHelmValues(path)
+	if err != nil {
+		t.Fatalf("LoadFromHelmValues() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	plugin, ok := settings.ConfigManagementPlugins["kustomize-build-with-helm-v2"]
+	if !ok {
+		t.Fatalf("ConfigManagementPlugins = %#v, want plugin from raw Helm values YAML", settings.ConfigManagementPlugins)
+	}
+	if got := strings.Join(append(plugin.GenerateCommand, plugin.GenerateArgs...), " "); got != "kustomize build --enable-helm" {
+		t.Fatalf("plugin command = %q", got)
+	}
+}
+
+func TestLoadConfigManagementPluginConfigMapDocument(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cmp.yaml")
+	if err := os.WriteFile(path, []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmp-cm
+data:
+  kustomize-build-with-helm.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: kustomize-build-with-helm
+    spec:
+      generate:
+        command: [kustomize, build]
+        args: [--enable-helm]
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	settings, diags, err := LoadConfigManagementPluginConfigMapDocument(path, 0)
+	if err != nil {
+		t.Fatalf("LoadConfigManagementPluginConfigMapDocument() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	plugin, ok := settings.ConfigManagementPlugins["kustomize-build-with-helm"]
+	if !ok {
+		t.Fatalf("ConfigManagementPlugins = %#v, want rendered ConfigMap plugin", settings.ConfigManagementPlugins)
+	}
+	if got := strings.Join(append(plugin.GenerateCommand, plugin.GenerateArgs...), " "); got != "kustomize build --enable-helm" {
+		t.Fatalf("plugin command = %q", got)
+	}
+}
+
+func TestMergeDiscoveredConfigManagementPluginConflictsAreRedacted(t *testing.T) {
+	leftPath := filepath.Join(t.TempDir(), "left.yaml")
+	rightPath := filepath.Join(t.TempDir(), "right.yaml")
+	left := DefaultSettings()
+	left.ConfigManagementPlugins["cmp"] = configManagementPluginFromSpec("cmp", cmpPluginSpec{
+		Generate: cmpCommand{Command: []string{"sh", "-c"}, Args: []string{"secret-token-one"}},
+	}, leftPath, "configs.cmp.plugins.cmp")
+	right := DefaultSettings()
+	right.ConfigManagementPlugins["cmp"] = configManagementPluginFromSpec("cmp", cmpPluginSpec{
+		Generate: cmpCommand{Command: []string{"sh", "-c"}, Args: []string{"secret-token-two"}},
+	}, rightPath, "configs.cmp.plugins.cmp")
+
+	_, diags := MergeDiscovered([]ArgoSettings{left, right})
+	if len(diags) != 1 {
+		t.Fatalf("diagnostics = %#v, want one conflict", diags)
+	}
+	if strings.Contains(diags[0].Message, "secret-token") {
+		t.Fatalf("diagnostic leaked command: %#v", diags[0])
+	}
+	if !strings.Contains(diags[0].Message, "cmp") {
+		t.Fatalf("diagnostic = %#v, want plugin name", diags[0])
+	}
+}
+
+func TestConfigManagementPluginsDoNotSerializeRawCommands(t *testing.T) {
+	settings := DefaultSettings()
+	settings.ConfigManagementPlugins["cmp"] = configManagementPluginFromSpec("cmp", cmpPluginSpec{
+		Generate: cmpCommand{Command: []string{"sh", "-c"}, Args: []string{"kustomize build --enable-helm"}},
+	}, "values.yaml", "configs.cmp.plugins.cmp")
+
+	jsonData, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	yamlData, err := yaml.Marshal(settings)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+	combined := string(jsonData) + string(yamlData)
+	for _, forbidden := range []string{"ConfigManagementPlugins", "kustomize build", "--enable-helm"} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("serialized settings leaked %q\njson:\n%s\nyaml:\n%s", forbidden, jsonData, yamlData)
+		}
 	}
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -180,6 +180,8 @@ func scanDocument(rel string, documentIndex int, obj *unstructured.Unstructured,
 		result.Projects = append(result.Projects, ProjectFile{Path: rel, DocumentIndex: documentIndex, Project: project})
 	case isCoreGVK(obj, "ConfigMap") && obj.GetName() == "argocd-cm":
 		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "argocd-cm"})
+	case isCoreGVK(obj, "ConfigMap") && obj.GetName() == "argocd-cmp-cm" && isConfigManagementPluginConfigMap(obj):
+		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "argocd-cmp-cm"})
 	case isCoreGVK(obj, "Secret") && obj.GetLabels()["argocd.argoproj.io/secret-type"] == "repository":
 		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "repository-secret"})
 	case isArgoHelmValuesSettings(obj):
@@ -202,6 +204,11 @@ func isArgoHelmValuesSettings(obj *unstructured.Unstructured) bool {
 	configs, ok := obj.Object["configs"].(map[string]any)
 	if !ok {
 		return false
+	}
+	if cmp, ok := configs["cmp"].(map[string]any); ok {
+		if plugins, ok := cmp["plugins"].(map[string]any); ok && len(plugins) > 0 {
+			return true
+		}
 	}
 	cm, ok := configs["cm"].(map[string]any)
 	if !ok {
@@ -228,6 +235,19 @@ func isKnownArgoCMSettingKey(key string) bool {
 	default:
 		return strings.HasPrefix(key, "resource.customizations.")
 	}
+}
+
+func isConfigManagementPluginConfigMap(obj *unstructured.Unstructured) bool {
+	data, ok, err := unstructured.NestedStringMap(obj.Object, "data")
+	if err != nil || !ok {
+		return false
+	}
+	for _, value := range data {
+		if looksLikeConfigManagementPluginYAML(value) {
+			return true
+		}
+	}
+	return false
 }
 
 func scanStart(root, relRoot string) (string, error) {
@@ -287,8 +307,13 @@ func looksLikeCandidate(path string) (bool, error) {
 	text := string(data)
 	return strings.Contains(text, "argoproj.io/v1alpha1") ||
 		strings.Contains(text, "argocd-cm") ||
+		strings.Contains(text, "ConfigManagementPlugin") ||
 		strings.Contains(text, "argocd.argoproj.io/secret-type") ||
-		(strings.Contains(text, "configs:") && strings.Contains(text, "cm:")), nil
+		(strings.Contains(text, "configs:") && (strings.Contains(text, "cm:") || strings.Contains(text, "cmp:"))), nil
+}
+
+func looksLikeConfigManagementPluginYAML(value string) bool {
+	return strings.Contains(value, "ConfigManagementPlugin")
 }
 
 func shouldSkipDir(name string) bool {

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -162,6 +162,29 @@ stringData:
     resource.exclusions: |
       - apiGroups: ["events.k8s.io"]
 `)
+	mustWriteFile(t, filepath.Join(root, "settings", "cmp-values.yaml"), `configs:
+  cmp:
+    plugins:
+      kustomize-build-with-helm:
+        generate:
+          command: [sh, -c]
+          args: [kustomize build --enable-helm]
+`)
+	mustWriteFile(t, filepath.Join(root, "settings", "cmp-configmap.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmp-cm
+data:
+  kustomize-build-with-helm.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: kustomize-build-with-helm
+    spec:
+      generate:
+        command: [kustomize, build]
+        args: [--enable-helm]
+`)
 	mustWriteFile(t, filepath.Join(root, "settings", "compare-values.yaml"), `configs:
   cm:
     resource.compareoptions: |
@@ -181,6 +204,8 @@ stringData:
 	}
 	wantSettings := []SettingsCandidate{
 		{Path: filepath.Join("settings", "argocd-cm.yaml"), DocumentIndex: 0, Kind: "argocd-cm"},
+		{Path: filepath.Join("settings", "cmp-configmap.yaml"), DocumentIndex: 0, Kind: "argocd-cmp-cm"},
+		{Path: filepath.Join("settings", "cmp-values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
 		{Path: filepath.Join("settings", "compare-values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
 		{Path: filepath.Join("settings", "repo-secret.yaml"), DocumentIndex: 0, Kind: "repository-secret"},
 		{Path: filepath.Join("settings", "values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
@@ -276,6 +301,32 @@ data:
 	}
 	if result.SettingsCandidates[0].DocumentIndex != 2 {
 		t.Fatalf("DocumentIndex = %d, want real YAML document index 2", result.SettingsCandidates[0].DocumentIndex)
+	}
+}
+
+func TestScanDoesNotTreatWorkloadConfigMapWithCMPExampleAsSettings(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "example-cmp.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-cmp-snippet
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: kustomize-build-with-helm
+    spec:
+      generate:
+        command: [kustomize, build]
+`)
+
+	result, err := Scan(root, Options{})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.SettingsCandidates) != 0 {
+		t.Fatalf("SettingsCandidates = %#v, want none", result.SettingsCandidates)
 	}
 }
 

--- a/internal/render/kustomize_build_options.go
+++ b/internal/render/kustomize_build_options.go
@@ -16,6 +16,11 @@ func defaultKustomizeBuildSettings() kustomizeBuildSettings {
 	return kustomizeBuildSettings{LoadRestrictions: types.LoadRestrictionsRootOnly}
 }
 
+func ValidateKustomizeBuildOptions(options []string) error {
+	_, err := parseKustomizeBuildOptions(options)
+	return err
+}
+
 func parseKustomizeBuildOptions(options []string) (kustomizeBuildSettings, error) {
 	settings := defaultKustomizeBuildSettings()
 	for i := 0; i < len(options); i++ {


### PR DESCRIPTION
## Summary
- discover Kustomize-build ConfigManagementPlugin metadata from Argo CD Helm values and rendered argocd-cmp-cm ConfigMaps
- render native-compatible kustomize build plugins through drydock's Go-native Kustomize renderer without executing plugin commands
- preserve fail-closed behavior for arbitrary plugins, init commands, unsafe shell forms, plugin env/parameters, and unmatched plugins
- document the native CMP boundary and keep raw plugin commands out of settings summaries

## Reviews
- Spec review: APPROVED
- Code quality review: APPROVED

## Verification
- go test ./...
- mise run lint
- go run github.com/shinagawa-web/gomarklint/v3@v3.0.5
- go run ./cmd/drydock test apps --path /private/tmp/drydock-vehagn-homelab (47 PASS)