### PR TITLE
feat: color diff output

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -159,6 +159,8 @@ Supported:
   add/delete diffs when the Application exists on only one side.
 - `diff apps`, `diff app`, and `diff images` against local Git refs through
   temporary local snapshots, without `git` shellouts or checkout mutation.
+- Git-style ANSI color for text diff output with
+  `--color=auto|always|never`; JSON and YAML payloads remain plain.
 - Changed-only Application selection with safe render-all fallback and strict
   failure mode.
 - Default diff ignores for common Helm chart/version labels and pod-template

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -301,6 +301,13 @@ support `-o json` and `-o yaml`, which serialize the structured `[]diff.Result`
 payload. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
 `-o name` is not supported for manifest diffs.
 
+Unified diff output supports git-style ANSI color with
+`--color=auto|always|never`. The default, `auto`, colors only when writing to a
+terminal. `always` forces ANSI color for text diff output, while `never`
+disables ANSI color for text diff output. Diagnostics keep their existing
+stderr terminal-color behavior. Structured JSON and YAML payloads never contain
+ANSI escapes.
+
 Manifest diffs hide common Helm-rendered metadata noise by default:
 
 - `metadata.labels.helm.sh/chart`
@@ -386,6 +393,8 @@ whose key is exactly `image`. It does not scan arbitrary string content, Secret
 manifests, top-level metadata/status, or ConfigMap data payloads. Use `-o json`
 or `-o yaml` for machine-readable `added`, `removed`, and `unchanged` image
 lists. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
+Text image diffs use the same `--color=auto|always|never` behavior as manifest
+diffs.
 
 ## Diagnostics
 

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -3,11 +3,19 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/sholdee/drydock/internal/app"
 	cliformat "github.com/sholdee/drydock/internal/format"
 	"github.com/sholdee/drydock/internal/source"
 	"github.com/spf13/cobra"
+)
+
+const (
+	diffColorAuto   = "auto"
+	diffColorAlways = "always"
+	diffColorNever  = "never"
 )
 
 func newDiffCommand(deps Dependencies) *cobra.Command {
@@ -22,8 +30,14 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 	}
 	bindCommonFlags(cmd, &flags)
 
+	cmd.AddCommand(newDiffAppsCommand(deps), newDiffAppCommand(deps), newDiffImagesCommand(deps))
+	return cmd
+}
+
+func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	appsFlags := defaultCommonFlags()
 	appsFlags.parallelism = defaultRenderAppsParallelism()
+	appsColor := diffColorAuto
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Diff all Applications",
@@ -33,31 +47,47 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			colorMode, err := parseDiffColorMode(appsColor)
+			if err != nil {
+				return err
+			}
 			repoMaps, err := parseRepoMaps(appsFlags.repoMaps)
 			if err != nil {
 				return err
 			}
 			result, err := deps.Orchestrator.DiffApps(context.Background(), diffRequestFromFlags(cmd, appsFlags, repoMaps))
+			diagnosticColor := deps.isTerminal(cmd.ErrOrStderr())
 			if err != nil {
-				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
+				if renderErr := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); renderErr != nil {
 					return renderErr
 				}
 				return err
 			}
-			return renderDiffResult(cmd, result, !appsFlags.exitCode, output)
+			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
+			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor)
 		},
 	}
 	bindCommonFlags(apps, &appsFlags)
 	bindDiffRefFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
+	bindDiffColorFlag(apps, &appsColor)
 
+	return apps
+}
+
+func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	appFlags := defaultCommonFlags()
+	appColor := diffColorAuto
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Diff one Application",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := parseDiffOutput(appFlags.output, "diff app")
+			if err != nil {
+				return err
+			}
+			colorMode, err := parseDiffColorMode(appColor)
 			if err != nil {
 				return err
 			}
@@ -69,21 +99,29 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 				Name:        args[0],
 				DiffRequest: diffRequestFromFlags(cmd, appFlags, repoMaps),
 			})
