### PR TITLE
feat: discover rendered kustomize apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ drydock diff apps --path . --path-orig ../baseline --offline
 drydock discovers and renders local Argo CD desired state, including:
 
 - `Application` resources and supported `ApplicationSet` generators.
+- Optional rendered discovery from explicit local Kustomize entrypoints with
+  `--discover-kustomize`.
 - Single-source and multi-source Applications.
 - Directory, Kustomize, local Helm chart, remote Helm chart, and remote
   Kustomize sources.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,6 +43,8 @@ silent approximations.
 Supported:
 
 - Direct Application discovery from repository manifests.
+- Explicit `--discover-kustomize PATH` discovery from rendered local
+  Kustomize entrypoints, with normal path containment and symlink checks.
 - ApplicationSet Git directories, Git files, list, matrix, and merge
   generators.
 - ApplicationSet list `elementsYaml`, including matrix-interpolated
@@ -55,6 +57,8 @@ Supported:
   provider, pull-request, and plugin ApplicationSet generators.
 - Fail-closed fixture diagnostics for invalid provider fixtures, no provider
   matches, and unsupported provider filters.
+- Warning diagnostics when a discovered ApplicationSet generates zero
+  Applications; `--strict` promotes those diagnostics to errors.
 
 Not supported:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,6 +46,22 @@ For generator details, fixture schemas, and stable template parameters, see
 Local `AppProject` manifests are discovered for offline diagnostics only.
 Discovery does not contact a Kubernetes cluster or Argo CD server.
 
+Some repositories commit Argo CD bootstrap inputs as Kustomize bases and
+overlays rather than committing the fully inflated Argo CD objects. Add
+`--discover-kustomize PATH` to render one or more local Kustomize entrypoints
+with drydock's native renderer, then discover `Application`, `ApplicationSet`,
+`AppProject`, and Argo CD settings objects from the rendered output:
+
+```bash
+drydock get apps --path . --discover-kustomize argocd/overlays/prod
+drydock test apps --path . --discover-kustomize clusters/prod/argocd
+```
+
+The path must be relative to `--path`, must not escape through `..`, and must
+not include symlinked path components. Rendered discovery is additive: normal
+repository scanning still runs, and rendered objects replace raw objects only
+when they have the same API version, kind, namespace, and name.
+
 ## Rendering
 
 Build every discovered Application:
