### PR TITLE
feat: cache drydock action installs

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -23,6 +23,13 @@ YAML:
 The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the release
 archive with `checksums.txt` unless `allow-unverified: "true"` is set.
 
+By default, the setup action caches the verified release archive by resolved
+version, runner OS/architecture, release repository, and checksum. `latest` is
+resolved to a concrete tag before cache lookup, so a new release receives a new
+cache key. Binary caching is skipped when `allow-unverified: "true"` is set.
+Disable it with `cache-binary: "false"` if a workflow wants every run to
+download the archive.
+
 ## Manual CLI Workflow
 
 Use `setup-action` directly when you want a minimal workflow and prefer to own
@@ -80,6 +87,8 @@ jobs:
 By default the action:
 
 - checks out the pull request head with credentials not persisted into Git;
+- restores or saves a verified drydock binary archive when installation is
+  enabled;
 - fetches the pull request base branch for ref-based diffs;
 - runs `drydock test apps --path .`;
 - runs `drydock diff apps --repo . --ref HEAD --ref-orig origin/<base>`;
@@ -120,6 +129,11 @@ The token is used for release downloads, checkout, baseline fetch, and PR
 comments. It is not exported to `drydock test`, `drydock diff`, cache contents,
 or uploaded artifacts.
 
+Binary caching is separate from drydock source caching. Binary cache entries
+contain only the released `drydock` archive and are keyed by release checksum.
+Source cache entries contain fetched Git, Helm, and remote Kustomize sources for
+the repository under test.
+
 ## Common Inputs
 
 | Input | Default | Purpose |
@@ -128,6 +142,8 @@ or uploaded artifacts.
 | `install` | `true` | Install drydock before running. |
 | `drydock-bin` | `drydock` | Preinstalled drydock binary when `install` is `false`. |
 | `release-repository` | `sholdee/drydock` | Repository that publishes drydock release artifacts. |
+| `cache-binary` | `true` | Restore and save the verified release archive when installing drydock. |
+| `cache-binary-key-suffix` | `v1` | Invalidate generated binary cache keys. |
 | `path` | `.` | Repository path for `drydock test apps`. |
 | `repo` | `.` | Local Git repository path for ref-based diffs. |
 | `base-ref` | PR base | Baseline branch name for diff commands. |

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,6 +56,11 @@ runners where `shasum` is the available SHA-256 verifier. Only a 404 for
 artifact, and only when `allow-unverified: true` is set. By default, missing
 checksums and checksum download failures fail the action.
 
