### PR TITLE
fix: link PR action artifact comments

### DIFF
--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -420,6 +420,7 @@ runs:
         DRYDOCK_INPUT_SKIP_SECRETS: ${{ inputs.skip-secrets }}
         DRYDOCK_INPUT_STRICT: ${{ inputs.strict }}
         DRYDOCK_INPUT_STRICT_CHANGED_ONLY: ${{ inputs.strict-changed-only }}
+        DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
       run: '"${GITHUB_ACTION_PATH}/run.sh"'
 
     - name: Save drydock source cache
@@ -428,6 +429,14 @@ runs:
       with:
         key: ${{ steps.prepare.outputs.cache-key }}
         path: ${{ steps.prepare.outputs.cache-path }}
+
+    - name: Upload rendered manifest diff
+      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.run.outputs.diff-artifact-name }}
+        path: ${{ steps.run.outputs.diff-path }}
+        retention-days: ${{ inputs.artifact-retention-days }}
 
     - name: Comment rendered manifest diff
       if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.diff-comment == 'true' }}
@@ -438,6 +447,14 @@ runs:
         message-path: ${{ steps.run.outputs.diff-comment-path }}
         repo-token: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
 
+    - name: Upload added images
+      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-images == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.run.outputs.image-artifact-name }}
+        path: ${{ steps.run.outputs.images-path }}
+        retention-days: ${{ inputs.artifact-retention-days }}
+
     - name: Comment added images
       if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.images-comment == 'true' }}
       continue-on-error: ${{ inputs.comment-continue-on-error == 'true' }}
@@ -446,19 +463,3 @@ runs:
         message-id: ${{ github.event.pull_request.number }}/drydock-images
         message-path: ${{ steps.run.outputs.images-comment-path }}
         repo-token: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
-
-    - name: Upload rendered manifest diff
-      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: ${{ steps.run.outputs.diff-artifact-name }}
-        path: ${{ steps.run.outputs.diff-path }}
-        retention-days: ${{ inputs.artifact-retention-days }}
-
-    - name: Upload added images
-      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-images == 'true' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: ${{ steps.run.outputs.image-artifact-name }}
-        path: ${{ steps.run.outputs.images-path }}
-        retention-days: ${{ inputs.artifact-retention-days }}

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -86,6 +86,18 @@ extract_image_diff_json() {
   jq -r '((.added // []) | length) + ((.removed // []) | length)' "${json_file}" > "${count_file}"
 }
 
