### PR TITLE
feat: add drydock pull request action

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -58,7 +58,7 @@ run = "git diff --check"
 
 [tasks.zizmor]
 description = "Audit GitHub Actions workflow security"
-run = "zizmor .github/workflows setup-action"
+run = "zizmor .github/workflows setup-action pr-action"
 
 [tasks.hooks-install]
 description = "Install optional local lefthook hooks"

--- a/README.md
+++ b/README.md
@@ -85,23 +85,6 @@ jobs:
           version: v0.1.7
 ```
 
-Minimal pull request check:
-
-```yaml
-jobs:
-  drydock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: sholdee/drydock/setup-action@main
-        with:
-          version: v0.1.7
-      - run: drydock test apps --path .
-      - run: drydock diff apps --path . --ref-orig origin/${{ github.base_ref }}
-```
-
 See [`docs/github-actions.md`](docs/github-actions.md) for full action inputs,
 GitHub App token support, cache behavior, comments, artifacts, and outputs.
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,55 @@ Pin a release when the workflow needs exact repeatability:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.0
+    version: v0.1.7
 ```
 
 The setup action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z` and verifies the
 selected archive with the release checksum manifest by default.
+
+For pull request validation, the PR action wraps the common drydock workflow:
+render tests, manifest diffs, added image reports, source caches, artifacts,
+and sticky PR comments.
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sholdee/drydock/pr-action@main
+        with:
+          version: v0.1.7
+```
+
+Minimal pull request check:
+
+```yaml
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: sholdee/drydock/setup-action@main
+        with:
+          version: v0.1.7
+      - run: drydock test apps --path .
+      - run: drydock diff apps --path . --ref-orig origin/${{ github.base_ref }}
+```
+
+See [`docs/github-actions.md`](docs/github-actions.md) for full action inputs,
+GitHub App token support, cache behavior, comments, artifacts, and outputs.
 
 Release containers are published to GHCR for Linux `amd64` and `arm64`:
 
@@ -93,6 +137,10 @@ Compare a pull request checkout against a baseline tree:
 git worktree add ../baseline main
 drydock diff apps --path . --path-orig ../baseline
 ```
+
+Diff commands use changed-only selection by default. Use
+`--changed-only=false` when you want to render and compare every discovered
+Application.
 
 You can also compare against committed Git refs without creating a baseline
 worktree:
@@ -272,6 +320,8 @@ Join the home-operations Discord at <https://discord.gg/home-operations>.
   editor schema, CMP compatibility, and exec plugin security.
 - [`docs/compatibility.md`](docs/compatibility.md): supported Argo CD behavior
   and intentional runtime boundaries.
+- [`docs/github-actions.md`](docs/github-actions.md): setup action and PR
+  action usage.
 - [`docs/release.md`](docs/release.md): release and Argo CD dependency upgrade
   notes.
 - [`docs/reports/live-integration-design-gate.md`](docs/reports/live-integration-design-gate.md):

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ copying the same rule into multiple files.
 | `docs/plugin-policy.md` | Trusted plugin policy provenance, editor schema, CMP compatibility, and exec security. |
 | `schemas/plugin-policy.schema.json` | Editor validation schema for `.drydock/plugins.yaml`; parser remains authoritative. |
 | `docs/compatibility.md` | Supported Argo CD behavior and runtime-boundary status. |
+| `docs/github-actions.md` | Setup action and full PR action usage, permissions, cache, comments, and outputs. |
 | `docs/release.md` | Release and Argo CD dependency upgrade notes. |
 | `docs/logo/` | Project logo assets. |
 | `docs/reports/live-integration-design-gate.md` | No-live-runtime boundary and gate for exceptions. |

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -193,9 +193,11 @@ support without an approved design update.
 
 Manifest diff output supports unified diff, JSON, and YAML. Image diff output
 also supports unified diff, JSON, and YAML for `added`, `removed`, and
-`unchanged` image lists. Diagnostics stay on stderr for structured diff
-output. `-o name` is for list-style commands such as `get apps` and
-`get images`, not `diff apps`, `diff app`, or `diff images`.
+`unchanged` image lists. `diff images -o name` prints current-only added image
+references, one per line. Removed-only image changes print no names but still
+count as a diff for exit-code semantics unless `--exit-code=false`.
+Diagnostics stay on stderr for structured diff output. `-o name` remains
+unsupported for `diff apps` and `diff app`.
 
 Application-local and global ignore rules support `jsonPointers`,
 `jqPathExpressions`, and `managedFieldsManagers`. Apply the union from both

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -23,6 +23,35 @@ YAML:
 The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the release
 archive with `checksums.txt` unless `allow-unverified: "true"` is set.
 
+## Manual CLI Workflow
+
+Use `setup-action` directly when you want a minimal workflow and prefer to own
+the drydock commands yourself:
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: sholdee/drydock/setup-action@main
+        with:
+          version: v0.1.7
+      - run: drydock test apps --path .
+      - run: drydock diff apps --path . --ref-orig origin/${{ github.base_ref }}
+```
+
 ## Pull Request Action
 
 Use the PR action when you want the standard render test, manifest diff, image

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,130 @@
+# GitHub Actions
+
+drydock publishes two repository-local composite actions:
+
+- `sholdee/drydock/setup-action`: install a released `drydock` binary.
+- `sholdee/drydock/pr-action`: install `drydock`, run PR validation, publish
+  diff artifacts, and optionally maintain sticky PR comments.
+
+The PR action is a convenience wrapper around the CLI. It does not run image
+pull verification and does not pass GitHub tokens to the `drydock` subprocess.
+
+## Setup Action
+
+Use the setup action when you want to own every drydock command in workflow
+YAML:
+
+```yaml
+- uses: sholdee/drydock/setup-action@main
+  with:
+    version: v0.1.7
+```
+
+The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the release
+archive with `checksums.txt` unless `allow-unverified: "true"` is set.
+
+## Pull Request Action
+
+Use the PR action when you want the standard render test, manifest diff, image
+diff, source cache, artifacts, and sticky comments:
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sholdee/drydock/pr-action@main
+        with:
+          version: v0.1.7
+```
+
+By default the action:
+
+- checks out the pull request head with credentials not persisted into Git;
+- fetches the pull request base branch for ref-based diffs;
+- runs `drydock test apps --path .`;
+- runs `drydock diff apps --repo . --ref HEAD --ref-orig origin/<base>`;
+- runs `drydock diff images --repo . --ref HEAD --ref-orig origin/<base> -o name`;
+- uses drydock source caches under the runner temp directory;
+- uploads full diff artifacts when differences are found;
+- writes sticky PR comments for trusted same-repository pull requests.
+
+Fork pull requests do not restore or save drydock source caches by default,
+because source caches can contain private repository or chart material. They
+also skip PR comments by default. Set `cache-untrusted-restore: "true"` only if
+restoring cache contents into fork PR runs is acceptable for that repository.
+Cache save remains disabled for fork PRs.
+
+## Authentication
+
+The action accepts either a normal token or GitHub App credentials:
+
+```yaml
+- uses: sholdee/drydock/pr-action@main
+  with:
+    version: v0.1.7
+    github-token: ${{ secrets.DRYDOCK_TOKEN }}
+```
+
+```yaml
+- uses: sholdee/drydock/pr-action@main
+  with:
+    version: v0.1.7
+    github-app-id: ${{ secrets.DRYDOCK_APP_ID }}
+    github-app-private-key: ${{ secrets.DRYDOCK_APP_PRIVATE_KEY }}
+```
+
+The token is used for release downloads, checkout, baseline fetch, and PR
+comments. It is not exported to `drydock test`, `drydock diff`, cache contents,
+or uploaded artifacts.
+
+## Common Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `version` | `latest` | Released drydock version to install. |
+| `path` | `.` | Repository path for `drydock test apps`. |
+| `repo` | `.` | Local Git repository path for ref-based diffs. |
+| `base-ref` | PR base | Baseline branch name for diff commands. |
+| `head-ref` | `HEAD` | Current ref for diff commands after checkout. |
+| `skip-secrets` | `true` | Omit Secret resources from output and diffs. |
+| `strict` | `false` | Promote diagnostics to errors. |
+| `strict-changed-only` | `false` | Fail ambiguous changed-only ownership. |
+| `changed-only` | drydock default | Override changed-only with `true` or `false`. |
+| `show-ignored-fields` | `false` | Show default ignored diff fields. |
+| `comment-mode` | `both` | One of `none`, `diff`, `images`, or `both`. |
+| `fail-on-diff` | `false` | Fail when manifest differences are detected. |
+| `fail-on-image-diff` | `false` | Fail when image differences are detected. |
+
+Newline-delimited inputs are passed as repeated drydock flags:
+
+- `discover-kustomize`
+- `repo-map`
+- `extra-test-args`
+- `extra-diff-args`
+- `extra-image-diff-args`
+
+Only use `extra-*` inputs with trusted workflow configuration. The action
+passes them as arguments without `eval`, but they still change drydock behavior.
+
+## Outputs
+
+| Output | Meaning |
+| --- | --- |
+| `has-diff` | Rendered manifest differences were detected. |
+| `has-images` | Current-only image references were detected. |
+| `has-image-diff` | Any image difference was detected, including removed-only diffs. |
+| `render-status` | `passed`, `failed`, or `skipped`. |
+| `diff-path` | Local path to the rendered manifest diff file. |
+| `images-path` | Local path to the current-only image list. |
+| `trusted-context` | Whether cache save and PR comments were allowed. |

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,7 +29,7 @@ redacted target, revision, cache hit, offline, refresh, and error fields.
 Events must not expose credentials, query tokens, SSH private keys,
 passphrases, or raw repository URLs with embedded secrets.
 
-## GitHub Action
+## GitHub Actions
 
 The repository includes an optional composite install action at `setup-action`.
 It is release metadata only; it does not change the default static binary,
@@ -67,12 +67,20 @@ Pinned example:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.0
+    version: v0.1.7
     install-dir: /usr/local/bin
 ```
 
 Public required CI should continue to build and test from source unless a
 workflow intentionally opts into installing a released binary.