+By default, the setup action may restore and save the verified release archive
+through GitHub Actions cache. `latest` is resolved to a concrete release tag
+before cache lookup, and cache keys include the release checksum. Cache restore
+and save are skipped when `allow-unverified: true` is set.
+
 Example:
 
 ```yaml

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: Directory to install the drydock binary into.
     required: false
     default: /usr/local/bin
+  cache-binary:
+    description: Restore and save the verified drydock release archive when install is true.
+    required: false
+    default: "true"
+  cache-binary-key-suffix:
+    description: Suffix for generated drydock binary cache keys.
+    required: false
+    default: v1
   github-token:
     description: GitHub token for checkout, release downloads, and comments.
     required: false
@@ -276,17 +284,48 @@ runs:
           exit 1
         fi
 
+    - name: Resolve drydock release
+      id: setup-resolve
+      if: ${{ inputs.install == 'true' }}
+      shell: bash
+      env:
+        DRYDOCK_ALLOW_UNVERIFIED: "false"
+        DRYDOCK_CACHE_BINARY: ${{ inputs.cache-binary }}
+        DRYDOCK_CACHE_BINARY_KEY_SUFFIX: ${{ inputs.cache-binary-key-suffix }}
+        DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
+        DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
+        DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
+        DRYDOCK_VERSION: ${{ inputs.version }}
+      run: '"${GITHUB_ACTION_PATH}/../setup-action/resolve.sh"'
+
+    - name: Restore drydock binary cache
+      id: setup-binary-cache-restore
+      if: ${{ inputs.install == 'true' && steps.setup-resolve.outputs.cache-enabled == 'true' }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.setup-resolve.outputs.cache-key }}
+        path: ${{ steps.setup-resolve.outputs.cache-path }}
+
     - name: Install drydock
       id: setup
       if: ${{ inputs.install == 'true' }}
       shell: bash
       env:
         DRYDOCK_ALLOW_UNVERIFIED: "false"
+        DRYDOCK_CACHE_ARCHIVE: ${{ steps.setup-resolve.outputs.cache-archive }}
+        DRYDOCK_EXPECTED_HASH: ${{ steps.setup-resolve.outputs.expected-hash }}
         DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
         DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
         DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
-        DRYDOCK_VERSION: ${{ inputs.version }}
+        DRYDOCK_RESOLVED_VERSION: ${{ steps.setup-resolve.outputs.version }}
       run: '"${GITHUB_ACTION_PATH}/../setup-action/install.sh"'
+
+    - name: Save drydock binary cache
+      if: ${{ inputs.install == 'true' && steps.setup-resolve.outputs.cache-enabled == 'true' && steps.setup-binary-cache-restore.outputs.cache-hit != 'true' && steps.setup.outputs.cache-save == 'true' }}
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.setup-resolve.outputs.cache-key }}
+        path: ${{ steps.setup-resolve.outputs.cache-path }}
 
     - name: Prepare drydock action
       id: prepare

--- a/setup-action/action.yml
+++ b/setup-action/action.yml
@@ -21,6 +21,14 @@ inputs:
     description: Allow installation when the release does not publish checksums.txt.
     required: false
     default: "false"
+  cache-binary:
+    description: Restore and save the verified drydock release archive.
+    required: false
+    default: "true"
+  cache-binary-key-suffix:
+    description: Suffix for generated drydock binary cache keys.
+    required: false
+    default: v1
 
 outputs:
   version:
@@ -29,17 +37,50 @@ outputs:
   install-dir:
     description: Directory where the drydock binary was installed.
     value: ${{ steps.install.outputs.install-dir }}
+  binary-cache-hit:
+    description: Whether the drydock release archive was restored from cache and verified.
+    value: ${{ steps.install.outputs.cache-hit }}
 
 runs:
   using: composite
   steps:
+    - name: Resolve drydock release
+      id: resolve
+      shell: bash
+      env:
+        DRYDOCK_ALLOW_UNVERIFIED: ${{ inputs.allow-unverified }}
+        DRYDOCK_CACHE_BINARY: ${{ inputs.cache-binary }}
+        DRYDOCK_CACHE_BINARY_KEY_SUFFIX: ${{ inputs.cache-binary-key-suffix }}
+        DRYDOCK_GITHUB_TOKEN: ${{ inputs.github-token }}
+        DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
+        DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
+        DRYDOCK_VERSION: ${{ inputs.version }}
+      run: '"${GITHUB_ACTION_PATH}/resolve.sh"'
+
+    - name: Restore drydock binary cache
+      id: binary-cache-restore
+      if: ${{ steps.resolve.outputs.cache-enabled == 'true' }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.resolve.outputs.cache-key }}
+        path: ${{ steps.resolve.outputs.cache-path }}
+
     - name: Install drydock
       id: install
       shell: bash
       env:
         DRYDOCK_ALLOW_UNVERIFIED: ${{ inputs.allow-unverified }}
+        DRYDOCK_CACHE_ARCHIVE: ${{ steps.resolve.outputs.cache-archive }}
+        DRYDOCK_EXPECTED_HASH: ${{ steps.resolve.outputs.expected-hash }}
         DRYDOCK_GITHUB_TOKEN: ${{ inputs.github-token }}
         DRYDOCK_INSTALL_DIR: ${{ inputs.install-dir }}
         DRYDOCK_RELEASE_REPOSITORY: ${{ inputs.release-repository }}
-        DRYDOCK_VERSION: ${{ inputs.version }}
+        DRYDOCK_RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
       run: '"${GITHUB_ACTION_PATH}/install.sh"'
+
+    - name: Save drydock binary cache
+      if: ${{ steps.resolve.outputs.cache-enabled == 'true' && steps.binary-cache-restore.outputs.cache-hit != 'true' && steps.install.outputs.cache-save == 'true' }}
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: ${{ steps.resolve.outputs.cache-key }}
+        path: ${{ steps.resolve.outputs.cache-path }}

--- a/setup-action/install.sh
+++ b/setup-action/install.sh
@@ -1,66 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-case "${RUNNER_OS}-${RUNNER_ARCH}" in
-  Linux-X64)
-    platform="linux-amd64"
-    ;;
-  Linux-ARM64)
-    platform="linux-arm64"
-    ;;
-  macOS-X64)
-    platform="darwin-amd64"
-    ;;
-  macOS-ARM64)
-    platform="darwin-arm64"
-    ;;
-  *)
-    echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-    exit 1
-    ;;
-esac
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=setup-action/lib.sh
+source "${script_dir}/lib.sh"
 
+platform="$(detect_platform)"
 repo="${DRYDOCK_RELEASE_REPOSITORY:-sholdee/drydock}"
-version="${DRYDOCK_VERSION:-latest}"
+version="${DRYDOCK_RESOLVED_VERSION:-${DRYDOCK_VERSION:-latest}}"
 token="${DRYDOCK_GITHUB_TOKEN:-}"
+expected_hash="${DRYDOCK_EXPECTED_HASH:-}"
+cache_archive="${DRYDOCK_CACHE_ARCHIVE:-}"
+cache_hit=false
+cache_save=false
 
-if [[ ! "${repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  echo "setup-action release-repository must be in owner/repo form, got '${repo}'." >&2
-  exit 1
-fi
-
-resolve_latest() {
-  if [[ -n "${token}" ]]; then
-    curl --fail --silent --show-error --location \
-      -H "Authorization: Bearer ${token}" \
-      -H "Accept: application/vnd.github+json" \
-      "https://api.github.com/repos/${repo}/releases/latest" \
-      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
-      | head -n 1
-  else
-    curl --write-out '%{url_effective}\n' --head --silent --show-error --location \
-      "https://github.com/${repo}/releases/latest" \
-      --output /dev/null \
-      | sed 's|.*/||'
-  fi
-}
+validate_repo "${repo}"
 
 if [[ -z "${version}" || "${version}" == "latest" ]]; then
-  version="$(resolve_latest)"
+  version="$(resolve_latest "${repo}" "${token}")"
 fi
 
-version="${version#refs/tags/}"
-candidate="${version#v}"
-semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
-if [[ -z "${candidate}" || ! "${candidate}" =~ ${semver_re} ]]; then
-  echo "setup-action requires latest or a semantic version tag, for example v0.1.7." >&2
-  exit 1
-fi
-version="v${candidate}"
-
-base_url="https://github.com/${repo}/releases/download/${version}"
-asset_url="${base_url}/drydock_${platform}.tar.gz"
-checksums_url="${base_url}/checksums.txt"
+version="$(normalize_version "${version}")"
+asset_url="$(asset_url "${repo}" "${version}" "${platform}")"
+checksums_url="$(checksums_url "${repo}" "${version}")"
+asset_name="$(basename "${asset_url}")"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
@@ -76,62 +39,95 @@ if [[ -z "${install_dir}" ]]; then
 fi
 
 allow_unverified="${DRYDOCK_ALLOW_UNVERIFIED:-false}"
-if [[ "${allow_unverified}" != "true" && "${allow_unverified}" != "false" ]]; then
-  echo "setup-action allow-unverified must be true or false." >&2
-  exit 1
-fi
-
-curl --fail --location --show-error "${headers[@]}" \
-  --output "${tmpdir}/drydock.tar.gz" \
-  "${asset_url}"
-asset_name="$(basename "${asset_url}")"
+validate_bool allow-unverified "${allow_unverified}"
 
 verify_checksum() {
+  local selected_file="$1"
+
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum --check "${tmpdir}/checksums.selected"
+    sha256sum --check "${selected_file}"
   elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 -c "${tmpdir}/checksums.selected"
+    shasum -a 256 -c "${selected_file}"
   else
     echo "No supported SHA-256 checksum tool found." >&2
     exit 1
   fi
 }
 
-checksum_http_code="$(
-  curl --location --silent --show-error --write-out '%{http_code}' \
-    "${headers[@]}" \
-    --output "${tmpdir}/checksums.txt" \
-    "${checksums_url}" || true
-)"
+verify_archive() {
+  local expected="$1"
+  local archive="$2"
+  local selected_file="$3"
 
-if [[ "${checksum_http_code}" == "200" ]]; then
-  expected_line="$(
-    awk -v asset="${asset_name}" '
-      $2 == asset { print; found=1; exit }
-      END { exit found ? 0 : 1 }
-    ' "${tmpdir}/checksums.txt" || true
+  printf '%s  %s\n' "${expected}" "${archive}" > "${selected_file}"
+  verify_checksum "${selected_file}"
+}
+
+resolve_expected_hash() {
+  if [[ -n "${expected_hash}" ]]; then
+    printf '%s\n' "${expected_hash}"
+    return 0
+  fi
+
+  checksum_http_code="$(
+    curl --location --silent --show-error --write-out '%{http_code}' \
+      "${headers[@]}" \
+      --output "${tmpdir}/checksums.txt" \
+      "${checksums_url}" || true
   )"
-  if [[ -z "${expected_line}" ]]; then
-    echo "checksums.txt did not contain the drydock artifact checksum." >&2
-    exit 1
-  fi
-  expected_hash="${expected_line%% *}"
-  printf '%s  %s\n' "${expected_hash}" "${tmpdir}/drydock.tar.gz" > "${tmpdir}/checksums.selected"
-  verify_checksum
-elif [[ "${checksum_http_code}" == "404" ]]; then
-  if [[ "${allow_unverified}" == "true" ]]; then
-    echo "No checksums.txt artifact found; continuing because allow-unverified is true." >&2
+
+  if [[ "${checksum_http_code}" == "200" ]]; then
+    if ! checksum_for_asset "${tmpdir}/checksums.txt" "${asset_name}"; then
+      echo "checksums.txt did not contain the drydock artifact checksum." >&2
+      exit 1
+    fi
+  elif [[ "${checksum_http_code}" == "404" ]]; then
+    if [[ "${allow_unverified}" == "true" ]]; then
+      echo "No checksums.txt artifact found; continuing because allow-unverified is true." >&2
+      printf '\n'
+    else
+      echo "No checksums.txt artifact found; refusing unverified install." >&2
+      exit 1
+    fi
   else
-    echo "No checksums.txt artifact found; refusing unverified install." >&2
+    echo "Failed to download checksums.txt; HTTP status ${checksum_http_code}." >&2
     exit 1
   fi
-else
-  echo "Failed to download checksums.txt; HTTP status ${checksum_http_code}." >&2
-  exit 1
+}
+
+archive_path=""
+if [[ -n "${cache_archive}" && -s "${cache_archive}" ]]; then
+  if [[ -n "${expected_hash}" ]]; then
+    if verify_archive "${expected_hash}" "${cache_archive}" "${tmpdir}/checksums.cache.selected"; then
+      archive_path="${cache_archive}"
+      cache_hit=true
+    else
+      echo "Cached drydock archive failed checksum verification; downloading ${version}." >&2
+    fi
+  else
+    echo "No expected checksum for cached drydock archive; downloading ${version}." >&2
+  fi
+fi
+
+if [[ -z "${archive_path}" ]]; then
+  archive_path="${tmpdir}/drydock.tar.gz"
+  curl --fail --location --show-error "${headers[@]}" \
+    --output "${archive_path}" \
+    "${asset_url}"
+
+  resolved_hash="$(resolve_expected_hash)"
+  if [[ -n "${resolved_hash}" ]]; then
+    verify_archive "${resolved_hash}" "${archive_path}" "${tmpdir}/checksums.download.selected"
+    if [[ -n "${cache_archive}" ]]; then
+      mkdir -p "$(dirname "${cache_archive}")"
+      cp "${archive_path}" "${cache_archive}"
+      cache_save=true
+    fi
+  fi
 fi
 
 mkdir -p "${install_dir}"
-tar -xzf "${tmpdir}/drydock.tar.gz" -C "${tmpdir}"
+tar -xzf "${archive_path}" -C "${tmpdir}"
 install -m 0755 "${tmpdir}/drydock" "${install_dir}/drydock"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -139,5 +135,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "version=${version}"
     echo "asset-url=${asset_url}"
     echo "install-dir=${install_dir}"
+    echo "cache-hit=${cache_hit}"
+    echo "cache-save=${cache_save}"
   } >> "${GITHUB_OUTPUT}"
 fi

--- a/setup-action/install_test.go
+++ b/setup-action/install_test.go
@@ -1,0 +1,153 @@
+package setupaction
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInstallUsesVerifiedCachedArchive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	archive := buildDrydockArchive(t, tmp, "cached")
+	hash := sha256File(t, archive)
+	writeExecutable(t, filepath.Join(tmp, "curl"), `#!/usr/bin/env bash
+echo "curl should not be called for a verified cached archive" >&2
+exit 2
+`)
+
+	installDir := filepath.Join(tmp, "bin")
+	outputPath := filepath.Join(tmp, "github-output")
+	cmd := exec.Command("bash", "install.sh")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+		"RUNNER_OS=Linux",
+		"RUNNER_ARCH=X64",
+		"DRYDOCK_ALLOW_UNVERIFIED=false",
+		"DRYDOCK_CACHE_ARCHIVE="+archive,
+		"DRYDOCK_EXPECTED_HASH="+hash,
+		"DRYDOCK_INSTALL_DIR="+installDir,
+		"DRYDOCK_RELEASE_REPOSITORY=sholdee/drydock",
+		"DRYDOCK_RESOLVED_VERSION=v1.2.3",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(filepath.Join(installDir, "drydock")); err != nil {
+		t.Fatalf("installed drydock missing: %v", err)
+	}
+	outputs := readGitHubOutput(t, outputPath)
+	if got, want := outputs["cache-hit"], "true"; got != want {
+		t.Fatalf("cache-hit = %q, want %q", got, want)
+	}
+	if got, want := outputs["cache-save"], "false"; got != want {
+		t.Fatalf("cache-save = %q, want %q", got, want)
+	}
+}
+
+func TestInstallCopiesVerifiedDownloadIntoCache(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	releaseArchive := buildDrydockArchive(t, tmp, "download")
+	hash := sha256File(t, releaseArchive)
+	cacheArchive := filepath.Join(tmp, "cache", "drydock.tar.gz")
+	writeExecutable(t, filepath.Join(tmp, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+
+out=""
+args="$*"
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+
+if [[ "${args}" == *"drydock_linux-amd64.tar.gz"* ]]; then
+  cp "${DRYDOCK_TEST_ARCHIVE}" "${out}"
+  exit 0
+fi
+if [[ "${args}" == *"checksums.txt"* ]]; then
+  printf '`+hash+`  drydock_linux-amd64.tar.gz\n' > "${out}"
+  printf '200'
+  exit 0
+fi
+echo "unexpected curl invocation: ${args}" >&2
+exit 2
+`)
+
+	installDir := filepath.Join(tmp, "bin")
+	outputPath := filepath.Join(tmp, "github-output")
+	cmd := exec.Command("bash", "install.sh")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+		"RUNNER_OS=Linux",
+		"RUNNER_ARCH=X64",
+		"DRYDOCK_ALLOW_UNVERIFIED=false",
+		"DRYDOCK_CACHE_ARCHIVE="+cacheArchive,
+		"DRYDOCK_INSTALL_DIR="+installDir,
+		"DRYDOCK_RELEASE_REPOSITORY=sholdee/drydock",
+		"DRYDOCK_RESOLVED_VERSION=v1.2.3",
+		"DRYDOCK_TEST_ARCHIVE="+releaseArchive,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, out)
+	}
+
+	if got := sha256File(t, cacheArchive); got != hash {
+		t.Fatalf("cached archive hash = %q, want %q", got, hash)
+	}
+	outputs := readGitHubOutput(t, outputPath)
+	if got, want := outputs["cache-hit"], "false"; got != want {
+		t.Fatalf("cache-hit = %q, want %q", got, want)
+	}
+	if got, want := outputs["cache-save"], "true"; got != want {
+		t.Fatalf("cache-save = %q, want %q", got, want)
+	}
+}
+
+func buildDrydockArchive(t *testing.T, tmp, label string) string {
+	t.Helper()
+
+	src := filepath.Join(tmp, "src-"+label)
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir archive src: %v", err)
+	}
+	writeExecutable(t, filepath.Join(src, "drydock"), "#!/usr/bin/env bash\necho drydock "+label+"\n")
+
+	archive := filepath.Join(tmp, "drydock-"+label+".tar.gz")
+	cmd := exec.Command("tar", "-czf", archive, "-C", src, "drydock")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build archive: %v\n%s", err, out)
+	}
+	return archive
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}

