### PR TITLE
chore: modernize Go lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - ineffassign
     - intrange
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - nilnil
@@ -26,6 +27,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
+    - usestdlibvars
     - wastedassign
     - whitespace
   settings:
@@ -39,6 +41,10 @@ linters:
   exclusions:
     presets:
       - std-error-handling
+    rules:
+      - linters:
+          - modernize
+        text: "omitzero:"
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,13 +5,18 @@ run:
 
 linters:
   enable:
+    - asciicheck
+    - bidichk
     - bodyclose
+    - canonicalheader
     - copyloopvar
     - dupword
     - durationcheck
     - errcheck
+    - errchkjson
     - errorlint
     - exhaustive
+    - gocheckcompilerdirectives
     - gocritic
     - gocyclo
     - govet
@@ -19,14 +24,18 @@ linters:
     - intrange
     - misspell
     - modernize
+    - makezero
     - nakedret
     - nilerr
+    - nilnesserr
     - nilnil
     - nolintlint
     - prealloc
+    - reassign
     - staticcheck
     - unconvert
     - unused
+    - usetesting
     - usestdlibvars
     - wastedassign
     - whitespace

--- a/internal/app/cmp_auto_discovery.go
+++ b/internal/app/cmp_auto_discovery.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -117,10 +118,8 @@ func cleanCMPDiscoveryPattern(pattern string) (string, bool) {
 	if pattern == "" || filepath.IsAbs(pattern) {
 		return "", false
 	}
-	for _, part := range strings.Split(pattern, string(filepath.Separator)) {
-		if part == ".." {
-			return "", false
-		}
+	if slices.Contains(strings.Split(pattern, string(filepath.Separator)), "..") {
+		return "", false
 	}
 	clean := filepath.Clean(pattern)
 	if clean == "." || pathsafety.RelEscapes(clean) {

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -268,8 +269,8 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 	var cleanups []func() error
 	cleanup := func() error {
 		var err error
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			err = errors.Join(err, cleanups[i]())
+		for _, v := range slices.Backward(cleanups) {
+			err = errors.Join(err, v())
 		}
 		return err
 	}

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1693,12 +1694,7 @@ metadata:
 }
 
 func containsString(items []string, want string) bool {
-	for _, item := range items {
-		if item == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, want)
 }
 
 func diffResultText(results []diff.Result) string {
@@ -1749,10 +1745,8 @@ func checkoutDiffGitBranch(t *testing.T, wt *git.Worktree, name string) {
 
 func requireStringInSlice(t *testing.T, values []string, want string) {
 	t.Helper()
-	for _, value := range values {
-		if value == want {
-			return
-		}
+	if slices.Contains(values, want) {
+		return
 	}
 	t.Fatalf("values = %#v, want %q", values, want)
 }

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -469,9 +470,9 @@ metadata:
   name: child
 `)
 
-	var calls int32
+	var calls atomic.Int32
 	renderer := internalPluginRendererFunc(func(_ context.Context, _ render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		return []render.Manifest{{
 			Path: "templates/child.yaml",
 			Object: &unstructured.Unstructured{Object: map[string]any{
@@ -506,7 +507,7 @@ metadata:
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
+	if got := calls.Load(); got != 1 {
 		t.Fatalf("plugin render calls = %d, want discovery result reused for final render", got)
 	}
 	if names := applicationNames(result.Applications); strings.Join(names, ",") != "child,root" {
@@ -718,10 +719,5 @@ func applicationInputPaths(inputs []ApplicationSelectionInput, name string) ([]s
 }
 
 func containsPath(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, want)
 }

--- a/internal/app/local_provider_helpers.go
+++ b/internal/app/local_provider_helpers.go
@@ -1,6 +1,10 @@
 package app
 
 import (
+	"maps"
+
+	"slices"
+
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/render"
 )
@@ -10,9 +14,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 		return map[string]string{}
 	}
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -21,9 +23,7 @@ func cloneResolvedSourceMap(in map[string]render.ResolvedSource) map[string]rend
 		return map[string]render.ResolvedSource{}
 	}
 	out := make(map[string]render.ResolvedSource, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -31,10 +31,8 @@ func appendUniqueString(values []string, value string) []string {
 	if value == "" {
 		return values
 	}
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }

--- a/internal/app/local_provider_paths.go
+++ b/internal/app/local_provider_paths.go
@@ -90,7 +90,7 @@ func rejectLocalSymlinkComponents(repoRoot, sourcePath string) error {
 	}
 
 	current := filepath.Clean(repoRoot)
-	for _, component := range strings.Split(sourcePath, string(filepath.Separator)) {
+	for component := range strings.SplitSeq(sourcePath, string(filepath.Separator)) {
 		if component == "" || component == "." {
 			continue
 		}

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -983,7 +983,7 @@ data:
 
 func indentLua(lua string) string {
 	var out strings.Builder
-	for _, line := range strings.Split(lua, "\n") {
+	for line := range strings.SplitSeq(lua, "\n") {
 		out.WriteString("    ")
 		out.WriteString(line)
 		out.WriteByte('\n')

--- a/internal/app/ordered_parallel.go
+++ b/internal/app/ordered_parallel.go
@@ -44,10 +44,7 @@ func runOrderedParallel[T any](ctx context.Context, options orderedParallelOptio
 }
 
 func orderedParallelWorkerCount(total, parallelism int) int {
-	workerCount := parallelism
-	if workerCount > total {
-		workerCount = total
-	}
+	workerCount := min(parallelism, total)
 	if workerCount < 1 && total > 0 {
 		workerCount = 1
 	}
@@ -63,16 +60,14 @@ func launchOrderedParallelWorkers[T any](
 ) {
 	var wg sync.WaitGroup
 	for range workerCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for index := range jobs {
 				resultsCh <- indexedOrderedResult[T]{
 					index:  index,
 					result: run(ctx, index),
 				}
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/internal/app/ref_roots.go
+++ b/internal/app/ref_roots.go
@@ -1,15 +1,13 @@
 package app
 
+import "maps"
+
 func mergeRefRoots(base, extra map[string]string) map[string]string {
 	if len(base) == 0 && len(extra) == 0 {
 		return map[string]string{}
 	}
 	out := make(map[string]string, len(base)+len(extra))
-	for key, value := range base {
-		out[key] = value
-	}
-	for key, value := range extra {
-		out[key] = value
-	}
+	maps.Copy(out, base)
+	maps.Copy(out, extra)
 	return out
 }

--- a/internal/appset/generator.go
+++ b/internal/appset/generator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	appsetutils "github.com/argoproj/argo-cd/v3/applicationset/utils"
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -289,8 +290,6 @@ func appendTemplatedValues(params map[string]any, values map[string]string, useG
 		}
 		renderedParams["values."+key] = rendered
 	}
-	for key, value := range renderedParams {
-		params[key] = value
-	}
+	maps.Copy(params, renderedParams)
 	return nil
 }

--- a/internal/appset/generator_combinators.go
+++ b/internal/appset/generator_combinators.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	"dario.cat/mergo"
 	appsetutils "github.com/argoproj/argo-cd/v3/applicationset/utils"
@@ -292,8 +293,6 @@ func mergeParams(base, override map[string]any, useGoTemplate bool) (map[string]
 		}
 		return out, nil
 	}
-	for key, value := range override {
-		out[key] = value
-	}
+	maps.Copy(out, override)
 	return out, nil
 }

--- a/internal/appset/generator_git.go
+++ b/internal/appset/generator_git.go
@@ -2,6 +2,7 @@ package appset
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -282,9 +283,7 @@ func gitFileParams(repoRoot, rel, prefix string, values map[string]string, useGo
 	for _, fileValues := range fileObjects {
 		params := map[string]any{}
 		if useGoTemplate {
-			for key, value := range fileValues {
-				params[key] = value
-			}
+			maps.Copy(params, fileValues)
 			addGoTemplateFilePathParams(params, rel, prefix)
 		} else {
 			flattenParams("", fileValues, params)

--- a/internal/appset/generator_provider_helpers.go
+++ b/internal/appset/generator_provider_helpers.go
@@ -1,6 +1,7 @@
 package appset
 
 import (
+	"slices"
 	"strings"
 )
 
@@ -64,12 +65,7 @@ func providerProjectFromPR(input PullRequestInput) string {
 }
 
 func stringSliceContains(values []string, value string) bool {
-	for _, candidate := range values {
-		if candidate == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, value)
 }
 
 func shortString(value string, limit int) string {

--- a/internal/appset/generator_provider_scm.go
+++ b/internal/appset/generator_provider_scm.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	appsetutils "github.com/argoproj/argo-cd/v3/applicationset/utils"
@@ -303,13 +304,7 @@ func scmRepositoryMatchesLabelFilter(input SCMRepositoryInput, filter argoappv1.
 		if err != nil {
 			return false, fmt.Errorf("labelMatch %q: %w", *filter.LabelMatch, err)
 		}
-		found := false
-		for _, label := range input.Labels {
-			if labelRE.MatchString(label) {
-				found = true
-				break
-			}
-		}
+		found := slices.ContainsFunc(input.Labels, labelRE.MatchString)
 		if !found {
 			return false, nil
 		}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -448,8 +449,8 @@ func resolvePathForContainment(targetPath string) (string, error) {
 	for {
 		resolved, err := filepath.EvalSymlinks(current)
 		if err == nil {
-			for i := len(missing) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, missing[i])
+			for _, v := range slices.Backward(missing) {
+				resolved = filepath.Join(resolved, v)
 			}
 			return filepath.Clean(resolved), nil
 		}

--- a/internal/cache/metadata_test.go
+++ b/internal/cache/metadata_test.go
@@ -38,6 +38,7 @@ func TestWriteMetadataGoldenRedactsTarget(t *testing.T) {
 	}
 	if read == nil {
 		t.Fatal("ReadMetadata() = nil, want metadata")
+		return
 	}
 	if read.Target != "https://example.test/repo.git" {
 		t.Fatalf("ReadMetadata().Target = %q, want redacted target", read.Target)

--- a/internal/cacheevent/cacheevent.go
+++ b/internal/cacheevent/cacheevent.go
@@ -305,7 +305,7 @@ func (c *variantCollector) addURLVariants(prefix string, rawURL string) {
 
 func parsedURLBases(parsed url.URL) []url.URL {
 	baseURLs := []url.URL{parsed}
-	if strippedPath := strings.TrimSuffix(parsed.Path, ".git"); strippedPath != parsed.Path {
+	if strippedPath, ok := strings.CutSuffix(parsed.Path, ".git"); ok {
 		stripped := parsed
 		stripped.Path = strippedPath
 		baseURLs = append(baseURLs, stripped)
@@ -379,7 +379,7 @@ func (c *variantCollector) addRawQueryAndFragment(raw string) {
 }
 
 func (c *variantCollector) addRawQueryValues(rawQuery string) {
-	for _, rawPart := range strings.Split(rawQuery, "&") {
+	for rawPart := range strings.SplitSeq(rawQuery, "&") {
 		_, rawValue, ok := strings.Cut(rawPart, "=")
 		if ok {
 			c.add(rawValue)

--- a/internal/chart/oci_test.go
+++ b/internal/chart/oci_test.go
@@ -195,14 +195,14 @@ func TestHelmOCIPullerDoesNotReadCallerDockerCredentials(t *testing.T) {
 	const secret = "secret-password"
 	callerDockerConfig := t.TempDir()
 	auth := base64.StdEncoding.EncodeToString([]byte("user:" + secret))
-	if err := os.WriteFile(filepath.Join(callerDockerConfig, "config.json"), []byte(fmt.Sprintf(`{
+	if err := os.WriteFile(filepath.Join(callerDockerConfig, "config.json"), fmt.Appendf(nil, `{
   "auths": {
     "registry.example.test": {
       "auth": %q
     }
   }
 }
-`, auth)), 0o600); err != nil {
+`, auth), 0o600); err != nil {
 		t.Fatalf("write caller Docker config: %v", err)
 	}
 	t.Setenv("DOCKER_CONFIG", callerDockerConfig)

--- a/internal/chart/repository_archive.go
+++ b/internal/chart/repository_archive.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -61,10 +62,8 @@ func safeChartArchivePath(name, chartName string) (string, error) {
 	if name == "" || path.IsAbs(normalized) || filepath.IsAbs(name) {
 		return "", fmt.Errorf("unsafe chart archive path %q", name)
 	}
-	for _, segment := range strings.Split(normalized, "/") {
-		if segment == ".." {
-			return "", fmt.Errorf("unsafe chart archive path %q", name)
-		}
+	if slices.Contains(strings.Split(normalized, "/"), "..") {
+		return "", fmt.Errorf("unsafe chart archive path %q", name)
 	}
 	cleaned := path.Clean(normalized)
 	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {

--- a/internal/chart/repository_oci.go
+++ b/internal/chart/repository_oci.go
@@ -165,7 +165,7 @@ func parseOCIChartRepository(repository string) (string, error) {
 	if cleanPath == "" {
 		return parsed.Host, nil
 	}
-	for _, segment := range strings.Split(cleanPath, "/") {
+	for segment := range strings.SplitSeq(cleanPath, "/") {
 		switch segment {
 		case "":
 			return "", fmt.Errorf("OCI chart repository path must not include empty path segment")

--- a/internal/chart/repository_test.go
+++ b/internal/chart/repository_test.go
@@ -122,6 +122,7 @@ entries:
 	}
 	if metadata == nil {
 		t.Fatal("metadata = nil, want metadata")
+		return
 	}
 	if strings.Contains(metadata.Target, "secret") || strings.Contains(metadata.Target, "?") || strings.Contains(metadata.Target, "#") {
 		t.Fatalf("metadata Target = %q, want redacted target", metadata.Target)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -282,8 +282,8 @@ func colorizeDiffLine(line string, color bool) string {
 	}
 	body := line
 	trailingNewline := ""
-	if strings.HasSuffix(body, "\n") {
-		body = strings.TrimSuffix(body, "\n")
+	if before, ok := strings.CutSuffix(body, "\n"); ok {
+		body = before
 		trailingNewline = "\n"
 	}
 	if body == "" {

--- a/internal/cli/parallelism_test.go
+++ b/internal/cli/parallelism_test.go
@@ -41,13 +41,8 @@ func TestTestAppsDefaultParallelismIsAuto(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}
 	executeParallelismCommand(t, recorder, "test", "apps")
 
-	want := runtime.GOMAXPROCS(0)
-	if want < 1 {
-		want = 1
-	}
-	if want > maxDefaultRenderAppsParallelism {
-		want = maxDefaultRenderAppsParallelism
-	}
+	want := max(runtime.GOMAXPROCS(0), 1)
+	want = min(want, maxDefaultRenderAppsParallelism)
 	if got := defaultRenderAppsParallelism(); got != want {
 		t.Fatalf("defaultRenderAppsParallelism() = %d, want %d", got, want)
 	}

--- a/internal/config/cluster_secret_test.go
+++ b/internal/config/cluster_secret_test.go
@@ -61,7 +61,7 @@ func TestLoadClusterSecretDataDecodesAllowlistedFields(t *testing.T) {
 	encoded := func(value string) string {
 		return base64.StdEncoding.EncodeToString([]byte(value))
 	}
-	if err := os.WriteFile(path, []byte(fmt.Sprintf(`apiVersion: v1
+	if err := os.WriteFile(path, fmt.Appendf(nil, `apiVersion: v1
 kind: Secret
 metadata:
   name: prod
@@ -74,7 +74,7 @@ data:
   clusterResources: %s
   project: %s
   config: %s
-`, encoded("prod"), encoded("https://prod.example/"), encoded("prod,shared"), encoded("true"), encoded("platform"), encoded(`{"tlsClientConfig":{"certData":"should-not-be-read"}}`))), 0o600); err != nil {
+`, encoded("prod"), encoded("https://prod.example/"), encoded("prod,shared"), encoded("true"), encoded("platform"), encoded(`{"tlsClientConfig":{"certData":"should-not-be-read"}}`)), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1254,7 +1255,7 @@ func TestLoadRepositorySecretDataParsesEnableOCI(t *testing.T) {
 	encoded := func(value string) string {
 		return base64.StdEncoding.EncodeToString([]byte(value))
 	}
-	if err := os.WriteFile(path, []byte(fmt.Sprintf(`apiVersion: v1
+	if err := os.WriteFile(path, fmt.Appendf(nil, `apiVersion: v1
 kind: Secret
 metadata:
   name: charts
@@ -1265,7 +1266,7 @@ data:
   type: %s
   url: %s
   enableOCI: %s
-`, encoded("charts"), encoded("helm"), encoded("ghcr.io/example/charts"), encoded("true"))), 0o600); err != nil {
+`, encoded("charts"), encoded("helm"), encoded("ghcr.io/example/charts"), encoded("true")), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
@@ -1722,12 +1723,7 @@ func TestMergeCompareOptionsIgnoresProvenance(t *testing.T) {
 }
 
 func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, want)
 }
 
 func assertValueStrings(t *testing.T, got []Value[string], want []string) {

--- a/internal/diff/configmap_binary_redaction.go
+++ b/internal/diff/configmap_binary_redaction.go
@@ -41,7 +41,7 @@ func redactedConfigMapBinaryDataBodies(from, to string) (string, string, error) 
 }
 
 func hasTopLevelBinaryDataMarker(body string) bool {
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if line == "" || line[0] == ' ' || line[0] == '\t' {
 			continue
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -397,7 +397,7 @@ func rejectSymlinkComponents(root, target string) error {
 	}
 
 	current := root
-	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+	for component := range strings.SplitSeq(rel, string(filepath.Separator)) {
 		if component == "" || component == "." {
 			continue
 		}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -112,9 +113,7 @@ func cloneTableRows(rows []map[string]string) []map[string]string {
 	out := make([]map[string]string, len(rows))
 	for i, row := range rows {
 		cloned := make(map[string]string, len(row))
-		for key, value := range row {
-			cloned[key] = value
-		}
+		maps.Copy(cloned, row)
 		out[i] = cloned
 	}
 	return out

--- a/internal/gitref/snapshot.go
+++ b/internal/gitref/snapshot.go
@@ -168,16 +168,9 @@ func materializeTreeParallelism(fileCount int) int {
 	if fileCount <= 1 {
 		return fileCount
 	}
-	workers := runtime.GOMAXPROCS(0)
-	if workers < 1 {
-		workers = 1
-	}
-	if workers > maxMaterializeTreeWorkers {
-		workers = maxMaterializeTreeWorkers
-	}
-	if workers > fileCount {
-		workers = fileCount
-	}
+	workers := max(runtime.GOMAXPROCS(0), 1)
+	workers = min(workers, maxMaterializeTreeWorkers)
+	workers = min(workers, fileCount)
 	return workers
 }
 

--- a/internal/gitref/snapshot_test.go
+++ b/internal/gitref/snapshot_test.go
@@ -159,7 +159,7 @@ func TestSnapshotLocalRefMaterializesManyFiles(t *testing.T) {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatalf("MkdirAll(%s) error = %v", name, err)
 		}
-		if err := os.WriteFile(path, []byte(fmt.Sprintf("value: %03d\n", i)), 0o644); err != nil {
+		if err := os.WriteFile(path, fmt.Appendf(nil, "value: %03d\n", i), 0o644); err != nil {
 			t.Fatalf("WriteFile(%s) error = %v", name, err)
 		}
 		if _, err := wt.Add(name); err != nil {

--- a/internal/pathsafety/pathsafety.go
+++ b/internal/pathsafety/pathsafety.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -65,8 +66,8 @@ func ResolveForContainment(targetPath string) (string, error) {
 	for {
 		resolved, err := filepath.EvalSymlinks(current)
 		if err == nil {
-			for i := len(missing) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, missing[i])
+			for _, v := range slices.Backward(missing) {
+				resolved = filepath.Join(resolved, v)
 			}
 			return filepath.Clean(resolved), nil
 		}

--- a/internal/remote/acquire_test.go
+++ b/internal/remote/acquire_test.go
@@ -289,6 +289,7 @@ func TestDefaultRemoteAcquirerWritesHTTPMetadata(t *testing.T) {
 	}
 	if metadata == nil {
 		t.Fatal("metadata = nil, want metadata")
+		return
 	}
 	if metadata.Target != request.URL {
 		t.Fatalf("Target = %q, want %q", metadata.Target, request.URL)

--- a/internal/remote/http.go
+++ b/internal/remote/http.go
@@ -175,7 +175,7 @@ func redactCredentialValues(message string, credentials Credentials, gitCredenti
 		message = strings.ReplaceAll(message, secret, "[redacted]")
 	}
 	if gitCredentials.SSHPrivateKey != "" {
-		for _, line := range strings.Split(gitCredentials.SSHPrivateKey, "\n") {
+		for line := range strings.SplitSeq(gitCredentials.SSHPrivateKey, "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue

--- a/internal/render/directory.go
+++ b/internal/render/directory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	argoglob "github.com/argoproj/argo-cd/v3/util/glob"
@@ -162,7 +163,7 @@ func directoryDataLooksKubernetesManifest(data []byte) bool {
 	if strings.Contains(text, `"apiVersion"`) || strings.Contains(text, `"kind"`) {
 		return true
 	}
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -289,12 +290,7 @@ func addKustomizeGeneratorRefToSkipSet(skipFiles map[string]bool, root, dir, ref
 }
 
 func isKustomizationFileName(name string) bool {
-	for _, candidate := range kustomizationFileNames {
-		if name == candidate {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(kustomizationFileNames, name)
 }
 
 func isManifestFile(path string) bool {
@@ -335,7 +331,7 @@ func rejectSymlinkComponents(repoRoot, sourcePath string) error {
 	}
 
 	current := filepath.Clean(repoRoot)
-	for _, component := range strings.Split(sourcePath, string(filepath.Separator)) {
+	for component := range strings.SplitSeq(sourcePath, string(filepath.Separator)) {
 		if component == "" || component == "." {
 			continue
 		}

--- a/internal/render/directory_jsonnet.go
+++ b/internal/render/directory_jsonnet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -165,8 +166,8 @@ func (i *boundedJsonnetImporter) importCandidates(importedFrom, importedPath str
 		seen[candidate] = true
 	}
 
-	for idx := len(i.roots) - 1; idx >= 0; idx-- {
-		root := i.roots[idx]
+	for _, v := range slices.Backward(i.roots) {
+		root := v
 		candidate := filepath.Clean(filepath.Join(root, importPath))
 		if err := rejectPathOutsideBoundary("jsonnet import", candidate, root); err != nil {
 			if len(candidates) == 0 {

--- a/internal/render/helm.go
+++ b/internal/render/helm.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -241,7 +242,7 @@ func shouldSkipHelmDocument(obj *unstructured.Unstructured, opts RenderOptions) 
 	if !opts.SkipTests {
 		return false
 	}
-	for _, part := range strings.Split(hook, ",") {
+	for part := range strings.SplitSeq(hook, ",") {
 		switch strings.TrimSpace(part) {
 		case "test", "test-success", "test-failure":
 			return true
@@ -265,9 +266,7 @@ func applyAVPCompatToHelmValues(values map[string]any, opts RenderOptions) []dia
 	for key := range values {
 		delete(values, key)
 	}
-	for key, value := range replacedMap {
-		values[key] = value
-	}
+	maps.Copy(values, replacedMap)
 	if opts.QuietAVPCompat {
 		return nil
 	}

--- a/internal/render/helm_values.go
+++ b/internal/render/helm_values.go
@@ -330,8 +330,8 @@ func helmValueFileSchemeAllowed(scheme string, opts RenderOptions) bool {
 }
 
 func resolveHelmValueFile(repoRoot, baseDir, boundaryDir string, refRoots map[string]string, file string) (string, string, error) {
-	if strings.HasPrefix(file, "$") {
-		ref, refPath, ok := strings.Cut(strings.TrimPrefix(file, "$"), "/")
+	if after, ok := strings.CutPrefix(file, "$"); ok {
+		ref, refPath, ok := strings.Cut(after, "/")
 		if !ok || ref == "" || refPath == "" {
 			return "", "", fmt.Errorf("helm value file %q must use $ref/path syntax", file)
 		}
@@ -389,7 +389,7 @@ func rejectHelmValueBaseDirSymlinkComponents(repoRoot, sourcePath string) error 
 	}
 
 	current := filepath.Clean(repoRoot)
-	for _, component := range strings.Split(sourcePath, string(filepath.Separator)) {
+	for component := range strings.SplitSeq(sourcePath, string(filepath.Separator)) {
 		if component == "" || component == "." {
 			continue
 		}

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sholdee/drydock/internal/cacheevent"
@@ -102,21 +103,15 @@ func kustomizeGraphHasHelmCharts(graph []kustomizeGraphNode) bool {
 
 func hasAcquirableRemoteKustomizeGraphRefs(graph []kustomizeGraphNode) bool {
 	for _, node := range graph {
-		for _, resource := range node.Kustomization.Resources {
-			if isAcquirableRemoteKustomizeResource(resource) {
-				return true
-			}
+		if slices.ContainsFunc(node.Kustomization.Resources, isAcquirableRemoteKustomizeResource) {
+			return true
 		}
-		//nolint:staticcheck // Kustomize still accepts bases; scan it for remote refs.
-		for _, base := range node.Kustomization.Bases {
-			if isAcquirableRemoteKustomizeResource(base) {
-				return true
-			}
+
+		if slices.ContainsFunc(node.Kustomization.Bases, isAcquirableRemoteKustomizeResource) { //nolint:staticcheck // Kustomize still accepts bases; scan it for remote refs.
+			return true
 		}
-		for _, component := range node.Kustomization.Components {
-			if isAcquirableRemoteKustomizeResource(component) {
-				return true
-			}
+		if slices.ContainsFunc(node.Kustomization.Components, isAcquirableRemoteKustomizeResource) {
+			return true
 		}
 		if hasAcquirableRemoteKustomizePathRefs(node.Kustomization) {
 			return true
@@ -130,30 +125,20 @@ func hasAcquirableRemoteKustomizePathRefs(kustomization types.Kustomization) boo
 	if isAcquirableRemoteKustomizePathRef(kustomization.OpenAPI["path"]) {
 		return true
 	}
-	for _, ref := range kustomization.Configurations {
-		if isAcquirableRemoteKustomizePathRef(ref) {
-			return true
-		}
+	if slices.ContainsFunc(kustomization.Configurations, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
-	for _, ref := range kustomization.Generators {
-		if isAcquirableRemoteKustomizePathRef(ref) {
-			return true
-		}
+	if slices.ContainsFunc(kustomization.Generators, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
-	for _, ref := range kustomization.Transformers {
-		if isAcquirableRemoteKustomizePathRef(ref) {
-			return true
-		}
+	if slices.ContainsFunc(kustomization.Transformers, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
-	for _, ref := range kustomization.Validators {
-		if isAcquirableRemoteKustomizePathRef(ref) {
-			return true
-		}
+	if slices.ContainsFunc(kustomization.Validators, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
-	for _, ref := range kustomization.Crds {
-		if isAcquirableRemoteKustomizePathRef(ref) {
-			return true
-		}
+	if slices.ContainsFunc(kustomization.Crds, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
 	for _, replacement := range kustomization.Replacements {
 		if isAcquirableRemoteKustomizePathRef(replacement.Path) {
@@ -165,14 +150,14 @@ func hasAcquirableRemoteKustomizePathRefs(kustomization types.Kustomization) boo
 			return true
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesJson6902; scan it for remote refs.
-	for _, patch := range kustomization.PatchesJson6902 {
+
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902; scan it for remote refs.
 		if isAcquirableRemoteKustomizePathRef(patch.Path) {
 			return true
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; scan it for remote refs.
-	for _, patch := range kustomization.PatchesStrategicMerge {
+
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; scan it for remote refs.
 		ref := string(patch)
 		if !isInlineStrategicMergePatch(ref) && isAcquirableRemoteKustomizePathRef(ref) {
 			return true
@@ -197,10 +182,8 @@ func hasAcquirableRemoteGeneratorRefs(sources types.KvPairSources) bool {
 			return true
 		}
 	}
-	for _, source := range sources.EnvSources {
-		if isAcquirableRemoteKustomizePathRef(source) {
-			return true
-		}
+	if slices.ContainsFunc(sources.EnvSources, isAcquirableRemoteKustomizePathRef) {
+		return true
 	}
 	return isAcquirableRemoteKustomizePathRef(sources.EnvSource)
 }

--- a/internal/render/kustomize_graph_validate.go
+++ b/internal/render/kustomize_graph_validate.go
@@ -191,8 +191,8 @@ func (v *kustomizeGraphValidator) validateOperandRefs(ctx context.Context, dir s
 			return err
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts bases; validate it to block unsafe refs.
-	for _, base := range kustomization.Bases {
+
+	for _, base := range kustomization.Bases { //nolint:staticcheck // Kustomize still accepts bases; validate it to block unsafe refs.
 		if err := v.validateKustomizationRef(ctx, dir, "bases", base, childInheritedHelmNamespace); err != nil {
 			return err
 		}
@@ -256,8 +256,8 @@ func (v *kustomizeGraphValidator) validatePatchRefs(dir string, kustomization *t
 			return err
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesJson6902; validate it to block unsafe refs.
-	for _, patch := range kustomization.PatchesJson6902 {
+
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902; validate it to block unsafe refs.
 		if patch.Path == "" {
 			continue
 		}
@@ -265,8 +265,8 @@ func (v *kustomizeGraphValidator) validatePatchRefs(dir string, kustomization *t
 			return err
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; validate it to block unsafe refs.
-	for _, patch := range kustomization.PatchesStrategicMerge {
+
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; validate it to block unsafe refs.
 		path := string(patch)
 		if isInlineStrategicMergePatch(path) {
 			continue

--- a/internal/render/kustomize_source_options.go
+++ b/internal/render/kustomize_source_options.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,9 +86,7 @@ func applySourceKustomizeOptions(kustomization *types.Kustomization, dir, bounda
 		if kustomization.CommonAnnotations == nil {
 			kustomization.CommonAnnotations = map[string]string{}
 		}
-		for key, value := range annotations {
-			kustomization.CommonAnnotations[key] = value
-		}
+		maps.Copy(kustomization.CommonAnnotations, annotations)
 	}
 	if len(kustomize.Patches) != 0 {
 		kustomization.Patches = append(kustomization.Patches, sourceKustomizePatches(kustomize.Patches)...)
@@ -201,9 +200,8 @@ func upsertReplicas(existing, overrides []types.Replica) []types.Replica {
 	return out
 }
 
-//nolint:staticcheck // CommonLabels remains part of the Kustomize API and Argo CD source override semantics.
 func applySourceKustomizeLabels(kustomization *types.Kustomization, labels map[string]string, kustomize *argoappv1.ApplicationSourceKustomize) error {
-	if err := mergeStringMap(kustomization.CommonLabels, labels, kustomize.ForceCommonLabels, "common label"); err != nil {
+	if err := mergeStringMap(kustomization.CommonLabels, labels, kustomize.ForceCommonLabels, "common label"); err != nil { //nolint:staticcheck // CommonLabels remains part of Argo CD source override semantics.
 		return err
 	}
 	for _, existing := range kustomization.Labels {
@@ -219,12 +217,10 @@ func applySourceKustomizeLabels(kustomization *types.Kustomization, labels map[s
 		})
 		return nil
 	}
-	if kustomization.CommonLabels == nil {
-		kustomization.CommonLabels = map[string]string{}
+	if kustomization.CommonLabels == nil { //nolint:staticcheck // CommonLabels remains part of Argo CD source override semantics.
+		kustomization.CommonLabels = map[string]string{} //nolint:staticcheck // CommonLabels remains part of Argo CD source override semantics.
 	}
-	for key, value := range labels {
-		kustomization.CommonLabels[key] = value
-	}
+	maps.Copy(kustomization.CommonLabels, labels) //nolint:staticcheck // CommonLabels remains part of Argo CD source override semantics.
 	return nil
 }
 
@@ -250,9 +246,7 @@ func envsubstStringMap(in map[string]string, env argoappv1.Env) map[string]strin
 
 func cloneStringMap(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/internal/render/kustomize_workspace.go
+++ b/internal/render/kustomize_workspace.go
@@ -128,13 +128,12 @@ func (w *kustomizeWorkspace) prepareKustomizationDir(ctx context.Context, dir, b
 	}
 	kustomization.Resources = resources
 
-	//nolint:staticcheck // Kustomize still accepts bases; rewrite it for parity.
-	bases, err := w.prepareKustomizeRefs(ctx, dir, boundaryRoot, "bases", graphIndex, kustomization.Bases, childInheritedHelmNamespace, false)
+	bases, err := w.prepareKustomizeRefs(ctx, dir, boundaryRoot, "bases", graphIndex, kustomization.Bases, childInheritedHelmNamespace, false) //nolint:staticcheck // Kustomize still accepts bases; rewrite it for parity.
 	if err != nil {
 		return fmt.Errorf("%s: %w", manifestPath, err)
 	}
-	//nolint:staticcheck // Kustomize still accepts bases; rewrite it for parity.
-	kustomization.Bases = bases
+
+	kustomization.Bases = bases //nolint:staticcheck // Kustomize still accepts bases; rewrite it for parity.
 
 	components, err := w.prepareKustomizeRefs(ctx, dir, boundaryRoot, "components", graphIndex, kustomization.Components, childInheritedHelmNamespace, false)
 	if err != nil {

--- a/internal/render/kustomize_workspace_copy.go
+++ b/internal/render/kustomize_workspace_copy.go
@@ -185,8 +185,8 @@ func referencedKustomizeWorkspacePaths(dir string, kustomization types.Kustomiza
 	for _, ref := range kustomization.Resources {
 		appendLocalRef(ref)
 	}
-	//nolint:staticcheck // Kustomize still accepts bases; copy local refs for parity.
-	for _, ref := range kustomization.Bases {
+
+	for _, ref := range kustomization.Bases { //nolint:staticcheck // Kustomize still accepts bases; copy local refs for parity.
 		appendLocalRef(ref)
 	}
 	for _, ref := range kustomization.Components {
@@ -214,12 +214,12 @@ func referencedKustomizeWorkspacePaths(dir string, kustomization types.Kustomiza
 	for _, patch := range kustomization.Patches {
 		appendLocalRef(patch.Path)
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesJson6902; copy local refs for parity.
-	for _, patch := range kustomization.PatchesJson6902 {
+
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902; copy local refs for parity.
 		appendLocalRef(patch.Path)
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; copy local refs for parity.
-	for _, patch := range kustomization.PatchesStrategicMerge {
+
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; copy local refs for parity.
 		ref := string(patch)
 		if !isInlineStrategicMergePatch(ref) {
 			appendLocalRef(ref)

--- a/internal/render/kustomize_workspace_remote.go
+++ b/internal/render/kustomize_workspace_remote.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sholdee/drydock/internal/cacheevent"
@@ -203,7 +204,7 @@ func rawKustomizeRemoteQueryValues(ref, key string) []string {
 	}
 	rawQuery, _, _ = strings.Cut(rawQuery, "#")
 	var out []string
-	for _, part := range strings.Split(rawQuery, "&") {
+	for part := range strings.SplitSeq(rawQuery, "&") {
 		rawKey, rawValue, hasValue := strings.Cut(part, "=")
 		decodedKey, err := url.QueryUnescape(rawKey)
 		if err != nil || decodedKey != key || !hasValue {
@@ -376,12 +377,7 @@ func isColonStyleKustomizeRemoteRef(ref string) bool {
 }
 
 func isKnownGitHost(host string) bool {
-	for _, known := range []string{"github.com", "gitlab.com", "bitbucket.org"} {
-		if host == known {
-			return true
-		}
-	}
-	return false
+	return slices.Contains([]string{"github.com", "gitlab.com", "bitbucket.org"}, host)
 }
 
 func looksLikeRemoteHost(host string) bool {

--- a/internal/render/kustomize_workspace_rewrite.go
+++ b/internal/render/kustomize_workspace_rewrite.go
@@ -105,8 +105,8 @@ func (w *kustomizeWorkspace) rewriteKustomizePatchRefs(ctx context.Context, node
 			kustomization.Patches[i].Path = rewritten
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesJson6902; rewrite it for parity.
-	for i, patch := range kustomization.PatchesJson6902 {
+
+	for i, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902; rewrite remote refs for parity.
 		if patch.Path == "" {
 			continue
 		}
@@ -115,11 +115,11 @@ func (w *kustomizeWorkspace) rewriteKustomizePatchRefs(ctx context.Context, node
 			return err
 		}
 		if ok {
-			kustomization.PatchesJson6902[i].Path = rewritten
+			kustomization.PatchesJson6902[i].Path = rewritten //nolint:staticcheck // Kustomize still accepts patchesJson6902; rewrite remote refs for parity.
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; rewrite it for parity.
-	for i, patch := range kustomization.PatchesStrategicMerge {
+
+	for i, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; rewrite remote refs for parity.
 		ref := string(patch)
 		if isInlineStrategicMergePatch(ref) {
 			continue
@@ -129,7 +129,7 @@ func (w *kustomizeWorkspace) rewriteKustomizePatchRefs(ctx context.Context, node
 			return err
 		}
 		if ok {
-			kustomization.PatchesStrategicMerge[i] = types.PatchStrategicMerge(rewritten)
+			kustomization.PatchesStrategicMerge[i] = types.PatchStrategicMerge(rewritten) //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; rewrite remote refs for parity.
 		}
 	}
 	return nil

--- a/internal/render/kustomize_workspace_validate.go
+++ b/internal/render/kustomize_workspace_validate.go
@@ -166,8 +166,8 @@ func validateWorkspacePatchRefs(boundaryRoot, dir string, kustomization *types.K
 			return err
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesJson6902; validate it to block unsafe refs.
-	for _, patch := range kustomization.PatchesJson6902 {
+
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902; validate it to block unsafe refs.
 		if patch.Path == "" {
 			continue
 		}
@@ -175,8 +175,8 @@ func validateWorkspacePatchRefs(boundaryRoot, dir string, kustomization *types.K
 			return err
 		}
 	}
-	//nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; validate it to block unsafe refs.
-	for _, patch := range kustomization.PatchesStrategicMerge {
+
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge; validate it to block unsafe refs.
 		path := string(patch)
 		if isInlineStrategicMergePatch(path) {
 			continue
@@ -244,7 +244,7 @@ func rejectSymlinkedPath(root, path string) error {
 	}
 
 	current := filepath.Clean(root)
-	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+	for component := range strings.SplitSeq(rel, string(filepath.Separator)) {
 		current = filepath.Join(current, component)
 		info, err := os.Lstat(current)
 		if err != nil {

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -1,6 +1,7 @@
 package requestopts
 
 import (
+	"maps"
 	"time"
 
 	"github.com/sholdee/drydock/internal/app"
@@ -242,9 +243,7 @@ func cloneStringMap(input map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -435,7 +435,7 @@ func redactGitCredentialError(message string, credentials GitCredentials) string
 		message = strings.ReplaceAll(message, secret, "[redacted]")
 	}
 	if credentials.SSHPrivateKey != "" {
-		for _, line := range strings.Split(credentials.SSHPrivateKey, "\n") {
+		for line := range strings.SplitSeq(credentials.SSHPrivateKey, "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue

--- a/pkg/drydock/drydock_acquisition_test.go
+++ b/pkg/drydock/drydock_acquisition_test.go
@@ -48,7 +48,7 @@ metadata:
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:          left,
 		Path:              right,
-		ChangedOnly:       boolPtr(false),
+		ChangedOnly:       new(false),
 		RecordCacheEvents: true,
 		ChartAcquirer:     &recordingChartAcquirer{chartDir: chartDir, fromCache: true},
 	})
@@ -92,7 +92,7 @@ spec:
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:          left,
 		Path:              right,
-		ChangedOnly:       boolPtr(false),
+		ChangedOnly:       new(false),
 		RecordCacheEvents: true,
 		ChartAcquirer:     &recordingChartAcquirer{chartDir: chartDir, fromCache: true},
 	})

--- a/pkg/drydock/drydock_diff_test.go
+++ b/pkg/drydock/drydock_diff_test.go
@@ -12,7 +12,7 @@ func TestDiffApplications(t *testing.T) {
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:    left,
 		Path:        right,
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 	})
 	if err != nil {
 		t.Fatalf("DiffApplications() error = %v", err)
@@ -31,7 +31,7 @@ func TestDiffApplicationsShowIgnoredFields(t *testing.T) {
 	defaultResult, err := DiffApplications(context.Background(), Config{
 		PathOrig:    left,
 		Path:        right,
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 	})
 	if err != nil {
 		t.Fatalf("DiffApplications(default) error = %v", err)
@@ -43,7 +43,7 @@ func TestDiffApplicationsShowIgnoredFields(t *testing.T) {
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:          left,
 		Path:              right,
-		ChangedOnly:       boolPtr(false),
+		ChangedOnly:       new(false),
 		ShowIgnoredFields: true,
 	})
 	if err != nil {
@@ -63,7 +63,7 @@ func TestPublicDiffApplicationsParallelismPreservesResults(t *testing.T) {
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:    left,
 		Path:        right,
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 		Parallelism: 2,
 	})
 	if err != nil {
@@ -88,7 +88,7 @@ func TestPublicDiffApplicationsRefOrig(t *testing.T) {
 		Path:        root,
 		Repo:        root,
 		RefOrig:     "HEAD",
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 	})
 	if err != nil {
 		t.Fatalf("DiffApplications() error = %v", err)
@@ -115,7 +115,7 @@ func TestPublicDiffApplicationsRefAndRefOrig(t *testing.T) {
 		Repo:        root,
 		RefOrig:     "master",
 		Ref:         "feature",
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 	})
 	if err != nil {
 		t.Fatalf("DiffApplications() error = %v", err)
@@ -140,7 +140,7 @@ func TestDiffImages(t *testing.T) {
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:    left,
 		Path:        right,
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 	})
 	if err != nil {
 		t.Fatalf("DiffImages() error = %v", err)
@@ -158,7 +158,7 @@ func TestPublicDiffImagesParallelismPreservesResults(t *testing.T) {
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:    left,
 		Path:        right,
-		ChangedOnly: boolPtr(false),
+		ChangedOnly: new(false),
 		Parallelism: 2,
 	})
 	if err != nil {

--- a/pkg/drydock/drydock_plugins_test.go
+++ b/pkg/drydock/drydock_plugins_test.go
@@ -143,7 +143,7 @@ func TestDiffApplicationsPluginRendererHonorsConfiguredTimeout(t *testing.T) {
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: blockingPublicPluginRenderer{},
 		PluginTimeout:  time.Nanosecond,
 	})
@@ -164,7 +164,7 @@ func TestDiffImagesPluginRendererHonorsConfiguredTimeout(t *testing.T) {
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: blockingPublicPluginRenderer{},
 		PluginTimeout:  time.Nanosecond,
 	})
@@ -187,7 +187,7 @@ func TestDiffApplicationsReturnsResultsFromSuccessfulAppsWithPluginFailure(t *te
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: failingPublicPluginRenderer{},
 	})
 	if err == nil {
@@ -215,7 +215,7 @@ func TestDiffImagesReturnsResultsFromSuccessfulAppsWithPluginFailure(t *testing.
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: failingPublicPluginRenderer{},
 	})
 	if err == nil {
@@ -342,7 +342,7 @@ func TestDiffApplicationsUsesInjectedPluginRenderer(t *testing.T) {
 	result, err := DiffApplications(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: renderer,
 	})
 	if err != nil {
@@ -381,7 +381,7 @@ func TestDiffImagesUsesInjectedPluginRenderer(t *testing.T) {
 	result, err := DiffImages(context.Background(), Config{
 		PathOrig:       left,
 		Path:           right,
-		ChangedOnly:    boolPtr(false),
+		ChangedOnly:    new(false),
 		PluginRenderer: renderer,
 	})
 	if err != nil {

--- a/pkg/drydock/drydock_test_helpers_test.go
+++ b/pkg/drydock/drydock_test_helpers_test.go
@@ -577,12 +577,7 @@ func hasStatus(statuses []ApplicationStatus, name, status string) bool {
 	return false
 }
 func containsString(items []string, want string) bool {
-	for _, item := range items {
-		if item == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, want)
 }
 func assertAPIMessageRedacted(t *testing.T, message string, secrets []string) {
 	t.Helper()
@@ -597,7 +592,4 @@ func assertAPIMessageRedacted(t *testing.T, message string, secrets []string) {
 	if message != "" {
 		t.Fatalf("message = %q, want redacted marker", message)
 	}
-}
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/pkg/drydock/plugins.go
+++ b/pkg/drydock/plugins.go
@@ -3,6 +3,7 @@ package drydock
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -216,9 +217,7 @@ func pluginManifestsToInternal(manifests []PluginManifest) []renderpkg.Manifest 
 
 func cloneStringMapPresent(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/pkg/drydock/results.go
+++ b/pkg/drydock/results.go
@@ -1,6 +1,8 @@
 package drydock
 
 import (
+	"maps"
+
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/app"
 	"github.com/sholdee/drydock/internal/cacheevent"
@@ -314,9 +316,7 @@ func cloneStringMap(input map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/setup-action/resolve_test.go
+++ b/setup-action/resolve_test.go
@@ -133,7 +133,7 @@ func readGitHubOutput(t *testing.T, path string) map[string]string {
 		t.Fatalf("read GITHUB_OUTPUT: %v", err)
 	}
 	outputs := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		key, value, ok := strings.Cut(line, "=")
 		if !ok {
 			continue


### PR DESCRIPTION
## Summary
- enable modernize and usestdlibvars in golangci-lint
- apply behavior-preserving Go modernization cleanup across tests and internal helpers
- keep omitzero excluded so JSON, cache keys, and diagnostic output shapes stay stable
- retain explicit legacy Kustomize field support with narrow staticcheck suppressions

## Behavior
No intended product behavior change.

## Validation
- mise run lint
- go test ./...
- mise run test-race
- git diff --check
- spec and quality review agents approved the completed branch