### PR TITLE
feat: add markdown image diff output

### DIFF
--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -191,13 +191,15 @@ replaces `--path`, and `--repo` defaults to `--path`. Do not add shellouts,
 `git worktree add`, checkout mutation, or top-level remote `--repo` URL
 support without an approved design update.
 
-Manifest diff output supports unified diff, JSON, and YAML. Image diff output
-also supports unified diff, JSON, and YAML for `added`, `removed`, and
-`unchanged` image lists. `diff images -o name` prints current-only added image
-references, one per line. Removed-only image changes print no names but still
-count as a diff for exit-code semantics unless `--exit-code=false`.
-Diagnostics stay on stderr for structured diff output. `-o name` remains
-unsupported for `diff apps` and `diff app`.
+Manifest diff output supports unified diff, markdown, JSON, and YAML. Image
+diff output supports unified diff, markdown, JSON, and YAML for `added`,
+`removed`, and `unchanged` image lists. Image markdown output is comment-facing
+and omits unchanged images by default. `diff images -o name` prints current-only
+added image references, one per line. Removed-only image changes print no names
+but still count as a diff for exit-code semantics unless `--exit-code=false`.
+Diagnostics stay on stderr for structured/name/unified diff output. Markdown
+diff output embeds successful diagnostics in the markdown document. `-o name`
+remains unsupported for `diff apps` and `diff app`.
 
 Application-local and global ignore rules support `jsonPointers`,
 `jqPathExpressions`, and `managedFieldsManagers`. Apply the union from both

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -92,7 +92,10 @@ By default the action:
 - fetches the pull request base branch for ref-based diffs;
 - runs `drydock test apps --path .`;
 - runs `drydock diff apps --repo . --ref HEAD --ref-orig origin/<base>`;
-- records current-only image additions from `drydock diff images`;
+- records current-only image additions from `drydock diff images` for the added
+  image artifact;
+- writes image diff comments with drydock markdown output, including removed
+  image references when present;
 - uses drydock source caches under the runner temp directory;
 - uploads full diff artifacts when differences are found;
 - writes sticky PR comments for trusted same-repository pull requests.

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -136,6 +136,7 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 	imagesFlags := defaultCommonFlags()
 	imagesFlags.parallelism = defaultRenderAppsParallelism()
 	imagesColor := diffColorAuto
+	imagesMarkdownMaxBytes := report.DefaultMaxBytes
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "Diff rendered image references",
@@ -143,6 +144,9 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			output, err := parseImageDiffOutput(imagesFlags.output)
 			if err != nil {
+				return err
+			}
+			if err := validateDiffMarkdownFlags(output, imagesMarkdownMaxBytes); err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(imagesColor)
@@ -162,12 +166,13 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output, diffColor, diagnosticColor)
+			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output, diffColor, diagnosticColor, imagesMarkdownMaxBytes)
 		},
 	}
 	bindCommonFlags(images, &imagesFlags)
 	bindDiffRefFlags(images, &imagesFlags)
 	bindDiffColorFlag(images, &imagesColor)
+	bindDiffMarkdownMaxBytesFlag(images, &imagesMarkdownMaxBytes)
 
 	return images
 }
@@ -187,9 +192,13 @@ func bindDiffColorFlag(cmd *cobra.Command, colorMode *string) {
 }
 
 func bindDiffMarkdownFlags(cmd *cobra.Command, markdownMaxBytes *int, rawOutputFile *string) {
+	bindDiffMarkdownMaxBytesFlag(cmd, markdownMaxBytes)
+	cmd.Flags().StringVar(rawOutputFile, "raw-output-file", *rawOutputFile, "write full uncolored unified diff output to this file")
+}
+
+func bindDiffMarkdownMaxBytesFlag(cmd *cobra.Command, markdownMaxBytes *int) {
 	cmd.Flags().IntVar(markdownMaxBytes, "markdown-max-bytes", *markdownMaxBytes,
 		fmt.Sprintf("maximum markdown output bytes; 0 disables the limit, positive values must be at least %d", report.MinPositiveMaxByte))
-	cmd.Flags().StringVar(rawOutputFile, "raw-output-file", *rawOutputFile, "write full uncolored unified diff output to this file")
 }
 
 func validateDiffMarkdownFlags(output string, markdownMaxBytes int) error {
@@ -269,9 +278,11 @@ func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExit
 	return nil
 }
 
-func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool) error {
-	if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
-		return err
+func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, markdownMaxBytes int) error {
+	if output != diffOutputMarkdown {
+		if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
+			return err
+		}
 	}
 	switch output {
 	case diffOutputUnified:
@@ -296,6 +307,10 @@ func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disab
 		}
 	case string(cliformat.OutputName):
 		if err := cliformat.Name(cmd.OutOrStdout(), result.Added); err != nil {
+			return err
+		}
+	case diffOutputMarkdown:
+		if _, err := report.WriteImageDiffMarkdown(cmd.OutOrStdout(), result, report.MarkdownOptions{MaxBytes: markdownMaxBytes}); err != nil {
 			return err
 		}
 	default:

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -284,41 +284,47 @@ func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disab
 			return err
 		}
 	}
+	if err := writeImageDiffOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes); err != nil {
+		return err
+	}
+	code := exitCode(nil, disableDiffExitCode, len(result.Added) > 0 || len(result.Removed) > 0)
+	if code != 0 {
+		return ExitError{Code: code}
+	}
+	return nil
+}
+
+func writeImageDiffOutput(w io.Writer, result app.ImageDiffResult, output string, diffColor bool, markdownMaxBytes int) error {
 	switch output {
 	case diffOutputUnified:
-		for _, image := range result.Removed {
-			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeDiffLine(fmt.Sprintf("- %s\n", image), diffColor)); err != nil {
-				return err
-			}
-		}
-		for _, image := range result.Added {
-			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeDiffLine(fmt.Sprintf("+ %s\n", image), diffColor)); err != nil {
-				return err
-			}
-		}
+		return writeUnifiedImageDiff(w, result, diffColor)
 	case string(cliformat.OutputJSON), string(cliformat.OutputYAML):
 		payload := imageDiffOutput{
 			Added:     cloneStringSlice(result.Added),
 			Removed:   cloneStringSlice(result.Removed),
 			Unchanged: cloneStringSlice(result.Unchanged),
 		}