+
+The repository also includes `pr-action`, a higher-level pull request wrapper
+around the released binary. It owns workflow ergonomics for render tests,
+manifest diffs, image diff comments, artifacts, and source cache restore/save.
+It must preserve the same token boundary as the CLI: GitHub tokens may be used
+for checkout, release downloads, baseline fetch, and comments, but they must
+not be exported to `drydock` subprocesses or stored in drydock caches or
+artifacts.
 
 ## Release Automation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -395,11 +395,13 @@ drydock diff images --path ./current --path-orig ../base
 
 This projection includes PodSpec container images plus scalar manifest fields
 whose key is exactly `image`. It does not scan arbitrary string content, Secret
-manifests, top-level metadata/status, or ConfigMap data payloads. Use `-o json`
-or `-o yaml` for machine-readable `added`, `removed`, and `unchanged` image
-lists. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
-Text image diffs use the same `--color=auto|always|never` behavior as manifest
-diffs.
+manifests, top-level metadata/status, or ConfigMap data payloads. Use `-o name`
+to print current-only added image references, one per line. Removed-only image
+changes print no names but still return the diff exit code unless
+`--exit-code=false` is set. Use `-o json` or `-o yaml` for machine-readable
+`added`, `removed`, and `unchanged` image lists. Diagnostics remain on stderr so
+stdout stays valid JSON or YAML. Text image diffs use the same
+`--color=auto|always|never` behavior as manifest diffs.
 
 ## Diagnostics
 

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -127,7 +127,7 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 		Short: "Diff rendered image references",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			output, err := parseDiffOutput(imagesFlags.output, "diff images")
+			output, err := parseImageDiffOutput(imagesFlags.output)
 			if err != nil {
 				return err
 			}
@@ -248,6 +248,10 @@ func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disab
 			Unchanged: cloneStringSlice(result.Unchanged),
 		}
 		if err := writeStructuredOutput(cmd.OutOrStdout(), output, payload); err != nil {
+			return err
+		}
+	case string(cliformat.OutputName):
+		if err := cliformat.Name(cmd.OutOrStdout(), result.Added); err != nil {
 			return err
 		}
 	default:

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -780,23 +780,41 @@ func TestDiffImagesYAMLOutput(t *testing.T) {
 	assertStringSliceEqual(t, payload.Unchanged, []string{"example/sidecar:v1"})
 }
 