+			diagnosticColor := deps.isTerminal(cmd.ErrOrStderr())
 			if err != nil {
-				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
+				if renderErr := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); renderErr != nil {
 					return renderErr
 				}
 				return err
 			}
-			return renderDiffResult(cmd, result, !appFlags.exitCode, output)
+			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
+			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor)
 		},
 	}
 	bindCommonFlags(appCmd, &appFlags)
 	bindDiffRefFlags(appCmd, &appFlags)
 	bindShowIgnoredFieldsFlag(appCmd, &appFlags)
+	bindDiffColorFlag(appCmd, &appColor)
 
+	return appCmd
+}
+
+func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 	imagesFlags := defaultCommonFlags()
 	imagesFlags.parallelism = defaultRenderAppsParallelism()
+	imagesColor := diffColorAuto
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "Diff rendered image references",
@@ -93,25 +131,31 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			colorMode, err := parseDiffColorMode(imagesColor)
+			if err != nil {
+				return err
+			}
 			repoMaps, err := parseRepoMaps(imagesFlags.repoMaps)
 			if err != nil {
 				return err
 			}
 			result, err := deps.Orchestrator.DiffImages(context.Background(), diffRequestFromFlags(cmd, imagesFlags, repoMaps))
+			diagnosticColor := deps.isTerminal(cmd.ErrOrStderr())
 			if err != nil {
-				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
+				if renderErr := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); renderErr != nil {
 					return renderErr
 				}
 				return err
 			}
-			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output)
+			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
+			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output, diffColor, diagnosticColor)
 		},
 	}
 	bindCommonFlags(images, &imagesFlags)
 	bindDiffRefFlags(images, &imagesFlags)
+	bindDiffColorFlag(images, &imagesColor)
 
-	cmd.AddCommand(apps, appCmd, images)
-	return cmd
+	return images
 }
 
 type imageDiffOutput struct {
@@ -124,14 +168,42 @@ func diffRequestFromFlags(cmd *cobra.Command, flags commonFlags, repoMaps []sour
 	return requestOptionsFromFlags(commandAwareFlags(cmd, flags), repoMaps).Diff()
 }
 
-func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string) error {
-	if err := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); err != nil {
+func bindDiffColorFlag(cmd *cobra.Command, colorMode *string) {
+	cmd.Flags().StringVar(colorMode, "color", *colorMode, "color diff output: auto, always, or never")
+}
+
+func parseDiffColorMode(value string) (string, error) {
+	mode := strings.TrimSpace(value)
+	if mode == "" {
+		return diffColorAuto, nil
+	}
+	switch mode {
+	case diffColorAuto, diffColorAlways, diffColorNever:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("color must be auto, always, or never, got %q", value)
+	}
+}
+
+func shouldColorDiffOutput(mode string, deps Dependencies, w io.Writer) bool {
+	switch mode {
+	case diffColorAlways:
+		return true
+	case diffColorNever:
+		return false
+	default:
+		return deps.isTerminal(w)
+	}
+}
+
+func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool) error {
+	if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
 		return err
 	}
 	switch output {
 	case diffOutputUnified:
 		for _, item := range result.Results {
-			if _, err := fmt.Fprint(cmd.OutOrStdout(), item.Diff); err != nil {
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeUnifiedDiff(item.Diff, diffColor)); err != nil {
 				return err
 			}
 		}
@@ -153,19 +225,19 @@ func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExit
 	return nil
 }
 
-func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string) error {
-	if err := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); err != nil {
+func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool) error {
+	if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
 		return err
 	}
 	switch output {
 	case diffOutputUnified:
 		for _, image := range result.Removed {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "- %s\n", image); err != nil {
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeDiffLine(fmt.Sprintf("- %s\n", image), diffColor)); err != nil {
 				return err
 			}
 		}
 		for _, image := range result.Added {
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "+ %s\n", image); err != nil {
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeDiffLine(fmt.Sprintf("+ %s\n", image), diffColor)); err != nil {
 				return err
 			}
 		}
