### PR TITLE
feat: discover rendered Argo CD fleets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ drydock diff apps --path . --path-orig ../baseline --offline
 
 drydock discovers and renders local Argo CD desired state, including:
 
-- `Application` resources and supported `ApplicationSet` generators.
-- Optional rendered discovery from explicit local Kustomize entrypoints with
-  `--discover-kustomize`.
+- Static `Application` resources, supported `ApplicationSet` generators, and
+  rendered child `Application`, `ApplicationSet`, `AppProject`, and settings
+  objects from app-of-apps/bootstrap sources.
+- Optional additional rendered discovery from explicit local Kustomize
+  entrypoints with `--discover-kustomize`.
 - Single-source and multi-source Applications.
 - Directory, Kustomize, local Helm chart, remote Helm chart, and remote
   Kustomize sources.
@@ -208,7 +210,7 @@ flowchart TD
   current --> discover
   baseline --> discover
 
-  discover[Discover Argo CD Applications and settings]
+  discover[Discover static and rendered Argo CD fleet objects]
   discover --> plan[Plan sources, resolve repo maps, use caches]
   plan --> render[Render desired manifests with Go libraries]
   render --> normalize[Apply Argo-aware filters and diff normalization]

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,9 +45,12 @@ Supported:
 - Direct Application discovery from repository manifests.
 - Recursive rendered fleet discovery from desired output, including rendered
   `Application`, `ApplicationSet`, `AppProject`, and Argo CD settings objects.
-  Static committed objects take precedence over rendered duplicates.
+  Static committed objects take precedence over default rendered fleet
+  duplicates.
 - Explicit `--discover-kustomize PATH` discovery from rendered local
-  Kustomize entrypoints, with normal path containment and symlink checks.
+  Kustomize entrypoints. Explicitly rendered Kustomize objects take precedence
+  over committed duplicates because the path is the operator-selected Argo CD
+  entrypoint.
 - ApplicationSet Git directories, Git files, list, matrix, and merge
   generators.
 - ApplicationSet list `elementsYaml`, including matrix-interpolated

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,6 +43,9 @@ silent approximations.
 Supported:
 
 - Direct Application discovery from repository manifests.
+- Recursive rendered fleet discovery from desired output, including rendered
+  `Application`, `ApplicationSet`, `AppProject`, and Argo CD settings objects.
+  Static committed objects take precedence over rendered duplicates.
 - Explicit `--discover-kustomize PATH` discovery from rendered local
   Kustomize entrypoints, with normal path containment and symlink checks.
 - ApplicationSet Git directories, Git files, list, matrix, and merge
@@ -123,6 +126,9 @@ Supported:
   `patchesStrategicMerge`, `generators`, `transformers`, `validators`,
   `configurations`, `crds`, `openapi.path`, `replacements.path`, and generator
   file/env refs.
+- Kustomize root Git remote refs such as
+  `https://github.com/org/repo?ref=v1` when they resolve to a repository-root
+  Kustomization directory.
 - Native-compatible Kustomize build config management plugin definitions
   discovered from Argo CD Helm values or rendered `argocd-cmp-cm` ConfigMaps.
   drydock parses those definitions as metadata and renders matched
@@ -183,6 +189,7 @@ Supported:
 - `diag --settings -o json|yaml` redacted settings summaries for parsed Argo
   CD settings metadata.
 - Local AppProject manifest discovery.
+- Rendered AppProject discovery from app-of-apps/bootstrap desired output.
 - Offline diagnostics for Application source repository, destination
   server/name/namespace, and source namespace validation from local AppProject
   manifests.

--- a/docs/source-acquisition.md
+++ b/docs/source-acquisition.md
@@ -36,9 +36,14 @@ Unsupported build options fail explicitly instead of being ignored.
 
 Supported Kustomize remote refs include:
 
+- `https://github.com/org/repo?ref=v1`
+- `https://github.com/org/repo.git?ref=v1`
 - `https://github.com/org/repo//path?ref=v1`
+- `git::https://github.com/org/repo.git?ref=v1`
 - `git::https://github.com/org/repo.git//path?ref=v1`
+- `ssh://git@github.com/org/repo.git?ref=v1`
 - `ssh://git@github.com/org/repo.git//path?ref=v1`
+- `git@github.com:org/repo.git?ref=v1`
 - `git@github.com:org/repo.git//path?ref=v1`
 
 Remote Kustomize refs are supported in `resources`, `bases`, `components`,
@@ -52,6 +57,12 @@ including remote bases and components, must use Git refs that resolve to
 Kustomization directories. The renderer copies acquired content into a
 temporary workspace under generated `.drydock` paths and does not write
 generated manifests into the source tree.
+
+Git refs may omit `ref`; omitted or empty `ref` values resolve to `HEAD`.
+Root Git refs copy the repository root as the remote Kustomization root.
+Ambiguous non-file HTTP(S) URLs are rejected unless they use known Git host
+shorthand, a `.git` repository path, or explicit Git syntax such as `git::`,
+`ssh://`, or SCP-style `git@host:org/repo.git`.
 
 ## Network And Cache Flags
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,9 @@ must be cache-only.
 
 ## Application Discovery
 