@@ -193,6 +209,9 @@ PASS renovate
 FAIL argocd/broken Application argocd/broken source[0] path="..." ...
 SKIPPED argocd/skipped unsupported ApplicationSet generator ...
 ```
+
+When `test apps` discovers no Applications, text output prints
+`No Applications discovered.` and structured JSON output prints `[]`.
 
 Status values are `PASS` for Applications that rendered successfully, `FAIL`
 for render or planning failures, and `SKIPPED` when discovery or expansion

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -33,6 +33,7 @@ type DiffRequest struct {
 	Repo                           string
 	Ref                            string
 	RefOrig                        string
+	DiscoverKustomizePaths         []string
 	ChangedOnly                    bool
 	StrictChangedOnly              bool
 	Strict                         bool
@@ -377,6 +378,7 @@ func (request DiffRequest) buildRequest(path string, forbiddenRoots []string) Bu
 	return BuildRequest{
 		Path:                           path,
 		Strict:                         request.Strict,
+		DiscoverKustomizePaths:         append([]string(nil), request.DiscoverKustomizePaths...),
 		Offline:                        request.Offline,
 		RefreshCharts:                  request.RefreshCharts,
 		ChartCacheDir:                  request.ChartCacheDir,

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -1228,6 +1228,7 @@ func TestDiffRequestCarriesProviderFixtureConfig(t *testing.T) {
 	request := DiffRequest{
 		LeftPath:                       "/tmp/left",
 		RightPath:                      "/tmp/right",
+		DiscoverKustomizePaths:         []string{"argocd/overlays/prod"},
 		ApplicationSetProviderFixtures: []string{"clusters.yaml"},
 		ApplicationSetProviderData:     appset.ProviderData{Clusters: []appset.ClusterInput{{Name: "prod", Server: "https://prod.example.invalid"}}},
 	}
@@ -1236,6 +1237,9 @@ func TestDiffRequestCarriesProviderFixtureConfig(t *testing.T) {
 	right := request.buildRequest(request.RightPath, []string{request.LeftPath, request.RightPath})
 
 	for side, buildRequest := range map[string]BuildRequest{"left": left, "right": right} {
+		if !reflect.DeepEqual(buildRequest.DiscoverKustomizePaths, request.DiscoverKustomizePaths) {
+			t.Fatalf("%s DiscoverKustomizePaths = %#v, want %#v", side, buildRequest.DiscoverKustomizePaths, request.DiscoverKustomizePaths)
+		}
 		if !reflect.DeepEqual(buildRequest.ApplicationSetProviderFixtures, request.ApplicationSetProviderFixtures) {
 			t.Fatalf("%s ApplicationSetProviderFixtures = %#v, want %#v", side, buildRequest.ApplicationSetProviderFixtures, request.ApplicationSetProviderFixtures)
 		}

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -1,0 +1,293 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/acquisition"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/discovery"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func (o Orchestrator) discoverRepository(ctx context.Context, root string, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+	discovered, err := discovery.Scan(root, discovery.Options{})
+	if err != nil {
+		return discovery.Result{}, nil, nil, err
+	}
+	if len(request.DiscoverKustomizePaths) == 0 {
+		return discovered, nil, nil, nil
+	}
+
+	settings, _, err := loadSettingsFromDiscovery(root, discovered)
+	if err != nil {
+		return discovered, nil, nil, err
+	}
+	rendered, diags, events, err := o.discoverRenderedKustomize(ctx, root, settings, request)
+	if err != nil {
+		return discovered, diags, events, err
+	}
+	return mergeDiscoveryResults(discovered, rendered), diags, events, nil
+}
+
+func (o Orchestrator) discoverRenderedKustomize(ctx context.Context, root string, settings config.ArgoSettings, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
+	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	if err != nil {
+		return discovery.Result{}, nil, recorder.Events(), err
+	}
+	defer cleanup()
+
+	var out discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	seenPaths := map[string]struct{}{}
+	for _, rawPath := range request.DiscoverKustomizePaths {
+		clean, err := cleanDiscoverKustomizePath(root, rawPath)
+		if err != nil {
+			return out, allDiags, recorder.Events(), err
+		}
+		displayPath := filepath.ToSlash(clean)
+		if _, ok := seenPaths[displayPath]; ok {
+			continue
+		}
+		seenPaths[displayPath] = struct{}{}
+
+		manifests, diags, err := provider.RenderSource(ctx, render.ResolvedSource{
+			RepoRoot: root,
+			Path:     clean,
+		}, render.RenderOptions{})
+		allDiags = append(allDiags, diags...)
+		if err != nil {
+			return out, allDiags, recorder.Events(), fmt.Errorf("discover kustomize %q: %w", displayPath, err)
+		}
+		next, err := discovery.ScanObjects(displayPath, manifestObjects(manifests))
+		if err != nil {
+			return out, allDiags, recorder.Events(), fmt.Errorf("discover kustomize %q: %w", displayPath, err)
+		}
+		out = mergeDiscoveryResults(out, next)
+	}
+	return out, allDiags, recorder.Events(), nil
+}
+
+func (o Orchestrator) discoveryProvider(root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder) (localProvider, func(), error) {
+	acquirer := o.ChartAcquirer
+	if acquirer == nil {
+		acquirer = chart.DefaultAcquirer{}
+	}
+	gitAcquirer := o.GitAcquirer
+	if gitAcquirer == nil {
+		gitAcquirer = sourcepkg.DefaultGitAcquirer{}
+	}
+	forbiddenRoots := append([]string(nil), request.RemoteResourceForbiddenRoots...)
+	forbiddenRoots = append(forbiddenRoots, root)
+	provider := localProvider{
+		repoRoot:                     root,
+		sourceResolver:               sourcepkg.NewResolver(sourcepkg.Options{RepoMaps: request.RepoMaps, Offline: request.Offline}),
+		chartAcquirer:                acquirer,
+		gitAcquirer:                  gitAcquirer,
+		remoteResourceAcquirer:       o.RemoteResourceAcquirer,
+		pluginRenderer:               o.pluginRenderer(request),
+		offline:                      request.Offline,
+		refreshCharts:                request.RefreshCharts,
+		chartCacheDir:                request.ChartCacheDir,
+		chartCredentials:             request.ChartCredentials,
+		ociChartRepositories:         ociChartRepositoriesFromSettings(settings),
+		gitCacheDir:                  request.GitCacheDir,
+		refreshGit:                   request.RefreshGit,
+		gitCredentials:               request.GitCredentials,
+		refreshRemoteResources:       request.RefreshRemoteResources,
+		remoteResourceCacheDir:       request.RemoteResourceCacheDir,
+		remoteResourceForbiddenRoots: forbiddenRoots,
+		remoteResourceCredentials:    request.RemoteResourceCredentials,
+		remoteResourceGitCredentials: request.RemoteResourceGitCredentials,
+		pluginTimeout:                request.PluginTimeout,
+		kustomizeBuildOptions:        settingsBuildOptions(settings),
+		configManagementPlugins:      settings.ConfigManagementPlugins,
+		cacheEvents:                  recorder,
+	}
+	snapshotRoot, err := os.MkdirTemp("", "drydock-discovery-cache-snapshots-*")
+	if err != nil {
+		return provider, func() {}, err
+	}
+	provider.acquisition = acquisition.Session{
+		Locks:              processCacheTargetLocks,
+		SnapshotRoot:       snapshotRoot,
+		SnapshotCacheReads: shouldSnapshotCacheReads(request),
+		SnapshotCache:      acquisition.NewSnapshotCache(),
+	}
+	return provider, func() { _ = os.RemoveAll(snapshotRoot) }, nil
+}
+
+func cleanDiscoverKustomizePath(root, rawPath string) (string, error) {
+	clean, err := cleanLocalSourcePath(rawPath)
+	if err != nil {
+		return "", fmt.Errorf("discover-kustomize path %q: %w", rawPath, err)
+	}
+	if err := rejectLocalSymlinkComponents(root, clean); err != nil {
+		return "", fmt.Errorf("discover-kustomize path %q: %w", rawPath, err)
+	}
+	if !hasKustomizationFile(filepath.Join(root, clean)) {
+		return "", fmt.Errorf("discover-kustomize path %q does not contain a kustomization file", rawPath)
+	}
+	return clean, nil
+}
+
+func hasKustomizationFile(root string) bool {
+	for _, name := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+		exists, err := localPathExists(filepath.Join(root, name))
+		if err == nil && exists {
+			return true
+		}
+	}
+	return false
+}
+
+func manifestObjects(manifests []render.Manifest) []*unstructured.Unstructured {
+	objects := make([]*unstructured.Unstructured, 0, len(manifests))
+	for _, manifest := range manifests {
+		if manifest.Object == nil {
+			continue
+		}
+		objects = append(objects, manifest.Object.DeepCopy())
+	}
+	return objects
+}
+
+func mergeDiscoveryResults(base, overlay discovery.Result) discovery.Result {
+	out := base
+	out.Applications = mergeApplications(out.Applications, overlay.Applications)
+	out.ApplicationSets = mergeApplicationSets(out.ApplicationSets, overlay.ApplicationSets)
+	out.Projects = mergeProjects(out.Projects, overlay.Projects)
+	out.SettingsCandidates = mergeSettingsCandidates(out.SettingsCandidates, overlay.SettingsCandidates)
+	return out
+}
+
+func mergeApplications(base, overlay []discovery.ApplicationFile) []discovery.ApplicationFile {
+	out := append([]discovery.ApplicationFile(nil), base...)
+	indexes := make(map[string]int, len(out))
+	for i, item := range out {
+		indexes[applicationDiscoveryKey(item.Application)] = i
+	}
+	for _, item := range overlay {
+		key := applicationDiscoveryKey(item.Application)
+		if index, ok := indexes[key]; ok {
+			out[index] = item
+			continue
+		}
+		indexes[key] = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func mergeApplicationSets(base, overlay []discovery.ApplicationSetFile) []discovery.ApplicationSetFile {
+	out := append([]discovery.ApplicationSetFile(nil), base...)
+	indexes := make(map[string]int, len(out))
+	for i, item := range out {
+		indexes[applicationSetDiscoveryKey(item.ApplicationSet)] = i
+	}
+	for _, item := range overlay {
+		key := applicationSetDiscoveryKey(item.ApplicationSet)
+		if index, ok := indexes[key]; ok {
+			out[index] = item
+			continue
+		}
+		indexes[key] = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func mergeProjects(base, overlay []discovery.ProjectFile) []discovery.ProjectFile {
+	out := append([]discovery.ProjectFile(nil), base...)
+	indexes := make(map[string]int, len(out))
+	for i, item := range out {
+		indexes[projectDiscoveryKey(item.Project)] = i
+	}
+	for _, item := range overlay {
+		key := projectDiscoveryKey(item.Project)
+		if index, ok := indexes[key]; ok {
+			out[index] = item
+			continue
+		}
+		indexes[key] = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func mergeSettingsCandidates(base, overlay []discovery.SettingsCandidate) []discovery.SettingsCandidate {
+	out := append([]discovery.SettingsCandidate(nil), base...)
+	indexes := make(map[string]int, len(out))
+	for i, item := range out {
+		indexes[settingsDiscoveryKey(item)] = i
+	}
+	for _, item := range overlay {
+		key := settingsDiscoveryKey(item)
+		if index, ok := indexes[key]; ok {
+			out[index] = item
+			continue
+		}
+		indexes[key] = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func applicationDiscoveryKey(app argoappv1.Application) string {
+	return objectDiscoveryKey("argoproj.io/v1alpha1", "Application", app.Namespace, app.Name)
+}
+
+func applicationSetDiscoveryKey(appSet argoappv1.ApplicationSet) string {
+	return objectDiscoveryKey("argoproj.io/v1alpha1", "ApplicationSet", appSet.Namespace, appSet.Name)
+}
+
+func projectDiscoveryKey(project argoappv1.AppProject) string {
+	return objectDiscoveryKey("argoproj.io/v1alpha1", "AppProject", project.Namespace, project.Name)
+}
+
+func settingsDiscoveryKey(candidate discovery.SettingsCandidate) string {
+	if candidate.Object != nil && candidate.Object.GetKind() != "" && candidate.Object.GetName() != "" {
+		return objectDiscoveryKey(candidate.Object.GetAPIVersion(), candidate.Object.GetKind(), candidate.Object.GetNamespace(), candidate.Object.GetName())
+	}
+	if candidate.APIVersion != "" && candidate.Name != "" {
+		return objectDiscoveryKey(candidate.APIVersion, settingsObjectKind(candidate.Kind), candidate.Namespace, candidate.Name)
+	}
+	return fmt.Sprintf("settings\x00%s\x00%s\x00%d", candidate.Kind, filepath.ToSlash(candidate.Path), candidate.DocumentIndex)
+}
+
+func settingsObjectKind(kind string) string {
+	switch kind {
+	case "argocd-cm", "argocd-cmp-cm":
+		return "ConfigMap"
+	case "repository-secret":
+		return "Secret"
+	default:
+		return kind
+	}
+}
+
+func objectDiscoveryKey(apiVersion, kind, namespace, name string) string {
+	return apiVersion + "\x00" + kind + "\x00" + namespace + "\x00" + name
+}
+
+func emptyApplicationSetDiagnostic(appSetFile discovery.ApplicationSetFile) diagnostic.Diagnostic {
+	name := appSetFile.ApplicationSet.Name
+	if appSetFile.ApplicationSet.Namespace != "" {
+		name = appSetFile.ApplicationSet.Namespace + "/" + name
+	}
+	return diagnostic.Diagnostic{
+		Severity:   diagnostic.SeverityWarning,
+		Category:   "appset",
+		Message:    fmt.Sprintf("ApplicationSet %s generated zero Applications", name),
+		Provenance: diagnostic.Provenance{Path: appSetFile.Path, Pointer: "spec.generators"},
+	}
+}

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+)
+
+func TestListApplicationsDiscoversRenderedKustomizeAndRenderedSettingsWin(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "application.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: apps/raw
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "argocd-cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  application.instanceLabelKey: app.kubernetes.io/raw
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "kustomization.yaml"), `resources:
+  - application.yaml
+  - argocd-cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "overlays", "prod", "kustomization.yaml"), `resources:
+  - ../../base
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: demo
+    patch: |-
+      - op: replace
+        path: /spec/source/path
+        value: apps/rendered
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: argocd-cm
+    patch: |-
+      - op: replace
+        path: /data/application.instanceLabelKey
+        value: app.kubernetes.io/rendered
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:                   root,
+		DiscoverKustomizePaths: []string{filepath.Join("argocd", "overlays", "prod")},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %#v, want one rendered Application", result.Applications)
+	}
+	if got := result.Applications[0].Spec.Source.Path; got != "apps/rendered" {
+		t.Fatalf("Application source path = %q, want rendered path", got)
+	}
+	if got := result.Settings.InstanceLabelKey.Value; got != "app.kubernetes.io/rendered" {
+		t.Fatalf("InstanceLabelKey = %q, want rendered settings", got)
+	}
+	if len(result.ApplicationInputs) != 1 || len(result.ApplicationInputs[0].Paths) != 1 || result.ApplicationInputs[0].Paths[0] != "argocd/overlays/prod" {
+		t.Fatalf("ApplicationInputs = %#v, want rendered discovery path", result.ApplicationInputs)
+	}
+}
+
+func TestListApplicationsRejectsUnsafeDiscoverKustomizePath(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "overlay", "kustomization.yaml"), "resources: []\n")
+
+	_, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:                   root,
+		DiscoverKustomizePaths: []string{filepath.Join(root, "overlay")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must be relative") {
+		t.Fatalf("ListApplications() error = %v, want relative path error", err)
+	}
+
+	if err := os.Symlink(filepath.Join(root, "overlay"), filepath.Join(root, "linked-overlay")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	_, err = Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:                   root,
+		DiscoverKustomizePaths: []string{"linked-overlay"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("ListApplications() error = %v, want symlink path error", err)
+	}
+}
+
+func TestListApplicationsWarnsWhenApplicationSetGeneratesZeroApplications(t *testing.T) {
+	root := t.TempDir()
+	writeZeroApplicationSet(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	if len(result.Applications) != 0 {
+		t.Fatalf("Applications = %#v, want none", result.Applications)
+	}
+	diag, ok := diagnosticByCategory(result.Diagnostics, "appset")
+	if !ok {
+		t.Fatalf("Diagnostics = %#v, want appset warning", result.Diagnostics)
+	}
+	if diag.Severity != diagnostic.SeverityWarning || !strings.Contains(diag.Message, "ApplicationSet argocd/empty generated zero Applications") {
+		t.Fatalf("Diagnostic = %#v, want zero-generated warning", diag)
+	}
+
+	_, err = Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root, Strict: true})
+	if err == nil || !strings.Contains(err.Error(), "generated zero Applications") {
+		t.Fatalf("strict ListApplications() error = %v, want zero-generated error", err)
+	}
+}
+
+func writeZeroApplicationSet(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "appset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: empty
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements: []
+  template:
+    metadata:
+      name: '{{name}}'
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: HEAD
+        path: apps/{{name}}
+`)
+}

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -29,6 +29,7 @@ type BuildRequest struct {
 	Strict bool
 	// StatusOnly renders Applications for validation without retaining manifests.
 	StatusOnly                     bool
+	DiscoverKustomizePaths         []string
 	ValidateLuaHealth              bool
 	Offline                        bool
 	RefreshCharts                  bool
@@ -137,23 +138,26 @@ func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult
 	return diagResult, nil
 }
 