+workflow_run_url() {
+  local server_url="${GITHUB_SERVER_URL:-}"
+  local repository="${GITHUB_REPOSITORY:-}"
+  local run_id="${GITHUB_RUN_ID:-}"
+
+  if [[ -z "${server_url}" || -z "${repository}" || -z "${run_id}" ]]; then
+    return 0
+  fi
+
+  printf '%s/%s/actions/runs/%s\n' "${server_url%/}" "${repository}" "${run_id}"
+}
+
 capture_command() {
   local stdout_file="$1"
   local stderr_file="$2"
@@ -145,6 +157,7 @@ bool "${DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR}" fail-on-render-error
 bool "${DRYDOCK_INPUT_FAIL_ON_DIFF}" fail-on-diff
 bool "${DRYDOCK_INPUT_FAIL_ON_IMAGE_DIFF}" fail-on-image-diff
 bool "${DRYDOCK_INPUT_COMMENT_EMPTY}" comment-empty
+bool "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" upload-artifacts
 positive_int "${DRYDOCK_INPUT_DIFF_MAX_BYTES}" diff-max-bytes
 optional_int "${DRYDOCK_INPUT_PARALLELISM}" parallelism
 optional_int "${DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH}" max-discovery-depth
@@ -188,6 +201,7 @@ repo="${DRYDOCK_INPUT_REPO:-.}"
 head_ref="${DRYDOCK_INPUT_HEAD_REF:-HEAD}"
 base_compare_ref="${DRYDOCK_BASE_COMPARE_REF:-}"
 drydock_bin="${DRYDOCK_BIN:-drydock}"
+run_url="$(workflow_run_url)"
 
 common_args=()
 if [[ -n "${cache_path}" ]]; then
@@ -333,8 +347,10 @@ if [[ "${diff_comment}" == "true" ]]; then
       echo '```diff'
       cat "${diff_snippet_path}"
       echo '```'
-      echo
-      echo "- Full output is available from the workflow artifacts when an artifact was uploaded."
+      if [[ "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && -n "${run_url}" ]]; then
+        echo
+        echo "- Full diff output: [${DRYDOCK_DIFF_ARTIFACT_NAME} artifact](${run_url})."
+      fi
     else
       echo "No rendered manifest differences detected."
     fi
@@ -350,6 +366,10 @@ if [[ "${images_comment}" == "true" ]]; then
         [[ -n "${image}" ]] || continue
         printf -- "- \`%s\`\n" "${image}"
       done < "${images_path}"
+      if [[ "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && "${diff_comment}" != "true" && -n "${run_url}" ]]; then
+        echo
+        echo "- Full added image output: [${DRYDOCK_IMAGE_ARTIFACT_NAME} artifact](${run_url})."
+      fi
     else
       echo "No added rendered images detected."
     fi

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -89,6 +89,235 @@ esac
 	}
 }
 
+func TestRunCommentsLinkWorkflowRunArtifactsWhenUploadEnabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		diffOutput:      true,
+		imageOutput:     true,
+	})
+
+	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
+	for _, want := range []string{
+		"Full diff output: [diff artifact](https://github.example.test/example/repo/actions/runs/12345).",
+		"```diff",
+	} {
+		if !strings.Contains(diffComment, want) {
+			t.Fatalf("diff comment = %q, want %q", diffComment, want)
+		}
+	}
+	if strings.Contains(diffComment, "Full output is available from the workflow artifacts") {
+		t.Fatalf("diff comment still has vague artifact text:\n%s", diffComment)
+	}
+
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	if !strings.Contains(imagesComment, "`example/app:v2`") {
+		t.Fatalf("images comment = %q, want added image", imagesComment)
+	}
+	if strings.Contains(imagesComment, "Full added image output") || strings.Contains(imagesComment, "actions/runs/12345") {
+		t.Fatalf("images comment repeated artifact link while diff comment has one:\n%s", imagesComment)
+	}
+	if strings.Contains(imagesComment, "Full output is available from the workflow artifacts") {
+		t.Fatalf("images comment has vague artifact text:\n%s", imagesComment)
+	}
+}
+
+func TestRunImagesOnlyCommentLinksWorkflowRunArtifact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		commentMode:     "images",
+		diffOutput:      true,
+		imageOutput:     true,
+	})
+
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	for _, want := range []string{
+		"Full added image output: [images artifact](https://github.example.test/example/repo/actions/runs/12345).",
+		"`example/app:v2`",
+	} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
+	}
+}
+
+func TestRunCommentsOmitArtifactLinksWhenUploadDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: false,
+		githubEnv:       true,
+		diffOutput:      true,
+		imageOutput:     true,
+	})
+
+	for _, name := range []string{"diff-comment.md", "images-comment.md"} {
+		comment := readFile(t, filepath.Join(workDir, name))
+		if strings.Contains(comment, "actions/runs/12345") || strings.Contains(comment, "Full diff output") || strings.Contains(comment, "Full added image output") {
+			t.Fatalf("%s contains artifact link when upload is disabled:\n%s", name, comment)
+		}
+		if strings.Contains(comment, "Full output is available from the workflow artifacts") {
+			t.Fatalf("%s contains old vague artifact text:\n%s", name, comment)
+		}
+	}
+}
+
+func TestRunCommentsOmitArtifactLinksWhenGitHubRunURLIsUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       false,
+		diffOutput:      true,
+		imageOutput:     true,
+	})
+
+	for _, name := range []string{"diff-comment.md", "images-comment.md"} {
+		comment := readFile(t, filepath.Join(workDir, name))
+		if strings.Contains(comment, "Full diff output") || strings.Contains(comment, "Full added image output") || strings.Contains(comment, "actions/runs") {
+			t.Fatalf("%s contains artifact link without GitHub run URL:\n%s", name, comment)
+		}
+		if strings.Contains(comment, "Full output is available from the workflow artifacts") {
+			t.Fatalf("%s contains old vague artifact text:\n%s", name, comment)
+		}
+	}
+}
+
+func TestRunCommentEmptyDoesNotLinkArtifactsWithoutOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		commentEmpty:    true,
+		diffOutput:      false,
+		imageOutput:     false,
+	})
+
+	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
+	if !strings.Contains(diffComment, "No rendered manifest differences detected.") {
+		t.Fatalf("diff comment = %q, want empty diff text", diffComment)
+	}
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	if !strings.Contains(imagesComment, "No added rendered images detected.") {
+		t.Fatalf("images comment = %q, want empty images text", imagesComment)
+	}
+	for _, comment := range []string{diffComment, imagesComment} {
+		if strings.Contains(comment, "artifact](") || strings.Contains(comment, "actions/runs/12345") {
+			t.Fatalf("empty comment contains artifact link:\n%s", comment)
+		}
+	}
+}
+
+type commentScenario struct {
+	uploadArtifacts bool
+	githubEnv       bool
+	commentEmpty    bool
+	commentMode     string
+	diffOutput      bool
+	imageOutput     bool
+}
+
+func runCommentScenario(t *testing.T, scenario commentScenario) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	writeCommentScenarioDrydock(t, filepath.Join(tmp, "drydock"), scenario)
+
+	workDir := filepath.Join(tmp, "work")
+	outputPath := filepath.Join(tmp, "github-output")
+	commentMode := scenario.commentMode
+	if commentMode == "" {
+		commentMode = "both"
+	}
+	env := append(defaultRunEnv(tmp, workDir, outputPath),
+		"DRYDOCK_INPUT_COMMENT_MODE="+commentMode,
+		"DRYDOCK_INPUT_RUN_DIFF=true",
+		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
+		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS="+boolString(scenario.uploadArtifacts),
+		"DRYDOCK_INPUT_COMMENT_EMPTY="+boolString(scenario.commentEmpty),
+		"GITHUB_SERVER_URL=",
+		"GITHUB_REPOSITORY=",
+		"GITHUB_RUN_ID=",
+	)
+	if scenario.githubEnv {
+		env = append(env,
+			"GITHUB_SERVER_URL=https://github.example.test",
+			"GITHUB_REPOSITORY=example/repo",
+			"GITHUB_RUN_ID=12345",
+		)
+	}
+
+	cmd := exec.Command("bash", "run.sh")
+	cmd.Dir = "."
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run.sh failed: %v\n%s%s", err, out, runDebugOutput(t, workDir))
+	}
+	return workDir
+}
+
+func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScenario) {
+	t.Helper()
+
+	diffOutput := ""
+	if scenario.diffOutput {
+		diffOutput = "printf 'diff --git a/apps/demo b/apps/demo\\n+kind: ConfigMap\\n'\n"
+	}
+	imageOutput := ""
+	if scenario.imageOutput {
+		imageOutput = "printf 'example/app:v2\\n'\n"
+	}
+
+	writeExecutable(t, path, `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"diff apps"* ]]; then
+  `+diffOutput+`  exit 0
+fi
+
+if [[ "$*" == *"diff images"* ]]; then
+  `+imageOutput+`  exit 0
+fi
+
+echo "unexpected drydock invocation: $*" >&2
+exit 2
+`)
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}
+
 func runDebugOutput(t *testing.T, workDir string) string {
 	t.Helper()
 
@@ -148,6 +377,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_INPUT_SKIP_SECRETS=true",
 		"DRYDOCK_INPUT_STRICT=false",
 		"DRYDOCK_INPUT_STRICT_CHANGED_ONLY=false",
+		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS=true",
 	)
 	return env
 }


### PR DESCRIPTION
## Summary

- replace vague artifact text in PR action comments with workflow-run artifact links
- emit links only when artifact upload is enabled, output exists, and GitHub run URL metadata is present
- upload each artifact before posting its matching PR comment
- add shell-action coverage for enabled, disabled, missing-env, and empty-output comment cases

## Validation

- go test ./pr-action
- mise run shellcheck
- mise run actionlint
- mise run zizmor
- git diff --check
- mise run lint
- go test ./...

## Review

- spec review approved
- quality review approved