### PR TITLE
feat: report runtime module versions

### DIFF
--- a/cmd/drydock/main.go
+++ b/cmd/drydock/main.go
@@ -4,8 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/sholdee/drydock/internal/cli"
+)
+
+const (
+	argoCDModulePath       = "github.com/argoproj/argo-cd/v3"
+	gitOpsEngineModulePath = "github.com/argoproj/argo-cd/gitops-engine"
+	helmModulePath         = "helm.sh/helm/v4"
+	kustomizeModulePath    = "sigs.k8s.io/kustomize/api"
+	kubernetesModulePath   = "k8s.io/apimachinery"
 )
 
 var (
@@ -15,9 +24,13 @@ var (
 
 func main() {
 	cmd := cli.NewRootCommand(cli.VersionInfo{
-		Version:      version,
-		Commit:       commit,
-		ArgoCDModule: "github.com/argoproj/argo-cd/v3",
+		Version:            version,
+		Commit:             commit,
+		ArgoCDModule:       moduleLabel(argoCDModulePath),
+		GitOpsEngineModule: moduleLabel(gitOpsEngineModulePath),
+		HelmModule:         moduleLabel(helmModulePath),
+		KustomizeModule:    moduleLabel(kustomizeModulePath),
+		KubernetesModule:   moduleLabel(kubernetesModulePath),
 	})
 	if err := cmd.Execute(); err != nil {
 		var exitErr cli.ExitError
@@ -27,4 +40,28 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+}
+
+func moduleLabel(modulePath string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return modulePath
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == modulePath {
+			return formatModuleLabel(*dep)
+		}
+	}
+	return modulePath
+}
+
+func formatModuleLabel(module debug.Module) string {
+	label := module.Path
+	if module.Version != "" {
+		label += "@" + module.Version
+	}
+	if module.Replace != nil {
+		label += " => " + formatModuleLabel(*module.Replace)
+	}
+	return label
 }

--- a/cmd/drydock/main_test.go
+++ b/cmd/drydock/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestModuleLabelIncludesRuntimeModuleVersions(t *testing.T) {
+	for _, modulePath := range []string{
+		argoCDModulePath,
+		gitOpsEngineModulePath,
+		helmModulePath,
+		kustomizeModulePath,
+		kubernetesModulePath,
+	} {
+		t.Run(modulePath, func(t *testing.T) {
+			label := moduleLabel(modulePath)
+			if !strings.HasPrefix(label, modulePath+"@") {
+				t.Fatalf("moduleLabel(%q) = %q, want module path with version", modulePath, label)
+			}
+			if strings.TrimPrefix(label, modulePath+"@") == "" {
+				t.Fatalf("moduleLabel(%q) = %q, want non-empty version", modulePath, label)
+			}
+		})
+	}
+}
+
+func TestFormatModuleLabelIncludesReplacement(t *testing.T) {
+	label := formatModuleLabel(debug.Module{
+		Path:    "example.test/module",
+		Version: "v1.2.3",
+		Replace: &debug.Module{
+			Path:    "../module",
+			Version: "v1.2.4-local",
+		},
+	})
+	want := "example.test/module@v1.2.3 => ../module@v1.2.4-local"
+	if label != want {
+		t.Fatalf("formatModuleLabel() = %q, want %q", label, want)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,9 +10,13 @@ import (
 )
 
 type VersionInfo struct {
-	Version      string
-	Commit       string
-	ArgoCDModule string
+	Version            string
+	Commit             string
+	ArgoCDModule       string
+	GitOpsEngineModule string
+	HelmModule         string
+	KustomizeModule    string
+	KubernetesModule   string
 }
 
 type Dependencies struct {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -8,9 +8,8 @@ import (
 
 func TestRootHelp(t *testing.T) {
 	cmd := NewRootCommand(VersionInfo{
-		Version:      "test",
-		Commit:       "none",
-		ArgoCDModule: "github.com/argoproj/argo-cd/v3",
+		Version: "test",
+		Commit:  "none",
 	})
 	cmd.SetArgs([]string{"--help"})
 	var out bytes.Buffer
@@ -31,9 +30,13 @@ func TestRootHelp(t *testing.T) {
 
 func TestVersionCommand(t *testing.T) {
 	cmd := NewRootCommand(VersionInfo{
-		Version:      "test",
-		Commit:       "abc123",
-		ArgoCDModule: "github.com/argoproj/argo-cd/v3",
+		Version:            "test",
+		Commit:             "abc123",
+		ArgoCDModule:       "github.com/argoproj/argo-cd/v3@test-version",
+		GitOpsEngineModule: "github.com/argoproj/argo-cd/gitops-engine@test-version",
+		HelmModule:         "helm.sh/helm/v4@test-version",
+		KustomizeModule:    "sigs.k8s.io/kustomize/api@test-version",
+		KubernetesModule:   "k8s.io/apimachinery@test-version",
 	})
 	cmd.SetArgs([]string{"version"})
 	var out bytes.Buffer
@@ -45,18 +48,47 @@ func TestVersionCommand(t *testing.T) {
 	}
 
 	got := out.String()
-	for _, want := range []string{"version: test", "commit: abc123", "argocdModule: github.com/argoproj/argo-cd/v3"} {
+	for _, want := range []string{
+		"version: test",
+		"commit: abc123",
+		"argocdModule: github.com/argoproj/argo-cd/v3@test-version",
+		"gitopsEngineModule: github.com/argoproj/argo-cd/gitops-engine@test-version",
+		"helmModule: helm.sh/helm/v4@test-version",
+		"kustomizeModule: sigs.k8s.io/kustomize/api@test-version",
+		"kubernetesModule: k8s.io/apimachinery@test-version",
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("version output missing %q:\n%s", want, got)
 		}
 	}
 }
 
+func TestVersionCommandOmitsEmptyModuleFields(t *testing.T) {
+	cmd := NewRootCommand(VersionInfo{
+		Version: "test",
+		Commit:  "abc123",
+	})
+	cmd.SetArgs([]string{"version"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	for _, unwanted := range []string{"argocdModule:", "gitopsEngineModule:", "helmModule:", "kustomizeModule:", "kubernetesModule:"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("version output included empty module field %q:\n%s", unwanted, got)
+		}
+	}
+}
+
 func TestVersionCommandRejectsOperands(t *testing.T) {
 	cmd := NewRootCommand(VersionInfo{
-		Version:      "test",
-		Commit:       "abc123",
-		ArgoCDModule: "github.com/argoproj/argo-cd/v3",
+		Version: "test",
+		Commit:  "abc123",
 	})
 	cmd.SetArgs([]string{"version", "unexpected"})
 	var out bytes.Buffer

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -13,14 +13,32 @@ func newVersionCommand(info VersionInfo) *cobra.Command {
 		Short: "Print version information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintf(cmd.OutOrStdout(),
-				"version: %s\ncommit: %s\ngoVersion: %s\nargocdModule: %s\n",
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(),
+				"version: %s\ncommit: %s\ngoVersion: %s\n",
 				info.Version,
 				info.Commit,
 				runtime.Version(),
-				info.ArgoCDModule,
-			)
-			return err
+			); err != nil {
+				return err
+			}
+			for _, module := range []struct {
+				name  string
+				value string
+			}{
+				{name: "argocdModule", value: info.ArgoCDModule},
+				{name: "gitopsEngineModule", value: info.GitOpsEngineModule},
+				{name: "helmModule", value: info.HelmModule},
+				{name: "kustomizeModule", value: info.KustomizeModule},
+				{name: "kubernetesModule", value: info.KubernetesModule},
+			} {
+				if module.value == "" {
+					continue
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", module.name, module.value); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- report runtime anchor module versions from Go build metadata in drydock version
- include Argo CD, GitOps Engine, Helm, Kustomize, and Kubernetes/apimachinery versions
- preserve Go module replacement details in version output for support/debugging
- omit empty module fields for tests and embedding callers

## Verification
- go test ./cmd/drydock ./internal/cli
- go test ./...
- git diff --check
- local binary check: /private/tmp/drydock-runtime-modules version