-func (o Orchestrator) ListApplications(_ context.Context, request BuildRequest) (BuildResult, error) {
+func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest) (BuildResult, error) {
 	root := request.Path
 	if root == "" {
 		root = "."
 	}
 
-	discovered, err := discovery.Scan(root, discovery.Options{})
+	var result BuildResult
+	discovered, discoveryDiags, cacheEvents, err := o.discoverRepository(ctx, root, request)
+	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
+	discoveryDiags = normalizeDiagnostics(discoveryDiags, request.Strict, false)
+	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)
 	if err != nil {
-		return BuildResult{}, err
+		return result, diagnosticsError(discoveryDiags, err)
 	}
 
 	settings, settingsDiags, err := loadSettingsFromDiscovery(root, discovered)
 	if err != nil {
-		return BuildResult{}, err
+		return result, err
 	}
 
-	var result BuildResult
 	result.Settings = settings
 	settingsDiags = normalizeDiagnostics(settingsDiags, request.Strict, false)
 	result.Diagnostics = append(result.Diagnostics, settingsDiags...)
@@ -173,23 +177,37 @@ func (o Orchestrator) ListApplications(_ context.Context, request BuildRequest) 
 		})
 	}
 
-	for _, appSetFile := range discovered.ApplicationSets {
+	if err := appendApplicationSetApplications(root, request, discovered.ApplicationSets, appsetOptions, &result); err != nil {
+		return result, err
+	}
+
+	if err := diagnosticFailure(result.Diagnostics, request.Strict); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func appendApplicationSetApplications(root string, request BuildRequest, appSetFiles []discovery.ApplicationSetFile, appsetOptions appset.Options, result *BuildResult) error {
+	for _, appSetFile := range appSetFiles {
 		generated, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
 		if err != nil {
 			if errors.Is(err, appset.ErrUnsupportedGenerator) && len(diags) > 0 {
 				diags = normalizeDiagnostics(diags, request.Strict, true)
 				result.Diagnostics = append(result.Diagnostics, diags...)
 				if request.Strict {
-					return result, diagnosticsError(diags, err)
+					return diagnosticsError(diags, err)
 				}
 				continue
 			}
-			return result, diagnosticsError(diags, err)
+			return diagnosticsError(diags, err)
 		}
 		diags = normalizeDiagnostics(diags, request.Strict, false)
 		result.Diagnostics = append(result.Diagnostics, diags...)
 		if err := diagnosticFailure(diags, request.Strict); err != nil {
-			return result, err
+			return err
+		}
+		if err := appendZeroApplicationSetDiagnostic(appSetFile, request.Strict, result, len(generated)); err != nil {
+			return err
 		}
 		for _, app := range generated {
 			result.Applications = append(result.Applications, app.Application)
@@ -199,11 +217,16 @@ func (o Orchestrator) ListApplications(_ context.Context, request BuildRequest) 
 			})
 		}
 	}