--- a/setup-action/lib.sh
+++ b/setup-action/lib.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+
+detect_platform() {
+  case "${RUNNER_OS}-${RUNNER_ARCH}" in
+    Linux-X64)
+      printf 'linux-amd64\n'
+      ;;
+    Linux-ARM64)
+      printf 'linux-arm64\n'
+      ;;
+    macOS-X64)
+      printf 'darwin-amd64\n'
+      ;;
+    macOS-ARM64)
+      printf 'darwin-arm64\n'
+      ;;
+    *)
+      echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+      return 1
+      ;;
+  esac
+}
+
+validate_repo() {
+  local repo="$1"
+  if [[ ! "${repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    echo "setup-action release-repository must be in owner/repo form, got '${repo}'." >&2
+    return 1
+  fi
+}
+
+validate_bool() {
+  local name="$1"
+  local value="$2"
+  case "${value}" in
+    true | false) ;;
+    *)
+      echo "setup-action ${name} must be true or false, got '${value}'." >&2
+      return 1
+      ;;
+  esac
+}
+
+resolve_latest() {
+  local repo="$1"
+  local token="$2"
+
+  if [[ -n "${token}" ]]; then
+    curl --fail --silent --show-error --location \
+      -H "Authorization: Bearer ${token}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${repo}/releases/latest" \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      | head -n 1
+  else
+    curl --write-out '%{url_effective}\n' --head --silent --show-error --location \
+      "https://github.com/${repo}/releases/latest" \
+      --output /dev/null \
+      | sed 's|.*/||'
+  fi
+}
+
+normalize_version() {
+  local raw_version="$1"
+  local candidate
+
+  raw_version="${raw_version#refs/tags/}"
+  candidate="${raw_version#v}"
+  if [[ -z "${candidate}" || ! "${candidate}" =~ ${semver_re} ]]; then
+    echo "setup-action requires latest or a semantic version tag, for example v0.1.7." >&2
+    return 1
+  fi
+  printf 'v%s\n' "${candidate}"
+}
+
+asset_url() {
+  local repo="$1"
+  local version="$2"
+  local platform="$3"
+
+  printf 'https://github.com/%s/releases/download/%s/drydock_%s.tar.gz\n' "${repo}" "${version}" "${platform}"
+}
+
+checksums_url() {
+  local repo="$1"
+  local version="$2"
+
+  printf 'https://github.com/%s/releases/download/%s/checksums.txt\n' "${repo}" "${version}"
+}
+
+sanitize_cache_part() {
+  local value="$1"
+
+  printf '%s' "${value}" | sed 's/[^A-Za-z0-9_.-]/-/g'
+}
+
+checksum_for_asset() {
+  local checksums_file="$1"
+  local asset_name="$2"
+
+  awk -v asset="${asset_name}" '
+    $2 == asset { print $1; found=1; exit }
+    END { exit found ? 0 : 1 }
+  ' "${checksums_file}"
+}