@@ -186,6 +258,43 @@ func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disab
 		return ExitError{Code: code}
 	}
 	return nil
+}
+
+func colorizeUnifiedDiff(text string, color bool) string {
+	if !color || text == "" {
+		return text
+	}
+	var builder strings.Builder
+	builder.Grow(len(text))
+	for _, line := range strings.SplitAfter(text, "\n") {
+		builder.WriteString(colorizeDiffLine(line, true))
+	}
+	return builder.String()
+}
+
+func colorizeDiffLine(line string, color bool) string {
+	if !color || line == "" {
+		return line
+	}
+	body := line
+	trailingNewline := ""
+	if strings.HasSuffix(body, "\n") {
+		body = strings.TrimSuffix(body, "\n")
+		trailingNewline = "\n"
+	}
+	if body == "" {
+		return line
+	}
+	switch {
+	case strings.HasPrefix(body, "--- "), strings.HasPrefix(body, "-"):
+		return "\x1b[31m" + body + "\x1b[0m" + trailingNewline
+	case strings.HasPrefix(body, "+++ "), strings.HasPrefix(body, "+"):
+		return "\x1b[32m" + body + "\x1b[0m" + trailingNewline
+	case strings.HasPrefix(body, "@@"):
+		return "\x1b[36m" + body + "\x1b[0m" + trailingNewline
+	default:
+		return line
+	}
 }
 
 func cloneStringSlice(values []string) []string {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -12,6 +13,9 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/diff"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -113,6 +117,97 @@ func TestDiffAppPrintsOnlyNamedApplicationDiff(t *testing.T) {
 	assertStdoutContainsAll(t, result, "Application: argocd/demo", "-  value: old", "+  value: new")
 	assertStdoutExcludesAll(t, result, "other", "changed-but-skipped")
 	assertStderrEmpty(t, result)
+}
+
+func TestDiffAppsColorAlwaysColorsUnifiedOutput(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: recorder,
+		IsTerminal: func(io.Writer) bool {
+			return false
+		},
+	}, "diff", "apps", "--path-orig", "left", "--path", "right", "--color=always", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"\x1b[31m--- Application: argocd/demo source[0]\x1b[0m\n",
+		"\x1b[32m+++ Application: argocd/demo source[0]\x1b[0m\n",
+		"\x1b[36m@@ -1,3 +1,3 @@\x1b[0m\n",
+		"\x1b[31m-  value: old\x1b[0m\n",
+		"\x1b[32m+  value: new\x1b[0m\n",
+	)
+	assertStderrEmpty(t, result)
+}
+
+func TestDiffAppsColorNeverKeepsTTYOutputPlain(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: recorder,
+		IsTerminal: func(io.Writer) bool {
+			return true
+		},
+	}, "diff", "apps", "--path-orig", "left", "--path", "right", "--color=never", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result, "-  value: old", "+  value: new")
+	assertStdoutExcludesAll(t, result, "\x1b[")
+	assertStderrEmpty(t, result)
+}
+
+func TestDiffAppsColorAutoUsesStdoutTerminal(t *testing.T) {
+	tests := []struct {
+		name      string
+		terminal  bool
+		wantANSI  bool
+		forbidden string
+	}{
+		{name: "terminal", terminal: true, wantANSI: true},
+		{name: "not terminal", terminal: false, forbidden: "\x1b["},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &recordingCLIOrchestrator{
+				diffAppsResult: app.DiffResult{
+					Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+				},
+			}
+
+			result := runCLIWithDependencies(t, Dependencies{
+				Orchestrator: recorder,
+				IsTerminal: func(io.Writer) bool {
+					return tt.terminal
+				},
+			}, "diff", "apps", "--path-orig", "left", "--path", "right", "--color=auto", "--exit-code=false")
+
+			if tt.wantANSI {
+				assertStdoutContainsAll(t, result, "\x1b[31m-  value: old\x1b[0m\n")
+			}
+			if tt.forbidden != "" {
+				assertStdoutExcludesAll(t, result, tt.forbidden)
+			}
+		})
+	}
+}
+
+func TestDiffAppColorFlagIsRegistered(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "app", "demo", "--path-orig", "left", "--path", "right", "--color=always", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result, "\x1b[31m-  value: old\x1b[0m\n", "\x1b[32m+  value: new\x1b[0m\n")
 }
 
 func TestDiffAppReportsMissingApplication(t *testing.T) {
@@ -404,6 +499,37 @@ func TestDiffAppsJSONOutput(t *testing.T) {
 	}
 }
 
