### PR TITLE
ci: add shellcheck coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,25 @@ jobs:
       - name: Audit GitHub Actions security
         run: mise run zizmor
 
+  shellcheck:
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.workflow == 'true' || needs.detect.outputs.lint == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Lint shell scripts
+        run: mise run shellcheck
+
   renovate:
     needs: detect
     if: github.event_name != 'pull_request' || needs.detect.outputs.renovate == 'true' || needs.detect.outputs.workflow == 'true'
@@ -254,6 +273,7 @@ jobs:
       - go-lint
       - markdownlint
       - workflow-lint
+      - shellcheck
       - renovate
       - whitespace
       - image
@@ -267,11 +287,12 @@ jobs:
           GO_LINT: ${{ needs.go-lint.result }}
           MARKDOWNLINT: ${{ needs.markdownlint.result }}
           WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
+          SHELLCHECK: ${{ needs.shellcheck.result }}
           RENOVATE: ${{ needs.renovate.result }}
           WHITESPACE: ${{ needs.whitespace.result }}
           IMAGE: ${{ needs.image.result }}
         run: |
-          echo "detect=${DETECT} go-test=${GO_TEST} go-lint=${GO_LINT} markdownlint=${MARKDOWNLINT} workflow-lint=${WORKFLOW_LINT} renovate=${RENOVATE} whitespace=${WHITESPACE} image=${IMAGE}"
+          echo "detect=${DETECT} go-test=${GO_TEST} go-lint=${GO_LINT} markdownlint=${MARKDOWNLINT} workflow-lint=${WORKFLOW_LINT} shellcheck=${SHELLCHECK} renovate=${RENOVATE} whitespace=${WHITESPACE} image=${IMAGE}"
 
           for result in \
             "${DETECT}" \
@@ -279,6 +300,7 @@ jobs:
             "${GO_LINT}" \
             "${MARKDOWNLINT}" \
             "${WORKFLOW_LINT}" \
+            "${SHELLCHECK}" \
             "${RENOVATE}" \
             "${WHITESPACE}" \
             "${IMAGE}"; do

--- a/mise.lock
+++ b/mise.lock
@@ -110,6 +110,38 @@ checksum = "sha256:1f29681dfbc36b9bdde52139cca6c4668ea4d51fd81e9127a3b78f49369db
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Windows_x86_64.gz"
 provenance = "github-attestations"
 
+[[tools.shellcheck]]
+version = "0.11.0"
+backend = "aqua:koalaman/shellcheck"
+
+[tools.shellcheck."platforms.linux-arm64"]
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-arm64-musl"]
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64"]
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64-musl"]
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.macos-arm64"]
+checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.macos-x64"]
+checksum = "sha256:3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.windows-x64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
+
 [[tools.zizmor]]
 version = "1.25.2"
 backend = "aqua:zizmorcore/zizmor"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 go = "1.26.3"
 golangci-lint = "2.12.2"
 lefthook = "2.1.9"
+shellcheck = "0.11.0"
 zizmor = "1.25.2"
 
 [tasks.fmt]
@@ -48,6 +49,10 @@ run = "go run github.com/shinagawa-web/gomarklint/v3@v3.2.2"
 description = "Lint GitHub Actions workflows"
 run = "go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12"
 
+[tasks.shellcheck]
+description = "Lint shell scripts"
+run = "shellcheck setup-action/*.sh pr-action/*.sh"
+
 [tasks.vuln]
 description = "Run advisory govulncheck"
 run = "go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./..."
@@ -66,4 +71,4 @@ run = "lefthook install"
 
 [tasks.ci]
 description = "Run the main local CI checks"
-depends = ["mod-verify", "mod-tidy-check", "test-race", "vet", "lint", "markdownlint", "actionlint", "zizmor", "whitespace"]
+depends = ["mod-verify", "mod-tidy-check", "test-race", "vet", "lint", "markdownlint", "actionlint", "shellcheck", "zizmor", "whitespace"]

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -30,6 +30,7 @@ positive_int() {
 }
 
 append_bool_flag() {
+  # shellcheck disable=SC2178
   local -n target="$1"
   local value="$2"
   local flag="$3"
@@ -39,6 +40,7 @@ append_bool_flag() {
 }
 
 append_value_flag() {
+  # shellcheck disable=SC2178
   local -n target="$1"
   local value="$2"
   local flag="$3"
@@ -48,6 +50,7 @@ append_value_flag() {
 }
 
 append_lines() {
+  # shellcheck disable=SC2178
   local -n target="$1"
   local value="$2"
   local flag="$3"
@@ -59,6 +62,7 @@ append_lines() {
 }
 
 append_extra_lines() {
+  # shellcheck disable=SC2178
   local -n target="$1"
   local value="$2"
   local line
@@ -344,7 +348,7 @@ if [[ "${images_comment}" == "true" ]]; then
     if [[ "${has_images}" == "true" ]]; then
       while IFS= read -r image; do
         [[ -n "${image}" ]] || continue
-        printf -- "- `%s`\n" "${image}"
+        printf -- "- \`%s\`\n" "${image}"
       done < "${images_path}"
     else
       echo "No added rendered images detected."


### PR DESCRIPTION
## Summary
- add ShellCheck to mise tooling with the short registry name
- add a shellcheck task to local CI
- add a CI job for shell scripts gated on action/workflow/lint changes
- clean up existing ShellCheck findings in pr-action/run.sh

## Validation
- mise run shellcheck
- mise run actionlint
- go test ./pr-action ./setup-action
- mise run lint
- mise run markdownlint
- git diff --check

Note: local `mise install --locked` was blocked by global mise config entries outside this repo lockfile; repo tasks passed.