--- a/setup-action/resolve.sh
+++ b/setup-action/resolve.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=setup-action/lib.sh
+source "${script_dir}/lib.sh"
+
+platform="$(detect_platform)"
+repo="${DRYDOCK_RELEASE_REPOSITORY:-sholdee/drydock}"
+version="${DRYDOCK_VERSION:-latest}"
+token="${DRYDOCK_GITHUB_TOKEN:-}"
+install_dir="${DRYDOCK_INSTALL_DIR:-/usr/local/bin}"
+allow_unverified="${DRYDOCK_ALLOW_UNVERIFIED:-false}"
+cache_binary="${DRYDOCK_CACHE_BINARY:-true}"
+cache_suffix="${DRYDOCK_CACHE_BINARY_KEY_SUFFIX:-v1}"
+
+validate_repo "${repo}"
+validate_bool allow-unverified "${allow_unverified}"
+validate_bool cache-binary "${cache_binary}"
+
+if [[ -z "${install_dir}" ]]; then
+  echo "setup-action requires a non-empty install-dir." >&2
+  exit 1
+fi
+
+if [[ -z "${version}" || "${version}" == "latest" ]]; then
+  version="$(resolve_latest "${repo}" "${token}")"
+fi
+version="$(normalize_version "${version}")"
+
+asset_url_value="$(asset_url "${repo}" "${version}" "${platform}")"
+checksums_url_value="$(checksums_url "${repo}" "${version}")"
+asset_name="$(basename "${asset_url_value}")"
+cache_enabled=false
+expected_hash=""
+
+if [[ "${cache_binary}" == "true" && "${allow_unverified}" == "false" ]]; then
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "${tmpdir}"' EXIT
+
+  headers=()
+  if [[ -n "${token}" ]]; then
+    headers=(-H "Authorization: Bearer ${token}")
+  fi
+
+  if curl --fail --silent --show-error --location \
+    "${headers[@]}" \
+    --output "${tmpdir}/checksums.txt" \
+    "${checksums_url_value}"; then
+    if expected_hash="$(checksum_for_asset "${tmpdir}/checksums.txt" "${asset_name}")"; then
+      cache_enabled=true
+    else
+      echo "checksums.txt did not contain ${asset_name}; skipping drydock binary cache." >&2
+    fi
+  else
+    echo "Could not resolve drydock checksum; skipping drydock binary cache." >&2
+  fi
+fi
+
+runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+repo_key="$(sanitize_cache_part "${repo}")"
+version_key="$(sanitize_cache_part "${version}")"
+platform_key="$(sanitize_cache_part "${platform}")"
+suffix_key="$(sanitize_cache_part "${cache_suffix}")"
+hash_key="$(sanitize_cache_part "${expected_hash}")"
+
+cache_path="${runner_temp%/}/drydock-binary-cache/${repo_key}/${version_key}/${platform_key}/${hash_key}"
+cache_key="drydock-binary-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-${version_key}-${platform_key}-${hash_key}-${suffix_key}"
+cache_archive="${cache_path}/drydock.tar.gz"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version=${version}"
+    echo "asset-url=${asset_url_value}"
+    echo "checksums-url=${checksums_url_value}"
+    echo "install-dir=${install_dir}"
+    echo "cache-enabled=${cache_enabled}"
+    echo "cache-key=${cache_key}"
+    echo "cache-path=${cache_path}"
+    echo "cache-archive=${cache_archive}"
+    echo "expected-hash=${expected_hash}"
+  } >> "${GITHUB_OUTPUT}"
+fi