-func TestDiffImagesRejectsNameOutput(t *testing.T) {
+func TestDiffImagesNameOutputPrintsAddedImages(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeTwoImageAppForCLI(t, left, "example/app:v1", "example/sidecar:v1")
+	writeTwoImageAppForCLI(t, right, "example/app:v2", "example/sidecar:v1")
+
+	result := runCLI(t, "diff", "images", "--path-orig", left, "--path", right, "-o", "name", "--exit-code=false")
+	if got, want := result.Stdout, "example/app:v2\n"; got != want {
+		t.Fatalf("diff images -o name output = %q, want %q", got, want)
+	}
+	assertStdoutExcludesAll(t, result, "example/app:v1", "example/sidecar:v1")
+	assertStderrEmpty(t, result)
+}
+
+func TestDiffImagesNameOutputKeepsRemovedOnlyExitDiff(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeImageAppForCLI(t, left, "example/app:v1")
+	writeSimpleAppForCLI(t, right, "unchanged")
+
 	cmd := NewRootCommand(VersionInfo{})
-	cmd.SetArgs([]string{"diff", "images", "-o", "name"})
+	cmd.SetArgs([]string{"diff", "images", "--path-orig", left, "--path", right, "-o", "name"})
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
 	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("Execute() error = nil, want unsupported output error")
-	}
-	if !strings.Contains(err.Error(), "name output is not supported for diff images") {
-		t.Fatalf("error = %v, want diff images name rejection", err)
+	if code := commandErrorCode(err); code != 1 {
+		t.Fatalf("error code = %d, want 1 for removed-only image diff; err = %v", code, err)
 	}
 	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+		t.Fatalf("stdout = %q, want empty for removed-only image name output", stdout.String())
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -26,6 +26,14 @@ func parseDiffOutput(value, command string) (string, error) {
 	}
 }
 
+func parseImageDiffOutput(value string) (string, error) {
+	output := strings.TrimSpace(value)
+	if output == string(cliformat.OutputName) {
+		return output, nil
+	}
+	return parseDiffOutput(value, "diff images")
+}
+
 func parseTestOutput(value string) (string, error) {
 	output := strings.TrimSpace(value)
 	switch output {

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -1,0 +1,379 @@
+name: drydock PR
+description: Run drydock pull request validation, diffs, image reports, comments, and artifacts
+
+inputs:
+  version:
+    description: drydock release version to install. Defaults to latest.
+    required: false
+    default: latest
+  install-dir:
+    description: Directory to install the drydock binary into.
+    required: false
+    default: /usr/local/bin
+  github-token:
+    description: GitHub token for checkout, release downloads, and comments.
+    required: false
+  github-app-id:
+    description: Optional GitHub App ID. When set with github-app-private-key, the action mints an installation token.
+    required: false
+  github-app-private-key:
+    description: Optional GitHub App private key.
+    required: false
+  checkout:
+    description: Check out the pull request head before running drydock.
+    required: false
+    default: "true"
+  fetch-depth:
+    description: Fetch depth for the checkout step.
+    required: false
+    default: "1"
+  path:
+    description: Repository path to inspect for render tests.
+    required: false
+    default: .
+  repo:
+    description: Local Git repository path used for ref-based diffs.
+    required: false
+    default: .
+  base-ref:
+    description: Baseline branch name for diff commands. Defaults to the pull request base branch.
+    required: false
+  head-ref:
+    description: Current Git ref for diff commands. Defaults to HEAD after checkout.
+    required: false
+  run-test:
+    description: Run drydock test apps.
+    required: false
+    default: "true"
+  run-diff:
+    description: Run drydock diff apps.
+    required: false
+    default: "true"
+  run-image-diff:
+    description: Run drydock diff images.
+    required: false
+    default: "true"
+  skip-secrets:
+    description: Omit Secret resources from output and diffs.
+    required: false
+    default: "true"
+  offline:
+    description: Disable source network access and use local files, repo maps, or existing caches.
+    required: false
+    default: "false"
+  strict:
+    description: Promote diagnostics to errors.
+    required: false
+    default: "false"
+  strict-changed-only:
+    description: Fail when changed-only input ownership is ambiguous or incomplete.
+    required: false
+    default: "false"
+  changed-only:
+    description: Override changed-only behavior with true or false. Leave empty for drydock defaults.
+    required: false
+  show-ignored-fields:
+    description: Show drydock default ignored diff fields.
+    required: false
+    default: "false"
+  discover-kustomize:
+    description: Newline-delimited local Kustomize paths to render for Argo CD Application discovery.
+    required: false
+  repo-map:
+    description: Newline-delimited repository URL mappings in URL=PATH form.
+    required: false
+  parallelism:
+    description: Maximum number of Applications to render concurrently.
+    required: false
+  max-discovery-depth:
+    description: Maximum recursive rendered Application discovery depth.
+    required: false
+  enable-avp-compat:
+    description: Replace argocd-vault-plugin placeholders with deterministic redacted values.
+    required: false
+    default: "false"
+  enable-plugins:
+    description: Enable trusted exec plugin policy entries.
+    required: false
+    default: "false"
+  plugin-policy-path:
+    description: Trusted plugin policy path relative to the selected policy root.
+    required: false
+  plugin-policy-ref:
+    description: Git ref to use as the trusted plugin policy source.
+    required: false
+  plugin-policy-repo:
+    description: Local Git repository path used to resolve plugin-policy-ref.
+    required: false
+  disable-plugin-policy:
+    description: Disable trusted plugin policy loading.
+    required: false
+    default: "false"
+  extra-test-args:
+    description: Newline-delimited additional trusted arguments for drydock test apps.
+    required: false
+  extra-diff-args:
+    description: Newline-delimited additional trusted arguments for drydock diff apps.
+    required: false
+  extra-image-diff-args:
+    description: Newline-delimited additional trusted arguments for drydock diff images.
+    required: false
+  cache:
+    description: Restore and save drydock source caches for trusted runs.
+    required: false
+    default: "true"
+  save-cache:
+    description: Save drydock source caches after trusted runs.
+    required: false
+    default: "true"
+  cache-untrusted-restore:
+    description: Restore drydock source caches for fork pull requests. Cache save remains disabled for forks.
+    required: false
+    default: "false"
+  cache-path:
+    description: Local drydock cache root. Defaults to a runner temp directory.
+    required: false
+  cache-key-prefix:
+    description: Prefix for generated cache keys.
+    required: false
+    default: drydock
+  cache-key-suffix:
+    description: Suffix for generated cache keys.
+    required: false
+    default: v1
+  cache-key:
+    description: Full cache key override.
+    required: false
+  cache-restore-keys:
+    description: Newline-delimited cache restore key override.
+    required: false
+  comment-mode:
+    description: Pull request comment mode. One of none, diff, images, or both.
+    required: false
+    default: both
+  comment-empty:
+    description: Comment even when the corresponding diff is empty.
+    required: false
+    default: "false"
+  comment-continue-on-error:
+    description: Do not fail the workflow when pull request commenting fails.
+    required: false
+    default: "true"
+  diff-max-bytes:
+    description: Maximum rendered diff bytes to include in pull request comments.
+    required: false
+    default: "61000"
+  upload-artifacts:
+    description: Upload full diff and image report artifacts when they are non-empty.
+    required: false
+    default: "true"
+  artifact-retention-days:
+    description: Retention days for uploaded artifacts.
+    required: false
+    default: "30"
+  diff-artifact-name:
+    description: Artifact name override for rendered manifest diffs.
+    required: false
+  image-artifact-name:
+    description: Artifact name override for added image output.
+    required: false
+  fail-on-render-error:
+    description: Fail the action when drydock test apps fails.
+    required: false
+    default: "true"
+  fail-on-diff:
+    description: Fail the action when rendered manifest differences are detected.
+    required: false
+    default: "false"
+  fail-on-image-diff:
+    description: Fail the action when rendered image differences are detected.
+    required: false
+    default: "false"
+
+outputs:
+  has-diff:
+    description: Whether rendered manifest differences were detected.
+    value: ${{ steps.run.outputs.has-diff }}
+  has-images:
+    description: Whether current-only image references were detected.
+    value: ${{ steps.run.outputs.has-images }}
+  has-image-diff:
+    description: Whether any image reference difference was detected.
+    value: ${{ steps.run.outputs.has-image-diff }}
+  render-status:
+    description: "Render test status: passed, failed, or skipped."
+    value: ${{ steps.run.outputs.render-status }}
+  diff-path:
+    description: Local path to the rendered manifest diff file.
+    value: ${{ steps.run.outputs.diff-path }}
+  images-path:
+    description: Local path to the current-only image references file.
+    value: ${{ steps.run.outputs.images-path }}
+  diff-artifact-name:
+    description: Rendered manifest diff artifact name.
+    value: ${{ steps.run.outputs.diff-artifact-name }}
+  image-artifact-name:
+    description: Added image artifact name.
+    value: ${{ steps.run.outputs.image-artifact-name }}
+  trusted-context:
+    description: Whether the action considered this event trusted for cache save and comments.
+    value: ${{ steps.prepare.outputs.trusted-context }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub App token
+      id: app-token
+      if: ${{ inputs.github-app-id != '' && inputs.github-app-private-key != '' }}
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ inputs.github-app-id }}
+        permission-contents: read
+        permission-pull-requests: write
+        private-key: ${{ inputs.github-app-private-key }}
+
+    - name: Install drydock
+      id: setup
+      shell: bash
+      env:
+        DRYDOCK_ALLOW_UNVERIFIED: "false"
+        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
+        DRYDOCK_VERSION: ${{ inputs.version }}
+      run: '"${GITHUB_ACTION_PATH}/../setup-action/install.sh"'
+
+    - name: Prepare drydock action
+      id: prepare
+      shell: bash
+      env:
+        DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS: ${{ inputs.artifact-retention-days }}
+        DRYDOCK_INPUT_CACHE: ${{ inputs.cache }}
+        DRYDOCK_INPUT_CACHE_KEY: ${{ inputs.cache-key }}
+        DRYDOCK_INPUT_CACHE_KEY_PREFIX: ${{ inputs.cache-key-prefix }}
+        DRYDOCK_INPUT_CACHE_KEY_SUFFIX: ${{ inputs.cache-key-suffix }}
+        DRYDOCK_INPUT_CACHE_PATH: ${{ inputs.cache-path }}
+        DRYDOCK_INPUT_CACHE_RESTORE_KEYS: ${{ inputs.cache-restore-keys }}
+        DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE: ${{ inputs.cache-untrusted-restore }}
+        DRYDOCK_INPUT_COMMENT_CONTINUE_ON_ERROR: ${{ inputs.comment-continue-on-error }}
+        DRYDOCK_INPUT_COMMENT_EMPTY: ${{ inputs.comment-empty }}
+        DRYDOCK_INPUT_COMMENT_MODE: ${{ inputs.comment-mode }}
+        DRYDOCK_INPUT_DIFF_ARTIFACT_NAME: ${{ inputs.diff-artifact-name }}
+        DRYDOCK_INPUT_DIFF_MAX_BYTES: ${{ inputs.diff-max-bytes }}
+        DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME: ${{ inputs.image-artifact-name }}
+        DRYDOCK_INPUT_SAVE_CACHE: ${{ inputs.save-cache }}
+        DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
+        DRYDOCK_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        DRYDOCK_RESOLVED_VERSION: ${{ steps.setup.outputs.version }}
+      run: '"${GITHUB_ACTION_PATH}/prepare.sh"'
+
+    - name: Check out pull request head
+      if: ${{ inputs.checkout == 'true' }}
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+        persist-credentials: false
+        ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.sha }}
+        token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+
+    - name: Fetch baseline ref
+      id: fetch-base
+      if: ${{ inputs.run-diff == 'true' || inputs.run-image-diff == 'true' }}
+      shell: bash
+      env:
+        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        DRYDOCK_INPUT_BASE_REF: ${{ inputs.base-ref }}
+        DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: '"${GITHUB_ACTION_PATH}/fetch-base.sh"'
+
+    - name: Restore drydock source cache
+      id: cache-restore
+      if: ${{ steps.prepare.outputs.cache-restore == 'true' }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.prepare.outputs.cache-key }}
+        path: ${{ steps.prepare.outputs.cache-path }}
+        restore-keys: ${{ steps.prepare.outputs.restore-keys }}
+
+    - name: Run drydock
+      id: run
+      shell: bash
+      env:
+        DRYDOCK_ACTION_WORK_DIR: ${{ steps.prepare.outputs.work-dir }}
+        DRYDOCK_BASE_COMPARE_REF: ${{ steps.fetch-base.outputs.compare-ref }}
+        DRYDOCK_BIN: ${{ steps.setup.outputs.install-dir }}/drydock
+        DRYDOCK_CACHE_PATH: ${{ steps.prepare.outputs.cache-path }}
+        DRYDOCK_DIFF_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-artifact-name }}
+        DRYDOCK_IMAGE_ARTIFACT_NAME: ${{ steps.prepare.outputs.image-artifact-name }}
+        DRYDOCK_INPUT_CHANGED_ONLY: ${{ inputs.changed-only }}
+        DRYDOCK_INPUT_COMMENT_EMPTY: ${{ inputs.comment-empty }}
+        DRYDOCK_INPUT_COMMENT_MODE: ${{ inputs.comment-mode }}
+        DRYDOCK_INPUT_DIFF_MAX_BYTES: ${{ inputs.diff-max-bytes }}
+        DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY: ${{ inputs.disable-plugin-policy }}
+        DRYDOCK_INPUT_DISCOVER_KUSTOMIZE: ${{ inputs.discover-kustomize }}
+        DRYDOCK_INPUT_ENABLE_AVP_COMPAT: ${{ inputs.enable-avp-compat }}
+        DRYDOCK_INPUT_ENABLE_PLUGINS: ${{ inputs.enable-plugins }}
+        DRYDOCK_INPUT_EXTRA_DIFF_ARGS: ${{ inputs.extra-diff-args }}
+        DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS: ${{ inputs.extra-image-diff-args }}
+        DRYDOCK_INPUT_EXTRA_TEST_ARGS: ${{ inputs.extra-test-args }}
+        DRYDOCK_INPUT_FAIL_ON_DIFF: ${{ inputs.fail-on-diff }}
+        DRYDOCK_INPUT_FAIL_ON_IMAGE_DIFF: ${{ inputs.fail-on-image-diff }}
+        DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR: ${{ inputs.fail-on-render-error }}
+        DRYDOCK_INPUT_HEAD_REF: ${{ inputs.head-ref }}
+        DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH: ${{ inputs.max-discovery-depth }}
+        DRYDOCK_INPUT_OFFLINE: ${{ inputs.offline }}
+        DRYDOCK_INPUT_PARALLELISM: ${{ inputs.parallelism }}
+        DRYDOCK_INPUT_PATH: ${{ inputs.path }}
+        DRYDOCK_INPUT_PLUGIN_POLICY_PATH: ${{ inputs.plugin-policy-path }}
+        DRYDOCK_INPUT_PLUGIN_POLICY_REF: ${{ inputs.plugin-policy-ref }}
+        DRYDOCK_INPUT_PLUGIN_POLICY_REPO: ${{ inputs.plugin-policy-repo }}
+        DRYDOCK_INPUT_REPO: ${{ inputs.repo }}
+        DRYDOCK_INPUT_REPO_MAP: ${{ inputs.repo-map }}
+        DRYDOCK_INPUT_RUN_DIFF: ${{ inputs.run-diff }}
+        DRYDOCK_INPUT_RUN_IMAGE_DIFF: ${{ inputs.run-image-diff }}
+        DRYDOCK_INPUT_RUN_TEST: ${{ inputs.run-test }}
+        DRYDOCK_INPUT_SHOW_IGNORED_FIELDS: ${{ inputs.show-ignored-fields }}
+        DRYDOCK_INPUT_SKIP_SECRETS: ${{ inputs.skip-secrets }}
+        DRYDOCK_INPUT_STRICT: ${{ inputs.strict }}
+        DRYDOCK_INPUT_STRICT_CHANGED_ONLY: ${{ inputs.strict-changed-only }}
+      run: '"${GITHUB_ACTION_PATH}/run.sh"'
+
+    - name: Save drydock source cache
+      if: ${{ always() && steps.prepare.outputs.cache-save == 'true' && steps.cache-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.prepare.outputs.cache-key }}
+        path: ${{ steps.prepare.outputs.cache-path }}
+
+    - name: Comment rendered manifest diff
+      if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.diff-comment == 'true' }}
+      continue-on-error: ${{ inputs.comment-continue-on-error == 'true' }}
+      uses: mshick/add-pr-comment@8a9bc8b153160f781ebd22854f5789cd6a0cbe62 # v3.11
+      with:
+        message-id: ${{ github.event.pull_request.number }}/drydock-diff
+        message-path: ${{ steps.run.outputs.diff-comment-path }}
+        repo-token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+
+    - name: Comment added images
+      if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.images-comment == 'true' }}
+      continue-on-error: ${{ inputs.comment-continue-on-error == 'true' }}
+      uses: mshick/add-pr-comment@8a9bc8b153160f781ebd22854f5789cd6a0cbe62 # v3.11
+      with:
+        message-id: ${{ github.event.pull_request.number }}/drydock-images
+        message-path: ${{ steps.run.outputs.images-comment-path }}
+        repo-token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+
+    - name: Upload rendered manifest diff
+      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.run.outputs.diff-artifact-name }}
+        path: ${{ steps.run.outputs.diff-path }}
+        retention-days: ${{ inputs.artifact-retention-days }}
+
+    - name: Upload added images
+      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-images == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.run.outputs.image-artifact-name }}
+        path: ${{ steps.run.outputs.images-path }}
+        retention-days: ${{ inputs.artifact-retention-days }}