+func TestDiffAppsStructuredOutputStaysPlainWithColorAlways(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI(), Change: diff.ChangeModified}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: recorder,
+		IsTerminal: func(io.Writer) bool {
+			return true
+		},
+	}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "json", "--color=always", "--exit-code=false")
+
+	assertStdoutExcludesAll(t, result, "\x1b[")
+	var results []map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &results); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\nstdout:\n%s", err, result.Stdout)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %#v, want one diff", results)
+	}
+	diffText, ok := results[0]["diff"].(string)
+	if !ok {
+		t.Fatalf("diff = %T, want string", results[0]["diff"])
+	}
+	if strings.Contains(diffText, "\x1b[") {
+		t.Fatalf("json diff contains ANSI escapes: %#v", diffText)
+	}
+}
+
 func TestDiffAppYAMLOutput(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, "left")
@@ -548,6 +674,68 @@ func TestDiffImagesPrintsImageDiff(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestDiffImagesColorAlwaysColorsImageDiff(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffImagesResult: app.ImageDiffResult{
+			Removed: []string{"example/app:v1"},
+			Added:   []string{"example/app:v2"},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "images", "--path-orig", "left", "--path", "right", "--color=always", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"\x1b[31m- example/app:v1\x1b[0m\n",
+		"\x1b[32m+ example/app:v2\x1b[0m\n",
+	)
+	assertStderrEmpty(t, result)
+}
+
+func TestDiffColorNeverLeavesDiagnosticsColorIndependent(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Diagnostics: []diagnostic.Diagnostic{
+				{Severity: diagnostic.SeverityWarning, Category: "changed-only", Message: "unowned input"},
+			},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: recorder,
+		IsTerminal: func(io.Writer) bool {
+			return true
+		},
+	}, "diff", "apps", "--path-orig", "left", "--path", "right", "--color=never", "--exit-code=false")
+
+	if !strings.Contains(result.Stderr, "\x1b[33mwarning\x1b[0m changed-only: unowned input") {
+		t.Fatalf("stderr = %q, want colored warning diagnostic", result.Stderr)
+	}
+}
+
+func TestDiffRejectsInvalidColorBeforeOrchestration(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: recorder})
+	cmd.SetArgs([]string{"diff", "apps", "--path-orig", "left", "--path", "right", "--color=sometimes"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want invalid color mode")
+	}
+	if !strings.Contains(err.Error(), `color must be auto, always, or never, got "sometimes"`) {
+		t.Fatalf("error = %v, want invalid color mode", err)
+	}
+	if len(recorder.diffAppsRequests) != 0 {
+		t.Fatalf("DiffApps requests = %#v, want none before color validation", recorder.diffAppsRequests)
+	}
+	if stdout.String() != "" || stderr.String() != "" {
+		t.Fatalf("stdout=%q stderr=%q, want empty output", stdout.String(), stderr.String())
 	}
 }
 