+	return nil
+}
 
-	if err := diagnosticFailure(result.Diagnostics, request.Strict); err != nil {
-		return result, err
+func appendZeroApplicationSetDiagnostic(appSetFile discovery.ApplicationSetFile, strict bool, result *BuildResult, generatedCount int) error {
+	if generatedCount > 0 {
+		return nil
 	}
-	return result, nil
+	diags := normalizeDiagnostics([]diagnostic.Diagnostic{emptyApplicationSetDiagnostic(appSetFile)}, strict, false)
+	result.Diagnostics = append(result.Diagnostics, diags...)
+	return diagnosticFailure(diags, strict)
 }
 
 func generatedApplicationInputPaths(appSetPath string, app appset.GeneratedApplication) []string {
@@ -506,10 +529,13 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 
 	var result BuildResult
 	result.Applications = append(result.Applications, request.Applications...)
-	discovered, err := discovery.Scan(root, discovery.Options{})
+	discovered, discoveryDiags, cacheEvents, err := o.discoverRepository(ctx, root, request)
+	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
+	discoveryDiags = normalizeDiagnostics(discoveryDiags, request.Strict, false)
+	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)
 	if err != nil {
 		result.Statuses = skippedApplicationStatuses(result.Applications, err)
-		return result, err
+		return result, diagnosticsError(discoveryDiags, err)
 	}
 	result.Projects = appendDiscoveredProjects(result.Projects, discovered)
 	settings, diags, err := loadSettingsFromDiscovery(root, discovered)
@@ -552,13 +578,29 @@ func loadSettingsFromDiscovery(root string, discovered discovery.Result) (config
 		)
 		switch candidate.Kind {
 		case "argocd-cm":
-			settings, nextDiags, err = config.LoadFromConfigMapDocument(path, candidate.DocumentIndex)
+			if candidate.Object != nil {
+				settings, nextDiags, err = config.LoadFromConfigMapObject(candidate.Path, candidate.Object)
+			} else {
+				settings, nextDiags, err = config.LoadFromConfigMapDocument(path, candidate.DocumentIndex)
+			}
 		case "argocd-cmp-cm":
-			settings, nextDiags, err = config.LoadConfigManagementPluginConfigMapDocument(path, candidate.DocumentIndex)
+			if candidate.Object != nil {
+				settings, nextDiags, err = config.LoadConfigManagementPluginConfigMapObject(candidate.Path, candidate.Object)
+			} else {
+				settings, nextDiags, err = config.LoadConfigManagementPluginConfigMapDocument(path, candidate.DocumentIndex)
+			}
 		case "argocd-values":
-			settings, nextDiags, err = config.LoadFromHelmValuesDocument(path, candidate.DocumentIndex)
+			if candidate.Object != nil {
+				settings, nextDiags, err = config.LoadFromHelmValuesObject(candidate.Path, candidate.Object)
+			} else {
+				settings, nextDiags, err = config.LoadFromHelmValuesDocument(path, candidate.DocumentIndex)
+			}
 		case "repository-secret":
-			settings, nextDiags, err = config.LoadRepositorySecretDocument(path, candidate.DocumentIndex)
+			if candidate.Object != nil {
+				settings, nextDiags, err = config.LoadRepositorySecretObject(candidate.Path, candidate.Object)
+			} else {
+				settings, nextDiags, err = config.LoadRepositorySecretDocument(path, candidate.DocumentIndex)
+			}
 		default:
 			continue
 		}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -18,6 +18,7 @@ type commonFlags struct {
 	ref               string
 	refOrig           string
 	selector          string
+	discoverKustomize []string
 	repoMaps          []string
 	offline           bool
 	refreshCharts     bool
@@ -73,6 +74,7 @@ func bindCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVar(&flags.path, "path", flags.path, "repository path to inspect")
 	cmd.Flags().StringVar(&flags.pathOrig, "path-orig", flags.pathOrig, "baseline repository path for diffs")
 	cmd.Flags().StringVarP(&flags.selector, "selector", "l", flags.selector, "label selector for Applications")
+	cmd.Flags().StringArrayVar(&flags.discoverKustomize, "discover-kustomize", flags.discoverKustomize, "additional local Kustomize path to render for Argo CD Application discovery")
 	cmd.Flags().StringArrayVar(&flags.repoMaps, "repo-map", flags.repoMaps, "repository URL mapping in from=to form")
 	cmd.Flags().BoolVar(&flags.offline, "offline", flags.offline, "disable network access and use local files, repo maps, or existing caches")
 	cmd.Flags().BoolVar(&flags.refreshCharts, "refresh-charts", flags.refreshCharts, "refresh cached Helm charts before rendering")
@@ -171,6 +173,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		Repo:                           flags.repo,
 		Ref:                            flags.ref,
 		RefOrig:                        flags.refOrig,
+		DiscoverKustomizePaths:         append([]string(nil), flags.discoverKustomize...),
 		ChangedOnly:                    &flags.changedOnly,
 		StrictChangedOnly:              flags.strictChangedOnly,
 		Strict:                         flags.strict,

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -88,7 +88,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 				}
 				return testCommandError(err, result.Statuses)
 			}