--- a/pr-action/fetch-base.sh
+++ b/pr-action/fetch-base.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${DRYDOCK_INPUT_BASE_REF:-}"
+if [[ -z "${base_ref}" ]]; then
+  base_ref="${DRYDOCK_PR_BASE_REF:-}"
+fi
+if [[ -z "${base_ref}" ]]; then
+  echo "base-ref is required for drydock diff steps outside pull_request events." >&2
+  exit 1
+fi
+if ! git check-ref-format --branch "${base_ref}" >/dev/null 2>&1; then
+  echo "base-ref must be a valid branch name, got '${base_ref}'." >&2
+  exit 1
+fi
+
+fetch_cmd=(git)
+if [[ -n "${DRYDOCK_GITHUB_TOKEN:-}" ]]; then
+  server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  basic_auth="$(printf 'x-access-token:%s' "${DRYDOCK_GITHUB_TOKEN}" | base64 | tr -d '\n')"
+  fetch_cmd+=(-c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${basic_auth}")
+fi
+fetch_cmd+=(fetch --no-tags --depth=1 origin "${base_ref}:refs/remotes/origin/${base_ref}")
+"${fetch_cmd[@]}"
+
+{
+  echo "base-ref=${base_ref}"
+  echo "compare-ref=origin/${base_ref}"
+} >> "${GITHUB_OUTPUT}"

--- a/pr-action/prepare.sh
+++ b/pr-action/prepare.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bool() {
+  case "$1" in
+    true | false) ;;
+    *)
+      echo "$2 must be true or false, got '$1'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+positive_int() {
+  case "$1" in
+    '' ) return 0 ;;
+    *[!0-9]* )
+      echo "$2 must be a positive integer, got '$1'." >&2
+      exit 1
+      ;;
+    0 )
+      echo "$2 must be greater than zero." >&2
+      exit 1
+      ;;
+  esac
+}
+
+bool "${DRYDOCK_INPUT_CACHE}" cache
+bool "${DRYDOCK_INPUT_SAVE_CACHE}" save-cache
+bool "${DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE}" cache-untrusted-restore
+bool "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" upload-artifacts
+bool "${DRYDOCK_INPUT_COMMENT_EMPTY}" comment-empty
+bool "${DRYDOCK_INPUT_COMMENT_CONTINUE_ON_ERROR}" comment-continue-on-error
+positive_int "${DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS}" artifact-retention-days
+positive_int "${DRYDOCK_INPUT_DIFF_MAX_BYTES}" diff-max-bytes
+
+case "${DRYDOCK_INPUT_COMMENT_MODE}" in
+  none | diff | images | both) ;;
+  *)
+    echo "comment-mode must be none, diff, images, or both, got '${DRYDOCK_INPUT_COMMENT_MODE}'." >&2
+    exit 1
+    ;;
+esac
+
+runner_temp="${RUNNER_TEMP:-/tmp}"
+work_dir="$(mktemp -d "${runner_temp%/}/drydock-pr-action.XXXXXX")"
+cache_path="${DRYDOCK_INPUT_CACHE_PATH}"
+if [[ -z "${cache_path}" ]]; then
+  cache_path="${runner_temp%/}/drydock-cache"
+fi
+mkdir -p "${cache_path}"
+
+trusted_context=true
+case "${GITHUB_EVENT_NAME:-}" in
+  pull_request | pull_request_target)
+    if [[ -n "${DRYDOCK_PR_HEAD_REPO:-}" && "${DRYDOCK_PR_HEAD_REPO}" != "${GITHUB_REPOSITORY:-}" ]]; then
+      trusted_context=false
+    fi
+    ;;
+esac
+
+cache_restore=false
+cache_save=false
+if [[ "${DRYDOCK_INPUT_CACHE}" == "true" ]]; then
+  if [[ "${trusted_context}" == "true" || "${DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE}" == "true" ]]; then
+    cache_restore=true
+  fi
+  if [[ "${trusted_context}" == "true" && "${DRYDOCK_INPUT_SAVE_CACHE}" == "true" ]]; then
+    cache_save=true
+  fi
+fi
+
+repo_key="${GITHUB_REPOSITORY:-repository}"
+repo_key="${repo_key//\//-}"
+prefix="${DRYDOCK_INPUT_CACHE_KEY_PREFIX:-drydock}"
+suffix="${DRYDOCK_INPUT_CACHE_KEY_SUFFIX:-v1}"
+version="${DRYDOCK_RESOLVED_VERSION:-unknown}"
+
+cache_key="${DRYDOCK_INPUT_CACHE_KEY}"
+if [[ -z "${cache_key}" ]]; then
+  cache_key="${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-${version}-${suffix}"
+fi
+
+restore_keys="${DRYDOCK_INPUT_CACHE_RESTORE_KEYS}"
+if [[ -z "${restore_keys}" ]]; then
+  restore_keys="${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-${version}-
+${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-
+${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-"
+fi
+
+diff_artifact_name="${DRYDOCK_INPUT_DIFF_ARTIFACT_NAME}"
+if [[ -z "${diff_artifact_name}" ]]; then
+  diff_artifact_name="drydock-diff-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}"
+fi
+image_artifact_name="${DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME}"
+if [[ -z "${image_artifact_name}" ]]; then
+  image_artifact_name="drydock-images-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}"
+fi
+
+{
+  echo "work-dir=${work_dir}"
+  echo "cache-path=${cache_path}"
+  echo "cache-key=${cache_key}"
+  echo "cache-restore=${cache_restore}"
+  echo "cache-save=${cache_save}"
+  echo "trusted-context=${trusted_context}"
+  echo "diff-artifact-name=${diff_artifact_name}"
+  echo "image-artifact-name=${image_artifact_name}"
+  echo "restore-keys<<EOF"
+  printf '%s\n' "${restore_keys}"
+  echo "EOF"
+} >> "${GITHUB_OUTPUT}"

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bool() {
+  case "$1" in
+    true | false) ;;
+    *)
+      echo "$2 must be true or false, got '$1'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+optional_int() {
+  case "$1" in
+    '' ) return 0 ;;
+    *[!0-9]* )
+      echo "$2 must be an integer, got '$1'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+positive_int() {
+  optional_int "$1" "$2"
+  if [[ -n "$1" && "$1" == "0" ]]; then
+    echo "$2 must be greater than zero." >&2
+    exit 1
+  fi
+}
+
+append_bool_flag() {
+  local -n target="$1"
+  local value="$2"
+  local flag="$3"
+  if [[ "${value}" == "true" ]]; then
+    target+=("${flag}")
+  fi
+}
+
+append_value_flag() {
+  local -n target="$1"
+  local value="$2"
+  local flag="$3"
+  if [[ -n "${value}" ]]; then
+    target+=("${flag}" "${value}")
+  fi
+}
+
+append_lines() {
+  local -n target="$1"
+  local value="$2"
+  local flag="$3"
+  local line
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    target+=("${flag}" "${line}")
+  done <<< "${value}"
+}
+
+append_extra_lines() {
+  local -n target="$1"
+  local value="$2"
+  local line
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    target+=("${line}")
+  done <<< "${value}"
+}
+
+capture_command() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  shift 2
+
+  set +e
+  "$@" > "${stdout_file}" 2> "${stderr_file}"
+  local status=$?
+  set -e
+
+  if [[ -s "${stdout_file}" ]]; then
+    cat "${stdout_file}"
+  fi
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2
+  fi
+  return "${status}"
+}
+
+truncate_file() {
+  local input="$1"
+  local output="$2"
+  local max_bytes="$3"
+
+  if [[ "$(wc -c < "${input}")" -gt "${max_bytes}" ]]; then
+    if command -v iconv >/dev/null 2>&1; then
+      head -c "${max_bytes}" "${input}" | iconv -c -f utf-8 -t utf-8 > "${output}"
+    else
+      head -c "${max_bytes}" "${input}" > "${output}"
+    fi
+    printf "\n\n####### TRUNCATED -- see artifact for full output #######\n" >> "${output}"
+  else
+    cp "${input}" "${output}"
+  fi
+}
+
+bool "${DRYDOCK_INPUT_RUN_TEST}" run-test
+bool "${DRYDOCK_INPUT_RUN_DIFF}" run-diff
+bool "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" run-image-diff
+bool "${DRYDOCK_INPUT_SKIP_SECRETS}" skip-secrets
+bool "${DRYDOCK_INPUT_OFFLINE}" offline
+bool "${DRYDOCK_INPUT_STRICT}" strict
+bool "${DRYDOCK_INPUT_STRICT_CHANGED_ONLY}" strict-changed-only
+bool "${DRYDOCK_INPUT_SHOW_IGNORED_FIELDS}" show-ignored-fields
+bool "${DRYDOCK_INPUT_ENABLE_AVP_COMPAT}" enable-avp-compat
+bool "${DRYDOCK_INPUT_ENABLE_PLUGINS}" enable-plugins
+bool "${DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY}" disable-plugin-policy
+bool "${DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR}" fail-on-render-error
+bool "${DRYDOCK_INPUT_FAIL_ON_DIFF}" fail-on-diff
+bool "${DRYDOCK_INPUT_FAIL_ON_IMAGE_DIFF}" fail-on-image-diff
+bool "${DRYDOCK_INPUT_COMMENT_EMPTY}" comment-empty
+positive_int "${DRYDOCK_INPUT_DIFF_MAX_BYTES}" diff-max-bytes
+optional_int "${DRYDOCK_INPUT_PARALLELISM}" parallelism
+optional_int "${DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH}" max-discovery-depth
+
+case "${DRYDOCK_INPUT_COMMENT_MODE}" in
+  none | diff | images | both) ;;
+  *)
+    echo "comment-mode must be none, diff, images, or both, got '${DRYDOCK_INPUT_COMMENT_MODE}'." >&2
+    exit 1
+    ;;
+esac
+case "${DRYDOCK_INPUT_CHANGED_ONLY}" in
+  '' | true | false) ;;
+  *)
+    echo "changed-only must be empty, true, or false, got '${DRYDOCK_INPUT_CHANGED_ONLY}'." >&2
+    exit 1
+    ;;
+esac
+
+work_dir="${DRYDOCK_ACTION_WORK_DIR}"
+mkdir -p "${work_dir}"
+cache_path="${DRYDOCK_CACHE_PATH:-}"
+if [[ -n "${cache_path}" ]]; then
+  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes"
+fi
+
+test_stdout="${work_dir}/test.out"
+test_stderr="${work_dir}/test.err"
+diff_path="${work_dir}/diff.txt"
+diff_stderr="${work_dir}/diff.err"
+images_path="${work_dir}/added-images.txt"
+images_stderr="${work_dir}/images.err"
+diff_comment_path="${work_dir}/diff-comment.md"
+images_comment_path="${work_dir}/images-comment.md"
+diff_snippet_path="${work_dir}/diff-snippet.txt"
+
+path="${DRYDOCK_INPUT_PATH:-.}"
+repo="${DRYDOCK_INPUT_REPO:-.}"
+head_ref="${DRYDOCK_INPUT_HEAD_REF:-HEAD}"
+base_compare_ref="${DRYDOCK_BASE_COMPARE_REF:-}"
+drydock_bin="${DRYDOCK_BIN:-drydock}"
+
+common_args=()
+if [[ -n "${cache_path}" ]]; then
+  common_args+=(
+    "--git-cache-dir" "${cache_path}/git"
+    "--chart-cache-dir" "${cache_path}/charts"
+    "--remote-cache-dir" "${cache_path}/remotes"
+  )
+fi
+append_bool_flag common_args "${DRYDOCK_INPUT_SKIP_SECRETS}" "--skip-secrets"
+append_bool_flag common_args "${DRYDOCK_INPUT_OFFLINE}" "--offline"
+append_bool_flag common_args "${DRYDOCK_INPUT_STRICT}" "--strict"
+append_bool_flag common_args "${DRYDOCK_INPUT_STRICT_CHANGED_ONLY}" "--strict-changed-only"
+append_bool_flag common_args "${DRYDOCK_INPUT_ENABLE_AVP_COMPAT}" "--enable-avp-compat"
+append_bool_flag common_args "${DRYDOCK_INPUT_ENABLE_PLUGINS}" "--enable-plugins"
+append_bool_flag common_args "${DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY}" "--disable-plugin-policy"
+append_value_flag common_args "${DRYDOCK_INPUT_PARALLELISM}" "--parallelism"
+append_value_flag common_args "${DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH}" "--max-discovery-depth"
+append_value_flag common_args "${DRYDOCK_INPUT_PLUGIN_POLICY_PATH}" "--plugin-policy-path"
+append_value_flag common_args "${DRYDOCK_INPUT_PLUGIN_POLICY_REF}" "--plugin-policy-ref"
+append_value_flag common_args "${DRYDOCK_INPUT_PLUGIN_POLICY_REPO}" "--plugin-policy-repo"
+append_lines common_args "${DRYDOCK_INPUT_DISCOVER_KUSTOMIZE}" "--discover-kustomize"
+append_lines common_args "${DRYDOCK_INPUT_REPO_MAP}" "--repo-map"
+if [[ -n "${DRYDOCK_INPUT_CHANGED_ONLY}" ]]; then
+  common_args+=("--changed-only=${DRYDOCK_INPUT_CHANGED_ONLY}")
+fi
+
+render_status="skipped"
+has_diff="false"
+has_images="false"
+has_image_diff="false"
+failed="false"
+
+if [[ "${DRYDOCK_INPUT_RUN_TEST}" == "true" ]]; then
+  test_args=("${drydock_bin}" test apps --path "${path}" "${common_args[@]}")
+  append_extra_lines test_args "${DRYDOCK_INPUT_EXTRA_TEST_ARGS}"
+  if capture_command "${test_stdout}" "${test_stderr}" "${test_args[@]}"; then
+    render_status="passed"
+  else
+    render_status="failed"
+    if [[ "${DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR}" == "true" ]]; then
+      failed="true"
+    fi
+  fi
+fi
+
+if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
+  if [[ -z "${base_compare_ref}" ]]; then
+    echo "A base ref is required when run-diff is true." >&2
+    exit 1
+  fi
+  diff_args=("${drydock_bin}" diff apps --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" --exit-code=false "${common_args[@]}")
+  append_bool_flag diff_args "${DRYDOCK_INPUT_SHOW_IGNORED_FIELDS}" "--show-ignored-fields"
+  append_extra_lines diff_args "${DRYDOCK_INPUT_EXTRA_DIFF_ARGS}"
+  if ! capture_command "${diff_path}" "${diff_stderr}" "${diff_args[@]}"; then
+    failed="true"
+  fi
+  if [[ -s "${diff_path}" ]]; then
+    has_diff="true"
+    if [[ "${DRYDOCK_INPUT_FAIL_ON_DIFF}" == "true" ]]; then
+      failed="true"
+    fi
+  fi
+else
+  : > "${diff_path}"
+fi
+
+if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
+  if [[ -z "${base_compare_ref}" ]]; then
+    echo "A base ref is required when run-image-diff is true." >&2
+    exit 1
+  fi
+  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" -o name "${common_args[@]}")
+  append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
+  set +e
+  capture_command "${images_path}" "${images_stderr}" "${image_args[@]}"
+  image_status=$?
+  set -e
+  case "${image_status}" in
+    0) ;;
+    1)
+      has_image_diff="true"
+      if [[ "${DRYDOCK_INPUT_FAIL_ON_IMAGE_DIFF}" == "true" ]]; then
+        failed="true"
+      fi
+      ;;
+    *)
+      failed="true"
+      ;;
+  esac
+  if [[ -s "${images_path}" ]]; then
+    has_images="true"
+    has_image_diff="true"
+  fi
+else
+  : > "${images_path}"
+fi
+
+comment_mode="${DRYDOCK_INPUT_COMMENT_MODE}"
+diff_comment="false"
+images_comment="false"
+if [[ "${comment_mode}" == "diff" || "${comment_mode}" == "both" ]]; then
+  if [[ "${has_diff}" == "true" || "${DRYDOCK_INPUT_COMMENT_EMPTY}" == "true" ]]; then
+    diff_comment="true"
+  fi
+fi
+if [[ "${comment_mode}" == "images" || "${comment_mode}" == "both" ]]; then
+  if [[ "${has_images}" == "true" || "${DRYDOCK_INPUT_COMMENT_EMPTY}" == "true" ]]; then
+    images_comment="true"
+  fi
+fi
+
+if [[ "${diff_comment}" == "true" ]]; then
+  {
+    echo "### drydock rendered diff"
+    echo
+    if [[ "${has_diff}" == "true" ]]; then
+      truncate_file "${diff_path}" "${diff_snippet_path}" "${DRYDOCK_INPUT_DIFF_MAX_BYTES}"
+      echo '```diff'
+      cat "${diff_snippet_path}"
+      echo '```'
+      echo
+      echo "- Full output is available from the workflow artifacts when an artifact was uploaded."
+    else
+      echo "No rendered manifest differences detected."
+    fi
+  } > "${diff_comment_path}"
+fi
+
+if [[ "${images_comment}" == "true" ]]; then
+  {
+    echo "### drydock added images"
+    echo
+    if [[ "${has_images}" == "true" ]]; then
+      while IFS= read -r image; do
+        [[ -n "${image}" ]] || continue
+        printf -- "- `%s`\n" "${image}"
+      done < "${images_path}"
+    else
+      echo "No added rendered images detected."
+    fi
+  } > "${images_comment_path}"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## drydock"
+    echo
+    echo "| Check | Result |"
+    echo "| --- | --- |"
+    echo "| Render test | ${render_status} |"
+    echo "| Manifest diff | ${has_diff} |"
+    echo "| Image additions | ${has_images} |"
+    echo "| Any image diff | ${has_image_diff} |"
+    echo
+    echo "- Diff artifact: ${DRYDOCK_DIFF_ARTIFACT_NAME}"
+    echo "- Image artifact: ${DRYDOCK_IMAGE_ARTIFACT_NAME}"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+{
+  echo "has-diff=${has_diff}"
+  echo "has-images=${has_images}"
+  echo "has-image-diff=${has_image_diff}"
+  echo "render-status=${render_status}"
+  echo "diff-path=${diff_path}"
+  echo "images-path=${images_path}"
+  echo "diff-comment-path=${diff_comment_path}"
+  echo "images-comment-path=${images_comment_path}"
+  echo "diff-comment=${diff_comment}"
+  echo "images-comment=${images_comment}"
+  echo "diff-artifact-name=${DRYDOCK_DIFF_ARTIFACT_NAME}"
+  echo "image-artifact-name=${DRYDOCK_IMAGE_ARTIFACT_NAME}"
+} >> "${GITHUB_OUTPUT}"
+
+if [[ "${failed}" == "true" ]]; then
+  exit 1
+fi

