### PR TITLE
fix: provide repository context for release bookkeeping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,6 +537,7 @@ jobs:
     steps:
       - name: Mark release latest and release-please PR tagged
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-meta.outputs.tag }}
         shell: bash


### PR DESCRIPTION
## Summary

- set GH_REPO for the checkout-free release-please bookkeeping step
- keep the job checkout-free while letting gh commands resolve sholdee/drydock without git context

## Verification

- mise run actionlint
- mise run zizmor
- git diff --check
- review agent approval
- verified PR #34 labels repaired and v0.1.4 is latest/non-draft
- verified GH_REPO lets gh release view work outside a git workspace