--- a/setup-action/resolve_test.go
+++ b/setup-action/resolve_test.go
@@ -1,0 +1,151 @@
+package setupaction
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveLatestBuildsChecksumScopedCacheKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	hash := strings.Repeat("a", 64)
+	writeExecutable(t, filepath.Join(tmp, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+if [[ "${args}" == *"api.github.com/repos/sholdee/drydock/releases/latest"* ]]; then
+  printf '{"tag_name":"v1.2.3"}\n'
+  exit 0
+fi
+if [[ "${args}" == *"checksums.txt"* ]]; then
+  out=""
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--output" ]]; then
+      out="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  printf '`+hash+`  drydock_linux-amd64.tar.gz\n' > "${out}"
+  exit 0
+fi
+echo "unexpected curl invocation: ${args}" >&2
+exit 2
+`)
+
+	outputPath := filepath.Join(tmp, "github-output")
+	cmd := exec.Command("bash", "resolve.sh")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+		"RUNNER_OS=Linux",
+		"RUNNER_ARCH=X64",
+		"RUNNER_TEMP="+tmp,
+		"DRYDOCK_ALLOW_UNVERIFIED=false",
+		"DRYDOCK_CACHE_BINARY=true",
+		"DRYDOCK_CACHE_BINARY_KEY_SUFFIX=v1",
+		"DRYDOCK_GITHUB_TOKEN=test-token",
+		"DRYDOCK_INSTALL_DIR=/usr/local/bin",
+		"DRYDOCK_RELEASE_REPOSITORY=sholdee/drydock",
+		"DRYDOCK_VERSION=latest",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve.sh failed: %v\n%s", err, out)
+	}
+
+	outputs := readGitHubOutput(t, outputPath)
+	if got, want := outputs["version"], "v1.2.3"; got != want {
+		t.Fatalf("version = %q, want %q", got, want)
+	}
+	if got, want := outputs["cache-enabled"], "true"; got != want {
+		t.Fatalf("cache-enabled = %q, want %q", got, want)
+	}
+	if got := outputs["expected-hash"]; got != hash {
+		t.Fatalf("expected-hash = %q, want %q", got, hash)
+	}
+	if got := outputs["cache-key"]; !strings.Contains(got, "v1.2.3") || strings.Contains(got, "latest") {
+		t.Fatalf("cache-key = %q, want resolved version and no latest", got)
+	}
+	if got := outputs["cache-key"]; !strings.Contains(got, hash) {
+		t.Fatalf("cache-key = %q, want checksum in key", got)
+	}
+}
+
+func TestResolveSkipsCacheForUnverifiedInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	writeExecutable(t, filepath.Join(tmp, "curl"), `#!/usr/bin/env bash
+echo "curl should not be called for pinned unverified cache-disabled resolution" >&2
+exit 2
+`)
+
+	outputPath := filepath.Join(tmp, "github-output")
+	cmd := exec.Command("bash", "resolve.sh")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+		"RUNNER_OS=Linux",
+		"RUNNER_ARCH=X64",
+		"RUNNER_TEMP="+tmp,
+		"DRYDOCK_ALLOW_UNVERIFIED=true",
+		"DRYDOCK_CACHE_BINARY=true",
+		"DRYDOCK_CACHE_BINARY_KEY_SUFFIX=v1",
+		"DRYDOCK_INSTALL_DIR=/usr/local/bin",
+		"DRYDOCK_RELEASE_REPOSITORY=sholdee/drydock",
+		"DRYDOCK_VERSION=v1.2.3",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve.sh failed: %v\n%s", err, out)
+	}
+
+	outputs := readGitHubOutput(t, outputPath)
+	if got, want := outputs["version"], "v1.2.3"; got != want {
+		t.Fatalf("version = %q, want %q", got, want)
+	}
+	if got, want := outputs["cache-enabled"], "false"; got != want {
+		t.Fatalf("cache-enabled = %q, want %q", got, want)
+	}
+	if got := outputs["expected-hash"]; got != "" {
+		t.Fatalf("expected-hash = %q, want empty", got)
+	}
+}
+
+func readGitHubOutput(t *testing.T, path string) map[string]string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read GITHUB_OUTPUT: %v", err)
+	}
+	outputs := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		outputs[key] = value
+	}
+	return outputs
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- cache verified drydock release archives in setup-action
- reuse the same binary install cache path from pr-action when install is enabled
- keep binary install cache separate from drydock source caches
- document cache behavior and add focused setup-action tests

## Validation
- go test ./setup-action ./pr-action
- mise run lint
- mise run markdownlint
- mise run actionlint
- shellcheck setup-action/*.sh
- mise run test
- git diff --check

## Review
- spec review approved
- quality review approved