--- a/setup-action/action.yml
+++ b/setup-action/action.yml
@@ -3,7 +3,7 @@ description: Install a drydock release artifact
 
 inputs:
   version:
-    description: drydock release version to install, for example v0.1.0. Defaults to latest.
+    description: drydock release version to install, for example v0.1.7. Defaults to latest.
     required: false
     default: latest
   install-dir:
@@ -18,152 +18,23 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  version:
+    description: Resolved drydock version that was installed.
+    value: ${{ steps.install.outputs.version }}
+  install-dir:
+    description: Directory where the drydock binary was installed.
+    value: ${{ steps.install.outputs.install-dir }}
+
 runs:
   using: composite
   steps:
-    - name: Resolve runner artifact
-      id: artifact
-      shell: bash
-      env:
-        DRYDOCK_GITHUB_TOKEN: ${{ inputs.github-token }}
-        DRYDOCK_VERSION: ${{ inputs.version }}
-      run: |
-        set -euo pipefail
-
-        case "${RUNNER_OS}-${RUNNER_ARCH}" in
-          Linux-X64)
-            platform="linux-amd64"
-            ;;
-          Linux-ARM64)
-            platform="linux-arm64"
-            ;;
-          macOS-X64)
-            platform="darwin-amd64"
-            ;;
-          macOS-ARM64)
-            platform="darwin-arm64"
-            ;;
-          *)
-            echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-            exit 1
-            ;;
-        esac
-
-        repo="${GITHUB_ACTION_REPOSITORY:-${GITHUB_REPOSITORY}}"
-
-        resolve_latest() {
-          if [[ -n "${DRYDOCK_GITHUB_TOKEN}" ]]; then
-            curl --fail --silent --show-error --location \
-              -H "Authorization: Bearer ${DRYDOCK_GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${repo}/releases/latest" \
-              | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
-              | head -n 1
-          else
-            curl --write-out '%{url_effective}\n' --head --silent --show-error --location \
-              "https://github.com/${repo}/releases/latest" \
-              --output /dev/null \
-              | sed 's|.*/||'
-          fi
-        }
-
-        version="${DRYDOCK_VERSION}"
-        if [[ -z "${version}" || "${version}" == "latest" ]]; then
-          version="$(resolve_latest)"
-        fi
-
-        version="${version#refs/tags/}"
-        candidate="${version#v}"
-        semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
-        if [[ -z "${candidate}" || ! "${candidate}" =~ ${semver_re} ]]; then
-          echo "setup-action requires latest or a semantic version tag, for example v0.1.0." >&2
-          exit 1
-        fi
-        version="v${candidate}"
-
-        base_url="https://github.com/${repo}/releases/download/${version}"
-        echo "asset_url=${base_url}/drydock_${platform}.tar.gz" >> "${GITHUB_OUTPUT}"
-        echo "checksums_url=${base_url}/checksums.txt" >> "${GITHUB_OUTPUT}"
-
-    - name: Download drydock
+    - name: Install drydock
+      id: install
       shell: bash
       env:
         DRYDOCK_ALLOW_UNVERIFIED: ${{ inputs.allow-unverified }}
