### PR TITLE
feat: add markdown diff comments

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -230,8 +230,10 @@ func shouldColorDiffOutput(mode string, deps Dependencies, w io.Writer) bool {
 }
 
 func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile string, markdownMaxBytes int) error {
-	if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
-		return err
+	if output != diffOutputMarkdown {
+		if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
+			return err
+		}
 	}
 	if rawOutputFile != "" {
 		if err := os.WriteFile(rawOutputFile, []byte(report.RawUnifiedDiff(result.Results)), 0o644); err != nil {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/sholdee/drydock/internal/app"
 	cliformat "github.com/sholdee/drydock/internal/format"
+	"github.com/sholdee/drydock/internal/report"
 	"github.com/sholdee/drydock/internal/source"
 	"github.com/spf13/cobra"
 )
@@ -38,6 +40,8 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	appsFlags := defaultCommonFlags()
 	appsFlags.parallelism = defaultRenderAppsParallelism()
 	appsColor := diffColorAuto
+	appsMarkdownMaxBytes := report.DefaultMaxBytes
+	appsRawOutputFile := ""
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Diff all Applications",
@@ -45,6 +49,9 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			output, err := parseDiffOutput(appsFlags.output, "diff apps")
 			if err != nil {
+				return err
+			}
+			if err := validateDiffMarkdownFlags(output, appsMarkdownMaxBytes); err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(appsColor)
@@ -64,13 +71,14 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor)
+			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor, appsRawOutputFile, appsMarkdownMaxBytes)
 		},
 	}
 	bindCommonFlags(apps, &appsFlags)
 	bindDiffRefFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
 	bindDiffColorFlag(apps, &appsColor)
+	bindDiffMarkdownFlags(apps, &appsMarkdownMaxBytes, &appsRawOutputFile)
 
 	return apps
 }
@@ -78,6 +86,8 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	appFlags := defaultCommonFlags()
 	appColor := diffColorAuto
+	appMarkdownMaxBytes := report.DefaultMaxBytes
+	appRawOutputFile := ""
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Diff one Application",
@@ -85,6 +95,9 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output, err := parseDiffOutput(appFlags.output, "diff app")
 			if err != nil {
+				return err
+			}
+			if err := validateDiffMarkdownFlags(output, appMarkdownMaxBytes); err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(appColor)
@@ -107,13 +120,14 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor)
+			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor, appRawOutputFile, appMarkdownMaxBytes)
 		},
 	}
 	bindCommonFlags(appCmd, &appFlags)
 	bindDiffRefFlags(appCmd, &appFlags)
 	bindShowIgnoredFieldsFlag(appCmd, &appFlags)
 	bindDiffColorFlag(appCmd, &appColor)
+	bindDiffMarkdownFlags(appCmd, &appMarkdownMaxBytes, &appRawOutputFile)
 
 	return appCmd
 }
@@ -172,6 +186,25 @@ func bindDiffColorFlag(cmd *cobra.Command, colorMode *string) {
 	cmd.Flags().StringVar(colorMode, "color", *colorMode, "color diff output: auto, always, or never")
 }
 
+func bindDiffMarkdownFlags(cmd *cobra.Command, markdownMaxBytes *int, rawOutputFile *string) {
+	cmd.Flags().IntVar(markdownMaxBytes, "markdown-max-bytes", *markdownMaxBytes,
+		fmt.Sprintf("maximum markdown output bytes; 0 disables the limit, positive values must be at least %d", report.MinPositiveMaxByte))
+	cmd.Flags().StringVar(rawOutputFile, "raw-output-file", *rawOutputFile, "write full uncolored unified diff output to this file")
+}
+
+func validateDiffMarkdownFlags(output string, markdownMaxBytes int) error {
+	if output != diffOutputMarkdown {
+		return nil
+	}
+	if markdownMaxBytes < 0 {
+		return fmt.Errorf("markdown max bytes must be greater than or equal to zero")
+	}
+	if markdownMaxBytes > 0 && markdownMaxBytes < report.MinPositiveMaxByte {
+		return fmt.Errorf("markdown max bytes must be zero or at least %d", report.MinPositiveMaxByte)
+	}
+	return nil
+}
+
 func parseDiffColorMode(value string) (string, error) {
 	mode := strings.TrimSpace(value)
 	if mode == "" {
@@ -196,9 +229,14 @@ func shouldColorDiffOutput(mode string, deps Dependencies, w io.Writer) bool {
 	}
 }
 
-func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool) error {
+func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile string, markdownMaxBytes int) error {
 	if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
 		return err
+	}
+	if rawOutputFile != "" {
+		if err := os.WriteFile(rawOutputFile, []byte(report.RawUnifiedDiff(result.Results)), 0o644); err != nil {
+			return fmt.Errorf("write raw diff output: %w", err)
+		}
 	}
 	switch output {
 	case diffOutputUnified:
@@ -206,6 +244,10 @@ func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExit
 			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeUnifiedDiff(item.Diff, diffColor)); err != nil {
 				return err
 			}
+		}
+	case diffOutputMarkdown:
+		if _, err := report.WriteDiffMarkdown(cmd.OutOrStdout(), result, report.MarkdownOptions{MaxBytes: markdownMaxBytes}); err != nil {
+			return err
 		}
 	case string(cliformat.OutputJSON):
 		if err := writeStructuredOutput(cmd.OutOrStdout(), output, result.Results); err != nil {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -172,7 +172,7 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 		"+  value: new",
 	)
 	assertStdoutExcludesAll(t, result, "\x1b[")
