### PR TITLE
test: harden exec plugin race fixture timeouts

### DIFF
--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -1323,6 +1323,8 @@ plugins:
 `)
 }
 
+const testExecPolicyCommandTimeout = "15s"
+
 func writeExecPluginPolicy(t *testing.T, root, name string, command []string) {
 	t.Helper()
 	quoted := make([]string, 0, len(command))
@@ -1336,7 +1338,7 @@ plugins:
     engine: exec
     generate:
       command: [`+strings.Join(quoted, ", ")+`]
-      timeout: 2s
+      timeout: `+testExecPolicyCommandTimeout+`
     env:
       allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
 `)
@@ -1390,10 +1392,10 @@ plugins:
     engine: exec
     generate:
       command: [`+strings.Join(quotedCommand, ", ")+`]
-      timeout: 2s
+      timeout: `+testExecPolicyCommandTimeout+`
     postRenderers:
       - command: [`+strings.Join(quotedPostRenderer, ", ")+`]
-        timeout: 2s
+        timeout: `+testExecPolicyCommandTimeout+`
     env:
       allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
 `)


### PR DESCRIPTION
## Summary
- increase exec plugin test fixture command timeouts from 2s to 15s
- avoid CI race-mode child test-binary startup timing out before invalid output assertions run

## Root Cause
The failing test shells out to the current Go test binary as an exec plugin helper. Under `go test -race ./...` on GitHub Actions, that child process can exceed the fixture's 2s timeout, causing a generate timeout diagnostic instead of the intended invalid final post-render diagnostic.

## Validation
- go test ./internal/app -run TestOrchestratorBuildReportsInvalidExecPolicyPostRendererOutput -count=1
- go test -race ./internal/app -run TestOrchestratorBuildReportsInvalidExecPolicyPostRendererOutput -count=5
- go test -race ./internal/app -count=1
- go test -race ./...
- go test ./...
- git diff --check