### PR TITLE
feat: allow PR action to use an existing drydock binary

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -109,9 +109,12 @@ The action accepts either a normal token or GitHub App credentials:
 - uses: sholdee/drydock/pr-action@main
   with:
     version: v0.1.7
-    github-app-id: ${{ secrets.DRYDOCK_APP_ID }}
+    github-app-client-id: ${{ secrets.DRYDOCK_APP_CLIENT_ID }}
     github-app-private-key: ${{ secrets.DRYDOCK_APP_PRIVATE_KEY }}
 ```
+
+`github-app-id` remains available as a legacy fallback for existing workflows,
+but new workflows should use the GitHub App client ID.
 
 The token is used for release downloads, checkout, baseline fetch, and PR
 comments. It is not exported to `drydock test`, `drydock diff`, cache contents,
@@ -122,6 +125,9 @@ or uploaded artifacts.
 | Input | Default | Purpose |
 | --- | --- | --- |
 | `version` | `latest` | Released drydock version to install. |
+| `install` | `true` | Install drydock before running. |
+| `drydock-bin` | `drydock` | Preinstalled drydock binary when `install` is `false`. |
+| `release-repository` | `sholdee/drydock` | Repository that publishes drydock release artifacts. |
 | `path` | `.` | Repository path for `drydock test apps`. |
 | `repo` | `.` | Local Git repository path for ref-based diffs. |
 | `base-ref` | PR base | Baseline branch name for diff commands. |

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: drydock release version to install. Defaults to latest.
     required: false
     default: latest
+  install:
+    description: Install drydock before running. Set to false when a pinned drydock binary is already on PATH.
+    required: false
+    default: "true"
+  drydock-bin:
+    description: drydock binary path or command to run when install is false.
+    required: false
+    default: drydock
   install-dir:
     description: Directory to install the drydock binary into.
     required: false
@@ -13,12 +21,19 @@ inputs:
   github-token:
     description: GitHub token for checkout, release downloads, and comments.
     required: false
+  github-app-client-id:
+    description: Optional GitHub App client ID. When set with github-app-private-key, the action mints an installation token.
+    required: false
   github-app-id:
-    description: Optional GitHub App ID. When set with github-app-private-key, the action mints an installation token.
+    description: Optional legacy GitHub App ID fallback. Prefer github-app-client-id.
     required: false
   github-app-private-key:
     description: Optional GitHub App private key.
     required: false
+  release-repository:
+    description: Repository that publishes drydock release artifacts.
+    required: false
+    default: sholdee/drydock
   checkout:
     description: Check out the pull request head before running drydock.
     required: false
@@ -223,8 +238,18 @@ runs:
   using: composite
   steps:
     - name: Create GitHub App token
-      id: app-token
-      if: ${{ inputs.github-app-id != '' && inputs.github-app-private-key != '' }}
+      id: app-token-client
+      if: ${{ inputs.github-app-client-id != '' && inputs.github-app-private-key != '' }}
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ inputs.github-app-client-id }}
+        permission-contents: read
+        permission-pull-requests: write
+        private-key: ${{ inputs.github-app-private-key }}
+
+    - name: Create GitHub App token from legacy App ID
+      id: app-token-legacy
+      if: ${{ inputs.github-app-client-id == '' && inputs.github-app-id != '' && inputs.github-app-private-key != '' }}
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ inputs.github-app-id }}
@@ -232,13 +257,34 @@ runs:
         permission-pull-requests: write
         private-key: ${{ inputs.github-app-private-key }}
 
+    - name: Validate drydock install mode
+      shell: bash
+      env:
+        DRYDOCK_INPUT_DRYDOCK_BIN: ${{ inputs.drydock-bin }}
+        DRYDOCK_INPUT_INSTALL: ${{ inputs.install }}
+      run: |
+        case "${DRYDOCK_INPUT_INSTALL}" in
+          true | false) ;;
+          *)
+            echo "install must be true or false, got '${DRYDOCK_INPUT_INSTALL}'." >&2
+            exit 1
+            ;;
+        esac
+
+        if [[ "${DRYDOCK_INPUT_INSTALL}" == "false" && -z "${DRYDOCK_INPUT_DRYDOCK_BIN}" ]]; then
+          echo "drydock-bin is required when install is false." >&2
+          exit 1
+        fi
+
     - name: Install drydock
       id: setup
+      if: ${{ inputs.install == 'true' }}
       shell: bash
       env:
         DRYDOCK_ALLOW_UNVERIFIED: "false"
-        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
         DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
+        DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
         DRYDOCK_VERSION: ${{ inputs.version }}
       run: '"${GITHUB_ACTION_PATH}/../setup-action/install.sh"'
 
@@ -263,7 +309,7 @@ runs:
         DRYDOCK_INPUT_SAVE_CACHE: ${{ inputs.save-cache }}
         DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
         DRYDOCK_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-        DRYDOCK_RESOLVED_VERSION: ${{ steps.setup.outputs.version }}
+        DRYDOCK_RESOLVED_VERSION: ${{ inputs.install == 'true' && steps.setup.outputs.version || inputs.version }}
       run: '"${GITHUB_ACTION_PATH}/prepare.sh"'
 
     - name: Check out pull request head
@@ -273,14 +319,14 @@ runs:
         fetch-depth: ${{ inputs.fetch-depth }}
         persist-credentials: false
         ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.sha }}
-        token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        token: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
 
     - name: Fetch baseline ref
       id: fetch-base
       if: ${{ inputs.run-diff == 'true' || inputs.run-image-diff == 'true' }}
       shell: bash
       env:
-        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
         DRYDOCK_INPUT_BASE_REF: ${{ inputs.base-ref }}
         DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: '"${GITHUB_ACTION_PATH}/fetch-base.sh"'
@@ -300,7 +346,7 @@ runs:
       env:
         DRYDOCK_ACTION_WORK_DIR: ${{ steps.prepare.outputs.work-dir }}
         DRYDOCK_BASE_COMPARE_REF: ${{ steps.fetch-base.outputs.compare-ref }}
-        DRYDOCK_BIN: ${{ steps.setup.outputs.install-dir }}/drydock
+        DRYDOCK_BIN: ${{ inputs.install == 'true' && format('{0}/drydock', steps.setup.outputs.install-dir) || inputs.drydock-bin }}
         DRYDOCK_CACHE_PATH: ${{ steps.prepare.outputs.cache-path }}
         DRYDOCK_DIFF_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-artifact-name }}
         DRYDOCK_IMAGE_ARTIFACT_NAME: ${{ steps.prepare.outputs.image-artifact-name }}
@@ -351,7 +397,7 @@ runs:
       with:
         message-id: ${{ github.event.pull_request.number }}/drydock-diff
         message-path: ${{ steps.run.outputs.diff-comment-path }}
-        repo-token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        repo-token: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
 
     - name: Comment added images
       if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.images-comment == 'true' }}
@@ -360,7 +406,7 @@ runs:
       with:
         message-id: ${{ github.event.pull_request.number }}/drydock-images
         message-path: ${{ steps.run.outputs.images-comment-path }}
-        repo-token: ${{ steps.app-token.outputs.token || inputs.github-token || github.token }}
+        repo-token: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
 
     - name: Upload rendered manifest diff
       if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}

--- a/setup-action/action.yml
+++ b/setup-action/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Directory to install the drydock binary into.
     required: false
     default: /usr/local/bin
+  release-repository:
+    description: Repository that publishes drydock release artifacts.
+    required: false
+    default: sholdee/drydock
   github-token:
     description: Optional GitHub token for downloading release artifacts.
     required: false
@@ -36,5 +40,6 @@ runs:
         DRYDOCK_ALLOW_UNVERIFIED: ${{ inputs.allow-unverified }}
         DRYDOCK_GITHUB_TOKEN: ${{ inputs.github-token }}
         DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
+        DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
         DRYDOCK_VERSION: ${{ inputs.version }}
       run: '"${GITHUB_ACTION_PATH}/install.sh"'

--- a/setup-action/install.sh
+++ b/setup-action/install.sh
@@ -20,9 +20,14 @@ case "${RUNNER_OS}-${RUNNER_ARCH}" in
     ;;
 esac
 
-repo="${GITHUB_ACTION_REPOSITORY:-${GITHUB_REPOSITORY}}"
+repo="${DRYDOCK_RELEASE_REPOSITORY:-sholdee/drydock}"
 version="${DRYDOCK_VERSION:-latest}"
 token="${DRYDOCK_GITHUB_TOKEN:-}"
+
+if [[ ! "${repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "setup-action release-repository must be in owner/repo form, got '${repo}'." >&2
+  exit 1
+fi
 
 resolve_latest() {
   if [[ -n "${token}" ]]; then


### PR DESCRIPTION
## Summary
- add pr-action inputs to skip installing drydock and use a preinstalled binary
- pin setup-action release downloads to the drydock release repository instead of the caller repository
- add GitHub App client ID support while keeping legacy app ID fallback
- document install, drydock-bin, release-repository, and client ID usage

## Root Cause
When pr-action runs inside another repository, setup-action/install.sh can resolve the release repository as the caller repository and attempt to download drydock assets from that repository, producing a 404. The installer now defaults release downloads to sholdee/drydock and exposes an override for advanced cases.

## Validation
- mise run actionlint
- mise run markdownlint
- git diff --check
- setup-action/install.sh downloaded and checksum-verified drydock v0.1.7 from sholdee/drydock with DRYDOCK_RELEASE_REPOSITORY=sholdee/drydock