-		if err := writeStructuredOutput(cmd.OutOrStdout(), output, payload); err != nil {
-			return err
-		}
+		return writeStructuredOutput(w, output, payload)
 	case string(cliformat.OutputName):
-		if err := cliformat.Name(cmd.OutOrStdout(), result.Added); err != nil {
-			return err
-		}
+		return cliformat.Name(w, result.Added)
 	case diffOutputMarkdown:
-		if _, err := report.WriteImageDiffMarkdown(cmd.OutOrStdout(), result, report.MarkdownOptions{MaxBytes: markdownMaxBytes}); err != nil {
-			return err
-		}
+		_, err := report.WriteImageDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes})
+		return err
 	default:
 		return fmt.Errorf("unsupported output %q for diff images", output)
 	}
-	code := exitCode(nil, disableDiffExitCode, len(result.Added) > 0 || len(result.Removed) > 0)
-	if code != 0 {
-		return ExitError{Code: code}
+}
+
+func writeUnifiedImageDiff(w io.Writer, result app.ImageDiffResult, color bool) error {
+	for _, image := range result.Removed {
+		if _, err := fmt.Fprint(w, colorizeDiffLine(fmt.Sprintf("- %s\n", image), color)); err != nil {
+			return err
+		}
+	}
+	for _, image := range result.Added {
+		if _, err := fmt.Fprint(w, colorizeDiffLine(fmt.Sprintf("+ %s\n", image), color)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -774,6 +774,35 @@ func TestDiffImagesColorAlwaysColorsImageDiff(t *testing.T) {
 	assertStderrEmpty(t, result)
 }
 
+func TestDiffImagesMarkdownOutput(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffImagesResult: app.ImageDiffResult{
+			Added:     []string{"example/app:v2"},
+			Removed:   []string{"example/app:v1"},
+			Unchanged: []string{"example/sidecar:v1"},
+			Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "image",
+				Message:  "warning with <tag>",
+			}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "images", "--path-orig", "left", "--path", "right", "-o", "markdown", "--color=always", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"## drydock image diff",
+		"**Summary:** 1 added, 1 removed, 1 warning.",
+		"Diagnostics:",
+		"&lt;tag&gt;",
+		"| Change | Image |",
+		"| added | `example/app:v2` |",
+		"| removed | `example/app:v1` |",
+	)
+	assertStdoutExcludesAll(t, result, "example/sidecar:v1", "\x1b[")
+	assertStderrEmpty(t, result)
+}
+
 func TestDiffColorNeverLeavesDiagnosticsColorIndependent(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{
 		diffAppsResult: app.DiffResult{
@@ -859,21 +888,32 @@ func TestDiffImagesYAMLOutput(t *testing.T) {
 	assertStringSliceEqual(t, payload.Unchanged, []string{"example/sidecar:v1"})
 }
 
-func TestDiffImagesRejectsMarkdownOutput(t *testing.T) {
-	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{
-		Orchestrator: &recordingCLIOrchestrator{},
-	})
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"diff", "images", "--path-orig", "left", "--path", "right", "-o", "markdown"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("Execute() error = nil, want markdown rejection")
-	}
-	if !strings.Contains(err.Error(), "markdown output is not supported for diff images") {
-		t.Fatalf("Execute() error = %v, want markdown rejection", err)
+func TestDiffImagesMarkdownRejectsInvalidMaxBytes(t *testing.T) {
+	for _, maxBytes := range []string{"-1", "1023"} {
+		t.Run(maxBytes, func(t *testing.T) {
+			recorder := &recordingCLIOrchestrator{}
+			cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{
+				Orchestrator: recorder,
+			})
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs([]string{"diff", "images", "--path-orig", "left", "--path", "right", "-o", "markdown", "--markdown-max-bytes", maxBytes, "--exit-code=false"})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want invalid markdown max bytes error")
+			}
+			if !strings.Contains(err.Error(), "markdown max bytes") {
+				t.Fatalf("Execute() error = %v, want markdown max bytes", err)
+			}
+			if len(recorder.diffImagesRequests) != 0 {
+				t.Fatalf("DiffImages requests = %#v, want none before invalid markdown max bytes error", recorder.diffImagesRequests)
+			}
+			if stdout.String() != "" || stderr.String() != "" {
+				t.Fatalf("stdout=%q stderr=%q, want empty output", stdout.String(), stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -34,9 +34,6 @@ func parseImageDiffOutput(value string) (string, error) {
 	if output == string(cliformat.OutputName) {
 		return output, nil
 	}
-	if output == diffOutputMarkdown {
-		return "", fmt.Errorf("markdown output is not supported for diff images")
-	}
 	return parseDiffOutput(value, "diff images")
 }
 

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -42,8 +42,22 @@ type appGroup struct {
 	diffBytes int
 }
 
+type imageDiffRow struct {
+	change string
+	image  string
+}
+
 func WriteDiffMarkdown(w io.Writer, result app.DiffResult, options MarkdownOptions) (MarkdownResult, error) {
 	data, meta, err := DiffMarkdown(result, options)
+	if err != nil {
+		return MarkdownResult{}, err
+	}
+	_, err = w.Write(data)
+	return meta, err
+}
+
+func WriteImageDiffMarkdown(w io.Writer, result app.ImageDiffResult, options MarkdownOptions) (MarkdownResult, error) {
+	data, meta, err := ImageDiffMarkdown(result, options)
 	if err != nil {
 		return MarkdownResult{}, err
 	}
@@ -85,6 +99,38 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 		Truncated:   state.truncated,
 		ShownApps:   state.shownApps,
 		OmittedApps: len(groups) - state.shownApps,
+	}, nil
+}
+
+func ImageDiffMarkdown(result app.ImageDiffResult, options MarkdownOptions) ([]byte, MarkdownResult, error) {
+	if options.MaxBytes < 0 {
+		return nil, MarkdownResult{}, fmt.Errorf("markdown max bytes must be greater than or equal to zero")
+	}
+	if options.MaxBytes > 0 && options.MaxBytes < MinPositiveMaxByte {
+		return nil, MarkdownResult{}, fmt.Errorf("markdown max bytes must be zero or at least %d", MinPositiveMaxByte)
+	}
+	if options.DiagnosticLimit <= 0 {
+		options.DiagnosticLimit = defaultDiagLimit
+	}
+	if strings.TrimSpace(options.Title) == "" {
+		options.Title = "drydock image diff"
+	}
+
+	rows := imageDiffRows(result)
+	state := markdownState{maxBytes: options.MaxBytes}
+	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
+	state.appendRequired(imageSummaryMarkdown(len(result.Added), len(result.Removed), result.Diagnostics))
+	state.appendBounded(diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit))
+	if len(rows) == 0 {
+		state.appendBounded(noImageDiffMarkdown())
+	} else {
+		state.appendImageRows(rows)
+	}
+
+	out := state.bytes()
+	return out, MarkdownResult{
+		Bytes:     len(out),
+		Truncated: state.truncated,
 	}, nil
 }
 
@@ -150,6 +196,39 @@ func (s *markdownState) appendAppDetails(groups []appGroup, openDetails bool) {
 	}
 }
 
+func (s *markdownState) appendImageRows(rows []imageDiffRow) {
+	table := "| Change | Image |\n| --- | --- |\n"
+	finalNote := imageRowsOmittedMarkdown(0, len(rows), true)
+	if s.maxBytes != 0 && s.buffer.Len()+len(table)+len(finalNote) > s.maxBytes {
+		s.truncated = true
+		s.appendBounded(finalNote)
+		return
+	}
+	s.buffer.WriteString(table)
+
+	shown := 0
+	for index, row := range rows {
+		line := imageDiffRowMarkdown(row)
+		remainingRows := len(rows) - index - 1
+		omittedNote := imageRowsOmittedMarkdown(shown+1, len(rows), true)
+		requiredAfterRow := 1
+		if remainingRows > 0 {
+			requiredAfterRow += len(omittedNote)
+		}
+		if s.maxBytes != 0 && s.buffer.Len()+len(line)+requiredAfterRow > s.maxBytes {
+			s.truncated = true
+			break
+		}
+		s.buffer.WriteString(line)
+		shown++
+	}
+	s.buffer.WriteByte('\n')
+	if omitted := len(rows) - shown; omitted > 0 {
+		s.truncated = true
+		s.appendBounded(imageRowsOmittedMarkdown(shown, len(rows), true))
+	}
+}
+
 func (s *markdownState) remaining() int {
 	if s.maxBytes == 0 {
 		return 0
@@ -200,6 +279,17 @@ func groupedDiffs(results []diff.Result) []appGroup {
 	return groups
 }
 
+func imageDiffRows(result app.ImageDiffResult) []imageDiffRow {
+	rows := make([]imageDiffRow, 0, len(result.Added)+len(result.Removed))
+	for _, image := range result.Added {
+		rows = append(rows, imageDiffRow{change: "added", image: image})
+	}
+	for _, image := range result.Removed {
+		rows = append(rows, imageDiffRow{change: "removed", image: image})
+	}
+	return rows
+}
+
 func applicationID(parent diff.Parent) string {
 	if parent.Namespace != "" {
 		return parent.Namespace + "/" + parent.Name
@@ -236,6 +326,21 @@ func summaryMarkdown(results, apps, added, removed int, diagnostics []diagnostic
 		plural(apps, "app", "apps"),
 		plural(results, "resource", "resources"),
 		fmt.Sprintf("+%d/-%d", added, removed),
+	}
+	if warnings > 0 {
+		parts = append(parts, plural(warnings, "warning", "warnings"))
+	}
+	if errors > 0 {
+		parts = append(parts, plural(errors, "error", "errors"))
+	}
+	return fmt.Sprintf("**Summary:** %s.\n\n", strings.Join(parts, ", "))
+}
+
+func imageSummaryMarkdown(added, removed int, diagnostics []diagnostic.Diagnostic) string {
+	warnings, errors := diagnosticCounts(diagnostics)
+	parts := []string{
+		plural(added, "added", "added"),
+		plural(removed, "removed", "removed"),
 	}
 	if warnings > 0 {
 		parts = append(parts, plural(warnings, "warning", "warnings"))
@@ -305,6 +410,27 @@ func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string 
 
 func noDiffMarkdown() string {
 	return "No rendered manifest differences detected.\n\n"
+}
+
+func noImageDiffMarkdown() string {
+	return "No rendered image differences detected.\n\n"
+}
+
+func imageDiffRowMarkdown(row imageDiffRow) string {
+	return fmt.Sprintf("| %s | %s |\n", row.change, markdownCodeSpan(tableCellText(row.image)))
+}
+
+func imageRowsOmittedMarkdown(shown, total int, truncated bool) string {
+	if total == 0 {
+		if truncated {
+			return "_Comment truncated._\n"
+		}
+		return ""
+	}
+	if truncated {
+		return fmt.Sprintf("_Image rows shown: %d/%d; comment truncated._\n", shown, total)
+	}
+	return fmt.Sprintf("_Image rows shown: %d/%d._\n", shown, total)
 }
 
 func omittedMarkdown(groups []appGroup) string {
@@ -489,6 +615,30 @@ func escapeMarkdownText(text string) string {
 
 func escapeCodeSpan(text string) string {
 	return strings.ReplaceAll(text, "`", "\\`")
+}
+
+func markdownCodeSpan(text string) string {
+	longest := 0
+	current := 0
+	for _, r := range text {
+		if r == '`' {
+			current++
+			longest = max(longest, current)
+			continue
+		}
+		current = 0
+	}
+	delimiter := strings.Repeat("`", longest+1)
+	if strings.HasPrefix(text, "`") || strings.HasSuffix(text, "`") || strings.Contains(text, delimiter) {
+		text = " " + text + " "
+	}
+	return delimiter + text + delimiter
+}
+
+func tableCellText(text string) string {
+	text = singleLine(text)
+	text = strings.ReplaceAll(text, "|", `\|`)
+	return text
 }
 
 func escapeHTML(text string) string {

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -181,6 +181,151 @@ func TestRawUnifiedDiffPreservesResultOrder(t *testing.T) {
 	}
 }
 
+func TestImageDiffMarkdownRendersAddedRemovedAndOmitsUnchanged(t *testing.T) {
+	out, meta, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Added:     []string{"registry.example.com/app:new", "registry.example.com/app:`tick`", "registry.example.com/app:pipe|line\nbreak"},
+		Removed:   []string{"registry.example.com/app:old"},
+		Unchanged: []string{"registry.example.com/app:same"},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"## drydock image diff",
+		"**Summary:** 3 added, 1 removed.",
+		"| Change | Image |",
+		"| added | `registry.example.com/app:new` |",
+		"| added | `` registry.example.com/app:`tick` `` |",
+		"| added | `registry.example.com/app:pipe\\|line break` |",
+		"| removed | `registry.example.com/app:old` |",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "registry.example.com/app:same") {
+		t.Fatalf("unchanged image rendered:\n%s", text)
+	}
+	if meta.Truncated || meta.ShownApps != 0 || meta.OmittedApps != 0 {
+		t.Fatalf("meta = %#v, want untruncated with app counts unset", meta)
+	}
+}
+
+func TestImageDiffMarkdownNoChangeOutputCompact(t *testing.T) {
+	out, meta, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Unchanged: []string{"registry.example.com/app:same"},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"**Summary:** 0 added, 0 removed.",
+		"No rendered image differences detected.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "| Change | Image |") || strings.Contains(text, "registry.example.com/app:same") {
+		t.Fatalf("no-change markdown was not compact:\n%s", text)
+	}
+	if meta.Truncated {
+		t.Fatalf("meta.Truncated = true, want false")
+	}
+}
+
+func TestImageDiffMarkdownEscapesDiagnosticsAndCountsSummary(t *testing.T) {
+	out, _, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Severity: diagnostic.SeverityWarning,
+				Category: "render",
+				Message:  "message with <tag> and [link](bad)",
+			},
+			{
+				Severity: diagnostic.SeverityError,
+				Category: "image",
+				Message:  "error with <secret>",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, "<tag>") || strings.Contains(text, "[link](bad)") || strings.Contains(text, "<secret>") {
+		t.Fatalf("diagnostic was not escaped:\n%s", text)
+	}
+	if !strings.Contains(text, "&lt;tag&gt;") || !strings.Contains(text, "\\[link\\]\\(bad\\)") {
+		t.Fatalf("diagnostic escape missing:\n%s", text)
+	}
+	if !strings.Contains(text, "**Summary:** 0 added, 0 removed, 1 warning, 1 error.") {
+		t.Fatalf("summary did not include diagnostic counts:\n%s", text)
+	}
+}
+
+func TestImageDiffMarkdownRejectsInvalidLimits(t *testing.T) {
+	for _, maxBytes := range []int{-1, MinPositiveMaxByte - 1} {
+		_, _, err := ImageDiffMarkdown(app.ImageDiffResult{}, MarkdownOptions{MaxBytes: maxBytes})
+		if err == nil {
+			t.Fatalf("ImageDiffMarkdown(MaxBytes=%d) error = nil, want error", maxBytes)
+		}
+	}
+}
+
+func TestImageDiffMarkdownCapsOutputAndPreservesUTF8(t *testing.T) {
+	images := make([]string, 0, 80)
+	for i := range 80 {
+		images = append(images, fmt.Sprintf("registry.example.com/team/image-%02d:%s", i, strings.Repeat("snowman-☃-", 8)))
+	}
+
+	out, meta, err := ImageDiffMarkdown(app.ImageDiffResult{Added: images}, MarkdownOptions{MaxBytes: MinPositiveMaxByte})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	if len(out) > MinPositiveMaxByte {
+		t.Fatalf("markdown length = %d, want <= %d", len(out), MinPositiveMaxByte)
+	}
+	if !utf8.Valid(out) {
+		t.Fatalf("markdown is not valid UTF-8:\n%s", string(out))
+	}
+	if !meta.Truncated {
+		t.Fatalf("meta.Truncated = false, want true")
+	}
+	if !strings.Contains(string(out), "Image rows shown:") || !strings.Contains(string(out), "comment truncated") {
+		t.Fatalf("truncation note missing:\n%s", string(out))
+	}
+}
+
+func TestImageDiffMarkdownUnlimitedIncludesAllRows(t *testing.T) {
+	images := make([]string, 0, 300)
+	for i := range 300 {
+		images = append(images, fmt.Sprintf("registry.example.com/team/image-%03d:tag", i))
+	}
+
+	out, meta, err := ImageDiffMarkdown(app.ImageDiffResult{Added: images}, MarkdownOptions{MaxBytes: 0})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"`registry.example.com/team/image-000:tag`",
+		"`registry.example.com/team/image-299:tag`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("unlimited markdown missing %q", want)
+		}
+	}
+	if meta.Truncated {
+		t.Fatalf("meta.Truncated = true, want false")
+	}
+	if strings.Contains(text, "Image rows shown:") {
+		t.Fatalf("unlimited markdown included omitted note:\n%s", text)
+	}
+}
+
 func diffResult(namespace, appName, resourceName, body string) diff.Result {
 	return diff.Result{
 		Parent: diff.Parent{

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -75,7 +75,8 @@ append_extra_lines() {
 extract_image_diff_json() {
   local json_file="$1"
   local added_file="$2"
-  local count_file="$3"
+  local removed_file="$3"
+  local count_file="$4"
 
   if ! command -v jq >/dev/null 2>&1; then
     echo "drydock diff images -o name is not supported by this drydock binary, and jq is required for JSON fallback parsing." >&2
@@ -83,7 +84,33 @@ extract_image_diff_json() {
   fi
 
   jq -r '(.added // [])[]' "${json_file}" > "${added_file}"
+  jq -r '(.removed // [])[]' "${json_file}" > "${removed_file}"
   jq -r '((.added // []) | length) + ((.removed // []) | length)' "${json_file}" > "${count_file}"
+}
+
+count_nonempty_lines() {
+  local file="$1"
+  if [[ ! -s "${file}" ]]; then
+    echo "0"
+    return 0
+  fi
+  awk 'NF { count++ } END { print count + 0 }' "${file}"
+}
+
+capture_image_diff_json() {
+  local stderr_file="$1"
+  local -a image_args
+
+  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+  append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
+  image_args+=(-o json --exit-code=false)
+  if capture_command_quiet "${images_json_path}" "${stderr_file}" "${image_args[@]}"; then
+    extract_image_diff_json "${images_json_path}" "${images_path}" "${images_removed_path}" "${images_count_path}"
+    return $?
+  else
+    local status=$?
+    return "${status}"
+  fi
 }
 
 workflow_run_url() {
@@ -169,18 +196,42 @@ validate_diff_comment_size() {
 
 write_legacy_images_comment() {
   local comment_file="$1"
+  local added_count
+  local removed_count
+
+  added_count="$(count_nonempty_lines "${images_path}")"
+  removed_count="$(count_nonempty_lines "${images_removed_path}")"
+
   {
     echo "## drydock image diff"
     echo
-    if [[ "${has_images}" == "true" ]]; then
-      echo "**Summary:** added images detected."
+    if [[ "${has_image_diff}" == "true" ]]; then
+      if [[ "${image_diff_details_complete}" == "true" ]]; then
+        echo "**Summary:** ${added_count} added, ${removed_count} removed."
+      elif [[ "${has_images}" == "true" ]]; then
+        echo "**Summary:** added image differences detected."
+      else
+        echo "**Summary:** image differences detected."
+      fi
       echo
-      echo "| Change | Image |"
-      echo "| --- | --- |"
-      while IFS= read -r image; do
-        [[ -n "${image}" ]] || continue
-        printf -- "| added | \`%s\` |\n" "${image}"
-      done < "${images_path}"
+      if [[ "${added_count}" -gt 0 || "${removed_count}" -gt 0 ]]; then
+        echo "| Change | Image |"
+        echo "| --- | --- |"
+        while IFS= read -r image; do
+          [[ -n "${image}" ]] || continue
+          printf -- "| added | \`%s\` |\n" "${image}"
+        done < "${images_path}"
+        while IFS= read -r image; do
+          [[ -n "${image}" ]] || continue
+          printf -- "| removed | \`%s\` |\n" "${image}"
+        done < "${images_removed_path}"
+        if [[ "${image_diff_details_complete}" != "true" ]]; then
+          echo
+          echo "Detailed removed-image rows are unavailable because this drydock binary does not support markdown image output."
+        fi
+      else
+        echo "Image differences detected, but detailed image rows are unavailable because this drydock binary does not support markdown image output."
+      fi
     else
       echo "**Summary:** 0 added, 0 removed."
       echo
@@ -247,12 +298,14 @@ test_stderr="${work_dir}/test.err"
 diff_path="${work_dir}/diff.txt"
 diff_stderr="${work_dir}/diff.err"
 images_path="${work_dir}/added-images.txt"
+images_removed_path="${work_dir}/removed-images.txt"
 images_json_path="${work_dir}/images.json"
 images_count_path="${work_dir}/images.count"
 images_stderr="${work_dir}/images.err"
 images_comment_stderr="${work_dir}/images-comment.err"
 diff_comment_path="${work_dir}/diff-comment.md"
 images_comment_path="${work_dir}/images-comment.md"
+: > "${images_removed_path}"
 
 path="${DRYDOCK_INPUT_PATH:-.}"
 repo="${DRYDOCK_INPUT_REPO:-.}"
@@ -291,6 +344,7 @@ render_status="skipped"
 has_diff="false"
 has_images="false"
 has_image_diff="false"
+image_diff_details_complete="false"
 failed="false"
 
 if [[ "${DRYDOCK_INPUT_RUN_TEST}" == "true" ]]; then
@@ -348,16 +402,13 @@ if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
     image_status=$?
   fi
   if [[ "${image_status}" -eq 2 ]] && grep -q "name output is not supported for diff images" "${images_stderr}"; then
-    image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
-    append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
-    image_args+=(-o json --exit-code=false)
-    if capture_command_quiet "${images_json_path}" "${images_stderr}" "${image_args[@]}"; then
+    if capture_image_diff_json "${images_stderr}"; then
       image_status=0
+      image_diff_details_complete="true"
     else
       image_status=$?
     fi
     if [[ "${image_status}" -eq 0 ]]; then
-      extract_image_diff_json "${images_json_path}" "${images_path}" "${images_count_path}"
       if [[ "$(cat "${images_count_path}")" -gt 0 ]]; then
         image_status=1
       fi
@@ -389,6 +440,7 @@ if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
   fi
 else
   : > "${images_path}"
+  : > "${images_removed_path}"
 fi
 
 comment_mode="${DRYDOCK_INPUT_COMMENT_MODE}"
@@ -432,6 +484,11 @@ if [[ "${images_comment}" == "true" ]]; then
     )
     if ! capture_command_quiet "${images_comment_path}" "${images_comment_stderr}" "${image_comment_args[@]}"; then
       if grep -Eq 'unsupported output "markdown" for diff images|markdown output is not supported for diff images' "${images_comment_stderr}"; then
+        if [[ "${image_diff_details_complete}" != "true" ]]; then
+          if capture_image_diff_json "${images_comment_stderr}"; then
+            image_diff_details_complete="true"
+          fi
+        fi
         write_legacy_images_comment "${images_comment_path}"
       else
         if [[ -s "${images_comment_stderr}" ]]; then

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -167,6 +167,39 @@ validate_diff_comment_size() {
   fi
 }
 
+write_legacy_images_comment() {
+  local comment_file="$1"
+  {
+    echo "## drydock image diff"
+    echo
+    if [[ "${has_images}" == "true" ]]; then
+      echo "**Summary:** added images detected."
+      echo
+      echo "| Change | Image |"
+      echo "| --- | --- |"
+      while IFS= read -r image; do
+        [[ -n "${image}" ]] || continue
+        printf -- "| added | \`%s\` |\n" "${image}"
+      done < "${images_path}"
+    else
+      echo "**Summary:** 0 added, 0 removed."
+      echo
+      echo "No rendered image differences detected."
+    fi
+  } > "${comment_file}"
+}
+
+write_empty_images_comment() {
+  local comment_file="$1"
+  {
+    echo "## drydock image diff"
+    echo
+    echo "**Summary:** 0 added, 0 removed."
+    echo
+    echo "No rendered image differences detected."
+  } > "${comment_file}"
+}
+
 bool "${DRYDOCK_INPUT_RUN_TEST}" run-test
 bool "${DRYDOCK_INPUT_RUN_DIFF}" run-diff
 bool "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" run-image-diff
@@ -217,6 +250,7 @@ images_path="${work_dir}/added-images.txt"
 images_json_path="${work_dir}/images.json"
 images_count_path="${work_dir}/images.count"
 images_stderr="${work_dir}/images.err"
+images_comment_stderr="${work_dir}/images-comment.err"
 diff_comment_path="${work_dir}/diff-comment.md"
 images_comment_path="${work_dir}/images-comment.md"
 
@@ -305,16 +339,18 @@ if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
     echo "A base ref is required when run-image-diff is true." >&2
     exit 1
   fi
-  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" -o name "${common_args[@]}")
+  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
   append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
+  image_args+=(-o name)
   if capture_command_quiet "${images_path}" "${images_stderr}" "${image_args[@]}"; then
     image_status=0
   else
     image_status=$?
   fi
   if [[ "${image_status}" -eq 2 ]] && grep -q "name output is not supported for diff images" "${images_stderr}"; then
-    image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" -o json --exit-code=false "${common_args[@]}")
+    image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
     append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
+    image_args+=(-o json --exit-code=false)
     if capture_command_quiet "${images_json_path}" "${images_stderr}" "${image_args[@]}"; then
       image_status=0
     else
@@ -364,7 +400,7 @@ if [[ "${comment_mode}" == "diff" || "${comment_mode}" == "both" ]]; then
   fi
 fi
 if [[ "${comment_mode}" == "images" || "${comment_mode}" == "both" ]]; then
-  if [[ "${has_images}" == "true" || "${DRYDOCK_INPUT_COMMENT_EMPTY}" == "true" ]]; then
+  if [[ "${has_image_diff}" == "true" || "${DRYDOCK_INPUT_COMMENT_EMPTY}" == "true" ]]; then
     images_comment="true"
   fi
 fi
@@ -386,22 +422,33 @@ if [[ "${diff_comment}" == "true" ]]; then
 fi
 
 if [[ "${images_comment}" == "true" ]]; then
-  {
-    echo "### drydock added images"
-    echo
-    if [[ "${has_images}" == "true" ]]; then
-      while IFS= read -r image; do
-        [[ -n "${image}" ]] || continue
-        printf -- "- \`%s\`\n" "${image}"
-      done < "${images_path}"
-      if [[ "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && "${diff_comment}" != "true" && -n "${run_url}" ]]; then
-        echo
-        echo "- Full added image output: [${DRYDOCK_IMAGE_ARTIFACT_NAME} artifact](${run_url})."
+  if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
+    image_comment_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+    append_extra_lines image_comment_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
+    image_comment_args+=(
+      -o markdown
+      --markdown-max-bytes "$(diff_comment_budget "${DRYDOCK_INPUT_DIFF_MAX_BYTES}")"
+      --exit-code=false
+    )
+    if ! capture_command_quiet "${images_comment_path}" "${images_comment_stderr}" "${image_comment_args[@]}"; then
+      if grep -Eq 'unsupported output "markdown" for diff images|markdown output is not supported for diff images' "${images_comment_stderr}"; then
+        write_legacy_images_comment "${images_comment_path}"
+      else
+        if [[ -s "${images_comment_stderr}" ]]; then
+          cat "${images_comment_stderr}" >&2
+        fi
+        failed="true"
       fi
-    else
-      echo "No added rendered images detected."
     fi
-  } > "${images_comment_path}"
+  else
+    write_empty_images_comment "${images_comment_path}"
+  fi
+  if [[ "${has_images}" == "true" && "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && "${diff_comment}" != "true" && -n "${run_url}" ]]; then
+    {
+      echo
+      echo "- Full added image output: [${DRYDOCK_IMAGE_ARTIFACT_NAME} artifact](${run_url})."
+    } >> "${images_comment_path}"
+  fi
 fi
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -115,8 +115,10 @@ func TestRunCommentsLinkWorkflowRunArtifactsWhenUploadEnabled(t *testing.T) {
 	}
 
 	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
-	if !strings.Contains(imagesComment, "`example/app:v2`") {
-		t.Fatalf("images comment = %q, want added image", imagesComment)
+	for _, want := range []string{"## drydock image diff", "| added | `example/app:v2` |", "| removed | `example/app:v1` |"} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
 	}
 	if strings.Contains(imagesComment, "Full added image output") || strings.Contains(imagesComment, "actions/runs/12345") {
 		t.Fatalf("images comment repeated artifact link while diff comment has one:\n%s", imagesComment)
@@ -142,7 +144,8 @@ func TestRunImagesOnlyCommentLinksWorkflowRunArtifact(t *testing.T) {
 	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
 	for _, want := range []string{
 		"Full added image output: [images artifact](https://github.example.test/example/repo/actions/runs/12345).",
-		"`example/app:v2`",
+		"| added | `example/app:v2` |",
+		"| removed | `example/app:v1` |",
 	} {
 		if !strings.Contains(imagesComment, want) {
 			t.Fatalf("images comment = %q, want %q", imagesComment, want)
@@ -214,13 +217,34 @@ func TestRunCommentEmptyDoesNotLinkArtifactsWithoutOutput(t *testing.T) {
 		t.Fatalf("diff comment = %q, want empty diff text", diffComment)
 	}
 	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
-	if !strings.Contains(imagesComment, "No added rendered images detected.") {
+	if !strings.Contains(imagesComment, "No rendered image differences detected.") {
 		t.Fatalf("images comment = %q, want empty images text", imagesComment)
 	}
 	for _, comment := range []string{diffComment, imagesComment} {
 		if strings.Contains(comment, "artifact](") || strings.Contains(comment, "actions/runs/12345") {
 			t.Fatalf("empty comment contains artifact link:\n%s", comment)
 		}
+	}
+}
+
+func TestRunCommentEmptyDoesNotRunImageDiffWhenImageDiffDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode:   "images",
+		commentEmpty:  true,
+		skipImageDiff: true,
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	if strings.Contains(args, "diff images") {
+		t.Fatalf("drydock args = %q, did not expect diff images call", args)
+	}
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	if !strings.Contains(imagesComment, "No rendered image differences detected.") {
+		t.Fatalf("images comment = %q, want empty images text", imagesComment)
 	}
 }
 
@@ -255,14 +279,106 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 	}
 }
 
+func TestRunImageCommentsUseMarkdownAfterExtraImageArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		commentMode:     "images",
+		imageOutput:     true,
+		extraImageArgs:  "-o json\n--exit-code=true",
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	for _, want := range []string{"-o json", "--exit-code=true", "-o name", "-o markdown", "--markdown-max-bytes 59488", "--exit-code=false"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("drydock args = %q, want %q", args, want)
+		}
+	}
+	if strings.Index(args, "-o json") > strings.Index(args, "-o name") {
+		t.Fatalf("forced name output did not come after extra image args:\n%s", args)
+	}
+	if strings.LastIndex(args, "-o json") > strings.LastIndex(args, "-o markdown") {
+		t.Fatalf("forced markdown output did not come after extra image args:\n%s", args)
+	}
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	for _, want := range []string{"## drydock image diff", "| added | `example/app:v2` |", "| removed | `example/app:v1` |"} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
+	}
+}
+
+func TestRunRemovedOnlyImageDiffCommentsWithoutAddedImagesArtifact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts: true,
+		githubEnv:       true,
+		commentMode:     "images",
+		imageRemoved:    true,
+	})
+
+	output := readFile(t, filepath.Join(filepath.Dir(workDir), "github-output"))
+	for _, want := range []string{"has-images=false", "has-image-diff=true", "images-comment=true"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("GITHUB_OUTPUT = %q, want %q", output, want)
+		}
+	}
+	addedImages := readFile(t, filepath.Join(workDir, "added-images.txt"))
+	if addedImages != "" {
+		t.Fatalf("added-images.txt = %q, want empty for removed-only diff", addedImages)
+	}
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	if !strings.Contains(imagesComment, "| removed | `example/app:v1` |") {
+		t.Fatalf("images comment = %q, want removed image markdown", imagesComment)
+	}
+	if strings.Contains(imagesComment, "Full added image output") {
+		t.Fatalf("removed-only comment linked added image artifact:\n%s", imagesComment)
+	}
+}
+
+func TestRunFallsBackToLegacyImageCommentWhenMarkdownUnsupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts:       true,
+		githubEnv:             true,
+		commentMode:           "images",
+		imageOutput:           true,
+		imageMarkdownDisabled: true,
+	})
+
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	for _, want := range []string{"## drydock image diff", "**Summary:** added images detected.", "| added | `example/app:v2` |"} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
+	}
+	if strings.Contains(imagesComment, "| removed |") {
+		t.Fatalf("legacy fallback should only report added images:\n%s", imagesComment)
+	}
+}
+
 type commentScenario struct {
-	uploadArtifacts bool
-	githubEnv       bool
-	commentEmpty    bool
-	commentMode     string
-	diffOutput      bool
-	imageOutput     bool
-	extraDiffArgs   string
+	uploadArtifacts       bool
+	githubEnv             bool
+	commentEmpty          bool
+	commentMode           string
+	diffOutput            bool
+	imageOutput           bool
+	imageRemoved          bool
+	imageMarkdownDisabled bool
+	skipImageDiff         bool
+	extraDiffArgs         string
+	extraImageArgs        string
 }
 
 func runCommentScenario(t *testing.T, scenario commentScenario) string {
@@ -280,8 +396,9 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 	env := append(defaultRunEnv(tmp, workDir, outputPath),
 		"DRYDOCK_INPUT_COMMENT_MODE="+commentMode,
 		"DRYDOCK_INPUT_EXTRA_DIFF_ARGS="+scenario.extraDiffArgs,
+		"DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS="+scenario.extraImageArgs,
 		"DRYDOCK_INPUT_RUN_DIFF=true",
-		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
+		"DRYDOCK_INPUT_RUN_IMAGE_DIFF="+boolString(!scenario.skipImageDiff),
 		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS="+boolString(scenario.uploadArtifacts),
 		"DRYDOCK_INPUT_COMMENT_EMPTY="+boolString(scenario.commentEmpty),
 		"GITHUB_SERVER_URL=",
@@ -313,9 +430,17 @@ func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScen
 	if scenario.diffOutput {
 		diffOutput = "diff_body='diff --git a/apps/demo b/apps/demo\n+kind: ConfigMap\n'\n"
 	}
-	imageOutput := ""
+	imageAdded := ""
 	if scenario.imageOutput {
-		imageOutput = "printf 'example/app:v2\\n'\n"
+		imageAdded = "example/app:v2"
+	}
+	imageRemoved := ""
+	if scenario.imageOutput || scenario.imageRemoved {
+		imageRemoved = "example/app:v1"
+	}
+	imageMarkdownSupport := "true"
+	if scenario.imageMarkdownDisabled {
+		imageMarkdownSupport = "false"
 	}
 
 	writeExecutable(t, path, `#!/usr/bin/env bash
@@ -362,7 +487,82 @@ if [[ "$*" == *"diff apps"* ]]; then
 fi
 
 if [[ "$*" == *"diff images"* ]]; then
-  `+imageOutput+`  exit 0
+  output="diff"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -o | --output)
+        output="$2"
+        shift 2
+        ;;
+      --output=*)
+        output="${1#--output=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  image_added="`+imageAdded+`"
+  image_removed="`+imageRemoved+`"
+  image_markdown_support="`+imageMarkdownSupport+`"
+  case "${output}" in
+    name)
+      if [[ -n "${image_added}" ]]; then
+        printf '%s\n' "${image_added}"
+      fi
+      if [[ -n "${image_added}" || -n "${image_removed}" ]]; then
+        exit 1
+      fi
+      exit 0
+      ;;
+    markdown)
+      if [[ "${image_markdown_support}" != "true" ]]; then
+        echo 'markdown output is not supported for diff images' >&2
+        exit 2
+      fi
+      printf '## drydock image diff\n\n'
+      if [[ -n "${image_added}" || -n "${image_removed}" ]]; then
+        printf '**Summary:**'
+        if [[ -n "${image_added}" ]]; then
+          printf ' 1 added'
+        else
+          printf ' 0 added'
+        fi
+        if [[ -n "${image_removed}" ]]; then
+          printf ', 1 removed'
+        else
+          printf ', 0 removed'
+        fi
+        printf '.\n\n| Change | Image |\n| --- | --- |\n'
+        if [[ -n "${image_added}" ]]; then
+          printf '| added | \x60%s\x60 |\n' "${image_added}"
+        fi
+        if [[ -n "${image_removed}" ]]; then
+          printf '| removed | \x60%s\x60 |\n' "${image_removed}"
+        fi
+      else
+        printf '**Summary:** 0 added, 0 removed.\n\nNo rendered image differences detected.\n'
+      fi
+      exit 0
+      ;;
+    json)
+      printf '{"added":['
+      if [[ -n "${image_added}" ]]; then
+        printf '"%s"' "${image_added}"
+      fi
+      printf '],"removed":['
+      if [[ -n "${image_removed}" ]]; then
+        printf '"%s"' "${image_removed}"
+      fi
+      printf '],"unchanged":[]}\n'
+      exit 0
+      ;;
+    *)
+      echo "unexpected image output: ${output}" >&2
+      exit 2
+      ;;
+  esac
 fi
 
 echo "unexpected drydock invocation: $*" >&2

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -42,6 +42,9 @@ case "$1" in
   '(.added // [])[]')
     printf 'example/app:v2\n'
     ;;
+  '(.removed // [])[]')
+    printf 'example/app:v1\n'
+    ;;
   '((.added // []) | length) + ((.removed // []) | length)')
     printf '2\n'
     ;;
@@ -357,13 +360,67 @@ func TestRunFallsBackToLegacyImageCommentWhenMarkdownUnsupported(t *testing.T) {
 	})
 
 	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
-	for _, want := range []string{"## drydock image diff", "**Summary:** added images detected.", "| added | `example/app:v2` |"} {
+	for _, want := range []string{"## drydock image diff", "**Summary:** 1 added, 1 removed.", "| added | `example/app:v2` |", "| removed | `example/app:v1` |"} {
 		if !strings.Contains(imagesComment, want) {
 			t.Fatalf("images comment = %q, want %q", imagesComment, want)
 		}
 	}
-	if strings.Contains(imagesComment, "| removed |") {
-		t.Fatalf("legacy fallback should only report added images:\n%s", imagesComment)
+}
+
+func TestRunFallsBackToLegacyImageCommentForRemovedOnlyImageDiff(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts:       true,
+		githubEnv:             true,
+		commentMode:           "images",
+		imageRemoved:          true,
+		imageMarkdownDisabled: true,
+	})
+
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	for _, want := range []string{"## drydock image diff", "**Summary:** 0 added, 1 removed.", "| removed | `example/app:v1` |"} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
+	}
+	for _, notWant := range []string{"No rendered image differences detected.", "Full added image output"} {
+		if strings.Contains(imagesComment, notWant) {
+			t.Fatalf("images comment = %q, did not want %q", imagesComment, notWant)
+		}
+	}
+}
+
+func TestRunFallsBackToGenericImageCommentWhenLegacyJSONFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		uploadArtifacts:       true,
+		githubEnv:             true,
+		commentMode:           "images",
+		imageRemoved:          true,
+		imageMarkdownDisabled: true,
+		imageJSONDisabled:     true,
+	})
+
+	imagesComment := readFile(t, filepath.Join(workDir, "images-comment.md"))
+	for _, want := range []string{
+		"## drydock image diff",
+		"**Summary:** image differences detected.",
+		"Image differences detected, but detailed image rows are unavailable because this drydock binary does not support markdown image output.",
+	} {
+		if !strings.Contains(imagesComment, want) {
+			t.Fatalf("images comment = %q, want %q", imagesComment, want)
+		}
+	}
+	for _, notWant := range []string{"**Summary:** 0 added, 0 removed.", "No rendered image differences detected.", "| removed |"} {
+		if strings.Contains(imagesComment, notWant) {
+			t.Fatalf("images comment = %q, did not want %q", imagesComment, notWant)
+		}
 	}
 }
 
@@ -376,6 +433,7 @@ type commentScenario struct {
 	imageOutput           bool
 	imageRemoved          bool
 	imageMarkdownDisabled bool
+	imageJSONDisabled     bool
 	skipImageDiff         bool
 	extraDiffArgs         string
 	extraImageArgs        string
@@ -442,6 +500,10 @@ func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScen
 	if scenario.imageMarkdownDisabled {
 		imageMarkdownSupport = "false"
 	}
+	imageJSONSupport := "true"
+	if scenario.imageJSONDisabled {
+		imageJSONSupport = "false"
+	}
 
 	writeExecutable(t, path, `#!/usr/bin/env bash
 set -euo pipefail
@@ -506,6 +568,7 @@ if [[ "$*" == *"diff images"* ]]; then
   image_added="`+imageAdded+`"
   image_removed="`+imageRemoved+`"
   image_markdown_support="`+imageMarkdownSupport+`"
+  image_json_support="`+imageJSONSupport+`"
   case "${output}" in
     name)
       if [[ -n "${image_added}" ]]; then
@@ -547,6 +610,10 @@ if [[ "$*" == *"diff images"* ]]; then
       exit 0
       ;;
     json)
+      if [[ "${image_json_support}" != "true" ]]; then
+        echo 'json output failed' >&2
+        exit 2
+      fi
       printf '{"added":['
       if [[ -n "${image_added}" ]]; then
         printf '"%s"' "${image_added}"


### PR DESCRIPTION
## Summary
- add markdown report output for drydock diff images
- wire PR action image comments to drydock-generated markdown while keeping added-image artifacts name-output based
- preserve removed-only image diff comments and legacy fallback behavior for older drydock binaries

## Validation
- go test ./...
- mise run lint
- mise run markdownlint
- git diff --check main...HEAD
- bash -n pr-action/run.sh

Review agents approved all implementation slices and the completed branch.