-	assertStderrContainsAll(t, result, "warning render:")
+	assertStderrEmpty(t, result)
 }
 
 func TestDiffAppsMarkdownRawOutputFilePreservesUnifiedDiff(t *testing.T) {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -141,6 +142,82 @@ func TestDiffAppsColorAlwaysColorsUnifiedOutput(t *testing.T) {
 		"\x1b[32m+  value: new\x1b[0m\n",
 	)
 	assertStderrEmpty(t, result)
+}
+
+func TestDiffAppsMarkdownOutput(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{
+				Parent: diff.Parent{Namespace: "argocd", Name: "demo"},
+				Diff:   sampleUnifiedDiffForCLI(),
+			}},
+			Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "render",
+				Message:  "warning with <tag>",
+			}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--color=always", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"## drydock diff preview",
+		"Applications changed: 1",
+		"Diagnostics:",
+		"&lt;tag&gt;",
+		"<summary>argocd/demo",
+		"```diff\n",
+		"-  value: old",
+		"+  value: new",
+	)
+	assertStdoutExcludesAll(t, result, "\x1b[")
+	assertStderrContainsAll(t, result, "warning render:")
+}
+
+func TestDiffAppsMarkdownRawOutputFilePreservesUnifiedDiff(t *testing.T) {
+	rawPath := filepath.Join(t.TempDir(), "diff.txt")
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--raw-output-file", rawPath, "--exit-code=false")
+	assertStdoutContainsAll(t, result, "## drydock diff preview")
+	raw, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", rawPath, err)
+	}
+	if got := string(raw); got != sampleUnifiedDiffForCLI() {
+		t.Fatalf("raw output = %q, want unified diff %q", got, sampleUnifiedDiffForCLI())
+	}
+}
+
+func TestDiffAppsMarkdownRejectsInvalidMaxBytes(t *testing.T) {
+	for _, maxBytes := range []string{"-1", "1023"} {
+		t.Run(maxBytes, func(t *testing.T) {
+			recorder := &recordingCLIOrchestrator{}
+			cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{
+				Orchestrator: recorder,
+			})
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs([]string{"diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--markdown-max-bytes", maxBytes, "--exit-code=false"})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want invalid markdown max bytes error")
+			}
+			if !strings.Contains(err.Error(), "markdown max bytes") {
+				t.Fatalf("Execute() error = %v, want markdown max bytes", err)
+			}
+			if len(recorder.diffAppsRequests) != 0 {
+				t.Fatalf("DiffApps requests = %#v, want none before invalid markdown max bytes error", recorder.diffAppsRequests)
+			}
+		})
+	}
 }
 
 func TestDiffAppsColorNeverKeepsTTYOutputPlain(t *testing.T) {
@@ -778,6 +855,24 @@ func TestDiffImagesYAMLOutput(t *testing.T) {
 	assertStringSliceEqual(t, payload.Added, []string{"example/app:v2"})
 	assertStringSliceEqual(t, payload.Removed, []string{"example/app:v1"})
 	assertStringSliceEqual(t, payload.Unchanged, []string{"example/sidecar:v1"})
+}
+
+func TestDiffImagesRejectsMarkdownOutput(t *testing.T) {
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{
+		Orchestrator: &recordingCLIOrchestrator{},
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"diff", "images", "--path-orig", "left", "--path", "right", "-o", "markdown"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want markdown rejection")
+	}
+	if !strings.Contains(err.Error(), "markdown output is not supported for diff images") {
+		t.Fatalf("Execute() error = %v, want markdown rejection", err)
+	}
 }
 
 func TestDiffImagesNameOutputPrintsAddedImages(t *testing.T) {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -162,8 +162,8 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--color=always", "--exit-code=false")
 
 	assertStdoutContainsAll(t, result,
-		"## drydock diff preview",
-		"Applications changed: 1",
+		"## drydock desired state diff",
+		"**Summary:** 1 app, 1 resource, +1/-1, 1 warning.",
 		"Diagnostics:",
 		"&lt;tag&gt;",
 		"<summary>argocd/demo",
@@ -172,6 +172,7 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 		"+  value: new",
 	)
 	assertStdoutExcludesAll(t, result, "\x1b[")
+	assertStdoutExcludesAll(t, result, "Changed Applications", "_Stats_")
 	assertStderrEmpty(t, result)
 }
 
@@ -184,7 +185,7 @@ func TestDiffAppsMarkdownRawOutputFilePreservesUnifiedDiff(t *testing.T) {
 	}
 
 	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--raw-output-file", rawPath, "--exit-code=false")
-	assertStdoutContainsAll(t, result, "## drydock diff preview")
+	assertStdoutContainsAll(t, result, "## drydock desired state diff")
 	raw, err := os.ReadFile(rawPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%s) error = %v", rawPath, err)

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -166,6 +166,7 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 		"**Summary:** 1 app, 1 resource, +1/-1, 1 warning.",
 		"Diagnostics:",
 		"&lt;tag&gt;",
+		"<details open>",
 		"<summary>argocd/demo",
 		"```diff\n",
 		"-  value: old",

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -8,7 +8,10 @@ import (
 	cliformat "github.com/sholdee/drydock/internal/format"
 )
 
-const diffOutputUnified = "diff"
+const (
+	diffOutputUnified  = "diff"
+	diffOutputMarkdown = "markdown"
+)
 
 const testOutputText = "text"
 
@@ -17,7 +20,7 @@ func parseDiffOutput(value, command string) (string, error) {
 	switch output {
 	case "", diffOutputUnified:
 		return diffOutputUnified, nil
-	case string(cliformat.OutputJSON), string(cliformat.OutputYAML):
+	case string(cliformat.OutputJSON), string(cliformat.OutputYAML), diffOutputMarkdown:
 		return output, nil
 	case string(cliformat.OutputName):
 		return "", fmt.Errorf("name output is not supported for %s", command)
@@ -30,6 +33,9 @@ func parseImageDiffOutput(value string) (string, error) {
 	output := strings.TrimSpace(value)
 	if output == string(cliformat.OutputName) {
 		return output, nil
+	}
+	if output == diffOutputMarkdown {
+		return "", fmt.Errorf("markdown output is not supported for diff images")
 	}
 	return parseDiffOutput(value, "diff images")
 }

--- a/internal/cli/test_harness_test.go
+++ b/internal/cli/test_harness_test.go
@@ -57,15 +57,6 @@ func assertStdoutExcludesAll(t *testing.T, result cliCommandResult, forbidden ..
 	}
 }
 
-func assertStderrContainsAll(t *testing.T, result cliCommandResult, wants ...string) {
-	t.Helper()
-	for _, want := range wants {
-		if !strings.Contains(result.Stderr, want) {
-			t.Fatalf("stderr missing %q:\nstdout:\n%s\nstderr:\n%s", want, result.Stdout, result.Stderr)
-		}
-	}
-}
-
 func assertStderrEmpty(t *testing.T, result cliCommandResult) {
 	t.Helper()
 	if result.Stderr != "" {

--- a/internal/cli/test_harness_test.go
+++ b/internal/cli/test_harness_test.go
@@ -57,6 +57,15 @@ func assertStdoutExcludesAll(t *testing.T, result cliCommandResult, forbidden ..
 	}
 }
 
+func assertStderrContainsAll(t *testing.T, result cliCommandResult, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(result.Stderr, want) {
+			t.Fatalf("stderr missing %q:\nstdout:\n%s\nstderr:\n%s", want, result.Stdout, result.Stderr)
+		}
+	}
+}
+
 func assertStderrEmpty(t *testing.T, result cliCommandResult) {
 	t.Helper()
 	if result.Stderr != "" {

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -62,7 +62,7 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 		options.DiagnosticLimit = defaultDiagLimit
 	}
 	if strings.TrimSpace(options.Title) == "" {
-		options.Title = "drydock diff preview"
+		options.Title = "drydock desired state diff"
 	}
 
 	groups := groupedDiffs(result.Results)
@@ -71,8 +71,11 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
 	state.appendRequired(summaryMarkdown(len(result.Results), len(groups), totalAdded, totalRemoved, result.Diagnostics))
 	state.appendBounded(diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit))
-	state.appendBounded(changedAppsMarkdown(groups))
-	state.appendAppDetails(groups)
+	if len(groups) == 0 {
+		state.appendBounded(noDiffMarkdown())
+	} else {
+		state.appendAppDetails(groups)
+	}
 	state.appendBounded(omittedMarkdown(groups[state.shownApps:]))
 	state.appendBounded(statsMarkdown(state.truncated, state.shownApps, len(groups)))
 
@@ -229,8 +232,25 @@ func lineChanges(text string) (int, int) {
 
 func summaryMarkdown(results, apps, added, removed int, diagnostics []diagnostic.Diagnostic) string {
 	warnings, errors := diagnosticCounts(diagnostics)
-	return fmt.Sprintf("Summary:\n\n```yaml\nApplications changed: %d\nResources changed: %d\nLines: +%d/-%d\nDiagnostics: %d warnings, %d errors\n```\n\n",
-		apps, results, added, removed, warnings, errors)
+	parts := []string{
+		plural(apps, "app", "apps"),
+		plural(results, "resource", "resources"),
+		fmt.Sprintf("+%d/-%d", added, removed),
+	}
+	if warnings > 0 {
+		parts = append(parts, plural(warnings, "warning", "warnings"))
+	}
+	if errors > 0 {
+		parts = append(parts, plural(errors, "error", "errors"))
+	}
+	return fmt.Sprintf("**Summary:** %s.\n\n", strings.Join(parts, ", "))
+}
+
+func plural(count int, singular, multiple string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, singular)
+	}
+	return fmt.Sprintf("%d %s", count, multiple)
 }
 
 func diagnosticCounts(diagnostics []diagnostic.Diagnostic) (int, int) {
@@ -253,7 +273,7 @@ func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string 
 		return ""
 	}
 	var builder strings.Builder
-	builder.WriteString("Diagnostics:\n\n")
+	builder.WriteString("Diagnostics:\n")
 	shown := min(limit, len(diagnostics))
 	for _, diag := range diagnostics[:shown] {
 		builder.WriteString("- ")
@@ -283,22 +303,8 @@ func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string 
 	return builder.String()
 }
 
-func changedAppsMarkdown(groups []appGroup) string {
-	if len(groups) == 0 {
-		return "No rendered manifest differences detected.\n\n"
-	}
-	var builder strings.Builder
-	builder.WriteString("Changed Applications:\n\n")
-	limit := min(len(groups), 50)
-	for _, group := range groups[:limit] {
-		fmt.Fprintf(&builder, "- `%s` (+%d/-%d, %d resources)\n",
-			escapeCodeSpan(group.id), group.added, group.removed, len(group.resources))
-	}
-	if omitted := len(groups) - limit; omitted > 0 {
-		fmt.Fprintf(&builder, "_... and %d more changed applications omitted from this summary._\n", omitted)
-	}
-	builder.WriteByte('\n')
-	return builder.String()
+func noDiffMarkdown() string {
+	return "No rendered manifest differences detected.\n\n"
 }
 
 func omittedMarkdown(groups []appGroup) string {
@@ -306,23 +312,35 @@ func omittedMarkdown(groups []appGroup) string {
 		return ""
 	}
 	var builder strings.Builder
-	builder.WriteString("Omitted Application Details:\n\n")
+	builder.WriteString("_Omitted details: ")
 	limit := min(len(groups), 25)
-	for _, group := range groups[:limit] {
-		fmt.Fprintf(&builder, "- `%s`\n", escapeCodeSpan(group.id))
+	for index, group := range groups[:limit] {
+		if index > 0 {
+			builder.WriteString(", ")
+		}
+		fmt.Fprintf(&builder, "`%s`", escapeCodeSpan(group.id))
 	}
 	if omitted := len(groups) - limit; omitted > 0 {
-		fmt.Fprintf(&builder, "_... and %d more omitted applications not listed._\n", omitted)
+		fmt.Fprintf(&builder, ", and %d more", omitted)
 	}
-	builder.WriteByte('\n')
+	builder.WriteString("._\n\n")
 	return builder.String()
 }
 
 func statsMarkdown(truncated bool, shown, total int) string {
-	if !truncated {
-		return fmt.Sprintf("_Stats_: [Applications shown: %d/%d]\n", shown, total)
+	if !truncated && shown == total {
+		return ""
 	}
-	return fmt.Sprintf("_Stats_: [Applications shown: %d/%d], [Comment truncated]\n", shown, total)
+	if total == 0 {
+		if truncated {
+			return "_Comment truncated._\n"
+		}
+		return ""
+	}
+	if truncated {
+		return fmt.Sprintf("_Details shown: %d/%d applications; comment truncated._\n", shown, total)
+	}
+	return fmt.Sprintf("_Details shown: %d/%d applications._\n", shown, total)
 }
 
 func allocateAppBudgets(groups []appGroup, budget int, unlimited bool) []int {

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -1,0 +1,471 @@
+package report
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"io"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/diff"
+)
+
+const (
+	OutputMarkdown     = "markdown"
+	DefaultMaxBytes    = 60000
+	MinPositiveMaxByte = 1024
+	defaultDiagLimit   = 10
+)
+
+type MarkdownOptions struct {
+	MaxBytes        int
+	DiagnosticLimit int
+	Title           string
+}
+
+type MarkdownResult struct {
+	Bytes       int
+	Truncated   bool
+	ShownApps   int
+	OmittedApps int
+}
+
+type appGroup struct {
+	id        string
+	resources []diff.Result
+	added     int
+	removed   int
+	diffBytes int
+}
+
+func WriteDiffMarkdown(w io.Writer, result app.DiffResult, options MarkdownOptions) (MarkdownResult, error) {
+	data, meta, err := DiffMarkdown(result, options)
+	if err != nil {
+		return MarkdownResult{}, err
+	}
+	_, err = w.Write(data)
+	return meta, err
+}
+
+func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, MarkdownResult, error) {
+	if options.MaxBytes < 0 {
+		return nil, MarkdownResult{}, fmt.Errorf("markdown max bytes must be greater than or equal to zero")
+	}
+	if options.MaxBytes > 0 && options.MaxBytes < MinPositiveMaxByte {
+		return nil, MarkdownResult{}, fmt.Errorf("markdown max bytes must be zero or at least %d", MinPositiveMaxByte)
+	}
+	if options.DiagnosticLimit <= 0 {
+		options.DiagnosticLimit = defaultDiagLimit
+	}
+	if strings.TrimSpace(options.Title) == "" {
+		options.Title = "drydock diff preview"
+	}
+
+	groups := groupedDiffs(result.Results)
+	totalAdded, totalRemoved := totalLineChanges(groups)
+	state := markdownState{maxBytes: options.MaxBytes}
+	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
+	state.appendRequired(summaryMarkdown(len(result.Results), len(groups), totalAdded, totalRemoved, result.Diagnostics))
+	state.appendBounded(diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit))
+	state.appendBounded(changedAppsMarkdown(groups))
+	state.appendAppDetails(groups)
+	state.appendBounded(omittedMarkdown(groups[state.shownApps:]))
+	state.appendBounded(statsMarkdown(state.truncated, state.shownApps, len(groups)))
+
+	out := state.bytes()
+	return out, MarkdownResult{
+		Bytes:       len(out),
+		Truncated:   state.truncated,
+		ShownApps:   state.shownApps,
+		OmittedApps: len(groups) - state.shownApps,
+	}, nil
+}
+
+func RawUnifiedDiff(results []diff.Result) string {
+	var builder strings.Builder
+	for _, item := range results {
+		builder.WriteString(item.Diff)
+	}
+	return builder.String()
+}
+
+type markdownState struct {
+	buffer    bytes.Buffer
+	maxBytes  int
+	truncated bool
+	shownApps int
+}
+
+func (s *markdownState) appendRequired(text string) {
+	if s.maxBytes == 0 || s.buffer.Len()+len(text) <= s.maxBytes {
+		s.buffer.WriteString(text)
+		return
+	}
+	s.truncated = true
+}
+
+func (s *markdownState) appendBounded(text string) {
+	if text == "" {
+		return
+	}
+	if s.maxBytes == 0 || s.buffer.Len()+len(text) <= s.maxBytes {
+		s.buffer.WriteString(text)
+		return
+	}
+	s.truncated = true
+}
+
+func (s *markdownState) appendAppDetails(groups []appGroup) {
+	if len(groups) == 0 {
+		return
+	}
+	remaining := s.remaining()
+	if remaining <= 0 && s.maxBytes != 0 {
+		s.truncated = true
+		return
+	}
+	allocations := allocateAppBudgets(groups, remaining, s.maxBytes == 0)
+	for i, group := range groups {
+		detail, truncated := appDetailMarkdown(group, allocations[i])
+		if detail == "" {
+			s.truncated = true
+			return
+		}
+		if s.maxBytes != 0 && s.buffer.Len()+len(detail) > s.maxBytes {
+			s.truncated = true
+			return
+		}
+		s.buffer.WriteString(detail)
+		s.shownApps++
+		if truncated {
+			s.truncated = true
+		}
+	}
+}
+
+func (s *markdownState) remaining() int {
+	if s.maxBytes == 0 {
+		return 0
+	}
+	return s.maxBytes - s.buffer.Len()
+}
+
+func (s *markdownState) bytes() []byte {
+	data := s.buffer.Bytes()
+	if s.maxBytes == 0 || len(data) <= s.maxBytes {
+		return append([]byte(nil), data...)
+	}
+	s.truncated = true
+	data = data[:s.maxBytes]
+	for !utf8.Valid(data) {
+		data = data[:len(data)-1]
+	}
+	return append([]byte(nil), data...)
+}
+
+func groupedDiffs(results []diff.Result) []appGroup {
+	byID := make(map[string]*appGroup)
+	for _, result := range results {
+		id := applicationID(result.Parent)
+		group := byID[id]
+		if group == nil {
+			group = &appGroup{id: id}
+			byID[id] = group
+		}
+		group.resources = append(group.resources, result)
+		added, removed := lineChanges(result.Diff)
+		group.added += added
+		group.removed += removed
+		group.diffBytes += len(result.Diff)
+	}
+	groups := make([]appGroup, 0, len(byID))
+	for _, group := range byID {
+		groups = append(groups, *group)
+	}
+	slices.SortFunc(groups, func(left, right appGroup) int {
+		leftChanged := left.added + left.removed
+		rightChanged := right.added + right.removed
+		if leftChanged != rightChanged {
+			return rightChanged - leftChanged
+		}
+		return strings.Compare(left.id, right.id)
+	})
+	return groups
+}
+
+func applicationID(parent diff.Parent) string {
+	if parent.Namespace != "" {
+		return parent.Namespace + "/" + parent.Name
+	}
+	return parent.Name
+}
+
+func totalLineChanges(groups []appGroup) (int, int) {
+	var added, removed int
+	for _, group := range groups {
+		added += group.added
+		removed += group.removed
+	}
+	return added, removed
+}
+
+func lineChanges(text string) (int, int) {
+	var added, removed int
+	for _, line := range strings.Split(text, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+		case strings.HasPrefix(line, "+"):
+			added++
+		case strings.HasPrefix(line, "-"):
+			removed++
+		}
+	}
+	return added, removed
+}
+
+func summaryMarkdown(results, apps, added, removed int, diagnostics []diagnostic.Diagnostic) string {
+	warnings, errors := diagnosticCounts(diagnostics)
+	return fmt.Sprintf("Summary:\n\n```yaml\nApplications changed: %d\nResources changed: %d\nLines: +%d/-%d\nDiagnostics: %d warnings, %d errors\n```\n\n",
+		apps, results, added, removed, warnings, errors)
+}
+
+func diagnosticCounts(diagnostics []diagnostic.Diagnostic) (int, int) {
+	var warnings, errors int
+	for _, diag := range diagnostics {
+		switch diag.Severity {
+		case diagnostic.SeverityError:
+			errors++
+		default:
+			warnings++
+		}
+	}
+	return warnings, errors
+}
+
+func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string {
+	if len(diagnostics) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString("Diagnostics:\n\n")
+	shown := min(limit, len(diagnostics))
+	for _, diag := range diagnostics[:shown] {
+		builder.WriteString("- ")
+		builder.WriteString(escapeMarkdownText(string(diag.Severity)))
+		builder.WriteString(" ")
+		if diag.Category != "" {
+			builder.WriteString("`")
+			builder.WriteString(escapeCodeSpan(diag.Category))
+			builder.WriteString("` ")
+		}
+		builder.WriteString(escapeMarkdownText(singleLine(diag.Message)))
+		if diag.Provenance.Path != "" {
+			builder.WriteString(" (")
+			builder.WriteString(escapeMarkdownText(diag.Provenance.Path))
+			if diag.Provenance.Pointer != "" {
+				builder.WriteString(" ")
+				builder.WriteString(escapeMarkdownText(diag.Provenance.Pointer))
+			}
+			builder.WriteString(")")
+		}
+		builder.WriteByte('\n')
+	}
+	if omitted := len(diagnostics) - shown; omitted > 0 {
+		builder.WriteString(fmt.Sprintf("_... and %d more diagnostics omitted._\n", omitted))
+	}
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func changedAppsMarkdown(groups []appGroup) string {
+	if len(groups) == 0 {
+		return "No rendered manifest differences detected.\n\n"
+	}
+	var builder strings.Builder
+	builder.WriteString("Changed Applications:\n\n")
+	limit := min(len(groups), 50)
+	for _, group := range groups[:limit] {
+		builder.WriteString(fmt.Sprintf("- `%s` (+%d/-%d, %d resources)\n",
+			escapeCodeSpan(group.id), group.added, group.removed, len(group.resources)))
+	}
+	if omitted := len(groups) - limit; omitted > 0 {
+		builder.WriteString(fmt.Sprintf("_... and %d more changed applications omitted from this summary._\n", omitted))
+	}
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func omittedMarkdown(groups []appGroup) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString("Omitted Application Details:\n\n")
+	limit := min(len(groups), 25)
+	for _, group := range groups[:limit] {
+		builder.WriteString(fmt.Sprintf("- `%s`\n", escapeCodeSpan(group.id)))
+	}
+	if omitted := len(groups) - limit; omitted > 0 {
+		builder.WriteString(fmt.Sprintf("_... and %d more omitted applications not listed._\n", omitted))
+	}
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func statsMarkdown(truncated bool, shown, total int) string {
+	if !truncated {
+		return fmt.Sprintf("_Stats_: [Applications shown: %d/%d]\n", shown, total)
+	}
+	return fmt.Sprintf("_Stats_: [Applications shown: %d/%d], [Comment truncated]\n", shown, total)
+}
+
+func allocateAppBudgets(groups []appGroup, budget int, unlimited bool) []int {
+	allocations := make([]int, len(groups))
+	if unlimited {
+		for i := range allocations {
+			allocations[i] = 0
+		}
+		return allocations
+	}
+	if len(groups) == 0 || budget <= 0 {
+		return allocations
+	}
+	const minimum = 512
+	minTotal := minimum * len(groups)
+	if minTotal >= budget {
+		shown := budget / minimum
+		for i := range min(shown, len(groups)) {
+			allocations[i] = minimum
+		}
+		return allocations
+	}
+	for i := range allocations {
+		allocations[i] = minimum
+	}
+	remaining := budget - minTotal
+	var totalBytes int
+	for _, group := range groups {
+		totalBytes += max(group.diffBytes, 1)
+	}
+	for i, group := range groups {
+		allocations[i] += remaining * max(group.diffBytes, 1) / totalBytes
+	}
+	return allocations
+}
+
+func appDetailMarkdown(group appGroup, budget int) (string, bool) {
+	diffText := rawGroupDiff(group)
+	truncated := false
+	if budget > 0 {
+		diffText, truncated = excerptDiff(diffText, max(budget/2, 128))
+	}
+	fence := codeFence(diffText)
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("<details>\n<summary>%s (+%d/-%d, %d resources)</summary>\n\n",
+		escapeHTML(group.id), group.added, group.removed, len(group.resources)))
+	builder.WriteString(fence)
+	builder.WriteString("diff\n")
+	builder.WriteString(diffText)
+	if !strings.HasSuffix(diffText, "\n") {
+		builder.WriteByte('\n')
+	}
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+	if truncated {
+		builder.WriteString("\n_Diff truncated for this application._\n")
+	}
+	builder.WriteString("\n</details>\n\n")
+	out := builder.String()
+	if budget > 0 && len(out) > budget {
+		return "", truncated
+	}
+	return out, truncated
+}
+
+func rawGroupDiff(group appGroup) string {
+	var builder strings.Builder
+	for _, item := range group.resources {
+		builder.WriteString(item.Diff)
+	}
+	return builder.String()
+}
+
+func excerptDiff(text string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(text) <= maxBytes {
+		return text, false
+	}
+	marker := "\n@@ drydock skipped remaining diff lines @@\n"
+	limit := maxBytes - len(marker)
+	if limit <= 0 {
+		return strings.TrimLeft(marker, "\n"), true
+	}
+	cut := validUTF8Prefix(text, limit)
+	if index := strings.LastIndex(cut, "\n"); index > 0 {
+		cut = cut[:index+1]
+	}
+	return cut + strings.TrimLeft(marker, "\n"), true
+}
+
+func validUTF8Prefix(text string, maxBytes int) string {
+	if len(text) <= maxBytes {
+		return text
+	}
+	data := []byte(text[:maxBytes])
+	for !utf8.Valid(data) {
+		data = data[:len(data)-1]
+	}
+	return string(data)
+}
+
+func codeFence(text string) string {
+	longest := 0
+	current := 0
+	for _, r := range text {
+		if r == '`' {
+			current++
+			longest = max(longest, current)
+			continue
+		}
+		current = 0
+	}
+	return strings.Repeat("`", max(3, longest+1))
+}
+
+func singleLine(text string) string {
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func escapeMarkdownText(text string) string {
+	text = html.EscapeString(text)
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"{", "\\{",
+		"}", "\\}",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		".", "\\.",
+		"!", "\\!",
+		"|", "\\|",
+	)
+	return replacer.Replace(text)
+}
+
+func escapeCodeSpan(text string) string {
+	return strings.ReplaceAll(text, "`", "\\`")
+}
+
+func escapeHTML(text string) string {
+	return html.EscapeString(text)
+}

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -215,7 +215,7 @@ func totalLineChanges(groups []appGroup) (int, int) {
 
 func lineChanges(text string) (int, int) {
 	var added, removed int
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		switch {
 		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
 		case strings.HasPrefix(line, "+"):
@@ -239,6 +239,8 @@ func diagnosticCounts(diagnostics []diagnostic.Diagnostic) (int, int) {
 		switch diag.Severity {
 		case diagnostic.SeverityError:
 			errors++
+		case diagnostic.SeverityWarning:
+			warnings++
 		default:
 			warnings++
 		}
@@ -275,7 +277,7 @@ func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string 
 		builder.WriteByte('\n')
 	}
 	if omitted := len(diagnostics) - shown; omitted > 0 {
-		builder.WriteString(fmt.Sprintf("_... and %d more diagnostics omitted._\n", omitted))
+		fmt.Fprintf(&builder, "_... and %d more diagnostics omitted._\n", omitted)
 	}
 	builder.WriteByte('\n')
 	return builder.String()
@@ -289,11 +291,11 @@ func changedAppsMarkdown(groups []appGroup) string {
 	builder.WriteString("Changed Applications:\n\n")
 	limit := min(len(groups), 50)
 	for _, group := range groups[:limit] {
-		builder.WriteString(fmt.Sprintf("- `%s` (+%d/-%d, %d resources)\n",
-			escapeCodeSpan(group.id), group.added, group.removed, len(group.resources)))
+		fmt.Fprintf(&builder, "- `%s` (+%d/-%d, %d resources)\n",
+			escapeCodeSpan(group.id), group.added, group.removed, len(group.resources))
 	}
 	if omitted := len(groups) - limit; omitted > 0 {
-		builder.WriteString(fmt.Sprintf("_... and %d more changed applications omitted from this summary._\n", omitted))
+		fmt.Fprintf(&builder, "_... and %d more changed applications omitted from this summary._\n", omitted)
 	}
 	builder.WriteByte('\n')
 	return builder.String()
@@ -307,10 +309,10 @@ func omittedMarkdown(groups []appGroup) string {
 	builder.WriteString("Omitted Application Details:\n\n")
 	limit := min(len(groups), 25)
 	for _, group := range groups[:limit] {
-		builder.WriteString(fmt.Sprintf("- `%s`\n", escapeCodeSpan(group.id)))
+		fmt.Fprintf(&builder, "- `%s`\n", escapeCodeSpan(group.id))
 	}
 	if omitted := len(groups) - limit; omitted > 0 {
-		builder.WriteString(fmt.Sprintf("_... and %d more omitted applications not listed._\n", omitted))
+		fmt.Fprintf(&builder, "_... and %d more omitted applications not listed._\n", omitted)
 	}
 	builder.WriteByte('\n')
 	return builder.String()
@@ -365,8 +367,8 @@ func appDetailMarkdown(group appGroup, budget int) (string, bool) {
 	}
 	fence := codeFence(diffText)
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("<details>\n<summary>%s (+%d/-%d, %d resources)</summary>\n\n",
-		escapeHTML(group.id), group.added, group.removed, len(group.resources)))
+	fmt.Fprintf(&builder, "<details>\n<summary>%s (+%d/-%d, %d resources)</summary>\n\n",
+		escapeHTML(group.id), group.added, group.removed, len(group.resources))
 	builder.WriteString(fence)
 	builder.WriteString("diff\n")
 	builder.WriteString(diffText)

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -74,7 +74,7 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 	if len(groups) == 0 {
 		state.appendBounded(noDiffMarkdown())
 	} else {
-		state.appendAppDetails(groups)
+		state.appendAppDetails(groups, len(groups) == 1)
 	}
 	state.appendBounded(omittedMarkdown(groups[state.shownApps:]))
 	state.appendBounded(statsMarkdown(state.truncated, state.shownApps, len(groups)))
@@ -122,7 +122,7 @@ func (s *markdownState) appendBounded(text string) {
 	s.truncated = true
 }
 
-func (s *markdownState) appendAppDetails(groups []appGroup) {
+func (s *markdownState) appendAppDetails(groups []appGroup, openDetails bool) {
 	if len(groups) == 0 {
 		return
 	}
@@ -133,7 +133,7 @@ func (s *markdownState) appendAppDetails(groups []appGroup) {
 	}
 	allocations := allocateAppBudgets(groups, remaining, s.maxBytes == 0)
 	for i, group := range groups {
-		detail, truncated := appDetailMarkdown(group, allocations[i])
+		detail, truncated := appDetailMarkdown(group, allocations[i], openDetails)
 		if detail == "" {
 			s.truncated = true
 			return
@@ -377,7 +377,7 @@ func allocateAppBudgets(groups []appGroup, budget int, unlimited bool) []int {
 	return allocations
 }
 
-func appDetailMarkdown(group appGroup, budget int) (string, bool) {
+func appDetailMarkdown(group appGroup, budget int, openDetails bool) (string, bool) {
 	diffText := rawGroupDiff(group)
 	truncated := false
 	if budget > 0 {
@@ -385,7 +385,12 @@ func appDetailMarkdown(group appGroup, budget int) (string, bool) {
 	}
 	fence := codeFence(diffText)
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "<details>\n<summary>%s (+%d/-%d, %d resources)</summary>\n\n",
+	detailsTag := "details"
+	if openDetails {
+		detailsTag = "details open"
+	}
+	fmt.Fprintf(&builder, "<%s>\n<summary>%s (+%d/-%d, %d resources)</summary>\n\n",
+		detailsTag,
 		escapeHTML(group.id), group.added, group.removed, len(group.resources))
 	builder.WriteString(fence)
 	builder.WriteString("diff\n")

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -1,0 +1,141 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/diff"
+)
+
+func TestDiffMarkdownGroupsByApplicationIdentity(t *testing.T) {
+	result := app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "demo", "cm-one", "-old\n+new\n"),
+			diffResult("other", "demo", "cm-two", "-old\n+new\n-old2\n+new2\n"),
+		},
+	}
+
+	out, meta, err := DiffMarkdown(result, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{"`argocd/demo`", "`other/demo`", "<summary>other/demo", "<summary>argocd/demo"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Index(text, "<summary>other/demo") > strings.Index(text, "<summary>argocd/demo") {
+		t.Fatalf("markdown did not sort larger diff first:\n%s", text)
+	}
+	if meta.ShownApps != 2 || meta.OmittedApps != 0 {
+		t.Fatalf("meta = %#v, want 2 shown and 0 omitted", meta)
+	}
+}
+
+func TestDiffMarkdownCapsOutputAndPreservesUTF8(t *testing.T) {
+	result := app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "emoji", "cm", strings.Repeat("- old snowman ☃\n+ new snowman ☃\n", 200)),
+		},
+	}
+
+	out, meta, err := DiffMarkdown(result, MarkdownOptions{MaxBytes: MinPositiveMaxByte})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if len(out) > MinPositiveMaxByte {
+		t.Fatalf("markdown length = %d, want <= %d", len(out), MinPositiveMaxByte)
+	}
+	if !utf8.Valid(out) {
+		t.Fatalf("markdown is not valid UTF-8:\n%s", string(out))
+	}
+	if !meta.Truncated {
+		t.Fatalf("meta.Truncated = false, want true")
+	}
+}
+
+func TestDiffMarkdownRejectsInvalidLimits(t *testing.T) {
+	for _, maxBytes := range []int{-1, MinPositiveMaxByte - 1} {
+		_, _, err := DiffMarkdown(app.DiffResult{}, MarkdownOptions{MaxBytes: maxBytes})
+		if err == nil {
+			t.Fatalf("DiffMarkdown(MaxBytes=%d) error = nil, want error", maxBytes)
+		}
+	}
+}
+
+func TestDiffMarkdownUnlimitedIncludesFullDiff(t *testing.T) {
+	diffText := strings.Repeat("- old\n+ new\n", 300)
+	out, meta, err := DiffMarkdown(app.DiffResult{
+		Results: []diff.Result{diffResult("argocd", "demo", "cm", diffText)},
+	}, MarkdownOptions{MaxBytes: 0})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if !strings.Contains(string(out), diffText) {
+		t.Fatalf("unlimited markdown omitted full diff")
+	}
+	if meta.Truncated {
+		t.Fatalf("meta.Truncated = true, want false")
+	}
+}
+
+func TestDiffMarkdownUsesDynamicFenceForBackticks(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Results: []diff.Result{diffResult("argocd", "demo", "cm", "- value: ```\n+ value: ````\n")},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if !strings.Contains(string(out), "`````diff\n") {
+		t.Fatalf("markdown did not use dynamic fence:\n%s", string(out))
+	}
+}
+
+func TestDiffMarkdownEscapesDiagnostics(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{{
+			Severity: diagnostic.SeverityWarning,
+			Category: "render",
+			Message:  "message with <tag> and [link](bad)",
+		}},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, "<tag>") || strings.Contains(text, "[link](bad)") {
+		t.Fatalf("diagnostic was not escaped:\n%s", text)
+	}
+	if !strings.Contains(text, "&lt;tag&gt;") {
+		t.Fatalf("diagnostic HTML escape missing:\n%s", text)
+	}
+}
+
+func TestRawUnifiedDiffPreservesResultOrder(t *testing.T) {
+	results := []diff.Result{
+		{Diff: "first\n"},
+		{Diff: "second\n"},
+	}
+	if got := RawUnifiedDiff(results); got != "first\nsecond\n" {
+		t.Fatalf("RawUnifiedDiff() = %q", got)
+	}
+}
+
+func diffResult(namespace, appName, resourceName, body string) diff.Result {
+	return diff.Result{
+		Parent: diff.Parent{
+			Namespace: namespace,
+			Name:      appName,
+		},
+		Resource: diff.Resource{
+			Kind: "ConfigMap",
+			Name: resourceName,
+		},
+		Change: diff.ChangeModified,
+		Diff:   "@@ Application modified: " + appName + " @@\n" + body,
+	}
+}

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -23,10 +24,13 @@ func TestDiffMarkdownGroupsByApplicationIdentity(t *testing.T) {
 		t.Fatalf("DiffMarkdown() error = %v", err)
 	}
 	text := string(out)
-	for _, want := range []string{"`argocd/demo`", "`other/demo`", "<summary>other/demo", "<summary>argocd/demo"} {
+	for _, want := range []string{"## drydock desired state diff", "**Summary:** 2 apps, 2 resources, +3/-3.", "<summary>other/demo", "<summary>argocd/demo"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("markdown missing %q:\n%s", want, text)
 		}
+	}
+	if strings.Contains(text, "Changed Applications") || strings.Contains(text, "_Stats_") {
+		t.Fatalf("markdown contains redundant app inventory or stats:\n%s", text)
 	}
 	if strings.Index(text, "<summary>other/demo") > strings.Index(text, "<summary>argocd/demo") {
 		t.Fatalf("markdown did not sort larger diff first:\n%s", text)
@@ -112,6 +116,35 @@ func TestDiffMarkdownEscapesDiagnostics(t *testing.T) {
 	}
 	if !strings.Contains(text, "&lt;tag&gt;") {
 		t.Fatalf("diagnostic HTML escape missing:\n%s", text)
+	}
+	if !strings.Contains(text, "**Summary:** 0 apps, 0 resources, +0/-0, 1 warning.") {
+		t.Fatalf("summary did not include compact diagnostic count:\n%s", text)
+	}
+	if !strings.Contains(text, "No rendered manifest differences detected.") {
+		t.Fatalf("no-diff message missing:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownShowsOmittedDetailsOnlyWhenTruncated(t *testing.T) {
+	results := make([]diff.Result, 0, 8)
+	for i := range 8 {
+		results = append(results, diffResult("argocd", fmt.Sprintf("app-%d", i), "cm", strings.Repeat("- old\n+ new\n", 80)))
+	}
+	out, meta, err := DiffMarkdown(app.DiffResult{Results: results}, MarkdownOptions{MaxBytes: MinPositiveMaxByte})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if !meta.Truncated {
+		t.Fatalf("meta.Truncated = false, want true")
+	}
+	if meta.ShownApps >= len(results) {
+		t.Fatalf("meta.ShownApps = %d, want fewer than %d", meta.ShownApps, len(results))
+	}
+	for _, want := range []string{"_Omitted details:", "_Details shown:"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
 	}
 }
 

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -85,6 +85,29 @@ func TestDiffMarkdownUnlimitedIncludesFullDiff(t *testing.T) {
 	if meta.Truncated {
 		t.Fatalf("meta.Truncated = true, want false")
 	}
+	text := string(out)
+	if !strings.Contains(text, "<details open>") {
+		t.Fatalf("single-app markdown did not expand details by default:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownClosesDetailsForMultipleApplications(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "one", "cm-one", "-old\n+new\n"),
+			diffResult("argocd", "two", "cm-two", "-old\n+new\n"),
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, "<details open>") {
+		t.Fatalf("multi-app markdown expanded details by default:\n%s", text)
+	}
+	if got := strings.Count(text, "<details>"); got != 2 {
+		t.Fatalf("closed details count = %d, want 2:\n%s", got, text)
+	}
 }
 
 func TestDiffMarkdownUsesDynamicFenceForBackticks(t *testing.T) {

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -183,9 +183,9 @@ inputs:
     required: false
     default: "true"
   diff-max-bytes:
-    description: Maximum rendered diff bytes to include in pull request comments.
+    description: Maximum rendered diff comment bytes. Values above 60000 are clamped to GitHub's comment budget.
     required: false
-    default: "61000"
+    default: "60000"
   upload-artifacts:
     description: Upload full diff and image report artifacts when they are non-empty.
     required: false

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -372,7 +372,9 @@ fi
 if [[ "${diff_comment}" == "true" ]]; then
   if [[ ! -s "${diff_comment_path}" ]]; then
     {
-      echo "## drydock diff preview"
+      echo "## drydock desired state diff"
+      echo
+      echo "**Summary:** 0 apps, 0 resources, +0/-0."
       echo
       echo "No rendered manifest differences detected."
     } > "${diff_comment_path}"

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -125,20 +125,45 @@ capture_command_quiet() {
   "$@" > "${stdout_file}" 2> "${stderr_file}"
 }
 
-truncate_file() {
-  local input="$1"
-  local output="$2"
-  local max_bytes="$3"
+diff_comment_budget() {
+  local requested="$1"
+  local cap=60000
+  local reserve=512
+  local minimum=1024
+  local effective
 
-  if [[ "$(wc -c < "${input}")" -gt "${max_bytes}" ]]; then
-    if command -v iconv >/dev/null 2>&1; then
-      head -c "${max_bytes}" "${input}" | iconv -c -f utf-8 -t utf-8 > "${output}"
-    else
-      head -c "${max_bytes}" "${input}" > "${output}"
-    fi
-    printf "\n\n####### TRUNCATED -- see artifact for full output #######\n" >> "${output}"
-  else
-    cp "${input}" "${output}"
+  effective="$((10#${requested}))"
+  if [[ "${effective}" -gt "${cap}" ]]; then
+    effective="${cap}"
+  fi
+  if [[ "${effective}" -lt $((minimum + reserve)) ]]; then
+    effective=$((minimum + reserve))
+  fi
+  printf '%s\n' "$((effective - reserve))"
+}
+
+append_diff_artifact_footer() {
+  local comment_file="$1"
+  local max_bytes=60000
+  local footer
+  footer="- Full diff output: [${DRYDOCK_DIFF_ARTIFACT_NAME} artifact](${run_url})."
+  local current footer_bytes
+  current="$(wc -c < "${comment_file}")"
+  footer_bytes="$(printf '\n%s\n' "${footer}" | wc -c)"
+  if [[ $((current + footer_bytes)) -le "${max_bytes}" ]]; then
+    {
+      echo
+      echo "${footer}"
+    } >> "${comment_file}"
+  fi
+}
+
+validate_diff_comment_size() {
+  local comment_file="$1"
+  local max_bytes=60000
+  if [[ "$(wc -c < "${comment_file}")" -gt "${max_bytes}" ]]; then
+    echo "drydock diff comment exceeds ${max_bytes} bytes." >&2
+    exit 1
   fi
 }
 
@@ -194,7 +219,6 @@ images_count_path="${work_dir}/images.count"
 images_stderr="${work_dir}/images.err"
 diff_comment_path="${work_dir}/diff-comment.md"
 images_comment_path="${work_dir}/images-comment.md"
-diff_snippet_path="${work_dir}/diff-snippet.txt"
 
 path="${DRYDOCK_INPUT_PATH:-.}"
 repo="${DRYDOCK_INPUT_REPO:-.}"
@@ -253,10 +277,16 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
     echo "A base ref is required when run-diff is true." >&2
     exit 1
   fi
-  diff_args=("${drydock_bin}" diff apps --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" --exit-code=false "${common_args[@]}")
+  diff_args=("${drydock_bin}" diff apps --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
   append_bool_flag diff_args "${DRYDOCK_INPUT_SHOW_IGNORED_FIELDS}" "--show-ignored-fields"
   append_extra_lines diff_args "${DRYDOCK_INPUT_EXTRA_DIFF_ARGS}"
-  if ! capture_command "${diff_path}" "${diff_stderr}" "${diff_args[@]}"; then
+  diff_args+=(
+    -o markdown
+    --markdown-max-bytes "$(diff_comment_budget "${DRYDOCK_INPUT_DIFF_MAX_BYTES}")"
+    --raw-output-file "${diff_path}"
+    --exit-code=false
+  )
+  if ! capture_command "${diff_comment_path}" "${diff_stderr}" "${diff_args[@]}"; then
     failed="true"
   fi
   if [[ -s "${diff_path}" ]]; then
@@ -267,6 +297,7 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
   fi
 else
   : > "${diff_path}"
+  : > "${diff_comment_path}"
 fi
 
 if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
@@ -339,22 +370,17 @@ if [[ "${comment_mode}" == "images" || "${comment_mode}" == "both" ]]; then
 fi
 
 if [[ "${diff_comment}" == "true" ]]; then
-  {
-    echo "### drydock rendered diff"
-    echo
-    if [[ "${has_diff}" == "true" ]]; then
-      truncate_file "${diff_path}" "${diff_snippet_path}" "${DRYDOCK_INPUT_DIFF_MAX_BYTES}"
-      echo '```diff'
-      cat "${diff_snippet_path}"
-      echo '```'
-      if [[ "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && -n "${run_url}" ]]; then
-        echo
-        echo "- Full diff output: [${DRYDOCK_DIFF_ARTIFACT_NAME} artifact](${run_url})."
-      fi
-    else
+  if [[ ! -s "${diff_comment_path}" ]]; then
+    {
+      echo "## drydock diff preview"
+      echo
       echo "No rendered manifest differences detected."
-    fi
-  } > "${diff_comment_path}"
+    } > "${diff_comment_path}"
+  fi
+  if [[ "${has_diff}" == "true" && "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && -n "${run_url}" ]]; then
+    append_diff_artifact_footer "${diff_comment_path}"
+  fi
+  validate_diff_comment_size "${diff_comment_path}"
 fi
 
 if [[ "${images_comment}" == "true" ]]; then

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -250,7 +250,7 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 		t.Fatalf("raw diff artifact = %q, want raw diff", rawDiff)
 	}
 	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
-	if !strings.Contains(diffComment, "## drydock diff preview") {
+	if !strings.Contains(diffComment, "## drydock desired state diff") {
 		t.Fatalf("diff comment = %q, want markdown report", diffComment)
 	}
 }
@@ -351,9 +351,9 @@ if [[ "$*" == *"diff apps"* ]]; then
   fi
   if [[ "${output}" == "markdown" ]]; then
     if [[ -n "${diff_body:-}" ]]; then
-      printf '## drydock diff preview\n\n~~~diff\n%s~~~\n' "${diff_body}"
+      printf '## drydock desired state diff\n\n~~~diff\n%s~~~\n' "${diff_body}"
     else
-      printf '## drydock diff preview\n\nNo rendered manifest differences detected.\n'
+      printf '## drydock desired state diff\n\n**Summary:** 0 apps, 0 resources, +0/-0.\n\nNo rendered manifest differences detected.\n'
     fi
   else
     printf '%s' "${diff_body:-}"

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -104,7 +104,7 @@ func TestRunCommentsLinkWorkflowRunArtifactsWhenUploadEnabled(t *testing.T) {
 	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
 	for _, want := range []string{
 		"Full diff output: [diff artifact](https://github.example.test/example/repo/actions/runs/12345).",
-		"```diff",
+		"~~~diff",
 	} {
 		if !strings.Contains(diffComment, want) {
 			t.Fatalf("diff comment = %q, want %q", diffComment, want)
@@ -224,6 +224,37 @@ func TestRunCommentEmptyDoesNotLinkArtifactsWithoutOutput(t *testing.T) {
 	}
 }
 
+func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		diffOutput:      true,
+		extraDiffArgs:   "-o json\n--raw-output-file /tmp/ignored\n--exit-code=true",
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	for _, want := range []string{"-o json", "--raw-output-file /tmp/ignored", "-o markdown", "--markdown-max-bytes 59488", "--raw-output-file " + filepath.Join(workDir, "diff.txt"), "--exit-code=false"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("drydock args = %q, want %q", args, want)
+		}
+	}
+	if strings.Index(args, "-o json") > strings.Index(args, "-o markdown") {
+		t.Fatalf("forced markdown output did not come after extra diff args:\n%s", args)
+	}
+	rawDiff := readFile(t, filepath.Join(workDir, "diff.txt"))
+	if !strings.Contains(rawDiff, "diff --git a/apps/demo b/apps/demo") {
+		t.Fatalf("raw diff artifact = %q, want raw diff", rawDiff)
+	}
+	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
+	if !strings.Contains(diffComment, "## drydock diff preview") {
+		t.Fatalf("diff comment = %q, want markdown report", diffComment)
+	}
+}
+
 type commentScenario struct {
 	uploadArtifacts bool
 	githubEnv       bool
@@ -231,6 +262,7 @@ type commentScenario struct {
 	commentMode     string
 	diffOutput      bool
 	imageOutput     bool
+	extraDiffArgs   string
 }
 
 func runCommentScenario(t *testing.T, scenario commentScenario) string {
@@ -247,6 +279,7 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 	}
 	env := append(defaultRunEnv(tmp, workDir, outputPath),
 		"DRYDOCK_INPUT_COMMENT_MODE="+commentMode,
+		"DRYDOCK_INPUT_EXTRA_DIFF_ARGS="+scenario.extraDiffArgs,
 		"DRYDOCK_INPUT_RUN_DIFF=true",
 		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
 		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS="+boolString(scenario.uploadArtifacts),
@@ -278,7 +311,7 @@ func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScen
 
 	diffOutput := ""
 	if scenario.diffOutput {
-		diffOutput = "printf 'diff --git a/apps/demo b/apps/demo\\n+kind: ConfigMap\\n'\n"
+		diffOutput = "diff_body='diff --git a/apps/demo b/apps/demo\n+kind: ConfigMap\n'\n"
 	}
 	imageOutput := ""
 	if scenario.imageOutput {
@@ -287,9 +320,45 @@ func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScen
 
 	writeExecutable(t, path, `#!/usr/bin/env bash
 set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
 
 if [[ "$*" == *"diff apps"* ]]; then
-  `+diffOutput+`  exit 0
+  `+diffOutput+`
+  raw_output_file=""
+  output="diff"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --raw-output-file)
+        raw_output_file="$2"
+        shift 2
+        ;;
+      -o | --output)
+        output="$2"
+        shift 2
+        ;;
+      --output=*)
+        output="${1#--output=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [[ -n "${raw_output_file}" ]]; then
+    printf '%s' "${diff_body:-}" > "${raw_output_file}"
+  fi
+  if [[ "${output}" == "markdown" ]]; then
+    if [[ -n "${diff_body:-}" ]]; then
+      printf '## drydock diff preview\n\n~~~diff\n%s~~~\n' "${diff_body}"
+    else
+      printf '## drydock diff preview\n\nNo rendered manifest differences detected.\n'
+    fi
+  else
+    printf '%s' "${diff_body:-}"
+  fi
+  exit 0
 fi
 
 if [[ "$*" == *"diff images"* ]]; then
@@ -349,7 +418,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_INPUT_CHANGED_ONLY=",
 		"DRYDOCK_INPUT_COMMENT_EMPTY=false",
 		"DRYDOCK_INPUT_COMMENT_MODE=none",
-		"DRYDOCK_INPUT_DIFF_MAX_BYTES=61000",
+		"DRYDOCK_INPUT_DIFF_MAX_BYTES=60000",
 		"DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY=false",
 		"DRYDOCK_INPUT_DISCOVER_KUSTOMIZE=",
 		"DRYDOCK_INPUT_ENABLE_AVP_COMPAT=false",


### PR DESCRIPTION
## Summary
- add markdown output for drydock diff app/apps with compact PR-friendly formatting
- wire the PR action to emit markdown comments plus full raw diff artifacts
- keep markdown diagnostics embedded once, open single-app diffs by default, and collapse multi-app diffs

## Validation
- go test ./internal/report ./internal/cli ./pr-action
- go test ./...
- mise run lint
- git diff --check
- built /private/tmp/drydock-markdown-diff
- review agent approval: APPROVED