-List direct `Application` CRs and supported generated `ApplicationSet`
-Applications:
+List discovered `Application` CRs, supported generated `ApplicationSet`
+Applications, and rendered child Applications from app-of-apps bootstrap
+sources:
 
 ```bash
 drydock get apps --path .
@@ -35,6 +36,23 @@ drydock get images --path . -o name
 `get images` uses the same output formats as `get apps`. Diagnostics are
 printed to stderr for both commands.
 
+By default, fleet commands recursively render discovered Applications to find
+additional Argo CD `Application`, `ApplicationSet`, `AppProject`, and settings
+objects in their desired output. This lets repositories that commit a bootstrap
+Application or Helm app-of-apps chart behave like repositories that commit the
+inflated child objects. Discovery stops when it converges, with a default
+maximum depth of `4`.
+
+Use `--discovery-mode static` to disable recursive rendered fleet discovery.
+Committed `ApplicationSet` objects still expand through supported offline
+generators. Use `--max-discovery-depth 0` to keep normal static discovery and
+explicit `--discover-kustomize` rendering while disabling recursive rendered
+fleet discovery.
+
+Static committed objects take precedence over rendered objects with the same
+API version, kind, namespace, and name. Rendered duplicates emit diagnostics
+instead of silently replacing committed intent.
+
 Supported local `ApplicationSet` generators are Git directories, Git files,
 list, matrix, merge, and explicit fixture-backed provider generators.
 Unsupported generators emit diagnostics; non-strict commands keep supported
@@ -43,8 +61,9 @@ Applications, while `--strict` promotes the diagnostics to errors.
 For generator details, fixture schemas, and stable template parameters, see
 [`applicationsets.md`](applicationsets.md).
 
-Local `AppProject` manifests are discovered for offline diagnostics only.
-Discovery does not contact a Kubernetes cluster or Argo CD server.
+Committed and rendered `AppProject` manifests are discovered for offline
+diagnostics only. Discovery does not contact a Kubernetes cluster or Argo CD
+server.
 
 Some repositories commit Argo CD bootstrap inputs as Kustomize bases and
 overlays rather than committing the fully inflated Argo CD objects. Add
@@ -59,8 +78,8 @@ drydock test apps --path . --discover-kustomize clusters/prod/argocd
 
 The path must be relative to `--path`, must not escape through `..`, and must
 not include symlinked path components. Rendered discovery is additive: normal
-repository scanning still runs, and rendered objects replace raw objects only
-when they have the same API version, kind, namespace, and name.
+repository scanning still runs, and committed objects retain precedence over
+rendered duplicates.
 
 ## Rendering
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,9 +49,9 @@ generators. Use `--max-discovery-depth 0` to keep normal static discovery and
 explicit `--discover-kustomize` rendering while disabling recursive rendered
 fleet discovery.
 
-Static committed objects take precedence over rendered objects with the same
-API version, kind, namespace, and name. Rendered duplicates emit diagnostics
-instead of silently replacing committed intent.
+Static committed objects take precedence over default rendered fleet objects
+with the same API version, kind, namespace, and name. Rendered duplicates emit
+diagnostics instead of silently replacing committed intent.
 
 Supported local `ApplicationSet` generators are Git directories, Git files,
 list, matrix, merge, and explicit fixture-backed provider generators.
@@ -78,8 +78,8 @@ drydock test apps --path . --discover-kustomize clusters/prod/argocd
 
 The path must be relative to `--path`, must not escape through `..`, and must
 not include symlinked path components. Rendered discovery is additive: normal
-repository scanning still runs, and committed objects retain precedence over
-rendered duplicates.
+repository scanning still runs, and explicitly rendered Kustomize objects take
+precedence over committed duplicates with the same identity.
 
 ## Rendering
 

--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -30,6 +30,12 @@ func newBuildSession(orchestrator Orchestrator, request BuildRequest) (*buildSes
 	if err != nil {
 		return nil, err
 	}
+	if _, err := normalizeDiscoveryMode(request.DiscoveryMode); err != nil {
+		return nil, err
+	}
+	if _, err := normalizeMaxDiscoveryDepth(request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet); err != nil {
+		return nil, err
+	}
 	return &buildSession{
 		orchestrator:  orchestrator,
 		request:       request,
@@ -122,22 +128,26 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 	}
 
 	rendered, renderErr := renderApplications(ctx, renderApplicationsRequest{
-		applications:    result.Applications,
-		provider:        provider,
-		strict:          session.request.Strict,
-		statusOnly:      session.request.StatusOnly,
-		settingsFilter:  settingsFilter,
-		resourceFilter:  resourceFilter,
-		healthEvaluator: healthEvaluator,
-		recordEvents:    session.request.RecordCacheEvents,
-		parallelism:     session.parallelism,
-		statusCallback:  session.request.StatusCallback,
+		applications:      result.Applications,
+		provider:          provider,
+		renderCache:       result.renderCache,
+		settingsSignature: result.renderSettingsSignature,
+		request:           session.request,
+		strict:            session.request.Strict,
+		statusOnly:        session.request.StatusOnly,
+		settingsFilter:    settingsFilter,
+		resourceFilter:    resourceFilter,
+		healthEvaluator:   healthEvaluator,
+		recordEvents:      session.request.RecordCacheEvents,
+		parallelism:       session.parallelism,
+		statusCallback:    session.request.StatusCallback,
 	})
 	result.Manifests = append(result.Manifests, rendered.manifests...)
 	result.ApplicationManifests = append(result.ApplicationManifests, rendered.applicationManifests...)
 	result.Diagnostics = append(result.Diagnostics, rendered.diagnostics...)
 	result.Statuses = append(result.Statuses, rendered.statuses...)
 	result.CacheEvents = append(result.CacheEvents, rendered.cacheEvents...)
+	result.Diagnostics = dedupeDiagnostics(result.Diagnostics)
 	if renderErr != nil {
 		return result, renderErr
 	}

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -33,6 +33,9 @@ type DiffRequest struct {
 	Repo                           string
 	Ref                            string
 	RefOrig                        string
+	DiscoveryMode                  string
+	MaxDiscoveryDepth              int
+	MaxDiscoveryDepthSet           bool
 	DiscoverKustomizePaths         []string
 	ChangedOnly                    bool
 	StrictChangedOnly              bool
@@ -150,11 +153,15 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	if err != nil {
 		return DiffResult{Diagnostics: diagnostics}, err
 	}
+	leftBuildRequest.renderCache = leftList.renderCache
+	leftBuildRequest.renderSettingsSignature = leftList.renderSettingsSignature
 	rightList, err := o.ListApplications(ctx, rightBuildRequest)
 	diagnostics = append(diagnostics, rightList.Diagnostics...)
 	if err != nil {
 		return DiffResult{Diagnostics: diagnostics}, err
 	}
+	rightBuildRequest.renderCache = rightList.renderCache
+	rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
 
 	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.Applications, name)
 	if err != nil {
@@ -378,6 +385,9 @@ func (request DiffRequest) buildRequest(path string, forbiddenRoots []string) Bu
 	return BuildRequest{
 		Path:                           path,
 		Strict:                         request.Strict,
+		DiscoveryMode:                  request.DiscoveryMode,
+		MaxDiscoveryDepth:              request.MaxDiscoveryDepth,
+		MaxDiscoveryDepthSet:           request.MaxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), request.DiscoverKustomizePaths...),
 		Offline:                        request.Offline,
 		RefreshCharts:                  request.RefreshCharts,
@@ -471,11 +481,15 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 		if err != nil {
 			return BuildResult{}, BuildResult{}, diagnostics, err
 		}
+		leftBuildRequest.renderCache = leftList.renderCache
+		leftBuildRequest.renderSettingsSignature = leftList.renderSettingsSignature
 		rightList, err := o.ListApplications(ctx, rightBuildRequest)
 		diagnostics = append(diagnostics, rightList.Diagnostics...)
 		if err != nil {
 			return BuildResult{}, BuildResult{}, diagnostics, err
 		}
+		rightBuildRequest.renderCache = rightList.renderCache
+		rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
 
 		changedPaths := request.changedPaths
 		if changedPaths == nil {

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -2,12 +2,17 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/acquisition"
+	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
@@ -18,15 +23,78 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (o Orchestrator) discoverRepository(ctx context.Context, root string, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+func (o Orchestrator) discoverRepository(ctx context.Context, root string, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, *applicationRenderCache, string, error) {
+	mode, err := normalizeDiscoveryMode(request.DiscoveryMode)
+	if err != nil {
+		return discovery.Result{}, nil, nil, nil, "", err
+	}
+	maxDepth, err := normalizeMaxDiscoveryDepth(request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	if err != nil {
+		return discovery.Result{}, nil, nil, nil, "", err
+	}
+	renderCache := request.renderCache
+	if renderCache == nil {
+		renderCache = newApplicationRenderCache()
+	}
+
 	discovered, err := discovery.Scan(root, discovery.Options{})
 	if err != nil {
-		return discovery.Result{}, nil, nil, err
+		return discovery.Result{}, nil, nil, renderCache, "", err
 	}
+	markDiscoveryTier(&discovered, discovery.SourceTierStatic, nil)
+
+	appsetOptions, providerDiags, err := applicationSetOptionsForRequest(request)
+	if err != nil {
+		return discovered, providerDiags, nil, renderCache, "", diagnosticsError(providerDiags, err)
+	}
+	var allDiags []diagnostic.Diagnostic
+	allDiags = append(allDiags, providerDiags...)
+	var allEvents []cacheevent.Event
+
+	discovered, explicitDiags, explicitEvents, err := o.applyExplicitKustomizeDiscovery(ctx, root, request, discovered)
+	allDiags = append(allDiags, explicitDiags...)
+	allEvents = append(allEvents, explicitEvents...)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+
+	var expansionDiags []diagnostic.Diagnostic
+	discovered, expansionDiags, err = expandApplicationSetDiscovery(root, request, discovered, appsetOptions)
+	allDiags = append(allDiags, expansionDiags...)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+
+	settings, _, err := loadSettingsFromDiscovery(root, discovered)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+	settingsSig, err := settingsSignature(settings)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+	renderSig, err := renderSettingsSignature(settings)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+	if mode == DiscoveryModeFleet && maxDepth > 0 {
+		rendered, _, nextRenderSig, diags, events, err := o.discoverRenderedFleet(ctx, root, request, discovered, appsetOptions, renderCache, maxDepth, settingsSig, renderSig)
+		allDiags = append(allDiags, diags...)
+		allEvents = append(allEvents, events...)
+		if err != nil {
+			return rendered, dedupeDiagnostics(allDiags), allEvents, renderCache, nextRenderSig, err
+		}
+		discovered = rendered
+		renderSig = nextRenderSig
+	}
+
+	return discovered, dedupeDiagnostics(allDiags), allEvents, renderCache, renderSig, nil
+}
+
+func (o Orchestrator) applyExplicitKustomizeDiscovery(ctx context.Context, root string, request BuildRequest, discovered discovery.Result) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
 	if len(request.DiscoverKustomizePaths) == 0 {
 		return discovered, nil, nil, nil
 	}
-
 	settings, _, err := loadSettingsFromDiscovery(root, discovered)
 	if err != nil {
 		return discovered, nil, nil, err
@@ -35,7 +103,9 @@ func (o Orchestrator) discoverRepository(ctx context.Context, root string, reque
 	if err != nil {
 		return discovered, diags, events, err
 	}
-	return mergeDiscoveryResults(discovered, rendered), diags, events, nil
+	next, mergeDiags := mergeDiscoveryResultsWithDiagnostics(discovered, rendered)
+	diags = append(diags, mergeDiags...)
+	return next, diags, events, nil
 }
 
 func (o Orchestrator) discoverRenderedKustomize(ctx context.Context, root string, settings config.ArgoSettings, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
@@ -72,9 +142,476 @@ func (o Orchestrator) discoverRenderedKustomize(ctx context.Context, root string
 		if err != nil {
 			return out, allDiags, recorder.Events(), fmt.Errorf("discover kustomize %q: %w", displayPath, err)
 		}
-		out = mergeDiscoveryResults(out, next)
+		markDiscoveryTier(&next, discovery.SourceTierExplicitRendered, []string{displayPath})
+		var mergeDiags []diagnostic.Diagnostic
+		out, mergeDiags = mergeDiscoveryResultsWithDiagnostics(out, next)
+		allDiags = append(allDiags, mergeDiags...)
 	}
 	return out, allDiags, recorder.Events(), nil
+}
+
+func (o Orchestrator) discoverRenderedFleet(ctx context.Context, root string, request BuildRequest, start discovery.Result, appsetOptions appset.Options, renderCache *applicationRenderCache, maxDepth int, initialSettingsSignature string, initialRenderSettingsSignature string) (discovery.Result, string, string, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+	current := start
+	settingsSig := initialSettingsSignature
+	renderSig := initialRenderSettingsSignature
+	var allDiags []diagnostic.Diagnostic
+	var allEvents []cacheevent.Event
+
+	for depth := 1; depth <= maxDepth; depth++ {
+		settings, _, err := loadSettingsFromDiscovery(root, current)
+		if err != nil {
+			return current, settingsSig, renderSig, allDiags, allEvents, err
+		}
+		settingsSig, err = settingsSignature(settings)
+		if err != nil {
+			return current, settingsSig, renderSig, allDiags, allEvents, err
+		}
+		renderSig, err = renderSettingsSignature(settings)
+		if err != nil {
+			return current, settingsSig, renderSig, allDiags, allEvents, err
+		}
+		before, err := discoveryFingerprint(current, settingsSig)
+		if err != nil {
+			return current, settingsSig, renderSig, allDiags, allEvents, err
+		}
+
+		rendered, diags, events, err := o.renderDiscoveryFrontier(ctx, root, request, current, settings, renderSig, renderCache)
+		allDiags = append(allDiags, diags...)
+		allEvents = append(allEvents, events...)
+		if err != nil {
+			return current, settingsSig, renderSig, allDiags, allEvents, err
+		}
+
+		next, mergeDiags := mergeDiscoveryResultsWithDiagnostics(current, rendered)
+		allDiags = append(allDiags, mergeDiags...)
+		var expansionDiags []diagnostic.Diagnostic
+		next, expansionDiags, err = expandApplicationSetDiscovery(root, request, next, appsetOptions)
+		allDiags = append(allDiags, expansionDiags...)
+		if err != nil {
+			return next, settingsSig, renderSig, allDiags, allEvents, err
+		}
+
+		nextSettings, _, err := loadSettingsFromDiscovery(root, next)
+		if err != nil {
+			return next, settingsSig, renderSig, allDiags, allEvents, err
+		}
+		nextSig, err := settingsSignature(nextSettings)
+		if err != nil {
+			return next, settingsSig, renderSig, allDiags, allEvents, err
+		}
+		nextRenderSig, err := renderSettingsSignature(nextSettings)
+		if err != nil {
+			return next, nextSig, renderSig, allDiags, allEvents, err
+		}
+		after, err := discoveryFingerprint(next, nextSig)
+		if err != nil {
+			return next, nextSig, nextRenderSig, allDiags, allEvents, err
+		}
+		if after == before {
+			return next, nextSig, nextRenderSig, allDiags, allEvents, nil
+		}
+		if depth == maxDepth {
+			diag := discoveryDepthExceededDiagnostic(maxDepth)
+			allDiags = append(allDiags, diag)
+			return next, nextSig, nextRenderSig, allDiags, allEvents, errors.New(diag.Message)
+		}
+		current = next
+		settingsSig = nextSig
+		renderSig = nextRenderSig
+	}
+	return current, settingsSig, renderSig, allDiags, allEvents, nil
+}
+
+func (o Orchestrator) renderDiscoveryFrontier(ctx context.Context, root string, request BuildRequest, discovered discovery.Result, settings config.ArgoSettings, settingsSig string, renderCache *applicationRenderCache) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
+	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	if err != nil {
+		return discovery.Result{}, nil, recorder.Events(), err
+	}
+	defer cleanup()
+
+	inputs := applicationInputsByKey(discovered)
+	parallelism, err := normalizeParallelism(request.Parallelism)
+	if err != nil {
+		return discovery.Result{}, nil, recorder.Events(), err
+	}
+	if parallelism > 1 && len(discovered.Applications) > 1 {
+		out, diags, err := renderDiscoveryFrontierParallel(ctx, root, request, discovered, inputs, provider, settingsSig, renderCache, parallelism)
+		return out, diags, recorder.Events(), err
+	}
+
+	var out discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, appFile := range discovered.Applications {
+		next, scanDiags, err := renderDiscoveryApplication(ctx, root, request, provider, settingsSig, renderCache, inputs, discovered, appFile)
+		allDiags = append(allDiags, scanDiags...)
+		if err != nil {
+			return out, allDiags, recorder.Events(), err
+		}
+		var mergeDiags []diagnostic.Diagnostic
+		out, mergeDiags = mergeDiscoveryResultsWithDiagnostics(out, next)
+		allDiags = append(allDiags, mergeDiags...)
+	}
+	return out, allDiags, recorder.Events(), nil
+}
+
+type indexedDiscoveryRenderResult struct {
+	index  int
+	result discovery.Result
+	diags  []diagnostic.Diagnostic
+	err    error
+}
+
+func renderDiscoveryFrontierParallel(ctx context.Context, root string, request BuildRequest, discovered discovery.Result, inputs map[string][]string, provider localProvider, settingsSig string, renderCache *applicationRenderCache, parallelism int) (discovery.Result, []diagnostic.Diagnostic, error) {
+	applications := discovered.Applications
+	workerCount := parallelism
+	if workerCount > len(applications) {
+		workerCount = len(applications)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan int)
+	resultsCh := make(chan indexedDiscoveryRenderResult, len(applications))
+	results := make([]indexedDiscoveryRenderResult, len(applications))
+	var wg sync.WaitGroup
+	for range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				result, diags, err := renderDiscoveryApplication(ctx, root, request, provider, settingsSig, renderCache, inputs, discovered, applications[index])
+				resultsCh <- indexedDiscoveryRenderResult{index: index, result: result, diags: diags, err: err}
+			}
+		}()
+	}
+
+	scheduleErrCh := make(chan error, 1)
+	go func() {
+		defer close(jobs)
+		for index := range applications {
+			select {
+			case <-ctx.Done():
+				scheduleErrCh <- ctx.Err()
+				return
+			case jobs <- index:
+			}
+		}
+		scheduleErrCh <- nil
+	}()
+
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	for indexed := range resultsCh {
+		results[indexed.index] = indexed
+		if indexed.err != nil {
+			cancel()
+		}
+	}
+	if scheduleErr := <-scheduleErrCh; scheduleErr != nil {
+		return discovery.Result{}, nil, scheduleErr
+	}
+
+	var out discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, result := range results {
+		allDiags = append(allDiags, result.diags...)
+		if result.err != nil {
+			return out, allDiags, result.err
+		}
+		var mergeDiags []diagnostic.Diagnostic
+		out, mergeDiags = mergeDiscoveryResultsWithDiagnostics(out, result.result)
+		allDiags = append(allDiags, mergeDiags...)
+	}
+	return out, allDiags, nil
+}
+
+func renderDiscoveryApplication(ctx context.Context, root string, request BuildRequest, provider localProvider, settingsSig string, renderCache *applicationRenderCache, inputs map[string][]string, discovered discovery.Result, appFile discovery.ApplicationFile) (discovery.Result, []diagnostic.Diagnostic, error) {
+	application := appFile.Application
+	if !applicationMayRenderDiscoveryObjects(root, request, discovered, application) {
+		return discovery.Result{}, nil, nil
+	}
+	rendered, err := renderApplicationCached(renderContext{
+		context:           ctx,
+		provider:          provider,
+		cache:             renderCache,
+		settingsSignature: settingsSig,
+		request:           request,
+	}, application)
+	if err != nil {
+		return skippedRenderedDiscovery()
+	}
+	parentInputs := inputs[applicationDiscoveryKey(application)]
+	return scanRenderedApplicationObjects(application, parentInputs, rendered.Manifests)
+}
+
+func skippedRenderedDiscovery() (discovery.Result, []diagnostic.Diagnostic, error) {
+	return discovery.Result{}, nil, nil
+}
+
+func scanRenderedApplicationObjects(parent argoappv1.Application, parentInputs []string, manifests []render.Manifest) (discovery.Result, []diagnostic.Diagnostic, error) {
+	var out discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, renderedManifest := range manifests {
+		if renderedManifest.Object == nil {
+			continue
+		}
+		displayPath := renderedObjectDiscoveryPath(parent, renderedManifest)
+		next, err := discovery.ScanObjects(displayPath, []*unstructured.Unstructured{renderedManifest.Object.DeepCopy()})
+		if err != nil {
+			return out, allDiags, fmt.Errorf("discover rendered Application %s output %q: %w", applicationDisplayName(parent), displayPath, err)
+		}
+		markDiscoveryTier(&next, discovery.SourceTierRenderedFleet, renderedInputPaths(parentInputs, renderedManifest))
+		var mergeDiags []diagnostic.Diagnostic
+		out, mergeDiags = mergeDiscoveryResultsWithDiagnostics(out, next)
+		allDiags = append(allDiags, mergeDiags...)
+	}
+	return out, allDiags, nil
+}
+
+func applicationMayRenderDiscoveryObjects(root string, request BuildRequest, discovered discovery.Result, application argoappv1.Application) bool {
+	plan, err := Plan(application)
+	if err != nil {
+		return true
+	}
+	for _, sourcePlan := range plan.Sources {
+		if sourcePlan.RefOnly {
+			continue
+		}
+		if sourcePlan.Source.Chart != "" && sourcePlan.Source.Path == "" {
+			continue
+		}
+		sourceRoot, ok := localDiscoverySourceRoot(root, request, sourcePlan.Source)
+		if !ok {
+			continue
+		}
+		matches, err := pathMayContainDiscoveryObjects(sourceRoot)
+		if err != nil || matches {
+			if localSourceAlreadyDiscovered(root, sourceRoot, discovered) && !sourceRootHasLocalChart(sourceRoot) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func localDiscoverySourceRoot(root string, request BuildRequest, source argoappv1.ApplicationSource) (string, bool) {
+	repoRoot := root
+	if mapped, ok := mappedRepositoryPath(request, source.RepoURL); ok {
+		repoRoot = mapped
+	}
+	sourcePath := source.Path
+	if strings.TrimSpace(sourcePath) == "" {
+		return repoRoot, true
+	}
+	clean, err := cleanLocalSourcePath(sourcePath)
+	if err != nil {
+		return "", false
+	}
+	path := filepath.Join(repoRoot, clean)
+	exists, err := localPathExists(path)
+	if err != nil || !exists {
+		return "", false
+	}
+	return path, true
+}
+
+func mappedRepositoryPath(request BuildRequest, repoURL string) (string, bool) {
+	normalized := sourcepkg.NormalizeURL(repoURL)
+	for _, repoMap := range request.RepoMaps {
+		if sourcepkg.NormalizeURL(repoMap.URL) == normalized {
+			return repoMap.Path, true
+		}
+	}
+	return "", false
+}
+
+func pathMayContainDiscoveryObjects(root string) (bool, error) {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+	if !info.IsDir() {
+		return fileMayContainDiscoveryObjects(root)
+	}
+	found := false
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if found {
+			return filepath.SkipAll
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			if path != root && shouldSkipDiscoveryCandidateDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		matches, err := fileMayContainDiscoveryObjects(path)
+		if err != nil {
+			return err
+		}
+		found = matches
+		return nil
+	})
+	return found, err
+}
+
+func fileMayContainDiscoveryObjects(path string) (bool, error) {
+	if !isDiscoveryCandidateYAML(path) {
+		return false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return textMayContainDiscoveryObjects(string(data)), nil
+}
+
+func textMayContainDiscoveryObjects(text string) bool {
+	return strings.Contains(text, "kind: Application") ||
+		strings.Contains(text, "kind: ApplicationSet") ||
+		strings.Contains(text, "kind: AppProject") ||
+		strings.Contains(text, "argocd-cm") ||
+		strings.Contains(text, "argocd-cmp-cm") ||
+		strings.Contains(text, "argocd.argoproj.io/secret-type")
+}
+
+func localSourceAlreadyDiscovered(root, sourceRoot string, discovered discovery.Result) bool {
+	rel, err := filepath.Rel(root, sourceRoot)
+	if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		return false
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." {
+		rel = ""
+	}
+	return discoveryHasPathUnder(discovered, rel)
+}
+
+func discoveryHasPathUnder(discovered discovery.Result, root string) bool {
+	for _, item := range discovered.Applications {
+		if pathUnderRoot(item.Path, root) {
+			return true
+		}
+	}
+	for _, item := range discovered.ApplicationSets {
+		if pathUnderRoot(item.Path, root) {
+			return true
+		}
+	}
+	for _, item := range discovered.Projects {
+		if pathUnderRoot(item.Path, root) {
+			return true
+		}
+	}
+	for _, item := range discovered.SettingsCandidates {
+		if pathUnderRoot(item.Path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathUnderRoot(pathValue, root string) bool {
+	pathValue = filepath.ToSlash(filepath.Clean(pathValue))
+	root = filepath.ToSlash(filepath.Clean(root))
+	if root == "." || root == "" {
+		return pathValue != "." && pathValue != ""
+	}
+	return pathValue == root || strings.HasPrefix(pathValue, root+"/")
+}
+
+func sourceRootHasLocalChart(root string) bool {
+	exists, err := localPathExists(filepath.Join(root, "Chart.yaml"))
+	return err == nil && exists
+}
+
+func shouldSkipDiscoveryCandidateDir(name string) bool {
+	return name == ".git" || name == ".out" || strings.HasPrefix(name, ".cache")
+}
+
+func isDiscoveryCandidateYAML(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+func renderedObjectDiscoveryPath(parent argoappv1.Application, renderedManifest render.Manifest) string {
+	base := filepath.ToSlash(filepath.Join("rendered", applicationDisplayName(parent)))
+	if renderedManifest.Path == "" {
+		return base
+	}
+	return filepath.ToSlash(filepath.Join(base, renderedManifest.Path))
+}
+
+func renderedInputPaths(parentInputs []string, renderedManifest render.Manifest) []string {
+	inputs := append([]string(nil), parentInputs...)
+	if renderedManifest.Path != "" {
+		inputs = append(inputs, filepath.ToSlash(renderedManifest.Path))
+	}
+	return uniqueStrings(inputs)
+}
+
+func applicationInputsByKey(discovered discovery.Result) map[string][]string {
+	out := make(map[string][]string, len(discovered.Applications))
+	for _, appFile := range discovered.Applications {
+		inputs := discoveredApplicationInputPaths(appFile)
+		inputs = applicationSelectionPaths(ApplicationSelectionInput{Application: appFile.Application, Paths: inputs})
+		out[applicationDiscoveryKey(appFile.Application)] = uniqueStrings(inputs)
+	}
+	return out
+}
+
+func expandApplicationSetDiscovery(root string, request BuildRequest, discovered discovery.Result, appsetOptions appset.Options) (discovery.Result, []diagnostic.Diagnostic, error) {
+	var generated discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, appSetFile := range discovered.ApplicationSets {
+		apps, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
+		if err != nil {
+			if errors.Is(err, appset.ErrUnsupportedGenerator) && len(diags) > 0 {
+				allDiags = append(allDiags, normalizeDiagnostics(diags, request.Strict, true)...)
+				continue
+			}
+			allDiags = append(allDiags, diags...)
+			return discovered, allDiags, diagnosticsError(diags, err)
+		}
+		allDiags = append(allDiags, normalizeDiagnostics(diags, request.Strict, false)...)
+		if len(apps) == 0 {
+			if len(diags) != 0 {
+				continue
+			}
+			diags := normalizeDiagnostics([]diagnostic.Diagnostic{emptyApplicationSetDiagnostic(appSetFile)}, request.Strict, false)
+			allDiags = append(allDiags, diags...)
+			if err := diagnosticFailure(diags, request.Strict); err != nil {
+				return discovered, allDiags, err
+			}
+			continue
+		}
+		for _, app := range apps {
+			generated.Applications = append(generated.Applications, discovery.ApplicationFile{
+				Path:          appSetFile.Path,
+				DocumentIndex: appSetFile.DocumentIndex,
+				Application:   app.Application,
+				Tier:          appSetFile.Tier,
+				InputPaths:    generatedApplicationInputPaths(appSetFile, app),
+			})
+		}
+	}
+	merged, mergeDiags := mergeDiscoveryResultsWithDiagnostics(discovered, generated)
+	allDiags = append(allDiags, mergeDiags...)
+	return merged, allDiags, nil
 }
 
 func (o Orchestrator) discoveryProvider(root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder) (localProvider, func(), error) {
@@ -161,83 +698,406 @@ func manifestObjects(manifests []render.Manifest) []*unstructured.Unstructured {
 	return objects
 }
 
-func mergeDiscoveryResults(base, overlay discovery.Result) discovery.Result {
-	out := base
-	out.Applications = mergeApplications(out.Applications, overlay.Applications)
-	out.ApplicationSets = mergeApplicationSets(out.ApplicationSets, overlay.ApplicationSets)
-	out.Projects = mergeProjects(out.Projects, overlay.Projects)
-	out.SettingsCandidates = mergeSettingsCandidates(out.SettingsCandidates, overlay.SettingsCandidates)
-	return out
+func markDiscoveryTier(result *discovery.Result, tier discovery.SourceTier, inputPaths []string) {
+	for i := range result.Applications {
+		result.Applications[i].Tier = tier
+		result.Applications[i].InputPaths = fallbackInputPaths(result.Applications[i].InputPaths, inputPaths, result.Applications[i].Path)
+	}
+	for i := range result.ApplicationSets {
+		result.ApplicationSets[i].Tier = tier
+		result.ApplicationSets[i].InputPaths = fallbackInputPaths(result.ApplicationSets[i].InputPaths, inputPaths, result.ApplicationSets[i].Path)
+	}
+	for i := range result.Projects {
+		result.Projects[i].Tier = tier
+	}
+	for i := range result.SettingsCandidates {
+		result.SettingsCandidates[i].Tier = tier
+	}
 }
 
-func mergeApplications(base, overlay []discovery.ApplicationFile) []discovery.ApplicationFile {
+func fallbackInputPaths(existing, fallback []string, path string) []string {
+	if len(fallback) != 0 {
+		return uniqueStrings(fallback)
+	}
+	if len(existing) != 0 {
+		return uniqueStrings(existing)
+	}
+	if path == "" {
+		return nil
+	}
+	return []string{filepath.ToSlash(path)}
+}
+
+func mergeDiscoveryResultsWithDiagnostics(base, overlay discovery.Result) (discovery.Result, []diagnostic.Diagnostic) {
+	out := base
+	diags := make([]diagnostic.Diagnostic, 0, len(overlay.Applications)+len(overlay.ApplicationSets)+len(overlay.Projects)+len(overlay.SettingsCandidates))
+	var next []diagnostic.Diagnostic
+	out.Applications, next = mergeApplications(out.Applications, overlay.Applications)
+	diags = append(diags, next...)
+	out.ApplicationSets, next = mergeApplicationSets(out.ApplicationSets, overlay.ApplicationSets)
+	diags = append(diags, next...)
+	out.Projects, next = mergeProjects(out.Projects, overlay.Projects)
+	diags = append(diags, next...)
+	out.SettingsCandidates, next = mergeSettingsCandidates(out.SettingsCandidates, overlay.SettingsCandidates)
+	diags = append(diags, next...)
+	return out, diags
+}
+
+func mergeApplications(base, overlay []discovery.ApplicationFile) ([]discovery.ApplicationFile, []diagnostic.Diagnostic) {
 	out := append([]discovery.ApplicationFile(nil), base...)
 	indexes := make(map[string]int, len(out))
+	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
 	for i, item := range out {
-		indexes[applicationDiscoveryKey(item.Application)] = i
+		addDiscoveryIndex(indexes, looseIndexes, applicationDiscoveryKey(item.Application), i)
 	}
+	var diags []diagnostic.Diagnostic
 	for _, item := range overlay {
 		key := applicationDiscoveryKey(item.Application)
 		if index, ok := indexes[key]; ok {
-			out[index] = item
+			if sameApplicationDiscoveryObject(out[index], item) {
+				continue
+			}
+			replacement, diag := resolveDiscoveryConflict("Application", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				out[index] = item
+			}
 			continue
 		}
-		indexes[key] = len(out)
+		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
+			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("Application", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				delete(indexes, existingKey)
+				removeDiscoveryLooseIndex(looseIndexes, existingKey)
+				out[index] = item
+				addDiscoveryIndex(indexes, looseIndexes, key, index)
+			}
+			continue
+		}
+		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
 		out = append(out, item)
 	}
-	return out
+	return out, diags
 }
 
-func mergeApplicationSets(base, overlay []discovery.ApplicationSetFile) []discovery.ApplicationSetFile {
+func mergeApplicationSets(base, overlay []discovery.ApplicationSetFile) ([]discovery.ApplicationSetFile, []diagnostic.Diagnostic) {
 	out := append([]discovery.ApplicationSetFile(nil), base...)
 	indexes := make(map[string]int, len(out))
+	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
 	for i, item := range out {
-		indexes[applicationSetDiscoveryKey(item.ApplicationSet)] = i
+		addDiscoveryIndex(indexes, looseIndexes, applicationSetDiscoveryKey(item.ApplicationSet), i)
 	}
+	var diags []diagnostic.Diagnostic
 	for _, item := range overlay {
 		key := applicationSetDiscoveryKey(item.ApplicationSet)
 		if index, ok := indexes[key]; ok {
-			out[index] = item
+			if sameApplicationSetDiscoveryObject(out[index], item) {
+				continue
+			}
+			replacement, diag := resolveDiscoveryConflict("ApplicationSet", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				out[index] = item
+			}
 			continue
 		}
-		indexes[key] = len(out)
+		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
+			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("ApplicationSet", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				delete(indexes, existingKey)
+				removeDiscoveryLooseIndex(looseIndexes, existingKey)
+				out[index] = item
+				addDiscoveryIndex(indexes, looseIndexes, key, index)
+			}
+			continue
+		}
+		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
 		out = append(out, item)
 	}
-	return out
+	return out, diags
 }
 
-func mergeProjects(base, overlay []discovery.ProjectFile) []discovery.ProjectFile {
+func mergeProjects(base, overlay []discovery.ProjectFile) ([]discovery.ProjectFile, []diagnostic.Diagnostic) {
 	out := append([]discovery.ProjectFile(nil), base...)
 	indexes := make(map[string]int, len(out))
+	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
 	for i, item := range out {
-		indexes[projectDiscoveryKey(item.Project)] = i
+		addDiscoveryIndex(indexes, looseIndexes, projectDiscoveryKey(item.Project), i)
 	}
+	var diags []diagnostic.Diagnostic
 	for _, item := range overlay {
 		key := projectDiscoveryKey(item.Project)
 		if index, ok := indexes[key]; ok {
-			out[index] = item
+			if sameProjectDiscoveryObject(out[index], item) {
+				continue
+			}
+			replacement, diag := resolveDiscoveryConflict("AppProject", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				out[index] = item
+			}
 			continue
 		}
-		indexes[key] = len(out)
+		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
+			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("AppProject", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				delete(indexes, existingKey)
+				removeDiscoveryLooseIndex(looseIndexes, existingKey)
+				out[index] = item
+				addDiscoveryIndex(indexes, looseIndexes, key, index)
+			}
+			continue
+		}
+		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
 		out = append(out, item)
+	}
+	return out, diags
+}
+
+func mergeSettingsCandidates(base, overlay []discovery.SettingsCandidate) ([]discovery.SettingsCandidate, []diagnostic.Diagnostic) {
+	out := append([]discovery.SettingsCandidate(nil), base...)
+	indexes := make(map[string]int, len(out))
+	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
+	for i, item := range out {
+		addDiscoveryIndex(indexes, looseIndexes, settingsDiscoveryKey(item), i)
+	}
+	var diags []diagnostic.Diagnostic
+	for _, item := range overlay {
+		key := settingsDiscoveryKey(item)
+		if index, ok := indexes[key]; ok {
+			if sameSettingsDiscoveryObject(out[index], item) {
+				continue
+			}
+			replacement, diag := resolveDiscoveryConflict(settingsObjectKind(item.Kind), key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				out[index] = item
+			}
+			continue
+		}
+		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
+			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict(settingsObjectKind(item.Kind), existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			if diag != nil {
+				diags = append(diags, *diag)
+			}
+			if replacement {
+				delete(indexes, existingKey)
+				removeDiscoveryLooseIndex(looseIndexes, existingKey)
+				out[index] = item
+				addDiscoveryIndex(indexes, looseIndexes, key, index)
+			}
+			continue
+		}
+		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
+		out = append(out, item)
+	}
+	return out, diags
+}
+
+type discoveryLooseIndex struct {
+	key       string
+	index     int
+	ambiguous bool
+}
+
+func addDiscoveryIndex(indexes map[string]int, looseIndexes map[string]discoveryLooseIndex, key string, index int) {
+	indexes[key] = index
+	looseKey, ok := looseDiscoveryKey(key)
+	if !ok {
+		return
+	}
+	if existing, ok := looseIndexes[looseKey]; ok && existing.key != key {
+		looseIndexes[looseKey] = discoveryLooseIndex{ambiguous: true}
+		return
+	}
+	looseIndexes[looseKey] = discoveryLooseIndex{key: key, index: index}
+}
+
+func removeDiscoveryLooseIndex(looseIndexes map[string]discoveryLooseIndex, key string) {
+	looseKey, ok := looseDiscoveryKey(key)
+	if !ok {
+		return
+	}
+	existing, ok := looseIndexes[looseKey]
+	if ok && existing.key == key && !existing.ambiguous {
+		delete(looseIndexes, looseKey)
+	}
+}
+
+func namespaceDefaultedConflict(indexes map[string]int, looseIndexes map[string]discoveryLooseIndex, key string) (int, string, bool) {
+	if _, ok := indexes[key]; ok {
+		return 0, "", false
+	}
+	looseKey, ok := looseDiscoveryKey(key)
+	if !ok {
+		return 0, "", false
+	}
+	existing, ok := looseIndexes[looseKey]
+	if !ok || existing.ambiguous {
+		return 0, "", false
+	}
+	existingNamespace, ok := discoveryKeyNamespace(existing.key)
+	if !ok {
+		return 0, "", false
+	}
+	incomingNamespace, ok := discoveryKeyNamespace(key)
+	if !ok || existingNamespace == incomingNamespace {
+		return 0, "", false
+	}
+	if existingNamespace == "" || incomingNamespace == "" {
+		return existing.index, existing.key, true
+	}
+	return 0, "", false
+}
+
+func looseDiscoveryKey(key string) (string, bool) {
+	parts := strings.Split(key, "\x00")
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return "", false
+	}
+	return parts[0] + "\x00" + parts[1] + "\x00" + parts[3], true
+}
+
+func discoveryKeyNamespace(key string) (string, bool) {
+	parts := strings.Split(key, "\x00")
+	if len(parts) != 4 {
+		return "", false
+	}
+	return parts[2], true
+}
+
+func resolveDiscoveryConflict(kind, key string, existingTier discovery.SourceTier, existingPath string, existingDocument int, incomingTier discovery.SourceTier, incomingPath string, incomingDocument int) (bool, *diagnostic.Diagnostic) {
+	if existingTier == incomingTier && existingPath == incomingPath && existingDocument == incomingDocument {
+		return true, nil
+	}
+	replace := incomingTier < existingTier
+	winnerPath := existingPath
+	ignoredPath := incomingPath
+	if replace {
+		winnerPath = incomingPath
+		ignoredPath = existingPath
+	}
+	message := fmt.Sprintf("duplicate %s %s from %s ignored; %s takes precedence", kind, displayDiscoveryKey(key), ignoredPath, winnerPath)
+	diag := diagnostic.Diagnostic{
+		Severity: diagnostic.SeverityWarning,
+		Category: "discovery",
+		Message:  message,
+		Provenance: diagnostic.Provenance{
+			Path: ignoredPath,
+		},
+	}
+	diag.Code = diagnostic.StableCode(diag)
+	return replace, &diag
+}
+
+func resolveNamespaceDefaultedDiscoveryConflict(kind, existingKey, incomingKey string, existingTier discovery.SourceTier, existingPath string, existingDocument int, incomingTier discovery.SourceTier, incomingPath string, incomingDocument int) (bool, *diagnostic.Diagnostic) {
+	existingNamespace, existingOK := discoveryKeyNamespace(existingKey)
+	incomingNamespace, incomingOK := discoveryKeyNamespace(incomingKey)
+	if !existingOK || !incomingOK || existingNamespace == incomingNamespace || (existingNamespace != "" && incomingNamespace != "") {
+		return resolveDiscoveryConflict(kind, incomingKey, existingTier, existingPath, existingDocument, incomingTier, incomingPath, incomingDocument)
+	}
+	replace := incomingNamespace != ""
+	return replace, nil
+}
+
+func sameApplicationDiscoveryObject(left, right discovery.ApplicationFile) bool {
+	return reflect.DeepEqual(left.Application, right.Application)
+}
+
+func sameApplicationSetDiscoveryObject(left, right discovery.ApplicationSetFile) bool {
+	return reflect.DeepEqual(left.ApplicationSet, right.ApplicationSet)
+}
+
+func sameProjectDiscoveryObject(left, right discovery.ProjectFile) bool {
+	return reflect.DeepEqual(left.Project, right.Project)
+}
+
+func sameSettingsDiscoveryObject(left, right discovery.SettingsCandidate) bool {
+	if left.Kind != right.Kind {
+		return false
+	}
+	if left.Object != nil || right.Object != nil {
+		if left.Object == nil || right.Object == nil {
+			return false
+		}
+		return reflect.DeepEqual(left.Object.Object, right.Object.Object)
+	}
+	return left.APIVersion == right.APIVersion &&
+		left.Namespace == right.Namespace &&
+		left.Name == right.Name
+}
+
+func displayDiscoveryKey(key string) string {
+	parts := strings.Split(key, "\x00")
+	if len(parts) < 4 {
+		return key
+	}
+	if parts[2] == "" {
+		return parts[3]
+	}
+	return parts[2] + "/" + parts[3]
+}
+
+func discoveryDepthExceededDiagnostic(maxDepth int) diagnostic.Diagnostic {
+	diag := diagnostic.Diagnostic{
+		Severity: diagnostic.SeverityError,
+		Category: "discovery",
+		Message:  fmt.Sprintf("maximum discovery depth %d reached before rendered Application discovery converged", maxDepth),
+	}
+	diag.Code = diagnostic.StableCode(diag)
+	return diag
+}
+
+func dedupeDiagnostics(input []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]diagnostic.Diagnostic, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, diag := range input {
+		key := fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s", diag.Code, diag.Severity, diag.Category, diag.Message, diag.Provenance.Path, diag.Provenance.Pointer)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, diag)
 	}
 	return out
 }
 
-func mergeSettingsCandidates(base, overlay []discovery.SettingsCandidate) []discovery.SettingsCandidate {
-	out := append([]discovery.SettingsCandidate(nil), base...)
-	indexes := make(map[string]int, len(out))
-	for i, item := range out {
-		indexes[settingsDiscoveryKey(item)] = i
+func uniqueStrings(input []string) []string {
+	if len(input) == 0 {
+		return nil
 	}
-	for _, item := range overlay {
-		key := settingsDiscoveryKey(item)
-		if index, ok := indexes[key]; ok {
-			out[index] = item
+	out := make([]string, 0, len(input))
+	seen := map[string]struct{}{}
+	for _, value := range input {
+		value = filepath.ToSlash(strings.TrimSpace(value))
+		if value == "" {
 			continue
 		}
-		indexes[key] = len(out)
-		out = append(out, item)
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
 	return out
 }

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -987,7 +987,7 @@ func resolveDiscoveryConflict(kind, key string, existingTier discovery.SourceTie
 	if existingTier == incomingTier && existingPath == incomingPath && existingDocument == incomingDocument {
 		return true, nil
 	}
-	replace := incomingTier < existingTier
+	replace := discoveryTierPriority(incomingTier) < discoveryTierPriority(existingTier)
 	winnerPath := existingPath
 	ignoredPath := incomingPath
 	if replace {
@@ -1005,6 +1005,19 @@ func resolveDiscoveryConflict(kind, key string, existingTier discovery.SourceTie
 	}
 	diag.Code = diagnostic.StableCode(diag)
 	return replace, &diag
+}
+
+func discoveryTierPriority(tier discovery.SourceTier) int {
+	switch tier {
+	case discovery.SourceTierExplicitRendered:
+		return 0
+	case discovery.SourceTierStatic:
+		return 1
+	case discovery.SourceTierRenderedFleet:
+		return 2
+	default:
+		return 1
+	}
 }
 
 func resolveNamespaceDefaultedDiscoveryConflict(kind, existingKey, incomingKey string, existingTier discovery.SourceTier, existingPath string, existingDocument int, incomingTier discovery.SourceTier, incomingPath string, incomingDocument int) (bool, *diagnostic.Diagnostic) {

--- a/internal/app/discovery_signature.go
+++ b/internal/app/discovery_signature.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/discovery"
+)
+
+func settingsSignature(settings config.ArgoSettings) (string, error) {
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint Argo CD settings: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func renderSettingsSignature(settings config.ArgoSettings) (string, error) {
+	plugins := make(map[string]renderSettingsPlugin, len(settings.ConfigManagementPlugins))
+	for key, plugin := range settings.ConfigManagementPlugins {
+		plugins[key] = renderSettingsPlugin{
+			Name:            plugin.Name,
+			Version:         plugin.Version,
+			GenerateCommand: append([]string(nil), plugin.GenerateCommand...),
+			GenerateArgs:    append([]string(nil), plugin.GenerateArgs...),
+			HasInit:         plugin.HasInit,
+		}
+	}
+	input := struct {
+		KustomizeBuildOptions   []config.Value[string]                 `json:"kustomizeBuildOptions,omitempty"`
+		HelmRepositories        map[string]config.RepositorySettings   `json:"helmRepositories,omitempty"`
+		ConfigManagementPlugins map[string]renderSettingsPlugin        `json:"configManagementPlugins,omitempty"`
+		ResourceCustomizations  map[string]renderSettingsCustomization `json:"resourceCustomizations,omitempty"`
+	}{
+		KustomizeBuildOptions:   settings.KustomizeBuildOptions,
+		HelmRepositories:        settings.HelmRepositories,
+		ConfigManagementPlugins: plugins,
+		ResourceCustomizations:  renderSettingsCustomizations(settings.ResourceCustomizations),
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint render-affecting Argo CD settings: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type renderSettingsPlugin struct {
+	Name            string   `json:"name,omitempty"`
+	Version         string   `json:"version,omitempty"`
+	GenerateCommand []string `json:"generateCommand,omitempty"`
+	GenerateArgs    []string `json:"generateArgs,omitempty"`
+	HasInit         bool     `json:"hasInit,omitempty"`
+}
+
+type renderSettingsCustomization struct {
+	HasHealthLua    bool   `json:"hasHealthLua,omitempty"`
+	HealthLuaSHA256 string `json:"healthLuaSHA256,omitempty"`
+	HasUseOpenLibs  bool   `json:"hasUseOpenLibs,omitempty"`
+	UseOpenLibs     bool   `json:"useOpenLibs,omitempty"`
+}
+
+func renderSettingsCustomizations(input map[string]config.ResourceCustomization) map[string]renderSettingsCustomization {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make(map[string]renderSettingsCustomization, len(input))
+	for key, value := range input {
+		out[key] = renderSettingsCustomization{
+			HasHealthLua:    value.HasHealthLua,
+			HealthLuaSHA256: value.HealthLuaSHA256,
+			HasUseOpenLibs:  value.HasUseOpenLibs,
+			UseOpenLibs:     value.UseOpenLibs,
+		}
+	}
+	return out
+}
+
+func discoveryFingerprint(result discovery.Result, settingsSig string) (string, error) {
+	parts := []any{
+		settingsSig,
+		discoveryApplicationsFingerprint(result.Applications),
+		discoveryApplicationSetsFingerprint(result.ApplicationSets),
+		discoveryProjectsFingerprint(result.Projects),
+		discoverySettingsFingerprint(result.SettingsCandidates),
+	}
+	data, err := json.Marshal(parts)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint discovery result: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func discoveryApplicationsFingerprint(items []discovery.ApplicationFile) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, objectContentFingerprint(applicationDiscoveryKey(item.Application), item.Application))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func discoveryApplicationSetsFingerprint(items []discovery.ApplicationSetFile) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, objectContentFingerprint(applicationSetDiscoveryKey(item.ApplicationSet), item.ApplicationSet))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func discoveryProjectsFingerprint(items []discovery.ProjectFile) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, objectContentFingerprint(projectDiscoveryKey(item.Project), item.Project))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func discoverySettingsFingerprint(items []discovery.SettingsCandidate) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		key := settingsDiscoveryKey(item)
+		if item.Object != nil {
+			out = append(out, objectContentFingerprint(key, item.Object.Object))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s:%d:%s", key, item.Path, item.DocumentIndex, item.Kind))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func objectContentFingerprint(key string, value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return key + ":[unfingerprintable]"
+	}
+	sum := sha256.Sum256(data)
+	return key + ":" + hex.EncodeToString(sum[:])
+}

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestListApplicationsKeepsStaticObjectsAheadOfRenderedKustomizeDuplicates(t *testing.T) {
+func TestListApplicationsUsesExplicitRenderedKustomizeAheadOfStaticDuplicates(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "argocd", "base", "application.yaml"), `apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -41,9 +41,22 @@ metadata:
 data:
   application.instanceLabelKey: app.kubernetes.io/raw
 `)
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "project.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://github.com/example/raw
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: raw
+`)
 	writeTestFile(t, filepath.Join(root, "argocd", "base", "kustomization.yaml"), `resources:
   - application.yaml
   - argocd-cm.yaml
+  - project.yaml
 `)
 	writeTestFile(t, filepath.Join(root, "argocd", "overlays", "prod", "kustomization.yaml"), `resources:
   - ../../base
@@ -65,6 +78,18 @@ patches:
       - op: replace
         path: /data/application.instanceLabelKey
         value: app.kubernetes.io/rendered
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: AppProject
+      name: demo
+    patch: |-
+      - op: replace
+        path: /spec/sourceRepos/0
+        value: https://github.com/example/rendered
+      - op: replace
+        path: /spec/destinations/0/namespace
+        value: rendered
 `)
 
 	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
