### PR TITLE
feat: add CLI profiling diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .worktrees/
+drydock-profiles/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -462,6 +462,46 @@ go test ./internal/app -run '^$' -bench 'BenchmarkOrchestrator(BuildManyLocalApp
 
 Benchmark numbers are trend signals, not hard pass/fail thresholds.
 
+Advanced profiling flags are available in release binaries and `go run` builds
+for maintainers diagnosing real repository performance:
+
+```bash
+drydock --profile cpu --profile-out ./drydock-profiles test apps --path .
+drydock --profile trace --profile-out ./drydock-profiles diff apps --path . --ref-orig main
+drydock --profile mem --profile-out ./drydock-profiles get images --path .
+```
+
+`--profile` accepts `cpu`, `mem`, `block`, `mutex`, or `trace`. Profile metadata
+is written to stderr, and profile artifacts are written under `--profile-out`.
+Normal stdout output remains unchanged for text, JSON, YAML, and diff formats.
+The `mem` mode writes a heap profile at command completion; it is not a memory
+timeline.
+
+Inspect pprof profiles with:
+
+```bash
+go tool pprof ./drydock-profiles/drydock-test-apps-*.cpu.pprof
+```
+
+Inspect traces with:
+
+```bash
+go tool trace ./drydock-profiles/drydock-diff-apps-*.trace.out
+```
+
+Profiles may include local paths, command arguments, symbols, and sampled
+in-memory strings. Review profile files before sharing them publicly.
+
+Use the optional maintainer script for repeated real-repository smokes:
+
+```bash
+scripts/profile-smoke.sh ~/git/home-ops --binary ./dist/drydock --profile cpu --warm-runs 3
+```
+
+The script is not a CI gate. It accepts explicit `--ref` and `--ref-orig`
+values, and otherwise tries to detect the baseline branch from `origin/HEAD`,
+`main`, or `master`.
+
 ## Runtime-Boundary Commands And Sources
 
 These source paths are outside the current default runtime contract:

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/sholdee/drydock/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+type profileFlags struct {
+	mode   string
+	outDir string
+}
+
+func defaultProfileFlags() profileFlags {
+	return profileFlags{outDir: profile.DefaultOutDir}
+}
+
+func bindProfileFlags(cmd *cobra.Command, flags *profileFlags) {
+	cmd.PersistentFlags().StringVar(&flags.mode, "profile", flags.mode, "write a Go runtime profile: cpu, mem, block, mutex, or trace")
+	cmd.PersistentFlags().StringVar(&flags.outDir, "profile-out", flags.outDir, "directory for profile artifacts")
+}
+
+func installProfileWrapper(cmd *cobra.Command, flags *profileFlags) {
+	if cmd.RunE != nil {
+		runE := cmd.RunE
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			return runWithProfile(cmd, flags, func() error {
+				return runE(cmd, args)
+			})
+		}
+	}
+	for _, child := range cmd.Commands() {
+		installProfileWrapper(child, flags)
+	}
+}
+
+func runWithProfile(cmd *cobra.Command, flags *profileFlags, run func() error) error {
+	if flags == nil || flags.mode == "" {
+		return run()
+	}
+	session, err := profile.Start(profile.Options{
+		Mode:        flags.mode,
+		OutDir:      flags.outDir,
+		CommandPath: cmd.CommandPath(),
+		Stderr:      cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return err
+	}
+	runErr := run()
+	if stopErr := session.Stop(); stopErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning profile: %v\n", stopErr)
+		if runErr != nil {
+			return runErr
+		}
+		return stopErr
+	}
+	return runErr
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,12 +47,14 @@ func NewRootCommand(info VersionInfo) *cobra.Command {
 }
 
 func NewRootCommandWithDependencies(info VersionInfo, deps Dependencies) *cobra.Command {
+	profileFlags := defaultProfileFlags()
 	cmd := &cobra.Command{
 		Use:           "drydock",
 		Short:         "Inspect your Argo CD fleet without getting wet",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	bindProfileFlags(cmd, &profileFlags)
 	cmd.AddCommand(newGetCommand(deps))
 	cmd.AddCommand(newBuildCommand(deps))
 	cmd.AddCommand(newTestCommand(deps))
@@ -60,6 +62,7 @@ func NewRootCommandWithDependencies(info VersionInfo, deps Dependencies) *cobra.
 	cmd.AddCommand(newCacheCommand())
 	cmd.AddCommand(newDiagCommand(deps))
 	cmd.AddCommand(newVersionCommand(info))
+	installProfileWrapper(cmd, &profileFlags)
 	return cmd
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,8 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sholdee/drydock/internal/app"
 )
 
 func TestRootHelp(t *testing.T) {
@@ -99,5 +104,88 @@ func TestVersionCommandRejectsOperands(t *testing.T) {
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatalf("Execute() error = nil, want error")
+	}
+}
+
+func TestProfileWritesFileAndKeepsStructuredStdoutClean(t *testing.T) {
+	root := t.TempDir()
+	profileOut := filepath.Join(t.TempDir(), "profiles")
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"--profile", "mem", "--profile-out", profileOut, "test", "apps", "--path", root, "-o", "json"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if got, want := strings.TrimSpace(stdout.String()), "[]"; got != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+	if !strings.Contains(stderr.String(), "profile mem: wrote ") {
+		t.Fatalf("stderr = %q, want profile write message", stderr.String())
+	}
+	matches, err := filepath.Glob(filepath.Join(profileOut, "drydock-test-apps-*.mem.pprof"))
+	if err != nil {
+		t.Fatalf("glob profile files: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("profile files = %v, want one mem profile", matches)
+	}
+	info, err := os.Stat(matches[0])
+	if err != nil {
+		t.Fatalf("stat profile file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("profile file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestProfileRejectsInvalidMode(t *testing.T) {
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"--profile", "sometimes", "version"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `profile must be cpu, mem, block, mutex, or trace, got "sometimes"`) {
+		t.Fatalf("Execute() error = %v, want invalid profile mode", err)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestProfileStopErrorDoesNotReplaceCommandError(t *testing.T) {
+	profileOut := filepath.Join(t.TempDir(), "profiles")
+	originalErr := errors.New("original command failure")
+	recorder := &recordingCLIOrchestrator{
+		buildError: originalErr,
+		buildHook: func(_ app.BuildRequest) error {
+			if err := os.RemoveAll(profileOut); err != nil {
+				return err
+			}
+			if err := os.WriteFile(profileOut, []byte("not a directory"), 0o600); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: recorder})
+	cmd.SetArgs([]string{"--profile", "mem", "--profile-out", profileOut, "build", "apps"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if !errors.Is(err, originalErr) {
+		t.Fatalf("Execute() error = %v, want original command error", err)
+	}
+	if !strings.Contains(stderr.String(), "warning profile:") {
+		t.Fatalf("stderr = %q, want profile warning", stderr.String())
 	}
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,213 @@
+package profile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+	"time"
+)
+
+const DefaultOutDir = "drydock-profiles"
+
+type Options struct {
+	Mode        string
+	OutDir      string
+	CommandPath string
+	Stderr      io.Writer
+	Now         func() time.Time
+}
+
+type Session struct {
+	mode       string
+	path       string
+	stderr     io.Writer
+	stop       func() error
+	stopped    bool
+	successMsg string
+}
+
+func Start(options Options) (*Session, error) {
+	if options.Mode == "" {
+		return &Session{}, nil
+	}
+	mode, err := normalizeMode(options.Mode)
+	if err != nil {
+		return nil, err
+	}
+	outDir := options.OutDir
+	if outDir == "" {
+		outDir = DefaultOutDir
+	}
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create profile output directory: %w", err)
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	path := filepath.Join(outDir, filename(options.CommandPath, mode, now().UTC()))
+	session := &Session{
+		mode:       mode,
+		path:       path,
+		stderr:     options.Stderr,
+		successMsg: fmt.Sprintf("profile %s: wrote %s\n", mode, path),
+	}
+
+	switch mode {
+	case "cpu":
+		file, err := openProfileFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := pprof.StartCPUProfile(file); err != nil {
+			closeErr := file.Close()
+			_ = os.Remove(path)
+			return nil, errors.Join(fmt.Errorf("start cpu profile: %w", err), closeErr)
+		}
+		session.stop = func() error {
+			pprof.StopCPUProfile()
+			return file.Close()
+		}
+	case "mem":
+		session.stop = func() error {
+			runtime.GC()
+			return writeRuntimeProfile(path, "heap")
+		}
+	case "block":
+		runtime.SetBlockProfileRate(1)
+		session.stop = func() error {
+			defer runtime.SetBlockProfileRate(0)
+			return writeRuntimeProfile(path, "block")
+		}
+	case "mutex":
+		previous := runtime.SetMutexProfileFraction(1)
+		session.stop = func() error {
+			defer runtime.SetMutexProfileFraction(previous)
+			return writeRuntimeProfile(path, "mutex")
+		}
+	case "trace":
+		file, err := openProfileFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := trace.Start(file); err != nil {
+			closeErr := file.Close()
+			_ = os.Remove(path)
+			return nil, errors.Join(fmt.Errorf("start trace profile: %w", err), closeErr)
+		}
+		session.stop = func() error {
+			trace.Stop()
+			return file.Close()
+		}
+	default:
+		return nil, fmt.Errorf("unsupported profile mode %q", mode)
+	}
+
+	return session, nil
+}
+
+func (session *Session) Stop() error {
+	if session == nil || session.stopped {
+		return nil
+	}
+	session.stopped = true
+	if session.stop == nil {
+		return nil
+	}
+	if err := session.stop(); err != nil {
+		return fmt.Errorf("write %s profile %s: %w", session.mode, session.path, err)
+	}
+	if session.stderr != nil {
+		_, _ = io.WriteString(session.stderr, session.successMsg)
+	}
+	return nil
+}
+
+func normalizeMode(mode string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "":
+		return "", nil
+	case "cpu", "mem", "block", "mutex", "trace":
+		return strings.ToLower(strings.TrimSpace(mode)), nil
+	default:
+		return "", fmt.Errorf("profile must be cpu, mem, block, mutex, or trace, got %q", mode)
+	}
+}
+
+func filename(commandPath string, mode string, now time.Time) string {
+	extension := "pprof"
+	if mode == "trace" {
+		extension = "out"
+	}
+	return fmt.Sprintf("%s-%s.%s.%s", sanitizeCommandPath(commandPath), now.Format("20060102T150405.000000000Z"), mode, extension)
+}
+
+func sanitizeCommandPath(commandPath string) string {
+	fields := strings.Fields(commandPath)
+	if len(fields) == 0 {
+		return "drydock"
+	}
+	var builder strings.Builder
+	lastDash := false
+	for _, field := range fields {
+		if builder.Len() > 0 && !lastDash {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+		for _, r := range field {
+			if sanitized, ok := sanitizeCommandPathRune(r); ok {
+				builder.WriteRune(sanitized)
+				lastDash = false
+				continue
+			}
+			if !lastDash && builder.Len() > 0 {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func sanitizeCommandPathRune(r rune) (rune, bool) {
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return r + ('a' - 'A'), true
+	case r >= 'a' && r <= 'z':
+		return r, true
+	case r >= '0' && r <= '9':
+		return r, true
+	case r == '.' || r == '_':
+		return r, true
+	default:
+		return 0, false
+	}
+}
+
+func openProfileFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create profile file: %w", err)
+	}
+	return file, nil
+}
+
+func writeRuntimeProfile(path string, name string) error {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		return fmt.Errorf("runtime profile %q is unavailable", name)
+	}
+	file, err := openProfileFile(path)
+	if err != nil {
+		return err
+	}
+	writeErr := profile.WriteTo(file, 0)
+	closeErr := file.Close()
+	return errors.Join(writeErr, closeErr)
+}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,80 @@
+package profile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartRejectsInvalidMode(t *testing.T) {
+	if _, err := Start(Options{Mode: "sometimes", OutDir: t.TempDir()}); err == nil {
+		t.Fatal("Start() error = nil, want invalid mode error")
+	} else if !strings.Contains(err.Error(), `profile must be cpu, mem, block, mutex, or trace, got "sometimes"`) {
+		t.Fatalf("Start() error = %v, want invalid mode message", err)
+	}
+}
+
+func TestMemProfileWritesRestrictiveFileAndStatus(t *testing.T) {
+	outDir := t.TempDir()
+	var stderr bytes.Buffer
+	session, err := Start(Options{
+		Mode:        "mem",
+		OutDir:      outDir,
+		CommandPath: "drydock test apps",
+		Stderr:      &stderr,
+		Now: func() time.Time {
+			return time.Date(2026, 5, 29, 15, 30, 12, 123456789, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := session.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	path := filepath.Join(outDir, "drydock-test-apps-20260529T153012.123456789Z.mem.pprof")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat profile file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("profile file mode = %v, want 0600", info.Mode().Perm())
+	}
+	if !strings.Contains(stderr.String(), "profile mem: wrote "+path) {
+		t.Fatalf("stderr = %q, want profile write message", stderr.String())
+	}
+}
+
+func TestTraceProfileUsesTraceExtension(t *testing.T) {
+	if got := filename("drydock diff apps", "trace", time.Date(2026, 5, 29, 15, 31, 55, 0, time.UTC)); got != "drydock-diff-apps-20260529T153155.000000000Z.trace.out" {
+		t.Fatalf("filename() = %q, want trace .out filename", got)
+	}
+}
+
+func TestMutexProfileRestoresPreviousFraction(t *testing.T) {
+	previous := runtime.SetMutexProfileFraction(7)
+	defer runtime.SetMutexProfileFraction(previous)
+
+	session, err := Start(Options{Mode: "mutex", OutDir: t.TempDir(), CommandPath: "drydock test apps"})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := session.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := runtime.SetMutexProfileFraction(previous); got != 7 {
+		t.Fatalf("mutex profile fraction after Stop = %d, want restored 7", got)
+	}
+}
+
+func TestSanitizeCommandPathUsesStableCommandWords(t *testing.T) {
+	got := sanitizeCommandPath("drydock build app")
+	if got != "drydock-build-app" {
+		t.Fatalf("sanitizeCommandPath() = %q", got)
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -51,7 +51,7 @@ run = "go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12"
 
 [tasks.shellcheck]
 description = "Lint shell scripts"
-run = "shellcheck setup-action/*.sh pr-action/*.sh"
+run = "shellcheck setup-action/*.sh pr-action/*.sh scripts/profile-smoke.sh"
 
 [tasks.vuln]
 description = "Run advisory govulncheck"

--- a/scripts/profile-smoke.sh
+++ b/scripts/profile-smoke.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PROFILE_MODE="cpu"
+PROFILE_OUT="${REPO_ROOT}/drydock-profiles"
+REF="HEAD"
+REF_ORIG=""
+WARM_RUNS="1"
+SKIP_DIFF="false"
+DRYDOCK_CMD=(go run ./cmd/drydock)
+TARGET_REPO=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/profile-smoke.sh <repo> [options]
+
+Options:
+  --binary <path>      drydock binary to run instead of go run ./cmd/drydock
+  --profile <mode>    profile mode: cpu, mem, block, mutex, or trace (default: cpu)
+  --out <dir>         profile output directory (default: ./drydock-profiles)
+  --ref <ref>         current Git ref for diff apps (default: HEAD)
+  --ref-orig <ref>    baseline Git ref for diff apps (default: origin/HEAD, main, or master)
+  --warm-runs <n>     number of times to run each command (default: 1)
+  --skip-diff         skip the ref diff command
+  -h, --help          show this help
+USAGE
+}
+
+fail() {
+  echo "profile smoke: $*" >&2
+  exit 2
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "${value}" ]] || fail "${flag} requires a value"
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      require_value "$1" "${2:-}"
+      DRYDOCK_CMD=("$2")
+      shift 2
+      ;;
+    --profile)
+      require_value "$1" "${2:-}"
+      PROFILE_MODE="$2"
+      shift 2
+      ;;
+    --out)
+      require_value "$1" "${2:-}"
+      PROFILE_OUT="$2"
+      shift 2
+      ;;
+    --ref)
+      require_value "$1" "${2:-}"
+      REF="$2"
+      shift 2
+      ;;
+    --ref-orig)
+      require_value "$1" "${2:-}"
+      REF_ORIG="$2"
+      shift 2
+      ;;
+    --warm-runs)
+      require_value "$1" "${2:-}"
+      WARM_RUNS="$2"
+      shift 2
+      ;;
+    --skip-diff)
+      SKIP_DIFF="true"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      if [[ -n "${TARGET_REPO}" ]]; then
+        fail "unexpected extra argument: $1"
+      fi
+      TARGET_REPO="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${TARGET_REPO}" ]] || {
+  usage >&2
+  exit 2
+}
+[[ -d "${TARGET_REPO}" ]] || fail "repository directory does not exist: ${TARGET_REPO}"
+[[ "${WARM_RUNS}" =~ ^[1-9][0-9]*$ ]] || fail "--warm-runs must be a positive integer"
+
+TARGET_REPO="$(cd "${TARGET_REPO}" && pwd)"
+PROFILE_OUT="$(mkdir -p "${PROFILE_OUT}" && cd "${PROFILE_OUT}" && pwd)"
+
+detect_ref_orig() {
+  local repo="$1"
+  local detected=""
+  detected="$(git -C "${repo}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  detected="${detected#origin/}"
+  if [[ -n "${detected}" ]]; then
+    echo "${detected}"
+    return
+  fi
+  if git -C "${repo}" show-ref --verify --quiet refs/heads/main; then
+    echo "main"
+    return
+  fi
+  if git -C "${repo}" show-ref --verify --quiet refs/heads/master; then
+    echo "master"
+    return
+  fi
+}
+
+if [[ -z "${REF_ORIG}" && "${SKIP_DIFF}" == "false" ]]; then
+  REF_ORIG="$(detect_ref_orig "${TARGET_REPO}")"
+  [[ -n "${REF_ORIG}" ]] || fail "could not detect --ref-orig; pass it explicitly or use --skip-diff"
+fi
+
+run_drydock() {
+  local label="$1"
+  shift
+  echo "==> ${label}" >&2
+  (cd "${REPO_ROOT}" && "${DRYDOCK_CMD[@]}" --profile "${PROFILE_MODE}" --profile-out "${PROFILE_OUT}" "$@")
+}
+
+run_count=0
+while [[ "${run_count}" -lt "${WARM_RUNS}" ]]; do
+  run_count=$((run_count + 1))
+  echo "profile smoke run ${run_count}/${WARM_RUNS}: ${TARGET_REPO}" >&2
+  run_drydock "test apps" test apps --path "${TARGET_REPO}"
+  if [[ "${SKIP_DIFF}" == "false" ]]; then
+    run_drydock "diff apps ${REF_ORIG}..${REF}" diff apps --repo "${TARGET_REPO}" --ref "${REF}" --ref-orig "${REF_ORIG}" --exit-code=false
+  fi
+  run_drydock "get images" get images --path "${TARGET_REPO}" -o name
+done
+
+echo "profile smoke complete: ${PROFILE_OUT}" >&2


### PR DESCRIPTION
## Summary
- add root `--profile` and `--profile-out` flags for cpu, mem, block, mutex, and trace profiles
- write profile artifacts with sanitized command names and restrictive permissions while keeping stdout clean
- add a maintainer `scripts/profile-smoke.sh` workflow and usage docs

## Review
- spec review approved with notes
- quality review approved with notes
- slice reviews approved after fixes
- final branch review approved

## Validation
- `go test ./internal/profile ./internal/cli`
- `go test ./...`
- `mise run vet`
- `mise run lint`
- `mise run shellcheck`
- `mise run markdownlint`
- `git diff --check`

## Home-ops performance smoke
Built binary: `/private/tmp/drydock-cli-profiling/drydock`

- `test apps`: 3.37s, 2.34s, 2.32s across three runs; 31 app results; no failures
- `diff apps --repo ~/git/home-ops --ref HEAD --ref-orig master`: 6.92s; rendered all apps because changed-only could not map `.github/workflows/drydock-gitops.yml`
- `get images`: 2.96s; 70 image output lines
- `test apps` with `--profile cpu`: 2.86s; profile written successfully

Profile smoke produced CPU profiles for `test apps`, `diff apps`, and `get images` under `/private/tmp/drydock-cli-profiling/profiles`.