-        DRYDOCK_ASSET_URL: ${{ steps.artifact.outputs.asset_url }}
-        DRYDOCK_CHECKSUMS_URL: ${{ steps.artifact.outputs.checksums_url }}
         DRYDOCK_GITHUB_TOKEN: ${{ inputs.github-token }}
         DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
-      run: |
-        set -euo pipefail
-
-        tmpdir="$(mktemp -d)"
-        trap 'rm -rf "${tmpdir}"' EXIT
-
-        headers=()
-        if [[ -n "${DRYDOCK_GITHUB_TOKEN}" ]]; then
-          headers=(-H "Authorization: Bearer ${DRYDOCK_GITHUB_TOKEN}")
-        fi
-        install_dir="${DRYDOCK_INSTALL_DIR}"
-        if [[ -z "${install_dir}" ]]; then
-          echo "setup-action requires a non-empty install-dir." >&2
-          exit 1
-        fi
-
-        allow_unverified="${DRYDOCK_ALLOW_UNVERIFIED}"
-        if [[ "${allow_unverified}" != "true" && "${allow_unverified}" != "false" ]]; then
-          echo "setup-action allow-unverified must be true or false." >&2
-          exit 1
-        fi
-
-        curl --fail --location --show-error "${headers[@]}" \
-          --output "${tmpdir}/drydock.tar.gz" \
-          "${DRYDOCK_ASSET_URL}"
-        asset_name="$(basename "${DRYDOCK_ASSET_URL}")"
-
-        verify_checksum() {
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum --check "${tmpdir}/checksums.selected"
-          elif command -v shasum >/dev/null 2>&1; then
-            shasum -a 256 -c "${tmpdir}/checksums.selected"
-          else
-            echo "No supported SHA-256 checksum tool found." >&2
-            exit 1
-          fi
-        }
-
-        checksum_http_code="$(
-          curl --location --silent --show-error --write-out '%{http_code}' \
-            "${headers[@]}" \
-            --output "${tmpdir}/checksums.txt" \
-            "${DRYDOCK_CHECKSUMS_URL}" || true
-        )"
-
-        if [[ "${checksum_http_code}" == "200" ]]; then
-          expected_line="$(
-            awk -v asset="${asset_name}" '
-              $2 == asset { print; found=1; exit }
-              END { exit found ? 0 : 1 }
-            ' "${tmpdir}/checksums.txt" || true
-          )"
-          if [[ -z "${expected_line}" ]]; then
-            echo "checksums.txt did not contain the drydock artifact checksum." >&2
-            exit 1
-          fi
-          expected_hash="${expected_line%% *}"
-          printf '%s  %s\n' "${expected_hash}" "${tmpdir}/drydock.tar.gz" > "${tmpdir}/checksums.selected"
-          verify_checksum
-        elif [[ "${checksum_http_code}" == "404" ]]; then
-          if [[ "${allow_unverified}" == "true" ]]; then
-            echo "No checksums.txt artifact found; continuing because allow-unverified is true." >&2
-          else
-            echo "No checksums.txt artifact found; refusing unverified install." >&2
-            exit 1
-          fi
-        else
-          echo "Failed to download checksums.txt; HTTP status ${checksum_http_code}." >&2
-          exit 1
-        fi
-
-        mkdir -p "${install_dir}"
-        tar -xzf "${tmpdir}/drydock.tar.gz" -C "${tmpdir}"
-        install -m 0755 "${tmpdir}/drydock" "${install_dir}/drydock"
+        DRYDOCK_VERSION: ${{ inputs.version }}
+      run: '"${GITHUB_ACTION_PATH}/install.sh"'

