### PR TITLE
fix: summarize ConfigMap binaryData diffs

### DIFF
--- a/internal/diff/configmap_binary_redaction.go
+++ b/internal/diff/configmap_binary_redaction.go
@@ -1,0 +1,145 @@
+package diff
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+func redactedConfigMapBinaryDataBodies(from, to string) (string, string, error) {
+	if !hasTopLevelBinaryDataMarker(from) && !hasTopLevelBinaryDataMarker(to) {
+		return from, to, nil
+	}
+
+	fromObject, _, err := decodeOptionalDiffYAML(from, "summarize ConfigMap before body")
+	if err != nil {
+		return "", "", err
+	}
+	toObject, _, err := decodeOptionalDiffYAML(to, "summarize ConfigMap after body")
+	if err != nil {
+		return "", "", err
+	}
+
+	summarizedFrom := summarizeConfigMapBinaryData(fromObject)
+	summarizedTo := summarizeConfigMapBinaryData(toObject)
+	if !summarizedFrom && !summarizedTo {
+		return from, to, nil
+	}
+
+	redactedFrom, err := encodeDiffYAML(fromObject)
+	if err != nil {
+		return "", "", fmt.Errorf("encode summarized ConfigMap before body: %w", err)
+	}
+	redactedTo, err := encodeDiffYAML(toObject)
+	if err != nil {
+		return "", "", fmt.Errorf("encode summarized ConfigMap after body: %w", err)
+	}
+	return redactedFrom, redactedTo, nil
+}
+
+func hasTopLevelBinaryDataMarker(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" || line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		field, _, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
+			continue
+		}
+		field = strings.Trim(strings.TrimSpace(field), `"'`)
+		if field == "binaryData" {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeConfigMapBinaryDataDocumentBodies(leftBody, rightBody string, left, right Document, hasLeft, hasRight bool) (string, string, error) {
+	resource := right.Resource
+	if !hasRight {
+		resource = left.Resource
+	}
+	if resource.Group != "" || resource.Kind != "ConfigMap" {
+		return leftBody, rightBody, nil
+	}
+	return redactedConfigMapBinaryDataBodies(leftBody, rightBody)
+}
+
+func decodeOptionalDiffYAML(body, context string) (map[string]any, bool, error) {
+	object, err := decodeDiffYAML(body)
+	if err != nil {
+		if errors.Is(err, errEmptyDiffBody) {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("%s: %w", context, err)
+	}
+	return object, false, nil
+}
+
+func summarizeConfigMapBinaryData(object map[string]any) bool {
+	if !isCoreConfigMapObject(object) {
+		return false
+	}
+	raw, ok := object["binaryData"]
+	if !ok {
+		return false
+	}
+
+	switch typed := raw.(type) {
+	case map[string]any:
+		for key, value := range typed {
+			typed[key] = binaryDataValueSummary(value)
+		}
+	case map[any]any:
+		converted := make(map[string]any, len(typed))
+		for key, value := range typed {
+			stringKey, ok := key.(string)
+			if !ok {
+				object["binaryData"] = malformedBinaryDataSummary(raw, "invalid-map")
+				return true
+			}
+			converted[stringKey] = binaryDataValueSummary(value)
+		}
+		object["binaryData"] = converted
+	default:
+		object["binaryData"] = malformedBinaryDataSummary(raw, "invalid-field")
+	}
+	return true
+}
+
+func isCoreConfigMapObject(object map[string]any) bool {
+	if object == nil {
+		return false
+	}
+	apiVersion, _ := object["apiVersion"].(string)
+	kind, _ := object["kind"].(string)
+	return apiVersion == "v1" && kind == "ConfigMap"
+}
+
+func binaryDataSummary(value string) string {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err == nil {
+		return fmt.Sprintf("<redacted binary data: %d bytes sha256:%s>", len(decoded), shortSHA256(decoded))
+	}
+	return fmt.Sprintf("<redacted binary data: invalid-base64 %d chars sha256:%s>", utf8.RuneCountInString(value), shortSHA256([]byte(value)))
+}
+
+func binaryDataValueSummary(value any) string {
+	if text, ok := value.(string); ok {
+		return binaryDataSummary(text)
+	}
+	return malformedBinaryDataSummary(value, "invalid-value")
+}
+
+func malformedBinaryDataSummary(value any, reason string) string {
+	body := []byte(fmt.Sprintf("%#v", value))
+	return fmt.Sprintf("<redacted binary data: %s %d bytes sha256:%s>", reason, len(body), shortSHA256(body))
+}
+
+func shortSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)[:16]
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -225,6 +225,241 @@ func TestRunRedactsSecretBinaryDataValues(t *testing.T) {
 	}
 }
 