@@ -818,6 +1006,15 @@ metadata:
 data:
   value: `+value+`
 `)
+}
+
+func sampleUnifiedDiffForCLI() string {
+	return "--- Application: argocd/demo source[0]\n" +
+		"+++ Application: argocd/demo source[0]\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" kind: ConfigMap\n" +
+		"-  value: old\n" +
+		"+  value: new\n"
 }
 
 func writeSimpleAppForCLI(t *testing.T, root, value string) {

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -20,6 +20,39 @@ func TestParseDiffOutputRejectsName(t *testing.T) {
 	}
 }
 
+func TestParseDiffColorMode(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{value: "", want: "auto"},
+		{value: "auto", want: "auto"},
+		{value: "always", want: "always"},
+		{value: "never", want: "never"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := parseDiffColorMode(tt.value)
+			if err != nil {
+				t.Fatalf("parseDiffColorMode(%q) error = %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseDiffColorMode(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDiffColorModeRejectsUnsupportedValue(t *testing.T) {
+	_, err := parseDiffColorMode("sometimes")
+	if err == nil {
+		t.Fatal("parseDiffColorMode() error = nil, want unsupported mode")
+	}
+	if !strings.Contains(err.Error(), `color must be auto, always, or never, got "sometimes"`) {
+		t.Fatalf("parseDiffColorMode() error = %v, want unsupported color message", err)
+	}
+}
+
 func TestParseTestOutputSupportsStructuredFormats(t *testing.T) {
 	tests := []struct {
 		value string

--- a/internal/cli/parallelism_test.go
+++ b/internal/cli/parallelism_test.go
@@ -279,6 +279,12 @@ type recordingCLIOrchestrator struct {
 	buildResult        app.BuildResult
 	buildError         error
 	buildHook          func(app.BuildRequest) error
+	diffAppsResult     app.DiffResult
+	diffAppsError      error
+	diffAppResult      app.DiffResult
+	diffAppError       error
+	diffImagesResult   app.ImageDiffResult
+	diffImagesError    error
 }
 
 func (orchestrator *recordingCLIOrchestrator) Build(_ context.Context, request app.BuildRequest) (app.BuildResult, error) {
@@ -303,17 +309,17 @@ func (orchestrator *recordingCLIOrchestrator) ListApplications(_ context.Context
 
 func (orchestrator *recordingCLIOrchestrator) DiffApps(_ context.Context, request app.DiffRequest) (app.DiffResult, error) {
 	orchestrator.diffAppsRequests = append(orchestrator.diffAppsRequests, request)
-	return app.DiffResult{}, nil
+	return orchestrator.diffAppsResult, orchestrator.diffAppsError
 }
 
 func (orchestrator *recordingCLIOrchestrator) DiffApp(_ context.Context, request app.DiffAppRequest) (app.DiffResult, error) {
 	orchestrator.diffAppRequests = append(orchestrator.diffAppRequests, request)
-	return app.DiffResult{}, nil
+	return orchestrator.diffAppResult, orchestrator.diffAppError
 }
 
 func (orchestrator *recordingCLIOrchestrator) DiffImages(_ context.Context, request app.DiffRequest) (app.ImageDiffResult, error) {
 	orchestrator.diffImagesRequests = append(orchestrator.diffImagesRequests, request)
-	return app.ImageDiffResult{}, nil
+	return orchestrator.diffImagesResult, orchestrator.diffImagesError
 }
 
 func (orchestrator *recordingCLIOrchestrator) Diag(_ context.Context, request app.DiagRequest) (app.DiagResult, error) {


### PR DESCRIPTION
## Summary
- add --color=auto|always|never to diff apps, diff app, and diff images
- color unified text diff payloads on stdout while keeping JSON/YAML plain
- keep stderr diagnostics on their existing independent terminal-color behavior
- document diff color behavior and cover CLI rendering with tests

## Validation
- go test ./internal/cli -run 'Diff.*Color|DiffRejectsInvalidColor|DiffAppColor|DiffAppsStructuredOutput' -count=1
- go test ./...
- mise run lint
- git diff --check

Review agents approved the plan and completed branch.