--- a/setup-action/install.sh
+++ b/setup-action/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${RUNNER_OS}-${RUNNER_ARCH}" in
+  Linux-X64)
+    platform="linux-amd64"
+    ;;
+  Linux-ARM64)
+    platform="linux-arm64"
+    ;;
+  macOS-X64)
+    platform="darwin-amd64"
+    ;;
+  macOS-ARM64)
+    platform="darwin-arm64"
+    ;;
+  *)
+    echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+repo="${GITHUB_ACTION_REPOSITORY:-${GITHUB_REPOSITORY}}"
+version="${DRYDOCK_VERSION:-latest}"
+token="${DRYDOCK_GITHUB_TOKEN:-}"
+
+resolve_latest() {
+  if [[ -n "${token}" ]]; then
+    curl --fail --silent --show-error --location \
+      -H "Authorization: Bearer ${token}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${repo}/releases/latest" \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      | head -n 1
+  else
+    curl --write-out '%{url_effective}\n' --head --silent --show-error --location \
+      "https://github.com/${repo}/releases/latest" \
+      --output /dev/null \
+      | sed 's|.*/||'
+  fi
+}
+
+if [[ -z "${version}" || "${version}" == "latest" ]]; then
+  version="$(resolve_latest)"
+fi
+
+version="${version#refs/tags/}"
+candidate="${version#v}"
+semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+if [[ -z "${candidate}" || ! "${candidate}" =~ ${semver_re} ]]; then
+  echo "setup-action requires latest or a semantic version tag, for example v0.1.7." >&2
+  exit 1
+fi
+version="v${candidate}"
+
+base_url="https://github.com/${repo}/releases/download/${version}"
+asset_url="${base_url}/drydock_${platform}.tar.gz"
+checksums_url="${base_url}/checksums.txt"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+headers=()
+if [[ -n "${token}" ]]; then
+  headers=(-H "Authorization: Bearer ${token}")
+fi
+install_dir="${DRYDOCK_INSTALL_DIR:-/usr/local/bin}"
+if [[ -z "${install_dir}" ]]; then
+  echo "setup-action requires a non-empty install-dir." >&2
+  exit 1
+fi
+
+allow_unverified="${DRYDOCK_ALLOW_UNVERIFIED:-false}"
+if [[ "${allow_unverified}" != "true" && "${allow_unverified}" != "false" ]]; then
+  echo "setup-action allow-unverified must be true or false." >&2
+  exit 1
+fi
+
+curl --fail --location --show-error "${headers[@]}" \
+  --output "${tmpdir}/drydock.tar.gz" \
+  "${asset_url}"
+asset_name="$(basename "${asset_url}")"
+
+verify_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum --check "${tmpdir}/checksums.selected"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${tmpdir}/checksums.selected"
+  else
+    echo "No supported SHA-256 checksum tool found." >&2
+    exit 1
+  fi
+}
+
+checksum_http_code="$(
+  curl --location --silent --show-error --write-out '%{http_code}' \
+    "${headers[@]}" \
+    --output "${tmpdir}/checksums.txt" \
+    "${checksums_url}" || true
+)"
+
+if [[ "${checksum_http_code}" == "200" ]]; then
+  expected_line="$(
+    awk -v asset="${asset_name}" '
+      $2 == asset { print; found=1; exit }
+      END { exit found ? 0 : 1 }
+    ' "${tmpdir}/checksums.txt" || true
+  )"
+  if [[ -z "${expected_line}" ]]; then
+    echo "checksums.txt did not contain the drydock artifact checksum." >&2
+    exit 1
+  fi
+  expected_hash="${expected_line%% *}"
+  printf '%s  %s\n' "${expected_hash}" "${tmpdir}/drydock.tar.gz" > "${tmpdir}/checksums.selected"
+  verify_checksum
+elif [[ "${checksum_http_code}" == "404" ]]; then
+  if [[ "${allow_unverified}" == "true" ]]; then
+    echo "No checksums.txt artifact found; continuing because allow-unverified is true." >&2
+  else
+    echo "No checksums.txt artifact found; refusing unverified install." >&2
+    exit 1
+  fi
+else
+  echo "Failed to download checksums.txt; HTTP status ${checksum_http_code}." >&2
+  exit 1
+fi
+
+mkdir -p "${install_dir}"
+tar -xzf "${tmpdir}/drydock.tar.gz" -C "${tmpdir}"
+install -m 0755 "${tmpdir}/drydock" "${install_dir}/drydock"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version=${version}"
+    echo "asset-url=${asset_url}"
+    echo "install-dir=${install_dir}"
+  } >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary
- add `drydock diff images -o name` for current-only image lists
- add a separate `pr-action` for render tests, manifest diffs, image reports, artifacts, cache handling, and PR comments
- keep `setup-action` install-only through a shared installer script
- document action usage, trust boundaries, and manual CLI workflow

## Validation
- `go test ./internal/cli`
- `go test ./...`
- `mise run actionlint`
- `mise run markdownlint`
- `mise run zizmor`
- `mise run vet`
- `mise run lint`
- `bash -n setup-action/install.sh pr-action/prepare.sh pr-action/fetch-base.sh pr-action/run.sh`
- `git diff --check`