+func TestRunSummarizesConfigMapBinaryDataValues(t *testing.T) {
+	left := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "YmluYXJ5LW9sZA==")}
+	right := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "YmluYXJ5LW5ldw==")}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	for _, forbidden := range []string{"YmluYXJ5LW9sZA==", "YmluYXJ5LW5ldw=="} {
+		if strings.Contains(diff, forbidden) {
+			t.Fatalf("Diff leaked ConfigMap binaryData value %q:\n%s", forbidden, diff)
+		}
+	}
+	for _, want := range []string{
+		"archive.bin:",
+		binaryDataSummary("YmluYXJ5LW9sZA=="),
+		binaryDataSummary("YmluYXJ5LW5ldw=="),
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("Diff = %q, want substring %q", diff, want)
+		}
+	}
+}
+
+func TestRunConfigMapBinaryDataEquivalentDecodedBytesDoNotDiff(t *testing.T) {
+	left := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "aGVsbG8=")}
+	right := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\nbinaryData:\n  archive.bin: |-\n    aGVs\n    bG8=\n",
+	}}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want equivalent decoded binaryData to suppress diff: %#v", len(results), results)
+	}
+}
+
+func TestRunConfigMapBinaryDataAddedAndRemovedKeysRemainVisible(t *testing.T) {
+	left := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\nbinaryData:\n  keep.bin: a2VlcA==\n  removed.bin: cmVtb3ZlZA==\n",
+	}}
+	right := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\nbinaryData:\n  keep.bin: a2VlcA==\n  added.bin: YWRkZWQ=\n",
+	}}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	for _, want := range []string{
+		"removed.bin:",
+		binaryDataSummary("cmVtb3ZlZA=="),
+		"added.bin:",
+		binaryDataSummary("YWRkZWQ="),
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("Diff = %q, want substring %q", diff, want)
+		}
+	}
+	if strings.Contains(diff, "cmVtb3ZlZA==") || strings.Contains(diff, "YWRkZWQ=") {
+		t.Fatalf("Diff leaked added/removed binaryData values:\n%s", diff)
+	}
+}
+
+func TestRunSummarizesAddedConfigMapBinaryDataResource(t *testing.T) {
+	right := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "YWRkZWQ=")}
+
+	results, err := Run(nil, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	if strings.Contains(diff, "YWRkZWQ=") {
+		t.Fatalf("Diff leaked added ConfigMap binaryData value:\n%s", diff)
+	}
+	if want := binaryDataSummary("YWRkZWQ="); !strings.Contains(diff, want) {
+		t.Fatalf("Diff = %q, want substring %q", diff, want)
+	}
+}
+
+func TestRunSummarizesRemovedConfigMapBinaryDataResource(t *testing.T) {
+	left := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "cmVtb3ZlZA==")}
+
+	results, err := Run(left, nil, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	if strings.Contains(diff, "cmVtb3ZlZA==") {
+		t.Fatalf("Diff leaked removed ConfigMap binaryData value:\n%s", diff)
+	}
+	if want := binaryDataSummary("cmVtb3ZlZA=="); !strings.Contains(diff, want) {
+		t.Fatalf("Diff = %q, want substring %q", diff, want)
+	}
+}
+
+func TestRunSummarizesMalformedConfigMapBinaryData(t *testing.T) {
+	left := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "not-base64-left")}
+	right := []Document{configMapBinaryDataDocument("cfg", "archive.bin", "not-base64-right")}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	for _, forbidden := range []string{"not-base64-left", "not-base64-right"} {
+		if strings.Contains(diff, forbidden) {
+			t.Fatalf("Diff leaked malformed ConfigMap binaryData value %q:\n%s", forbidden, diff)
+		}
+	}
+	for _, want := range []string{
+		"archive.bin:",
+		binaryDataSummary("not-base64-left"),
+		binaryDataSummary("not-base64-right"),
+		"invalid-base64",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("Diff = %q, want substring %q", diff, want)
+		}
+	}
+}
+
+func TestRunKeepsConfigMapDataVisibleWhenBinaryDataIsSummarized(t *testing.T) {
+	left := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\ndata:\n  script.sh: echo old\nbinaryData:\n  archive.bin: YmluYXJ5\n",
+	}}
+	right := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\ndata:\n  script.sh: echo new\nbinaryData:\n  archive.bin: YmluYXJ5\n",
+	}}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	for _, want := range []string{"script.sh: echo old", "script.sh: echo new"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("Diff = %q, want visible ConfigMap.data substring %q", diff, want)
+		}
+	}
+	if strings.Contains(diff, "YmluYXJ5") {
+		t.Fatalf("Diff leaked ConfigMap binaryData while data stayed visible:\n%s", diff)
+	}
+}
+
+func TestRunDoesNotDecodeDataOnlyConfigMapForBinaryDataSummary(t *testing.T) {
+	left := []Document{{
+		Parent:        testParent(),
+		Resource:      Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:          "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\ndata:\n  value: old\n",
+		Normalization: Normalization{CompareOptions: CompareOptions{IgnoreResourceStatusField: IgnoreResourceStatusNone}},
+	}}
+	right := []Document{{
+		Parent:        testParent(),
+		Resource:      Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:          "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\ndata:\n  value: [unterminated\n",
+		Normalization: Normalization{CompareOptions: CompareOptions{IgnoreResourceStatusField: IgnoreResourceStatusNone}},
+	}}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v, want data-only ConfigMap bodies to skip binaryData summary decoding", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want raw data-only ConfigMap diff preserved", len(results))
+	}
+	if diff := results[0].Diff; !strings.Contains(diff, "[unterminated") {
+		t.Fatalf("Diff = %q, want raw data-only ConfigMap body retained", diff)
+	}
+}
+
+func TestRunRedactsMalformedConfigMapBinaryDataShapes(t *testing.T) {
+	left := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\nbinaryData: raw-scalar-left\n",
+	}}
+	right := []Document{{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: "cfg"},
+		Body:     "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n  namespace: default\nbinaryData:\n  archive.bin: 12345\n",
+	}}
+
+	results, err := Run(left, right, Options{Unified: 3})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	diff := results[0].Diff
+	for _, forbidden := range []string{"raw-scalar-left", "12345"} {
+		if strings.Contains(diff, forbidden) {
+			t.Fatalf("Diff leaked malformed ConfigMap binaryData shape value %q:\n%s", forbidden, diff)
+		}
+	}
+	for _, want := range []string{"invalid-field", "invalid-value", "archive.bin:"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("Diff = %q, want substring %q", diff, want)
+		}
+	}
+}
+
 func TestRunRedactsMalformedSecretBearingFields(t *testing.T) {
 	left := []Document{{
 		Parent: Parent{
@@ -1254,6 +1489,21 @@ rules:
     verbs: ["get"]
 `,
 		Normalization: normalization,
+	}
+}
+
+func configMapBinaryDataDocument(name, key, value string) Document {
+	return Document{
+		Parent:   testParent(),
+		Resource: Resource{Kind: "ConfigMap", Namespace: "default", Name: name},
+		Body: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ` + name + `
+  namespace: default
+binaryData:
+  ` + key + `: ` + value + `
+`,
 	}
 }
 

--- a/internal/diff/normalization.go
+++ b/internal/diff/normalization.go
@@ -15,7 +15,11 @@ var errEmptyDiffBody = errors.New("empty diff body")
 
 func normalizedDocumentBodies(left, right Document, hasLeft, hasRight bool, opts Options) (string, string, error) {
 	if hasLeft && hasRight && len(left.Normalization.ManagedFieldsManagers) > 0 {
-		return normalizedDocumentPairBodies(left, right, opts)
+		leftBody, rightBody, err := normalizedDocumentPairBodies(left, right, opts)
+		if err != nil {
+			return "", "", err
+		}
+		return summarizeConfigMapBinaryDataDocumentBodies(leftBody, rightBody, left, right, hasLeft, hasRight)
 	}
 
 	var leftBody string
@@ -36,7 +40,7 @@ func normalizedDocumentBodies(left, right Document, hasLeft, hasRight bool, opts
 		rightBody = body
 	}
 
-	return leftBody, rightBody, nil
+	return summarizeConfigMapBinaryDataDocumentBodies(leftBody, rightBody, left, right, hasLeft, hasRight)
 }
 func normalizedDocumentPairBodies(left, right Document, opts Options) (string, string, error) {
 	leftObject, leftRemoved, err := normalizeDiffObject(left.Body, opts, left.Normalization, left.Resource)

--- a/internal/diff/presentation.go
+++ b/internal/diff/presentation.go
@@ -24,8 +24,8 @@ func unified(doc Document, from, to string, opts Options) (string, error) {
 	return diff, nil
 }
 func displayBodies(doc Document, from, to string) (string, string, error) {
-	if doc.Resource.Kind != "Secret" {
-		return from, to, nil
+	if doc.Resource.Kind == "Secret" {
+		return redactedSecretBodies(from, to)
 	}
-	return redactedSecretBodies(from, to)
+	return from, to, nil
 }


### PR DESCRIPTION
## Summary
- summarize core v1 ConfigMap binaryData values in diffs instead of printing raw payloads
- preserve useful byte-count/hash change signal and keep ConfigMap data visible
- cover added, removed, invalid-base64, malformed, and equivalent-decoded binaryData cases

## Validation
- go test ./internal/diff
- go test ./...
- mise run lint
- git diff --check
- home-ops canary smoke with temporary ConfigMaps: raw base64 stayed hidden, data changes stayed visible, equivalent decoded payloads produced no diff