@@ -75,16 +100,172 @@ patches:
 		t.Fatalf("ListApplications() error = %v", err)
 	}
 	if len(result.Applications) != 1 {
-		t.Fatalf("Applications = %#v, want one static Application", result.Applications)
+		t.Fatalf("Applications = %#v, want one rendered Application", result.Applications)
 	}
-	if got := result.Applications[0].Spec.Source.Path; got != "apps/raw" {
-		t.Fatalf("Application source path = %q, want static path", got)
+	if got := result.Applications[0].Spec.Source.Path; got != "apps/rendered" {
+		t.Fatalf("Application source path = %q, want rendered path", got)
 	}
-	if got := result.Settings.InstanceLabelKey.Value; got != "app.kubernetes.io/raw" {
-		t.Fatalf("InstanceLabelKey = %q, want static settings", got)
+	if got := result.Settings.InstanceLabelKey.Value; got != "app.kubernetes.io/rendered" {
+		t.Fatalf("InstanceLabelKey = %q, want rendered settings", got)
 	}
-	if len(result.ApplicationInputs) != 1 || len(result.ApplicationInputs[0].Paths) != 1 || result.ApplicationInputs[0].Paths[0] != "argocd/base/application.yaml" {
-		t.Fatalf("ApplicationInputs = %#v, want static discovery path", result.ApplicationInputs)
+	if len(result.Projects) != 1 || len(result.Projects[0].Spec.SourceRepos) != 1 || result.Projects[0].Spec.SourceRepos[0] != "https://github.com/example/rendered" {
+		t.Fatalf("Projects = %#v, want explicit rendered project", result.Projects)
+	}
+	if len(result.ApplicationInputs) != 1 || len(result.ApplicationInputs[0].Paths) != 1 || result.ApplicationInputs[0].Paths[0] != "argocd/overlays/prod" {
+		t.Fatalf("ApplicationInputs = %#v, want explicit rendered discovery path", result.ApplicationInputs)
+	}
+	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); !ok || !strings.Contains(diag.Message, "duplicate Application") {
+		t.Fatalf("Diagnostics = %#v, want duplicate discovery warning", result.Diagnostics)
+	}
+}
+
+func TestExplicitRenderedKustomizeApplicationSetWinsOverStaticBase(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "application-set.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        files:
+          - path: "*/configurations/{{ cluster.name }}/cluster-config.yaml"
+  template:
+    metadata:
+      name: "{{ cluster.name }}-{{ app.name }}"
+      namespace: argocd
+    spec:
+      project: "{{ project.name }}"
+      source:
+        repoURL: "{{ source.repoURL }}"
+        targetRevision: "{{ source.targetRevision }}"
+        path: "{{ source.path }}"
+      destination:
+        server: "{{ destination.server }}"
+        namespace: "{{ destination.namespace }}"
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "kustomization.yaml"), `resources:
+  - application-set.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "overlays", "nuc10-cluster", "kustomization.yaml"), `resources:
+  - ../../base
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: argocd
+    patch: |-
+      - op: replace
+        path: /spec/generators/0/git/files/0/path
+        value: "*/configurations/nuc10-cluster/cluster-config.yaml"
+`)
+	writeTestFile(t, filepath.Join(root, "demo", "configurations", "nuc10-cluster", "cluster-config.yaml"), `cluster:
+  name: nuc10
+app:
+  name: demo
+project:
+  name: homelab
+source:
+  repoURL: https://github.com/example/repo.git
+  targetRevision: main
+  path: demo/overlays/nuc10-cluster
+destination:
+  server: https://kubernetes.default.svc
+  namespace: demo
+`)
+	writeTestFile(t, filepath.Join(root, "demo", "overlays", "nuc10-cluster", "kustomization.yaml"), `resources: []
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:                   root,
+		DiscoverKustomizePaths: []string{"argocd/overlays/nuc10-cluster"},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	names := applicationNames(result.Applications)
+	if strings.Join(names, ",") != "nuc10-demo" {
+		t.Fatalf("Applications = %#v, want generated rendered overlay app", names)
+	}
+	if got := result.Applications[0].Spec.Source.Path; got != "demo/overlays/nuc10-cluster" {
+		t.Fatalf("Application source path = %q, want patched overlay path", got)
+	}
+	for _, diag := range result.Diagnostics {
+		if diag.Category == "appset" && strings.Contains(diag.Message, "generated zero Applications") {
+			t.Fatalf("Diagnostics = %#v, explicit overlay should replace zero-app static base", result.Diagnostics)
+		}
+	}
+}
+
+func TestListApplicationsKeepsStaticObjectsAheadOfRenderedFleetDuplicates(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "bootstrap.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bootstrap
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: bootstrap-chart
+  destination:
+    name: in-cluster
+    namespace: argocd
+`)
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: apps/raw
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "Chart.yaml"), `apiVersion: v2
+name: bootstrap-chart
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: apps/rendered
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "bootstrap,demo" {
+		t.Fatalf("Applications = %#v, want bootstrap and demo", names)
+	}
+	var demo argoappv1.Application
+	for _, application := range result.Applications {
+		if application.Name == "demo" {
+			demo = application
+		}
+	}
+	if got := demo.Spec.GetSource().Path; got != "apps/raw" {
+		t.Fatalf("demo source path = %q, want static committed path", got)
 	}
 	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); !ok || !strings.Contains(diag.Message, "duplicate Application") {
 		t.Fatalf("Diagnostics = %#v, want duplicate discovery warning", result.Diagnostics)

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/discovery"
+	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestListApplicationsDiscoversRenderedKustomizeAndRenderedSettingsWin(t *testing.T) {
+func TestListApplicationsKeepsStaticObjectsAheadOfRenderedKustomizeDuplicates(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "argocd", "base", "application.yaml"), `apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -69,16 +75,288 @@ patches:
 		t.Fatalf("ListApplications() error = %v", err)
 	}
 	if len(result.Applications) != 1 {
-		t.Fatalf("Applications = %#v, want one rendered Application", result.Applications)
+		t.Fatalf("Applications = %#v, want one static Application", result.Applications)
 	}
-	if got := result.Applications[0].Spec.Source.Path; got != "apps/rendered" {
-		t.Fatalf("Application source path = %q, want rendered path", got)
+	if got := result.Applications[0].Spec.Source.Path; got != "apps/raw" {
+		t.Fatalf("Application source path = %q, want static path", got)
 	}
+	if got := result.Settings.InstanceLabelKey.Value; got != "app.kubernetes.io/raw" {
+		t.Fatalf("InstanceLabelKey = %q, want static settings", got)
+	}
+	if len(result.ApplicationInputs) != 1 || len(result.ApplicationInputs[0].Paths) != 1 || result.ApplicationInputs[0].Paths[0] != "argocd/base/application.yaml" {
+		t.Fatalf("ApplicationInputs = %#v, want static discovery path", result.ApplicationInputs)
+	}
+	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); !ok || !strings.Contains(diag.Message, "duplicate Application") {
+		t.Fatalf("Diagnostics = %#v, want duplicate discovery warning", result.Diagnostics)
+	}
+}
+
+func TestListApplicationsDiscoversRenderedFleetApplicationsByDefault(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedFleetFixture(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+
+	names := applicationNames(result.Applications)
+	if strings.Join(names, ",") != "child,root" {
+		t.Fatalf("Applications = %#v, want child and root", names)
+	}
+	inputs, ok := applicationInputPaths(result.ApplicationInputs, "child")
+	if !ok {
+		t.Fatalf("ApplicationInputs = %#v, missing child", result.ApplicationInputs)
+	}
+	for _, want := range []string{"apps/root.yaml", "bootstrap-chart/templates/child.yaml"} {
+		if !containsPath(inputs, want) {
+			t.Fatalf("child inputs = %#v, missing %q", inputs, want)
+		}
+	}
+}
+
+func TestListApplicationsStaticDiscoveryModeDisablesRenderedFleetExpansion(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedFleetFixture(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		DiscoveryMode: DiscoveryModeStatic,
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+
+	names := applicationNames(result.Applications)
+	if strings.Join(names, ",") != "root" {
+		t.Fatalf("Applications = %#v, want only static root", names)
+	}
+}
+
+func TestListApplicationsPrefersRenderedNamespaceOverNamespaceLessApplicationSet(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "overlays", "argocd", "appset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: apps
+spec:
+  generators:
+    - list:
+        elements:
+          - name: demo
+  template:
+    metadata:
+      name: '{{name}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: main
+        path: workloads/{{name}}
+      destination:
+        name: in-cluster
+        namespace: '{{name}}'
+`)
+	writeTestFile(t, filepath.Join(root, "overlays", "argocd", "kustomization.yaml"), `namespace: argocd
+resources:
+  - appset.yaml
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:                   root,
+		DiscoverKustomizePaths: []string{"overlays/argocd"},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "demo" {
+		t.Fatalf("Applications = %#v, want demo", names)
+	}
+	if got := result.Applications[0].Namespace; got != "argocd" {
+		t.Fatalf("Application namespace = %q, want rendered namespace", got)
+	}
+	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); ok && strings.Contains(diag.Message, "duplicate") {
+		t.Fatalf("Diagnostics = %#v, want namespace-defaulted duplicate to stay quiet", result.Diagnostics)
+	}
+}
+
+func TestListApplicationsErrorsWhenRenderedFleetDiscoveryDoesNotConverge(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedFleetFixture(t, root)
+
+	_, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path:              root,
+		MaxDiscoveryDepth: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "maximum discovery depth 1") {
+		t.Fatalf("ListApplications() error = %v, want max discovery depth error", err)
+	}
+}
+
+func TestListApplicationsDiscoversRenderedProjectsAndSettings(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedFleetFixture(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+
 	if got := result.Settings.InstanceLabelKey.Value; got != "app.kubernetes.io/rendered" {
 		t.Fatalf("InstanceLabelKey = %q, want rendered settings", got)
 	}
-	if len(result.ApplicationInputs) != 1 || len(result.ApplicationInputs[0].Paths) != 1 || result.ApplicationInputs[0].Paths[0] != "argocd/overlays/prod" {
-		t.Fatalf("ApplicationInputs = %#v, want rendered discovery path", result.ApplicationInputs)
+	projectNames := make([]string, 0, len(result.Projects))
+	for _, project := range result.Projects {
+		projectNames = append(projectNames, project.Name)
+	}
+	if strings.Join(projectNames, ",") != "rendered" {
+		t.Fatalf("Projects = %#v, want rendered project", projectNames)
+	}
+}
+
+func TestRenderedFleetApplicationInputsIncludeParentAndRenderedPaths(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedFleetFixture(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+
+	selected, unowned := SelectChangedApplicationInputs(result.ApplicationInputs, []string{"workloads/child/cm.yaml"})
+	if len(unowned) != 0 {
+		t.Fatalf("unowned = %#v, want none", unowned)
+	}
+	if names := applicationNames(selected); strings.Join(names, ",") != "child" {
+		t.Fatalf("selected for child source change = %#v, want child", names)
+	}
+
+	selected, unowned = SelectChangedApplicationInputs(result.ApplicationInputs, []string{"bootstrap-chart/templates/child.yaml"})
+	if len(unowned) != 0 {
+		t.Fatalf("unowned = %#v, want none", unowned)
+	}
+	if names := applicationNames(selected); strings.Join(names, ",") != "child,root" {
+		t.Fatalf("selected for rendered child definition change = %#v, want child and root", names)
+	}
+
+	selected, unowned = SelectChangedApplicationInputs(result.ApplicationInputs, []string{"apps/root.yaml"})
+	if len(unowned) != 0 {
+		t.Fatalf("unowned = %#v, want none", unowned)
+	}
+	if names := applicationNames(selected); strings.Join(names, ",") != "child,root" {
+		t.Fatalf("selected for parent change = %#v, want child and root", names)
+	}
+}
+
+func TestBuildReusesRenderedDiscoveryCacheForFinalRender(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "root.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: manifests/root
+    plugin:
+      name: app-of-apps
+  destination:
+    name: in-cluster
+    namespace: argocd
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "root", "marker.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+`)
+	writeTestFile(t, filepath.Join(root, "workloads", "child", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: child
+`)
+
+	var calls int32
+	renderer := internalPluginRendererFunc(func(_ context.Context, _ render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		atomic.AddInt32(&calls, 1)
+		return []render.Manifest{{
+			Path: "templates/child.yaml",
+			Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind":       "Application",
+				"metadata": map[string]any{
+					"name":      "child",
+					"namespace": "argocd",
+				},
+				"spec": map[string]any{
+					"project": "default",
+					"source": map[string]any{
+						"repoURL":        "https://github.com/example/repo",
+						"targetRevision": "main",
+						"path":           "workloads/child",
+					},
+					"destination": map[string]any{
+						"name":      "in-cluster",
+						"namespace": "child",
+					},
+				},
+			}},
+		}}, nil, nil
+	})
+
+	result, err := (Orchestrator{PluginRenderer: renderer}).Build(context.Background(), BuildRequest{
+		Path:        root,
+		Parallelism: 1,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("plugin render calls = %d, want discovery result reused for final render", got)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "child,root" {
+		t.Fatalf("Applications = %#v, want child and root", names)
+	}
+}
+
+func TestApplicationMayRenderDiscoveryObjectsUsesLocalSourcePrefilter(t *testing.T) {
+	root := t.TempDir()
+	leaf := argoappv1.Application{}
+	leaf.Name = "leaf"
+	leaf.Spec.Source = &argoappv1.ApplicationSource{
+		RepoURL:        "https://github.com/example/repo",
+		TargetRevision: "main",
+		Path:           "leaf",
+	}
+	writeTestFile(t, filepath.Join(root, "leaf", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: leaf
+`)
+	if applicationMayRenderDiscoveryObjects(root, BuildRequest{}, discovery.Result{}, leaf) {
+		t.Fatal("leaf Application prefilter = true, want false")
+	}
+
+	appOfApps := argoappv1.Application{}
+	appOfApps.Name = "app-of-apps"
+	appOfApps.Spec.Source = &argoappv1.ApplicationSource{
+		RepoURL:        "https://github.com/example/repo",
+		TargetRevision: "main",
+		Path:           "chart",
+	}
+	writeTestFile(t, filepath.Join(root, "chart", "Chart.yaml"), `apiVersion: v2
+name: app-of-apps
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "chart", "templates", "app.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+`)
+	if !applicationMayRenderDiscoveryObjects(root, BuildRequest{}, discovery.Result{}, appOfApps) {
+		t.Fatal("app-of-apps prefilter = false, want true")
 	}
 }
 
@@ -155,4 +433,98 @@ spec:
         targetRevision: HEAD
         path: apps/{{name}}
 `)
+}
+
+func writeRenderedFleetFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "root.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: bootstrap-chart
+  destination:
+    name: in-cluster
+    namespace: argocd
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "Chart.yaml"), `apiVersion: v2
+name: bootstrap-chart
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "child.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+  namespace: argocd
+spec:
+  project: rendered
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: workloads/child
+  destination:
+    name: in-cluster
+    namespace: child
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "project.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: rendered
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+      name: '*'
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "argocd-cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  application.instanceLabelKey: app.kubernetes.io/rendered
+`)
+	writeTestFile(t, filepath.Join(root, "workloads", "child", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: child
+  namespace: child
+data:
+  source: rendered-fleet
+`)
+}
+
+func applicationNames(applications []argoappv1.Application) []string {
+	names := make([]string, 0, len(applications))
+	for _, application := range applications {
+		names = append(names, application.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func applicationInputPaths(inputs []ApplicationSelectionInput, name string) ([]string, bool) {
+	for _, input := range inputs {
+		if input.Application.Name == name {
+			return input.Paths, true
+		}
+	}
+	return nil, false
+}
+
+func containsPath(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -24,11 +23,21 @@ import (
 	"time"
 )
 
+const (
+	DiscoveryModeFleet  = "fleet"
+	DiscoveryModeStatic = "static"
+
+	DefaultMaxDiscoveryDepth = 4
+)
+
 type BuildRequest struct {
 	Path   string
 	Strict bool
 	// StatusOnly renders Applications for validation without retaining manifests.
 	StatusOnly                     bool
+	DiscoveryMode                  string
+	MaxDiscoveryDepth              int
+	MaxDiscoveryDepthSet           bool
 	DiscoverKustomizePaths         []string
 	ValidateLuaHealth              bool
 	Offline                        bool
@@ -55,6 +64,8 @@ type BuildRequest struct {
 	ApplicationSetProviderData     appset.ProviderData
 	RecordCacheEvents              bool
 	StatusCallback                 ApplicationStatusCallback
+	renderCache                    *applicationRenderCache
+	renderSettingsSignature        string
 }
 
 type BuildAppRequest struct {
@@ -94,15 +105,17 @@ type ApplicationStatusEvent struct {
 type ApplicationStatusCallback func(ApplicationStatusEvent) error
 
 type BuildResult struct {
-	Applications         []argoappv1.Application
-	ApplicationInputs    []ApplicationSelectionInput
-	Projects             []argoappv1.AppProject
-	Manifests            []render.Manifest
-	ApplicationManifests []ApplicationManifest
-	Diagnostics          []diagnostic.Diagnostic
-	Settings             config.ArgoSettings
-	Statuses             []ApplicationStatus
-	CacheEvents          []cacheevent.Event
+	Applications            []argoappv1.Application
+	ApplicationInputs       []ApplicationSelectionInput
+	Projects                []argoappv1.AppProject
+	Manifests               []render.Manifest
+	ApplicationManifests    []ApplicationManifest
+	Diagnostics             []diagnostic.Diagnostic
+	Settings                config.ArgoSettings
+	Statuses                []ApplicationStatus
+	CacheEvents             []cacheevent.Event
+	renderCache             *applicationRenderCache
+	renderSettingsSignature string
 }
 
 type DiagRequest = BuildRequest
@@ -145,7 +158,9 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 	}
 
 	var result BuildResult
-	discovered, discoveryDiags, cacheEvents, err := o.discoverRepository(ctx, root, request)
+	discovered, discoveryDiags, cacheEvents, renderCache, renderSettingsSignature, err := o.discoverRepository(ctx, root, request)
+	result.renderCache = renderCache
+	result.renderSettingsSignature = renderSettingsSignature
 	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
 	discoveryDiags = normalizeDiagnostics(discoveryDiags, request.Strict, false)
 	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)
@@ -162,75 +177,47 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 	settingsDiags = normalizeDiagnostics(settingsDiags, request.Strict, false)
 	result.Diagnostics = append(result.Diagnostics, settingsDiags...)
 	result.Projects = appendDiscoveredProjects(result.Projects, discovered)
-	appsetOptions, providerDiags, err := applicationSetOptionsForRequest(request)
-	if err != nil {
-		result.Diagnostics = append(result.Diagnostics, providerDiags...)
-		return result, diagnosticsError(providerDiags, err)
-	}
-	result.Diagnostics = append(result.Diagnostics, normalizeDiagnostics(providerDiags, request.Strict, false)...)
-
-	for _, appFile := range discovered.Applications {
-		result.Applications = append(result.Applications, appFile.Application)
-		result.ApplicationInputs = append(result.ApplicationInputs, ApplicationSelectionInput{
-			Application: appFile.Application,
-			Paths:       []string{filepath.ToSlash(appFile.Path)},
-		})
-	}
-
-	if err := appendApplicationSetApplications(root, request, discovered.ApplicationSets, appsetOptions, &result); err != nil {
+	if err := appendDiscoveredApplications(discovered, &result); err != nil {
 		return result, err
 	}
 
+	result.Diagnostics = dedupeDiagnostics(result.Diagnostics)
 	if err := diagnosticFailure(result.Diagnostics, request.Strict); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func appendApplicationSetApplications(root string, request BuildRequest, appSetFiles []discovery.ApplicationSetFile, appsetOptions appset.Options, result *BuildResult) error {
-	for _, appSetFile := range appSetFiles {
-		generated, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
-		if err != nil {
-			if errors.Is(err, appset.ErrUnsupportedGenerator) && len(diags) > 0 {
-				diags = normalizeDiagnostics(diags, request.Strict, true)
-				result.Diagnostics = append(result.Diagnostics, diags...)
-				if request.Strict {
-					return diagnosticsError(diags, err)
-				}
-				continue
-			}
-			return diagnosticsError(diags, err)
-		}
-		diags = normalizeDiagnostics(diags, request.Strict, false)
-		result.Diagnostics = append(result.Diagnostics, diags...)
-		if err := diagnosticFailure(diags, request.Strict); err != nil {
-			return err
-		}
-		if err := appendZeroApplicationSetDiagnostic(appSetFile, request.Strict, result, len(generated)); err != nil {
-			return err
-		}
-		for _, app := range generated {
-			result.Applications = append(result.Applications, app.Application)
-			result.ApplicationInputs = append(result.ApplicationInputs, ApplicationSelectionInput{
-				Application: app.Application,
-				Paths:       generatedApplicationInputPaths(appSetFile.Path, app),
-			})
-		}
+func appendDiscoveredApplications(discovered discovery.Result, result *BuildResult) error {
+	for _, appFile := range discovered.Applications {
+		result.Applications = append(result.Applications, appFile.Application)
+		result.ApplicationInputs = append(result.ApplicationInputs, ApplicationSelectionInput{
+			Application: appFile.Application,
+			Paths:       discoveredApplicationInputPaths(appFile),
+		})
 	}
 	return nil
 }
 
-func appendZeroApplicationSetDiagnostic(appSetFile discovery.ApplicationSetFile, strict bool, result *BuildResult, generatedCount int) error {
-	if generatedCount > 0 {
-		return nil
+func discoveredApplicationInputPaths(appFile discovery.ApplicationFile) []string {
+	paths := append([]string(nil), appFile.InputPaths...)
+	if len(paths) == 0 && appFile.Path != "" {
+		paths = []string{appFile.Path}
 	}
-	diags := normalizeDiagnostics([]diagnostic.Diagnostic{emptyApplicationSetDiagnostic(appSetFile)}, strict, false)
-	result.Diagnostics = append(result.Diagnostics, diags...)
-	return diagnosticFailure(diags, strict)
+	for i := range paths {
+		paths[i] = filepath.ToSlash(paths[i])
+	}
+	return paths
 }
 
-func generatedApplicationInputPaths(appSetPath string, app appset.GeneratedApplication) []string {
-	paths := []string{filepath.ToSlash(appSetPath)}
+func generatedApplicationInputPaths(appSetFile discovery.ApplicationSetFile, app appset.GeneratedApplication) []string {
+	paths := append([]string(nil), appSetFile.InputPaths...)
+	if len(paths) == 0 && appSetFile.Path != "" {
+		paths = []string{appSetFile.Path}
+	}
+	for i := range paths {
+		paths[i] = filepath.ToSlash(paths[i])
+	}
 	sourcePaths := app.SourcePaths
 	if len(sourcePaths) == 0 && app.SourcePath != "" {
 		sourcePaths = []string{app.SourcePath}
@@ -279,17 +266,43 @@ func normalizeParallelism(value int) (int, error) {
 	return value, nil
 }
 
+func normalizeDiscoveryMode(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return DiscoveryModeFleet, nil
+	}
+	switch value {
+	case DiscoveryModeFleet, DiscoveryModeStatic:
+		return value, nil
+	default:
+		return "", fmt.Errorf("discovery-mode must be %q or %q", DiscoveryModeFleet, DiscoveryModeStatic)
+	}
+}
+
+func normalizeMaxDiscoveryDepth(value int, explicitlySet bool) (int, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("max-discovery-depth must be greater than or equal to 0")
+	}
+	if value == 0 && !explicitlySet {
+		return DefaultMaxDiscoveryDepth, nil
+	}
+	return value, nil
+}
+
 type renderApplicationsRequest struct {
-	applications    []argoappv1.Application
-	provider        localProvider
-	strict          bool
-	statusOnly      bool
-	settingsFilter  manifest.SettingsResourceFilter
-	resourceFilter  manifest.ResourceFilter
-	healthEvaluator *luahealth.Evaluator
-	recordEvents    bool
-	parallelism     int
-	statusCallback  ApplicationStatusCallback
+	applications      []argoappv1.Application
+	provider          localProvider
+	renderCache       *applicationRenderCache
+	settingsSignature string
+	request           BuildRequest
+	strict            bool
+	statusOnly        bool
+	settingsFilter    manifest.SettingsResourceFilter
+	resourceFilter    manifest.ResourceFilter
+	healthEvaluator   *luahealth.Evaluator
+	recordEvents      bool
+	parallelism       int
+	statusCallback    ApplicationStatusCallback
 }
 
 type renderApplicationsResult struct {
@@ -443,7 +456,13 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 	provider.cacheEvents = recorder
 	out := applicationRenderResult{set: true}
 
-	rendered, err := RenderApplication(ctx, application, provider)
+	rendered, err := renderApplicationCached(renderContext{
+		context:           ctx,
+		provider:          provider,
+		cache:             request.renderCache,
+		settingsSignature: request.settingsSignature,
+		request:           request.request,
+	}, application)
 	if err != nil {
 		out.diagnostics = append(out.diagnostics, normalizeDiagnostics(rendered.Diagnostics, request.strict, false)...)
 		out.diagnostics = append(out.diagnostics, renderFailureDiagnostic(application, err))
@@ -529,7 +548,9 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 
 	var result BuildResult
 	result.Applications = append(result.Applications, request.Applications...)
-	discovered, discoveryDiags, cacheEvents, err := o.discoverRepository(ctx, root, request)
+	discovered, discoveryDiags, cacheEvents, renderCache, renderSettingsSignature, err := o.discoverRepository(ctx, root, request)
+	result.renderCache = renderCache
+	result.renderSettingsSignature = renderSettingsSignature
 	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
 	discoveryDiags = normalizeDiagnostics(discoveryDiags, request.Strict, false)
 	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)
@@ -657,9 +678,12 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	}
 
 	buildRequest.Applications = []argoappv1.Application{selected}
+	buildRequest.renderCache = listResult.renderCache
+	buildRequest.renderSettingsSignature = listResult.renderSettingsSignature
 	buildResult, err := o.Build(ctx, buildRequest)
 	buildResult.ApplicationInputs = selectApplicationInputsForApplication(listResult.ApplicationInputs, selected)
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
+	buildResult.Diagnostics = dedupeDiagnostics(buildResult.Diagnostics)
 	return buildResult, err
 }
 

--- a/internal/app/render_cache.go
+++ b/internal/app/render_cache.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+)
+
+type applicationRenderCache struct {
+	mu      sync.Mutex
+	entries map[string]applicationRenderCacheEntry
+}
+
+type applicationRenderCacheEntry struct {
+	result RenderResult
+	err    error
+}
+
+func newApplicationRenderCache() *applicationRenderCache {
+	return &applicationRenderCache{entries: map[string]applicationRenderCacheEntry{}}
+}
+
+func (cache *applicationRenderCache) get(key string) (RenderResult, error, bool) {
+	if cache == nil || key == "" {
+		return RenderResult{}, nil, false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	entry, ok := cache.entries[key]
+	if !ok {
+		return RenderResult{}, nil, false
+	}
+	return cloneRenderResult(entry.result), entry.err, true
+}
+
+func (cache *applicationRenderCache) set(key string, result RenderResult, err error) {
+	if cache == nil || key == "" {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.entries[key] = applicationRenderCacheEntry{
+		result: cloneRenderResult(result),
+		err:    err,
+	}
+}
+
+func cloneRenderResult(result RenderResult) RenderResult {
+	return RenderResult{
+		Manifests:   cloneRenderManifests(result.Manifests),
+		Diagnostics: cloneDiagnostics(result.Diagnostics),
+	}
+}
+
+func cloneRenderManifests(input []render.Manifest) []render.Manifest {
+	if input == nil {
+		return nil
+	}
+	out := make([]render.Manifest, len(input))
+	for i, item := range input {
+		out[i] = item
+		if item.Object != nil {
+			out[i].Object = item.Object.DeepCopy()
+		}
+	}
+	return out
+}
+
+func cloneDiagnostics(input []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	if input == nil {
+		return nil
+	}
+	out := make([]diagnostic.Diagnostic, len(input))
+	copy(out, input)
+	return out
+}
+
+func renderApplicationCached(ctx renderContext, application argoappv1.Application) (RenderResult, error) {
+	key, err := applicationRenderCacheKey(ctx, application)
+	if err != nil {
+		return RenderResult{}, err
+	}
+	if result, err, ok := ctx.cache.get(key); ok {
+		return result, err
+	}
+	if fallbackKey, ok := namespaceDefaultedApplicationRenderCacheKey(ctx, application); ok {
+		if result, err, hit := ctx.cache.get(fallbackKey); hit {
+			ctx.cache.set(key, result, err)
+			return result, err
+		}
+	}
+	result, err := RenderApplication(ctx.context, application, ctx.provider)
+	if ctx.context.Err() == nil {
+		ctx.cache.set(key, result, err)
+	}
+	return result, err
+}
+
+func namespaceDefaultedApplicationRenderCacheKey(ctx renderContext, application argoappv1.Application) (string, bool) {
+	if application.Namespace == "" || applicationUsesPluginSource(application) {
+		return "", false
+	}
+	fallback := application
+	fallback.Namespace = ""
+	key, err := applicationRenderCacheKey(ctx, fallback)
+	return key, err == nil
+}
+
+func applicationUsesPluginSource(application argoappv1.Application) bool {
+	sources := application.Spec.Sources
+	if len(sources) == 0 && application.Spec.Source != nil {
+		sources = argoappv1.ApplicationSources{*application.Spec.Source}
+	}
+	for _, source := range sources {
+		if source.Plugin != nil {
+			return true
+		}
+	}
+	return false
+}
+
+type renderContext struct {
+	context           context.Context
+	provider          localProvider
+	cache             *applicationRenderCache
+	settingsSignature string
+	request           BuildRequest
+}
+
+func applicationRenderCacheKey(ctx renderContext, application argoappv1.Application) (string, error) {
+	input := struct {
+		Root                    string                      `json:"root"`
+		Application             applicationRenderCacheInput `json:"application"`
+		SettingsSignature       string                      `json:"settingsSignature"`
+		RepoMaps                []sourcepkg.RepoMap         `json:"repoMaps,omitempty"`
+		Offline                 bool                        `json:"offline"`
+		RefreshCharts           bool                        `json:"refreshCharts"`
+		ChartCacheDir           string                      `json:"chartCacheDir,omitempty"`
+		GitCacheDir             string                      `json:"gitCacheDir,omitempty"`
+		RefreshGit              bool                        `json:"refreshGit"`
+		RefreshRemoteResources  bool                        `json:"refreshRemoteResources"`
+		RemoteResourceCacheDir  string                      `json:"remoteResourceCacheDir,omitempty"`
+		PluginTimeout           string                      `json:"pluginTimeout,omitempty"`
+		HasInjectedPluginRender bool                        `json:"hasInjectedPluginRender"`
+	}{
+		Root:                    ctx.provider.repoRoot,
+		Application:             newApplicationRenderCacheInput(application),
+		SettingsSignature:       ctx.settingsSignature,
+		RepoMaps:                append([]sourcepkg.RepoMap(nil), ctx.request.RepoMaps...),
+		Offline:                 ctx.request.Offline,
+		RefreshCharts:           ctx.request.RefreshCharts,
+		ChartCacheDir:           ctx.request.ChartCacheDir,
+		GitCacheDir:             ctx.request.GitCacheDir,
+		RefreshGit:              ctx.request.RefreshGit,
+		RefreshRemoteResources:  ctx.request.RefreshRemoteResources,
+		RemoteResourceCacheDir:  ctx.request.RemoteResourceCacheDir,
+		PluginTimeout:           ctx.request.PluginTimeout.String(),
+		HasInjectedPluginRender: ctx.request.PluginRenderer != nil,
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint Application %s: %w", applicationDisplayName(application), err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type applicationRenderCacheInput struct {
+	Name      string                    `json:"name"`
+	Namespace string                    `json:"namespace,omitempty"`
+	Spec      argoappv1.ApplicationSpec `json:"spec"`
+}
+
+func newApplicationRenderCacheInput(application argoappv1.Application) applicationRenderCacheInput {
+	return applicationRenderCacheInput{
+		Name:      application.Name,
+		Namespace: application.Namespace,
+		Spec:      application.Spec,
+	}
+}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -31,7 +31,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deps.Orchestrator.Build(context.Background(), buildRequestFromFlags(appsFlags, repoMaps))
+			result, err := deps.Orchestrator.Build(context.Background(), buildRequestFromFlags(cmd, appsFlags, repoMaps))
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
 					return renderErr
@@ -55,7 +55,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 			}
 			result, err := deps.Orchestrator.BuildApp(context.Background(), app.BuildAppRequest{
 				Name:         args[0],
-				BuildRequest: buildRequestFromFlags(appFlags, repoMaps),
+				BuildRequest: buildRequestFromFlags(cmd, appFlags, repoMaps),
 			})
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -12,61 +12,66 @@ import (
 )
 
 type commonFlags struct {
-	path              string
-	pathOrig          string
-	repo              string
-	ref               string
-	refOrig           string
-	selector          string
-	discoverKustomize []string
-	repoMaps          []string
-	offline           bool
-	refreshCharts     bool
-	chartCacheDir     string
-	gitCacheDir       string
-	refreshGit        bool
-	gitUsername       string
-	gitPassword       string
-	gitBearerToken    string
-	gitSSHKeyFile     string
-	gitSSHPassphrase  string
-	gitKnownHostsFile string
-	helmUsername      string
-	helmPassword      string
-	helmBearerToken   string
-	registryConfig    string
-	refreshRemotes    bool
-	remoteCacheDir    string
-	remoteUsername    string
-	remotePassword    string
-	remoteBearerToken string
-	appsetFixtures    []string
-	skipKinds         []string
-	skipCRDs          bool
-	skipSecrets       bool
-	skipLuaHealth     bool
-	changedOnly       bool
-	strictChangedOnly bool
-	strict            bool
-	exitCode          bool
-	output            string
-	unified           int
-	stripAttrs        []string
-	showIgnoredFields bool
-	limitBytes        int
-	cacheEvents       bool
-	parallelism       int
+	path                 string
+	pathOrig             string
+	repo                 string
+	ref                  string
+	refOrig              string
+	selector             string
+	discoveryMode        string
+	maxDiscoveryDepth    int
+	maxDiscoveryDepthSet bool
+	discoverKustomize    []string
+	repoMaps             []string
+	offline              bool
+	refreshCharts        bool
+	chartCacheDir        string
+	gitCacheDir          string
+	refreshGit           bool
+	gitUsername          string
+	gitPassword          string
+	gitBearerToken       string
+	gitSSHKeyFile        string
+	gitSSHPassphrase     string
+	gitKnownHostsFile    string
+	helmUsername         string
+	helmPassword         string
+	helmBearerToken      string
+	registryConfig       string
+	refreshRemotes       bool
+	remoteCacheDir       string
+	remoteUsername       string
+	remotePassword       string
+	remoteBearerToken    string
+	appsetFixtures       []string
+	skipKinds            []string
+	skipCRDs             bool
+	skipSecrets          bool
+	skipLuaHealth        bool
+	changedOnly          bool
+	strictChangedOnly    bool
+	strict               bool
+	exitCode             bool
+	output               string
+	unified              int
+	stripAttrs           []string
+	showIgnoredFields    bool
+	limitBytes           int
+	cacheEvents          bool
+	parallelism          int
 }
 
 func defaultCommonFlags() commonFlags {
 	return commonFlags{
-		path:        ".",
-		changedOnly: true,
-		exitCode:    true,
-		output:      "diff",
-		unified:     3,
-		limitBytes:  65536,
-		parallelism: 1,
+		path:              ".",
+		changedOnly:       true,
+		exitCode:          true,
+		output:            "diff",
+		unified:           3,
+		limitBytes:        65536,
+		parallelism:       1,
+		discoveryMode:     "fleet",
+		maxDiscoveryDepth: 4,
 	}
 }
 
@@ -74,6 +79,8 @@ func bindCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVar(&flags.path, "path", flags.path, "repository path to inspect")
 	cmd.Flags().StringVar(&flags.pathOrig, "path-orig", flags.pathOrig, "baseline repository path for diffs")
 	cmd.Flags().StringVarP(&flags.selector, "selector", "l", flags.selector, "label selector for Applications")
+	cmd.Flags().StringVar(&flags.discoveryMode, "discovery-mode", flags.discoveryMode, "Application discovery mode: fleet or static")
+	cmd.Flags().IntVar(&flags.maxDiscoveryDepth, "max-discovery-depth", flags.maxDiscoveryDepth, "maximum recursive rendered Application discovery depth")
 	cmd.Flags().StringArrayVar(&flags.discoverKustomize, "discover-kustomize", flags.discoverKustomize, "additional local Kustomize path to render for Argo CD Application discovery")
 	cmd.Flags().StringArrayVar(&flags.repoMaps, "repo-map", flags.repoMaps, "repository URL mapping in from=to form")
 	cmd.Flags().BoolVar(&flags.offline, "offline", flags.offline, "disable network access and use local files, repo maps, or existing caches")
@@ -173,6 +180,9 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		Repo:                           flags.repo,
 		Ref:                            flags.ref,
 		RefOrig:                        flags.refOrig,
+		DiscoveryMode:                  flags.discoveryMode,
+		MaxDiscoveryDepth:              flags.maxDiscoveryDepth,
+		MaxDiscoveryDepthSet:           flags.maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), flags.discoverKustomize...),
 		ChangedOnly:                    &flags.changedOnly,
 		StrictChangedOnly:              flags.strictChangedOnly,
@@ -199,6 +209,11 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		SkipSecrets:                    flags.skipSecrets,
 		RecordCacheEvents:              flags.cacheEvents,
 	}
+}
+
+func commandAwareFlags(cmd *cobra.Command, flags commonFlags) commonFlags {
+	flags.maxDiscoveryDepthSet = cmd.Flags().Changed("max-discovery-depth")
+	return flags
 }
 
 func exitCode(err error, disableDiffExitCode bool, hasDiff bool) int {

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -59,7 +59,7 @@ func newDiagCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			request := buildRequestFromFlags(flags, repoMaps)
+			request := buildRequestFromFlags(cmd, flags, repoMaps)
 			request.RecordCacheEvents = flags.cacheEvents
 			result, err := deps.Orchestrator.Diag(context.Background(), request)
 			result.Diagnostics = diagnostic.WithStableCodes(result.Diagnostics)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -37,7 +37,7 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deps.Orchestrator.DiffApps(context.Background(), diffRequestFromFlags(appsFlags, repoMaps))
+			result, err := deps.Orchestrator.DiffApps(context.Background(), diffRequestFromFlags(cmd, appsFlags, repoMaps))
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
 					return renderErr
@@ -67,7 +67,7 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			}
 			result, err := deps.Orchestrator.DiffApp(context.Background(), app.DiffAppRequest{
 				Name:        args[0],
-				DiffRequest: diffRequestFromFlags(appFlags, repoMaps),
+				DiffRequest: diffRequestFromFlags(cmd, appFlags, repoMaps),
 			})
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
@@ -97,7 +97,7 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deps.Orchestrator.DiffImages(context.Background(), diffRequestFromFlags(imagesFlags, repoMaps))
+			result, err := deps.Orchestrator.DiffImages(context.Background(), diffRequestFromFlags(cmd, imagesFlags, repoMaps))
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
 					return renderErr
@@ -120,8 +120,8 @@ type imageDiffOutput struct {
 	Unchanged []string `json:"unchanged" yaml:"unchanged"`
 }
 
-func diffRequestFromFlags(flags commonFlags, repoMaps []source.RepoMap) app.DiffRequest {
-	return requestOptionsFromFlags(flags, repoMaps).Diff()
+func diffRequestFromFlags(cmd *cobra.Command, flags commonFlags, repoMaps []source.RepoMap) app.DiffRequest {
+	return requestOptionsFromFlags(commandAwareFlags(cmd, flags), repoMaps).Diff()
 }
 
 func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string) error {

--- a/internal/cli/discovery_flags_test.go
+++ b/internal/cli/discovery_flags_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import "testing"
+
+func TestMaxDiscoveryDepthFlagDistinguishesDefaultFromExplicitZero(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "get", "apps")
+	if len(recorder.listRequests) != 1 {
+		t.Fatalf("len(listRequests) = %d, want 1", len(recorder.listRequests))
+	}
+	if request := recorder.listRequests[0]; request.MaxDiscoveryDepth != 4 || request.MaxDiscoveryDepthSet {
+		t.Fatalf("default max discovery depth = %d set=%t, want 4 set=false", request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	}
+
+	recorder = &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "get", "apps", "--max-discovery-depth", "0")
+	if len(recorder.listRequests) != 1 {
+		t.Fatalf("len(listRequests) = %d, want 1", len(recorder.listRequests))
+	}
+	if request := recorder.listRequests[0]; request.MaxDiscoveryDepth != 0 || !request.MaxDiscoveryDepthSet {
+		t.Fatalf("explicit max discovery depth = %d set=%t, want 0 set=true", request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	}
+}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -30,6 +30,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 
 	appsFlags := defaultCommonFlags()
 	appsFlags.output = string(cliformat.OutputTable)
+	appsFlags.parallelism = defaultRenderAppsParallelism()
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "List Applications",
@@ -47,7 +48,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deps.Orchestrator.ListApplications(context.Background(), buildRequestFromFlags(appsFlags, repoMaps))
+			result, err := deps.Orchestrator.ListApplications(context.Background(), buildRequestFromFlags(cmd, appsFlags, repoMaps))
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
 					return renderErr
@@ -64,6 +65,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 
 	imagesFlags := defaultCommonFlags()
 	imagesFlags.output = string(cliformat.OutputTable)
+	imagesFlags.parallelism = defaultRenderAppsParallelism()
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "List rendered image references",
@@ -81,7 +83,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			buildRequest := buildRequestFromFlags(imagesFlags, repoMaps)
+			buildRequest := buildRequestFromFlags(cmd, imagesFlags, repoMaps)
 			listResult, err := deps.Orchestrator.ListApplications(context.Background(), buildRequest)
 			if err != nil {
 				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), listResult.Diagnostics); renderErr != nil {

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -44,7 +44,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			buildRequest := buildRequestFromFlags(appsFlags, repoMaps)
+			buildRequest := buildRequestFromFlags(cmd, appsFlags, repoMaps)
 			buildRequest.StatusOnly = true
 			buildRequest.ValidateLuaHealth = !appsFlags.skipLuaHealth
 			var liveReporter *testLiveReporter
@@ -112,7 +112,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			buildRequest := buildRequestFromFlags(appFlags, repoMaps)
+			buildRequest := buildRequestFromFlags(cmd, appFlags, repoMaps)
 			buildRequest.StatusOnly = true
 			buildRequest.ValidateLuaHealth = !appFlags.skipLuaHealth
 			result, err := deps.Orchestrator.BuildApp(context.Background(), app.BuildAppRequest{
@@ -135,8 +135,8 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 	return cmd
 }
 
-func buildRequestFromFlags(flags commonFlags, repoMaps []source.RepoMap) app.BuildRequest {
-	return requestOptionsFromFlags(flags, repoMaps).Build()
+func buildRequestFromFlags(cmd *cobra.Command, flags commonFlags, repoMaps []source.RepoMap) app.BuildRequest {
+	return requestOptionsFromFlags(commandAwareFlags(cmd, flags), repoMaps).Build()
 }
 
 func renderTestResult(cmd *cobra.Command, statuses []app.ApplicationStatus, output string, color, showEmptyMessage bool) error {

--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -112,11 +112,25 @@ func StableCode(diag Diagnostic) string {
 		return "render.repeated-resource"
 	case "changed-only":
 		return "diff.changed-only-incomplete"
+	case "discovery":
+		return discoveryCode(diag.Message)
 	}
 	if diag.Category == "" {
 		return "diagnostic.unspecified"
 	}
 	return diag.Category + ".unspecified"
+}
+
+func discoveryCode(message string) string {
+	switch {
+	case strings.Contains(message, "duplicate"):
+		return "discovery.duplicate"
+	case strings.Contains(message, "maximum discovery depth"):
+		return "discovery.depth-exceeded"
+	case strings.Contains(message, "could not be rendered"):
+		return "discovery.render-failed"
+	}
+	return "discovery.unspecified"
 }
 
 func appSetCode(message string) string {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -16,22 +16,35 @@ type Options struct {
 	AppManifestPaths []string
 }
 
+type SourceTier int
+
+const (
+	SourceTierStatic SourceTier = iota
+	SourceTierExplicitRendered
+	SourceTierRenderedFleet
+)
+
 type ApplicationFile struct {
 	Path          string
 	DocumentIndex int
 	Application   argoappv1.Application
+	Tier          SourceTier
+	InputPaths    []string
 }
 
 type ApplicationSetFile struct {
 	Path           string
 	DocumentIndex  int
 	ApplicationSet argoappv1.ApplicationSet
+	Tier           SourceTier
+	InputPaths     []string
 }
 
 type ProjectFile struct {
 	Path          string
 	DocumentIndex int
 	Project       argoappv1.AppProject
+	Tier          SourceTier
 }
 
 type SettingsCandidate struct {
@@ -42,6 +55,7 @@ type SettingsCandidate struct {
 	Namespace     string
 	Name          string
 	Object        *unstructured.Unstructured
+	Tier          SourceTier
 }
 
 type Result struct {
@@ -182,13 +196,13 @@ func scanDocument(rel string, documentIndex int, obj *unstructured.Unstructured,
 		if err := unstructuredToTyped(obj.Object, &app); err != nil {
 			return fmt.Errorf("%s: decode Application: %w", rel, err)
 		}
-		result.Applications = append(result.Applications, ApplicationFile{Path: rel, DocumentIndex: documentIndex, Application: app})
+		result.Applications = append(result.Applications, ApplicationFile{Path: rel, DocumentIndex: documentIndex, Application: app, InputPaths: []string{rel}})
 	case isArgoGVK(obj, "ApplicationSet"):
 		var appSet argoappv1.ApplicationSet
 		if err := unstructuredToTyped(obj.Object, &appSet); err != nil {
 			return fmt.Errorf("%s: decode ApplicationSet: %w", rel, err)
 		}
-		result.ApplicationSets = append(result.ApplicationSets, ApplicationSetFile{Path: rel, DocumentIndex: documentIndex, ApplicationSet: appSet})
+		result.ApplicationSets = append(result.ApplicationSets, ApplicationSetFile{Path: rel, DocumentIndex: documentIndex, ApplicationSet: appSet, InputPaths: []string{rel}})
 	case isArgoGVK(obj, "AppProject"):
 		var project argoappv1.AppProject
 		if err := unstructuredToTyped(obj.Object, &project); err != nil {

--- a/internal/render/kustomize_remote.go
+++ b/internal/render/kustomize_remote.go
@@ -55,6 +55,9 @@ func parseKustomizeGitRemoteRef(ref string) (kustomizeRemoteRef, bool, error) {
 	if strings.Contains(withoutPrefix, "://") {
 		return parseKustomizeGitURLRef(trimmed, withoutPrefix)
 	}
+	if scpRefHasRemoteCredentialUserinfo(withoutPrefix) {
+		return kustomizeRemoteRef{}, true, fmt.Errorf("kustomize remote ref %q must not include userinfo", redactKustomizeRemoteRef(trimmed))
+	}
 	if isSCPStyleKustomizeGitRef(withoutPrefix) {
 		return parseKustomizeGitSCPRef(trimmed, withoutPrefix)
 	}
@@ -93,9 +96,10 @@ func parseKustomizeGitURLRef(original, raw string) (kustomizeRemoteRef, bool, er
 	}
 	repoPath = strings.TrimSuffix(repoPath, "/")
 	subpath = strings.TrimPrefix(subpath, "/")
-	if repoPath == "" || subpath == "" {
+	if repoPath == "" {
 		return kustomizeRemoteRef{}, false, nil
 	}
+	subpath = cleanKustomizeGitSubpath(subpath)
 
 	repo := *parsed
 	repo.Path = repoPath
@@ -118,13 +122,16 @@ func inferKustomizeGitURLPath(host, rawPath string) (string, string, bool) {
 	for i, segment := range segments {
 		if strings.HasSuffix(segment, ".git") {
 			if i == len(segments)-1 {
-				return "", "", false
+				return "/" + path.Join(segments[:i+1]...), ".", true
 			}
 			return "/" + path.Join(segments[:i+1]...), path.Join(segments[i+1:]...), true
 		}
 	}
-	if !isKnownGitHost(strings.ToLower(host)) || len(segments) < 3 {
+	if !isKnownGitHost(strings.ToLower(host)) || len(segments) < 2 {
 		return "", "", false
+	}
+	if len(segments) == 2 {
+		return "/" + path.Join(segments[:2]...), ".", true
 	}
 	return "/" + path.Join(segments[:2]...), path.Join(segments[2:]...), true
 }
@@ -158,13 +165,18 @@ func parseKustomizeGitSCPRef(original, raw string) (kustomizeRemoteRef, bool, er
 
 	repo, subpath, ok := strings.Cut(beforeQuery, "//")
 	if !ok {
-		return kustomizeRemoteRef{}, false, nil
+		if !isRootSCPStyleKustomizeGitRepo(beforeQuery) {
+			return kustomizeRemoteRef{}, false, nil
+		}
+		repo = beforeQuery
+		subpath = "."
 	}
 	repo = strings.TrimSuffix(repo, "/")
 	subpath = strings.TrimPrefix(subpath, "/")
-	if repo == "" || subpath == "" {
+	if repo == "" {
 		return kustomizeRemoteRef{}, false, nil
 	}
+	subpath = cleanKustomizeGitSubpath(subpath)
 	if userHost, _, ok := strings.Cut(repo, ":"); ok {
 		if user, _, ok := strings.Cut(userHost, "@"); ok && strings.Contains(user, ":") {
 			return kustomizeRemoteRef{}, true, fmt.Errorf("kustomize remote ref %q must not include userinfo", redactKustomizeRemoteRef(original))
@@ -178,6 +190,14 @@ func parseKustomizeGitSCPRef(original, raw string) (kustomizeRemoteRef, bool, er
 		Revision: revision,
 		Subpath:  path.Clean(subpath),
 	}, true, nil
+}
+
+func cleanKustomizeGitSubpath(subpath string) string {
+	cleaned := path.Clean(subpath)
+	if cleaned == "" {
+		return "."
+	}
+	return cleaned
 }
 
 func kustomizeRemoteRevision(rawQuery, original string) (string, error) {
@@ -286,9 +306,21 @@ func isSCPStyleKustomizeGitRef(ref string) bool {
 		beforePath = before
 	}
 	repo, _, ok := strings.Cut(beforePath, "//")
-	if !ok || repo == "" {
+	if !ok {
+		return isRootSCPStyleKustomizeGitRepo(beforePath)
+	}
+	if repo == "" {
 		return false
 	}
+	return isSCPStyleKustomizeGitRepo(repo)
+}
+
+func isRootSCPStyleKustomizeGitRepo(repo string) bool {
+	repo = strings.TrimSuffix(strings.TrimSpace(repo), "/")
+	return strings.HasSuffix(repo, ".git") && isSCPStyleKustomizeGitRepo(repo)
+}
+
+func isSCPStyleKustomizeGitRepo(repo string) bool {
 	beforeColon, afterColon, ok := strings.Cut(repo, ":")
 	if !ok || beforeColon == "" || afterColon == "" || strings.ContainsAny(beforeColon, `/\`) {
 		return false
@@ -321,6 +353,31 @@ func scpRefHasCredentialUserinfo(ref string) bool {
 		return false
 	}
 	return strings.Contains(repo[:at], ":")
+}
+
+func scpRefHasRemoteCredentialUserinfo(ref string) bool {
+	beforePath := ref
+	if before, _, ok := strings.Cut(beforePath, "?"); ok {
+		beforePath = before
+	}
+	if before, _, ok := strings.Cut(beforePath, "#"); ok {
+		beforePath = before
+	}
+	repo, _, ok := strings.Cut(beforePath, "//")
+	if !ok {
+		repo = beforePath
+	}
+	at := strings.LastIndex(repo, "@")
+	if at <= 0 || !strings.Contains(repo[:at], ":") {
+		return false
+	}
+	hostPath := repo[at+1:]
+	host, _, ok := strings.Cut(hostPath, ":")
+	if !ok {
+		return false
+	}
+	host = strings.ToLower(host)
+	return isKnownGitHost(host) || looksLikeRemoteHost(host)
 }
 
 func safeRemoteRefNamePart(value string) string {

--- a/internal/render/kustomize_remote_refs_test.go
+++ b/internal/render/kustomize_remote_refs_test.go
@@ -283,6 +283,55 @@ metadata:
 	}
 }
 
+func TestKustomizeRendererRendersRemoteGitRootResourceDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/example/root.git?ref=v1.2.3
+`)
+	remoteRepo := t.TempDir()
+	writeFile(t, filepath.Join(remoteRepo, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+`)
+	writeFile(t, filepath.Join(remoteRepo, "base", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeFile(t, filepath.Join(remoteRepo, "base", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remote-root
+`)
+	acquirer := &fakeRemoteAcquirer{path: remoteRepo}
+
+	manifests, diags, err := (KustomizeRenderer{}).Render(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     "app",
+	}, RenderOptions{
+		RemoteResourceAcquirer: acquirer,
+		RemoteResourceCacheDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	if len(acquirer.requests) != 1 {
+		t.Fatalf("remote acquire calls = %d, want 1", len(acquirer.requests))
+	}
+	if got := acquirer.requests[0]; got.Kind != remote.RequestGitRepo || got.RepoURL != "https://github.com/example/root.git" || got.Revision != "v1.2.3" {
+		t.Fatalf("remote request = %#v, want root Git repo metadata", got)
+	}
+	if !containsManifest(manifests, "ConfigMap", "remote-root") {
+		t.Fatalf("rendered manifests = %#v, want remote root ConfigMap", manifests)
+	}
+}
+
 func TestKustomizeRendererRendersRemoteGitHubShorthandResourceDirectory(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "app", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1

--- a/internal/render/kustomize_remote_test.go
+++ b/internal/render/kustomize_remote_test.go
@@ -30,6 +30,30 @@ func TestParseKustomizeRemoteRef(t *testing.T) {
 			subpath:  "deploy/base",
 		},
 		{
+			name:     "github root shorthand ref",
+			ref:      "https://github.com/org/repo?ref=v1",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://github.com/org/repo",
+			revision: "v1",
+			subpath:  ".",
+		},
+		{
+			name:     "github git suffix root shorthand ref",
+			ref:      "https://github.com/org/repo.git?ref=v1",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://github.com/org/repo.git",
+			revision: "v1",
+			subpath:  ".",
+		},
+		{
+			name:     "github root shorthand defaults revision",
+			ref:      "https://github.com/org/repo",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://github.com/org/repo",
+			revision: "HEAD",
+			subpath:  ".",
+		},
+		{
 			name:     "github shorthand ref",
 			ref:      "https://github.com/argoproj/argo-cd/manifests/crds?ref=v3.4.2",
 			kind:     kustomizeRemoteGit,
@@ -44,6 +68,14 @@ func TestParseKustomizeRemoteRef(t *testing.T) {
 			repoURL:  "https://git.example.test/platform/repo.git",
 			revision: "main",
 			subpath:  "deploy/base",
+		},
+		{
+			name:     "git path segment root ref",
+			ref:      "https://git.example.test/platform/repo.git?ref=main",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://git.example.test/platform/repo.git",
+			revision: "main",
+			subpath:  ".",
 		},
 		{
 			name:     "git URL ref defaults revision",
@@ -62,6 +94,22 @@ func TestParseKustomizeRemoteRef(t *testing.T) {
 			subpath:  "deploy/base",
 		},
 		{
+			name:     "git prefix root URL ref",
+			ref:      "git::https://host.example.test/org/repo.git?ref=v1",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://host.example.test/org/repo.git",
+			revision: "v1",
+			subpath:  ".",
+		},
+		{
+			name:     "git prefix root URL defaults revision",
+			ref:      "git::https://host.example.test/org/repo.git",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "https://host.example.test/org/repo.git",
+			revision: "HEAD",
+			subpath:  ".",
+		},
+		{
 			name:     "ssh URL ref",
 			ref:      "ssh://git@github.com/org/repo.git//deploy/base?ref=release",
 			kind:     kustomizeRemoteGit,
@@ -70,12 +118,36 @@ func TestParseKustomizeRemoteRef(t *testing.T) {
 			subpath:  "deploy/base",
 		},
 		{
+			name:     "ssh root URL ref",
+			ref:      "ssh://git@host.example.test/org/repo.git?ref=v1",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "ssh://git@host.example.test/org/repo.git",
+			revision: "v1",
+			subpath:  ".",
+		},
+		{
 			name:     "scp-like ref",
 			ref:      "git@github.com:org/repo.git//deploy/base?ref=release",
 			kind:     kustomizeRemoteGit,
 			repoURL:  "git@github.com:org/repo.git",
 			revision: "release",
 			subpath:  "deploy/base",
+		},
+		{
+			name:     "scp-like root ref",
+			ref:      "git@host.example.test:org/repo.git?ref=v1",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "git@host.example.test:org/repo.git",
+			revision: "v1",
+			subpath:  ".",
+		},
+		{
+			name:     "scp-like root defaults revision",
+			ref:      "git@host.example.test:org/repo.git",
+			kind:     kustomizeRemoteGit,
+			repoURL:  "git@host.example.test:org/repo.git",
+			revision: "HEAD",
+			subpath:  ".",
 		},
 	}
 
@@ -114,10 +186,27 @@ func TestParseKustomizeRemoteRefIgnoresLocalRefs(t *testing.T) {
 	}
 }
 
+func TestParseKustomizeRemoteRefRejectsAmbiguousHTTPGitLikeRefs(t *testing.T) {
+	for _, ref := range []string{
+		"https://example.test/org/repo?ref=v1",
+		"https://example.test/org/repo",
+		"https://example.test/org/repo/base?ref=v1",
+	} {
+		got, ok, err := parseKustomizeRemoteRef(ref)
+		if err != nil {
+			t.Fatalf("parseKustomizeRemoteRef(%q) error = %v", ref, err)
+		}
+		if ok {
+			t.Fatalf("parseKustomizeRemoteRef(%q) = %#v, true; want false", ref, got)
+		}
+	}
+}
+
 func TestParseKustomizeRemoteRefRejectsSecretBearingUnsupportedQuery(t *testing.T) {
 	for _, ref := range []string{
 		"https://github.com/org/repo//base?token=secret&ref=main",
 		"https://github.com/org/repo//base?secret=value&ref=main",
+		"https://github.com/org/repo?token=secret&ref=main",
 	} {
 		_, ok, err := parseKustomizeRemoteRef(ref)
 		if err == nil {
@@ -134,7 +223,9 @@ func TestParseKustomizeRemoteRefRejectsUserinfo(t *testing.T) {
 	for _, ref := range []string{
 		"https://user:secret@example.test/file.yaml",
 		"https://user:secret@github.com/org/repo//base?ref=main",
+		"https://user:secret@github.com/org/repo?ref=main",
 		"git::https://user:secret@github.com/org/repo.git//base?ref=main",
+		"alice:secret@github.com:org/repo.git?ref=main",
 	} {
 		_, ok, err := parseKustomizeRemoteRef(ref)
 		if err == nil {

--- a/internal/render/kustomize_workspace_remote.go
+++ b/internal/render/kustomize_workspace_remote.go
@@ -260,7 +260,7 @@ func acquiredRemoteKustomizePath(acquired remote.Result, ref kustomizeRemoteRef)
 		return acquiredPath, nil
 	case kustomizeRemoteGit:
 		subpath := path.Clean(strings.TrimPrefix(ref.Subpath, "/"))
-		if subpath == "." || pathsafety.SlashRelEscapes(subpath) {
+		if pathsafety.SlashRelEscapes(subpath) {
 			return "", fmt.Errorf("remote kustomize resource %s subpath %q escapes acquired repository", redactKustomizeRef(ref.Original), ref.Subpath)
 		}
 		repoRoot := filepath.Clean(acquiredPath)

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -17,6 +17,9 @@ type Options struct {
 	Repo                           string
 	Ref                            string
 	RefOrig                        string
+	DiscoveryMode                  string
+	MaxDiscoveryDepth              int
+	MaxDiscoveryDepthSet           bool
 	DiscoverKustomizePaths         []string
 	ChangedOnly                    *bool
 	StrictChangedOnly              bool
@@ -52,6 +55,9 @@ func (options Options) Build() app.BuildRequest {
 	return app.BuildRequest{
 		Path:                           options.Path,
 		Strict:                         options.Strict,
+		DiscoveryMode:                  options.DiscoveryMode,
+		MaxDiscoveryDepth:              options.MaxDiscoveryDepth,
+		MaxDiscoveryDepthSet:           options.MaxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), options.DiscoverKustomizePaths...),
 		ValidateLuaHealth:              options.ValidateLuaHealth,
 		Offline:                        options.Offline,
@@ -89,6 +95,9 @@ func (options Options) Diff() app.DiffRequest {
 		Repo:                           options.Repo,
 		Ref:                            options.Ref,
 		RefOrig:                        options.RefOrig,
+		DiscoveryMode:                  options.DiscoveryMode,
+		MaxDiscoveryDepth:              options.MaxDiscoveryDepth,
+		MaxDiscoveryDepthSet:           options.MaxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), options.DiscoverKustomizePaths...),
 		ChangedOnly:                    changedOnly,
 		StrictChangedOnly:              options.StrictChangedOnly,

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -18,6 +18,9 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 
 	assertDeepEqual(t, "Path", request.Path, "repo")
 	assertDeepEqual(t, "Strict", request.Strict, true)
+	assertDeepEqual(t, "DiscoveryMode", request.DiscoveryMode, "fleet")
+	assertDeepEqual(t, "MaxDiscoveryDepth", request.MaxDiscoveryDepth, 2)
+	assertDeepEqual(t, "MaxDiscoveryDepthSet", request.MaxDiscoveryDepthSet, true)
 	assertDeepEqual(t, "DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "Offline", request.Offline, true)
 	assertDeepEqual(t, "RefreshCharts", request.RefreshCharts, true)
@@ -60,6 +63,9 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "Repo", request.Repo, "repo-root")
 	assertDeepEqual(t, "Ref", request.Ref, "feature")
 	assertDeepEqual(t, "RefOrig", request.RefOrig, "main")
+	assertDeepEqual(t, "DiscoveryMode", request.DiscoveryMode, "fleet")
+	assertDeepEqual(t, "MaxDiscoveryDepth", request.MaxDiscoveryDepth, 2)
+	assertDeepEqual(t, "MaxDiscoveryDepthSet", request.MaxDiscoveryDepthSet, true)
 	assertDeepEqual(t, "DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "ChangedOnly", request.ChangedOnly, true)
 	assertDeepEqual(t, "StrictChangedOnly", request.StrictChangedOnly, true)
@@ -113,6 +119,9 @@ func fixtureOptions() Options {
 		Repo:                         "repo-root",
 		Ref:                          "feature",
 		RefOrig:                      "main",
+		DiscoveryMode:                "fleet",
+		MaxDiscoveryDepth:            2,
+		MaxDiscoveryDepthSet:         true,
 		DiscoverKustomizePaths:       []string{"argocd/overlays/prod"},
 		StrictChangedOnly:            true,
 		Strict:                       true,

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -21,6 +21,8 @@ type Config struct {
 	Repo                   string
 	Ref                    string
 	RefOrig                string
+	DiscoveryMode          string
+	MaxDiscoveryDepth      *int
 	DiscoverKustomizePaths []string
 	Strict                 bool
 	Offline                bool
@@ -165,6 +167,12 @@ func (client *Client) requestOptions() requestopts.Options {
 	if unified == 0 {
 		unified = 3
 	}
+	maxDiscoveryDepth := app.DefaultMaxDiscoveryDepth
+	maxDiscoveryDepthSet := false
+	if client.config.MaxDiscoveryDepth != nil {
+		maxDiscoveryDepth = *client.config.MaxDiscoveryDepth
+		maxDiscoveryDepthSet = true
+	}
 	return requestopts.Options{
 		Path:                           client.config.Path,
 		LeftPath:                       client.config.PathOrig,
@@ -172,6 +180,9 @@ func (client *Client) requestOptions() requestopts.Options {
 		Repo:                           client.config.Repo,
 		Ref:                            client.config.Ref,
 		RefOrig:                        client.config.RefOrig,
+		DiscoveryMode:                  client.config.DiscoveryMode,
+		MaxDiscoveryDepth:              maxDiscoveryDepth,
+		MaxDiscoveryDepthSet:           maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), client.config.DiscoverKustomizePaths...),
 		ChangedOnly:                    client.config.ChangedOnly,
 		StrictChangedOnly:              client.config.StrictChangedOnly,

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -33,6 +33,7 @@ func TestPublicRenderParallelismPreservesManifestOrder(t *testing.T) {
 	go func() {
 		result, err := Render(context.Background(), Config{
 			Path:           root,
+			DiscoveryMode:  "static",
 			Parallelism:    3,
 			PluginRenderer: renderer,
 		})
@@ -77,6 +78,22 @@ func TestPublicConfigParallelismWiresRequests(t *testing.T) {
 		t.Fatalf("diff request Parallelism = %d, want 5", got)
 	}
 }
+
+func TestPublicConfigMaxDiscoveryDepthDistinguishesUnsetFromExplicitZero(t *testing.T) {
+	client := NewClient(Config{})
+	request := client.buildRequest()
+	if request.MaxDiscoveryDepth != 4 || request.MaxDiscoveryDepthSet {
+		t.Fatalf("default max discovery depth = %d set=%t, want 4 set=false", request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	}
+
+	zero := 0
+	client = NewClient(Config{MaxDiscoveryDepth: &zero})
+	request = client.buildRequest()
+	if request.MaxDiscoveryDepth != 0 || !request.MaxDiscoveryDepthSet {
+		t.Fatalf("explicit max discovery depth = %d set=%t, want 0 set=true", request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	}
+}
+
 func TestPublicConfigUnifiedDefaultsToThree(t *testing.T) {
 	client := NewClient(Config{})
 


### PR DESCRIPTION
## Summary
- enable default recursive rendered fleet discovery for Argo CD app-of-apps repositories
- add bounded discovery depth, static discovery mode, and public/CLI options
- support root Git Kustomize refs and cache rendered Application results across discovery/build
- update docs for rendered discovery, source acquisition, and compatibility

## Verification
- go test ./...
- mise run ci
- home-ops smoke: default/static both detected 31 apps, no duplicates, app lists identical
- home-ops test apps: default 3.10s then 2.53s, static 2.31s
- procinger smoke: 14 apps PASS in 2.12s

Review approvals: spec/product and code quality reviewers approved the completed slice.