-			if renderErr := renderTestResult(cmd, result.Statuses, output, false); renderErr != nil {
+			if renderErr := renderTestResult(cmd, result.Statuses, output, false, true); renderErr != nil {
 				return renderErr
 			}
 			return testCommandError(err, result.Statuses)
@@ -122,7 +122,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 			if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
 				return renderErr
 			}
-			if renderErr := renderTestResult(cmd, result.Statuses, output, deps.isTerminal(cmd.OutOrStdout())); renderErr != nil {
+			if renderErr := renderTestResult(cmd, result.Statuses, output, deps.isTerminal(cmd.OutOrStdout()), false); renderErr != nil {
 				return renderErr
 			}
 			return testCommandError(err, result.Statuses)
@@ -139,26 +139,40 @@ func buildRequestFromFlags(flags commonFlags, repoMaps []source.RepoMap) app.Bui
 	return requestOptionsFromFlags(flags, repoMaps).Build()
 }
 
-func renderTestResult(cmd *cobra.Command, statuses []app.ApplicationStatus, output string, color bool) error {
+func renderTestResult(cmd *cobra.Command, statuses []app.ApplicationStatus, output string, color, showEmptyMessage bool) error {
 	switch output {
 	case testOutputText:
-		return renderTestStatuses(cmd.OutOrStdout(), statuses, color)
+		return renderTestStatuses(cmd.OutOrStdout(), statuses, color, showEmptyMessage)
 	case string(cliformat.OutputJSON):
-		return writeStructuredOutput(cmd.OutOrStdout(), output, statuses)
+		return writeStructuredOutput(cmd.OutOrStdout(), output, nonNilTestStatuses(statuses))
 	case string(cliformat.OutputYAML):
-		return writeStructuredOutput(cmd.OutOrStdout(), output, statuses)
+		return writeStructuredOutput(cmd.OutOrStdout(), output, nonNilTestStatuses(statuses))
 	default:
 		return fmt.Errorf("unsupported output %q for test", output)
 	}
 }
 
-func renderTestStatuses(w io.Writer, statuses []app.ApplicationStatus, color bool) error {
+func renderTestStatuses(w io.Writer, statuses []app.ApplicationStatus, color, showEmptyMessage bool) error {
+	if len(statuses) == 0 {
+		if !showEmptyMessage {
+			return nil
+		}
+		_, err := fmt.Fprintln(w, "No Applications discovered.")
+		return err
+	}
 	for _, status := range statuses {
 		if err := renderApplicationStatus(w, status, color); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func nonNilTestStatuses(statuses []app.ApplicationStatus) []app.ApplicationStatus {
+	if statuses == nil {
+		return []app.ApplicationStatus{}
+	}
+	return statuses
 }
 
 func renderApplicationStatus(w io.Writer, status app.ApplicationStatus, color bool) error {
@@ -245,6 +259,10 @@ func (reporter *testLiveReporter) RenderMissingStatuses(statuses []app.Applicati
 }
 
 func (reporter *testLiveReporter) Summary(statuses []app.ApplicationStatus) error {
+	if len(statuses) == 0 {
+		_, err := fmt.Fprintln(reporter.out, "No Applications discovered.")
+		return err
+	}
 	counts := summarizeTestStatuses(statuses)
 	if _, err := fmt.Fprintf(reporter.out, "%d applications: %d passed, %d failed, %d skipped in %s\n",
 		len(statuses), counts.passed, counts.failed, counts.skipped, formatTestDuration(time.Since(reporter.started))); err != nil {

--- a/internal/cli/test_test.go
+++ b/internal/cli/test_test.go
@@ -35,6 +35,46 @@ func TestTestAppsPassesAllApplications(t *testing.T) {
 	}
 }
 
+func TestTestAppsReportsNoApplicationsInTextOutput(t *testing.T) {
+	root := t.TempDir()
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"test", "apps", "--path", root})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := stdout.String(), "No Applications discovered.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTestAppsReportsEmptyJSONArrayWhenNoApplicationsDiscovered(t *testing.T) {
+	root := t.TempDir()
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"test", "apps", "--path", root, "-o", "json"})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := strings.TrimSpace(stdout.String()), "[]"; got != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestTestAppsReportsFailures(t *testing.T) {
 	root := t.TempDir()
 	writeFailingCLIApplication(t, root, "broken")

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"go.yaml.in/yaml/v4"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func LoadFromHelmValues(path string) (ArgoSettings, []diagnostic.Diagnostic, error) {
@@ -38,6 +39,21 @@ func LoadFromHelmValuesDocument(path string, documentIndex int) (ArgoSettings, [
 	var doc helmValuesSettingsDocument
 	if err := decodeYAMLDocumentAt(path, documentIndex, &doc); err != nil {
 		return settings, nil, fmt.Errorf("parse helm values %s document %d: %w", path, documentIndex, err)
+	}
+	diags := applyCMMap(&settings, doc.Configs.CM, path, "configs.cm")
+	cmpDiags, err := applyCMPPlugins(&settings, doc.Configs.CMP.Plugins, path, "configs.cmp.plugins")
+	if err != nil {
+		return settings, diags, err
+	}
+	diags = append(diags, cmpDiags...)
+	return settings, diags, nil
+}
+
+func LoadFromHelmValuesObject(path string, obj *unstructured.Unstructured) (ArgoSettings, []diagnostic.Diagnostic, error) {
+	settings := DefaultSettings()
+	var doc helmValuesSettingsDocument
+	if err := decodeUnstructuredObject(obj, &doc); err != nil {
+		return settings, nil, fmt.Errorf("parse helm values %s: %w", path, err)
 	}
 	diags := applyCMMap(&settings, doc.Configs.CM, path, "configs.cm")
 	cmpDiags, err := applyCMPPlugins(&settings, doc.Configs.CMP.Plugins, path, "configs.cmp.plugins")
@@ -102,6 +118,30 @@ func LoadFromConfigMapDocument(path string, documentIndex int) (ArgoSettings, []
 	return settings, diags, nil
 }
 
+func LoadFromConfigMapObject(path string, obj *unstructured.Unstructured) (ArgoSettings, []diagnostic.Diagnostic, error) {
+	settings := DefaultSettings()
+	var doc struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := decodeUnstructuredObject(obj, &doc); err != nil {
+		return settings, nil, fmt.Errorf("parse configmap %s: %w", path, err)
+	}
+	if doc.Kind != "ConfigMap" || doc.Metadata.Name != "argocd-cm" {
+		return settings, []diagnostic.Diagnostic{{
+			Severity:   diagnostic.SeverityWarning,
+			Category:   "settings",
+			Message:    "object is not argocd-cm ConfigMap",
+			Provenance: diagnostic.Provenance{Path: path},
+		}}, nil
+	}
+	diags := applyCMMap(&settings, doc.Data, path, "data")
+	return settings, diags, nil
+}
+
 func LoadConfigManagementPluginConfigMapDocument(path string, documentIndex int) (ArgoSettings, []diagnostic.Diagnostic, error) {
 	settings := DefaultSettings()
 	var doc struct {
@@ -131,6 +171,45 @@ func LoadConfigManagementPluginConfigMapDocument(path string, documentIndex int)
 		plugins, err := configManagementPluginsFromYAML([]byte(value), path, "data."+key)
 		if err != nil {
 			return settings, nil, fmt.Errorf("parse config management plugin %s document %d data %q: %w", path, documentIndex, key, err)
+		}
+		for _, plugin := range plugins {
+			if diag := addConfigManagementPlugin(&settings, plugin); diag != nil {
+				diags = append(diags, *diag)
+			}
+		}
+	}
+	return settings, diags, nil
+}
+
+func LoadConfigManagementPluginConfigMapObject(path string, obj *unstructured.Unstructured) (ArgoSettings, []diagnostic.Diagnostic, error) {
+	settings := DefaultSettings()
+	var doc struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := decodeUnstructuredObject(obj, &doc); err != nil {
+		return settings, nil, fmt.Errorf("parse config management plugin ConfigMap %s: %w", path, err)
+	}
+	if doc.Kind != "ConfigMap" || doc.Metadata.Name != "argocd-cmp-cm" {
+		return settings, []diagnostic.Diagnostic{{
+			Severity:   diagnostic.SeverityWarning,
+			Category:   "settings",
+			Message:    "object is not argocd-cmp-cm ConfigMap",
+			Provenance: diagnostic.Provenance{Path: path},
+		}}, nil
+	}
+
+	var diags []diagnostic.Diagnostic
+	for key, value := range doc.Data {
+		if !looksLikeConfigManagementPluginYAML(value) {
+			continue
+		}
+		plugins, err := configManagementPluginsFromYAML([]byte(value), path, "data."+key)
+		if err != nil {
+			return settings, nil, fmt.Errorf("parse config management plugin %s data %q: %w", path, key, err)
 		}
 		for _, plugin := range plugins {
 			if diag := addConfigManagementPlugin(&settings, plugin); diag != nil {
@@ -202,6 +281,35 @@ func LoadRepositorySecretDocument(path string, documentIndex int) (ArgoSettings,
 	}
 	settings, diags := repositorySecretSettings(path, doc)
 	return settings, diags, nil
+}
+
+func LoadRepositorySecretObject(path string, obj *unstructured.Unstructured) (ArgoSettings, []diagnostic.Diagnostic, error) {
+	settings := DefaultSettings()
+	var doc repositorySecretDocument
+	if err := decodeUnstructuredObject(obj, &doc); err != nil {
+		return settings, nil, fmt.Errorf("parse repository secret %s: %w", path, err)
+	}
+	if doc.Kind != "Secret" || doc.Metadata.Labels["argocd.argoproj.io/secret-type"] != "repository" {
+		return settings, []diagnostic.Diagnostic{{
+			Severity:   diagnostic.SeverityWarning,
+			Category:   "settings",
+			Message:    "object is not an Argo CD repository Secret",
+			Provenance: diagnostic.Provenance{Path: path},
+		}}, nil
+	}
+	settings, diags := repositorySecretSettings(path, doc)
+	return settings, diags, nil
+}
+
+func decodeUnstructuredObject(obj *unstructured.Unstructured, out any) error {
+	if obj == nil {
+		return fmt.Errorf("object is nil")
+	}
+	data, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, out)
 }
 
 func decodeYAMLDocumentAt(path string, documentIndex int, out any) error {

--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -129,6 +129,8 @@ func appSetCode(message string) string {
 		return "appset.provider-unsupported-filter"
 	case strings.Contains(message, "unsupported ApplicationSet generator"):
 		return "appset.unsupported-generator"
+	case strings.Contains(message, "generated zero Applications"):
+		return "appset.generated-zero-applications"
 	default:
 		return "appset.unspecified"
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -38,6 +38,10 @@ type SettingsCandidate struct {
 	Path          string
 	DocumentIndex int
 	Kind          string
+	APIVersion    string
+	Namespace     string
+	Name          string
+	Object        *unstructured.Unstructured
 }
 
 type Result struct {
@@ -67,6 +71,19 @@ func Scan(root string, opts Options) (Result, error) {
 			}
 		}
 		if err := scanPath(root, start, explicit, seen, &result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func ScanObjects(path string, objects []*unstructured.Unstructured) (Result, error) {
+	var result Result
+	for index, obj := range objects {
+		if obj == nil {
+			continue
+		}
+		if err := scanDocument(path, index, obj, true, &result); err != nil {
 			return result, err
 		}
 	}
@@ -151,14 +168,14 @@ func scanYAMLFile(path, rel string, result *Result) error {
 		return err
 	}
 	for _, doc := range docs {
-		if err := scanDocument(rel, doc.Index, doc.Object, result); err != nil {
+		if err := scanDocument(rel, doc.Index, doc.Object, false, result); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func scanDocument(rel string, documentIndex int, obj *unstructured.Unstructured, result *Result) error {
+func scanDocument(rel string, documentIndex int, obj *unstructured.Unstructured, includeObject bool, result *Result) error {
 	switch {
 	case isArgoGVK(obj, "Application"):
 		var app argoappv1.Application
@@ -179,15 +196,33 @@ func scanDocument(rel string, documentIndex int, obj *unstructured.Unstructured,
 		}
 		result.Projects = append(result.Projects, ProjectFile{Path: rel, DocumentIndex: documentIndex, Project: project})
 	case isCoreGVK(obj, "ConfigMap") && obj.GetName() == "argocd-cm":
-		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "argocd-cm"})
+		result.SettingsCandidates = append(result.SettingsCandidates, settingsCandidate(rel, documentIndex, "argocd-cm", obj, includeObject))
 	case isCoreGVK(obj, "ConfigMap") && obj.GetName() == "argocd-cmp-cm" && isConfigManagementPluginConfigMap(obj):
-		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "argocd-cmp-cm"})
+		result.SettingsCandidates = append(result.SettingsCandidates, settingsCandidate(rel, documentIndex, "argocd-cmp-cm", obj, includeObject))
 	case isCoreGVK(obj, "Secret") && obj.GetLabels()["argocd.argoproj.io/secret-type"] == "repository":
-		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "repository-secret"})
+		result.SettingsCandidates = append(result.SettingsCandidates, settingsCandidate(rel, documentIndex, "repository-secret", obj, includeObject))
 	case isArgoHelmValuesSettings(obj):
-		result.SettingsCandidates = append(result.SettingsCandidates, SettingsCandidate{Path: rel, DocumentIndex: documentIndex, Kind: "argocd-values"})
+		result.SettingsCandidates = append(result.SettingsCandidates, settingsCandidate(rel, documentIndex, "argocd-values", obj, includeObject))
 	}
 	return nil
+}
+
+func settingsCandidate(rel string, documentIndex int, kind string, obj *unstructured.Unstructured, includeObject bool) SettingsCandidate {
+	candidate := SettingsCandidate{
+		Path:          rel,
+		DocumentIndex: documentIndex,
+		Kind:          kind,
+	}
+	if obj == nil {
+		return candidate
+	}
+	candidate.APIVersion = obj.GetAPIVersion()
+	candidate.Namespace = obj.GetNamespace()
+	candidate.Name = obj.GetName()
+	if includeObject {
+		candidate.Object = obj.DeepCopy()
+	}
+	return candidate
 }
 
 func isArgoGVK(obj *unstructured.Unstructured, kind string) bool {

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -203,11 +203,11 @@ data:
 		t.Fatalf("ApplicationSet = %#v, want path and document index 0", result.ApplicationSets[0])
 	}
 	wantSettings := []SettingsCandidate{
-		{Path: filepath.Join("settings", "argocd-cm.yaml"), DocumentIndex: 0, Kind: "argocd-cm"},
-		{Path: filepath.Join("settings", "cmp-configmap.yaml"), DocumentIndex: 0, Kind: "argocd-cmp-cm"},
+		{Path: filepath.Join("settings", "argocd-cm.yaml"), DocumentIndex: 0, Kind: "argocd-cm", APIVersion: "v1", Namespace: "argocd", Name: "argocd-cm"},
+		{Path: filepath.Join("settings", "cmp-configmap.yaml"), DocumentIndex: 0, Kind: "argocd-cmp-cm", APIVersion: "v1", Name: "argocd-cmp-cm"},
 		{Path: filepath.Join("settings", "cmp-values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
 		{Path: filepath.Join("settings", "compare-values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
-		{Path: filepath.Join("settings", "repo-secret.yaml"), DocumentIndex: 0, Kind: "repository-secret"},
+		{Path: filepath.Join("settings", "repo-secret.yaml"), DocumentIndex: 0, Kind: "repository-secret", APIVersion: "v1", Namespace: "argocd", Name: "repo"},
 		{Path: filepath.Join("settings", "values.yaml"), DocumentIndex: 0, Kind: "argocd-values"},
 	}
 	if !reflect.DeepEqual(result.SettingsCandidates, wantSettings) {

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	Repo                           string
 	Ref                            string
 	RefOrig                        string
+	DiscoverKustomizePaths         []string
 	ChangedOnly                    *bool
 	StrictChangedOnly              bool
 	Strict                         bool
@@ -51,6 +52,7 @@ func (options Options) Build() app.BuildRequest {
 	return app.BuildRequest{
 		Path:                           options.Path,
 		Strict:                         options.Strict,
+		DiscoverKustomizePaths:         append([]string(nil), options.DiscoverKustomizePaths...),
 		ValidateLuaHealth:              options.ValidateLuaHealth,
 		Offline:                        options.Offline,
 		RefreshCharts:                  options.RefreshCharts,
@@ -87,6 +89,7 @@ func (options Options) Diff() app.DiffRequest {
 		Repo:                           options.Repo,
 		Ref:                            options.Ref,
 		RefOrig:                        options.RefOrig,
+		DiscoverKustomizePaths:         append([]string(nil), options.DiscoverKustomizePaths...),
 		ChangedOnly:                    changedOnly,
 		StrictChangedOnly:              options.StrictChangedOnly,
 		Strict:                         options.Strict,

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -18,6 +18,7 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 
 	assertDeepEqual(t, "Path", request.Path, "repo")
 	assertDeepEqual(t, "Strict", request.Strict, true)
+	assertDeepEqual(t, "DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "Offline", request.Offline, true)
 	assertDeepEqual(t, "RefreshCharts", request.RefreshCharts, true)
 	assertDeepEqual(t, "ChartCacheDir", request.ChartCacheDir, "chart-cache")
@@ -41,6 +42,7 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RecordCacheEvents", request.RecordCacheEvents, true)
 
 	mutateOptions(&options)
+	assertDeepEqual(t, "copied DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "copied RepoMaps", request.RepoMaps, []source.RepoMap{{URL: "https://example.test/repo.git", Path: "/repo"}})
 	assertDeepEqual(t, "copied RemoteResourceForbiddenRoots", request.RemoteResourceForbiddenRoots, []string{"/repo"})
 	assertDeepEqual(t, "copied SkipKinds", request.SkipKinds, []string{"Secret"})
@@ -58,6 +60,7 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "Repo", request.Repo, "repo-root")
 	assertDeepEqual(t, "Ref", request.Ref, "feature")
 	assertDeepEqual(t, "RefOrig", request.RefOrig, "main")
+	assertDeepEqual(t, "DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "ChangedOnly", request.ChangedOnly, true)
 	assertDeepEqual(t, "StrictChangedOnly", request.StrictChangedOnly, true)
 	assertDeepEqual(t, "Strict", request.Strict, true)
@@ -86,6 +89,7 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RecordCacheEvents", request.RecordCacheEvents, true)
 
 	mutateOptions(&options)
+	assertDeepEqual(t, "copied DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "copied StripAttrs", request.StripAttrs, []string{"metadata.annotations.checksum/config"})
 	assertDeepEqual(t, "copied RepoMaps", request.RepoMaps, []source.RepoMap{{URL: "https://example.test/repo.git", Path: "/repo"}})
 	assertDeepEqual(t, "copied SkipKinds", request.SkipKinds, []string{"Secret"})
@@ -109,6 +113,7 @@ func fixtureOptions() Options {
 		Repo:                         "repo-root",
 		Ref:                          "feature",
 		RefOrig:                      "main",
+		DiscoverKustomizePaths:       []string{"argocd/overlays/prod"},
 		StrictChangedOnly:            true,
 		Strict:                       true,
 		StripAttrs:                   []string{"metadata.annotations.checksum/config"},
@@ -150,6 +155,7 @@ func providerDataFixture() appset.ProviderData {
 
 func mutateOptions(options *Options) {
 	options.StripAttrs[0] = "mutated"
+	options.DiscoverKustomizePaths[0] = "mutated"
 	options.RepoMaps[0].Path = "/mutated"
 	options.RemoteResourceForbiddenRoots[0] = "/mutated"
 	options.SkipKinds[0] = "ConfigMap"

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -16,17 +16,18 @@ import (
 // side for diff operations. PathOrig is the left side for diff operations. Use
 // keyed struct literals; new fields may be added as drydock gains parity.
 type Config struct {
-	Path             string
-	PathOrig         string
-	Repo             string
-	Ref              string
-	RefOrig          string
-	Strict           bool
-	Offline          bool
-	RefreshCharts    bool
-	ChartCacheDir    string
-	ChartCredentials ChartCredentials
-	RepoMaps         []RepoMap
+	Path                   string
+	PathOrig               string
+	Repo                   string
+	Ref                    string
+	RefOrig                string
+	DiscoverKustomizePaths []string
+	Strict                 bool
+	Offline                bool
+	RefreshCharts          bool
+	ChartCacheDir          string
+	ChartCredentials       ChartCredentials
+	RepoMaps               []RepoMap
 	// Deprecated: Git, chart, and remote resource acquisition are enabled by
 	// default. Set Offline to true to disable network acquisition. Offline is
 	// authoritative when both fields are set.
@@ -171,6 +172,7 @@ func (client *Client) requestOptions() requestopts.Options {
 		Repo:                           client.config.Repo,
 		Ref:                            client.config.Ref,
 		RefOrig:                        client.config.RefOrig,
+		DiscoverKustomizePaths:         append([]string(nil), client.config.DiscoverKustomizePaths...),
 		ChangedOnly:                    client.config.ChangedOnly,
 		StrictChangedOnly:              client.config.StrictChangedOnly,
 		Strict:                         client.config.Strict,


### PR DESCRIPTION
## Summary
- add explicit --discover-kustomize PATH support for rendered local Kustomize discovery
- keep rendered discovery in memory, path-contained, and deduped by object identity
- improve zero-Application and zero-generated ApplicationSet diagnostics/output

## Verification
- go test ./internal/app ./internal/discovery ./internal/config ./internal/cli ./internal/requestopts ./pkg/drydock
- go test ./...
- mise run ci
- /private/tmp/drydock-smoke get apps --path /private/tmp/drydock-vehagn-homelab -o name
- /private/tmp/drydock-smoke get apps --path /private/tmp/drydock-vehagn-homelab --discover-kustomize k8s/sets -o name
- /private/tmp/drydock-smoke test apps --path /private/tmp/drydock-vehagn-homelab --discover-kustomize k8s/sets --offline -o json

Review agent approval: APPROVED with no findings.