### PR TITLE
feat: add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: read
     outputs:
       docs: ${{ steps.paths.outputs.docs }}
+      docs-site: ${{ steps.paths.outputs.docs-site }}
       go: ${{ steps.paths.outputs.go }}
       image: ${{ steps.paths.outputs.image }}
       lint: ${{ steps.paths.outputs.lint }}
@@ -48,6 +49,12 @@ jobs:
           filters: |
             docs:
               - '**/*.md'
+            docs-site:
+              - 'docs/**'
+              - 'schemas/**'
+              - 'site/**'
+              - 'mise.lock'
+              - 'mise.toml'
             go:
               - '**/*.go'
               - '**/testdata/**'
@@ -142,6 +149,25 @@ jobs:
 
       - name: Lint Markdown
         run: mise run markdownlint
+
+  docs-site:
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.docs-site == 'true' || needs.detect.outputs.workflow == 'true' || needs.detect.outputs.lint == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Build documentation site
+        run: mise run docs-check
 
   workflow-lint:
     needs: detect
@@ -272,6 +298,7 @@ jobs:
       - go-test
       - go-lint
       - markdownlint
+      - docs-site
       - workflow-lint
       - shellcheck
       - renovate
@@ -286,19 +313,21 @@ jobs:
           GO_TEST: ${{ needs.go-test.result }}
           GO_LINT: ${{ needs.go-lint.result }}
           MARKDOWNLINT: ${{ needs.markdownlint.result }}
+          DOCS_SITE: ${{ needs.docs-site.result }}
           WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
           SHELLCHECK: ${{ needs.shellcheck.result }}
           RENOVATE: ${{ needs.renovate.result }}
           WHITESPACE: ${{ needs.whitespace.result }}
           IMAGE: ${{ needs.image.result }}
         run: |
-          echo "detect=${DETECT} go-test=${GO_TEST} go-lint=${GO_LINT} markdownlint=${MARKDOWNLINT} workflow-lint=${WORKFLOW_LINT} shellcheck=${SHELLCHECK} renovate=${RENOVATE} whitespace=${WHITESPACE} image=${IMAGE}"
+          echo "detect=${DETECT} go-test=${GO_TEST} go-lint=${GO_LINT} markdownlint=${MARKDOWNLINT} docs-site=${DOCS_SITE} workflow-lint=${WORKFLOW_LINT} shellcheck=${SHELLCHECK} renovate=${RENOVATE} whitespace=${WHITESPACE} image=${IMAGE}"
 
           for result in \
             "${DETECT}" \
             "${GO_TEST}" \
             "${GO_LINT}" \
             "${MARKDOWNLINT}" \
+            "${DOCS_SITE}" \
             "${WORKFLOW_LINT}" \
             "${SHELLCHECK}" \
             "${RENOVATE}" \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/pages.yml"
+      - "docs/**"
+      - "schemas/**"
+      - "site/**"
+      - "mise.lock"
+      - "mise.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Build documentation site
+        run: mise run docs-build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: site/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .worktrees/
 drydock-profiles/
+site/.hugo_build.lock
+site/public/
+site/resources/_gen/
+resources/_gen/

--- a/.gomarklint.json
+++ b/.gomarklint.json
@@ -5,7 +5,7 @@
     "heading-level": false,
     "max-line-length": { "enabled": false }
   },
-  "include": ["README.md", "AGENTS.md", "docs"],
+  "include": ["README.md", "AGENTS.md", "docs", "site/content"],
   "ignore": [".worktrees"],
   "output": "text"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ renderers require an approved design update first.
 - `docs/plugin-policy.md`: trusted plugin policy and opt-in exec rendering.
 - `docs/reports/live-integration-design-gate.md`: required before proposing
   live runtime, server-side diff, defaulting, admission, or managed-fields work.
+- `site/`: Hugo docs site source and curated operator-facing pages.
 
 ## Subagent Sandbox Rules
 
@@ -110,6 +111,7 @@ when the user-facing task requires it.
 | Manifest diffs and image extraction | `internal/diff`, `internal/manifest` |
 | Cache lifecycle and cache events | `internal/cache`, `internal/cacheevent`, `internal/cli/cache.go` |
 | Path containment and symlink rules | `internal/pathsafety`, then caller-specific checks |
+| Documentation site | `site/`, `docs/README.md`, then canonical `docs/*.md` owner |
 
 For detailed task constraints, read the matching section in
 `docs/agent-reference.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 ## Product Contract
 
 `drydock` is an independent Go CLI and library for Argo CD GitOps repository
-analysis. Its job is offline desired-state analysis for Argo CD Applications:
-discover, render, test, diff, inspect images, and report diagnostics without a
-running Argo CD instance or Kubernetes cluster.
+analysis. Its job is runtime-offline desired-state analysis for Argo CD
+Applications: discover, render, test, diff, inspect images, and report
+diagnostics without a running Argo CD instance or Kubernetes cluster.
 
 Default render, diff, test, image, and diag paths must remain native Go
 execution in a single static binary. Do not require `kubectl`, `argocd`, Helm

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ change reaches the cluster. Pull request diffing is the primary workflow, but
 the same native engine also supports render validation, image inventory,
 repository diagnostics, cache inspection, and Go API embedding.
 
+Full documentation is available at
+[sholdee.github.io/drydock](https://sholdee.github.io/drydock/).
+
 Core properties:
 
 - Single static Go binary for local use and CI.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Inspect your Argo CD fleet without getting wet.
 [![Go Version](https://img.shields.io/github/go-mod/go-version/sholdee/drydock)](go.mod)
 
 `drydock` is a fast, single static Go binary and embeddable library for
-offline Argo CD desired-state analysis. It discovers, renders, tests, diffs,
-and diagnoses GitOps Applications without requiring a live Argo CD instance or
-Kubernetes cluster.
+runtime-offline Argo CD desired-state analysis. It discovers, renders, tests,
+diffs, and diagnoses GitOps Applications without requiring a live Argo CD
+instance or Kubernetes cluster.
 
 It is built for operators who want quick, deterministic feedback before a
-change reaches the cluster. Pull request diffing is the primary workflow, but
+change reaches the cluster. Pull request diffing is a key workflow, but
 the same native engine also supports render validation, image inventory,
 repository diagnostics, cache inspection, and Go API embedding.
 
@@ -58,15 +58,15 @@ Pin a release when the workflow needs exact repeatability:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.7
+    version: v0.1.9
 ```
 
 The setup action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z` and verifies the
 selected archive with the release checksum manifest by default.
 
 For pull request validation, the PR action wraps the common drydock workflow:
-render tests, manifest diffs, added image reports, source caches, artifacts,
-and sticky PR comments.
+render tests, manifest diffs, companion image diff reports, source caches,
+artifacts, and sticky PR comments.
 
 ```yaml
 name: drydock
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: sholdee/drydock/pr-action@main
         with:
-          version: v0.1.7
+          version: v0.1.9
 ```
 
 See [`docs/github-actions.md`](docs/github-actions.md) for full action inputs,

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pin a release when the workflow needs exact repeatability:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.9
+    version: vX.Y.Z
 ```
 
 The setup action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z` and verifies the
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: sholdee/drydock/pr-action@main
         with:
-          version: v0.1.9
+          version: vX.Y.Z
 ```
 
 See [`docs/github-actions.md`](docs/github-actions.md) for full action inputs,

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ copying the same rule into multiple files.
 | `docs/release.md` | Release and Argo CD dependency upgrade notes. |
 | `docs/logo/` | Project logo assets. |
 | `docs/reports/live-integration-design-gate.md` | No-live-runtime boundary and gate for exceptions. |
+| `site/` | Hugo docs site source, curated operator pages, local layouts, and GitHub Pages configuration. |
 
 ## Anti-Sprawl Rules
 
@@ -35,4 +36,6 @@ copying the same rule into multiple files.
   `docs/usage.md` or `docs/design.md`.
 - Keep `README.md`, `AGENTS.md`, and `docs/agent-reference.md` as routing
   surfaces; link to canonical docs instead of duplicating long explanations.
+- Keep `site/content` concise and operator-facing. It should summarize and
+  route to canonical docs rather than replacing them.
 - Update this file when adding, deleting, or changing ownership of docs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ copying the same rule into multiple files.
 - Do not add plan files for completed implementation work. Use git history for
   closed plans and audits.
 - Keep `docs/reports` for active design gates only.
-- Put durable product behavior in `docs/design.md`, `docs/usage.md`,
-  `docs/applicationsets.md`, `docs/source-acquisition.md`, or
-  `docs/plugin-policy.md`, or `docs/compatibility.md`, depending on ownership
-  above.
+- Put durable product behavior in the canonical owner above, usually
+  `docs/design.md`, `docs/usage.md`, `docs/applicationsets.md`,
+  `docs/source-acquisition.md`, `docs/plugin-policy.md`, or
+  `docs/compatibility.md`.
 - Split a focused reference page only when it removes dense detail from
   `docs/usage.md` or `docs/design.md`.
 - Keep `README.md`, `AGENTS.md`, and `docs/agent-reference.md` as routing

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # Argo CD Compatibility Notes
 
-`drydock` tracks Argo CD compatibility for offline-runtime desired-state
+`drydock` tracks Argo CD compatibility for runtime-offline desired-state
 analysis. Default commands discover, render, test, diff, inspect images, and
 diagnose local Argo CD desired state without contacting live Argo CD or
 Kubernetes runtime. Declared sources may be fetched into explicit caches unless

--- a/docs/design.md
+++ b/docs/design.md
@@ -5,7 +5,7 @@ repository analysis. It discovers Argo CD Applications, renders desired
 manifests, validates renderability, inspects images and diagnostics, and
 compares current and baseline desired state for pull request diffs.
 
-The core design target is offline-runtime analysis: default workflows require
+The core design target is runtime-offline analysis: default workflows require
 no running Kubernetes cluster, Argo CD instance, `kubectl`, `argocd`, Helm CLI,
 Kustomize CLI, repo-server, or external render service. Declared Git, HTTP
 Helm, OCI Helm, and remote Kustomize sources may be fetched into explicit

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -17,7 +17,7 @@ YAML:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.7
+    version: v0.1.9
 ```
 
 The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the release
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
       - uses: sholdee/drydock/setup-action@main
         with:
-          version: v0.1.7
+          version: v0.1.9
       - run: drydock test apps --path .
       - run: drydock diff apps --path . --ref-orig origin/${{ github.base_ref }}
 ```
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: sholdee/drydock/pr-action@main
         with:
-          version: v0.1.7
+          version: v0.1.9
 ```
 
 By default the action:
@@ -113,14 +113,14 @@ The action accepts either a normal token or GitHub App credentials:
 ```yaml
 - uses: sholdee/drydock/pr-action@main
   with:
-    version: v0.1.7
+    version: v0.1.9
     github-token: ${{ secrets.DRYDOCK_TOKEN }}
 ```
 
 ```yaml
 - uses: sholdee/drydock/pr-action@main
   with:
-    version: v0.1.7
+    version: v0.1.9
     github-app-client-id: ${{ secrets.DRYDOCK_APP_CLIENT_ID }}
     github-app-private-key: ${{ secrets.DRYDOCK_APP_PRIVATE_KEY }}
 ```

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -17,7 +17,7 @@ YAML:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.9
+    version: vX.Y.Z
 ```
 
 The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the release
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
       - uses: sholdee/drydock/setup-action@main
         with:
-          version: v0.1.9
+          version: vX.Y.Z
       - run: drydock test apps --path .
       - run: drydock diff apps --path . --ref-orig origin/${{ github.base_ref }}
 ```
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: sholdee/drydock/pr-action@main
         with:
-          version: v0.1.9
+          version: vX.Y.Z
 ```
 
 By default the action:
@@ -113,14 +113,14 @@ The action accepts either a normal token or GitHub App credentials:
 ```yaml
 - uses: sholdee/drydock/pr-action@main
   with:
-    version: v0.1.9
+    version: vX.Y.Z
     github-token: ${{ secrets.DRYDOCK_TOKEN }}
 ```
 
 ```yaml
 - uses: sholdee/drydock/pr-action@main
   with:
-    version: v0.1.9
+    version: vX.Y.Z
     github-app-client-id: ${{ secrets.DRYDOCK_APP_CLIENT_ID }}
     github-app-private-key: ${{ secrets.DRYDOCK_APP_PRIVATE_KEY }}
 ```

--- a/docs/logo/drydock-display-dark.svg
+++ b/docs/logo/drydock-display-dark.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 128" width="480" height="128">
+  <defs>
+    <linearGradient id="hull-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#b95a2d"/>
+      <stop offset="100%" stop-color="#e07a3f"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Basin walls -->
+  <path d="M16 58 L28 58 L34 102 L94 102 L100 58 L112 58 L106 110 L22 110 Z" fill="#d6e0eb"/>
+  <!-- Keel block -->
+  <rect x="59" y="90" width="10" height="12" fill="#8fa1b7"/>
+  <!-- Hull with subtle gradient -->
+  <path d="M35 32 L93 32 L93 58 C93 80 77 90 64 90 C51 90 35 80 35 58 Z" fill="url(#hull-grad)"/>
+  <!-- Waterline stripe at basin wall tops -->
+  <line x1="36" y1="58" x2="92" y2="58" stroke="#ffad73" stroke-width="1.5"/>
+  <!-- Ark cabin -->
+  <path d="M64 12 L87 22 L87 32 L41 32 L41 22 Z" fill="#e6a15f"/>
+
+  <!-- Wordmark -->
+  <text x="144" y="76" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="52" font-weight="600" fill="#f3f7fb" letter-spacing="2">drydock</text>
+</svg>

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,7 @@
 # Release And Upgrade Notes
 
 `drydock` is a single static Go binary and embeddable Go module. Release
-artifacts should preserve the offline-runtime core contract: render and diff
+artifacts should preserve the runtime-offline core contract: render and diff
 from checked-out files plus explicit caches, without requiring a cluster,
 Argo CD server, `kubectl`, `argocd`, Helm/Kustomize command-line tools, or
 external rendering processes.
@@ -33,7 +33,7 @@ passphrases, or raw repository URLs with embedded secrets.
 
 The repository includes an optional composite install action at `setup-action`.
 It is release metadata only; it does not change the default static binary,
-`--offline` behavior, or offline-runtime render/diff contract.
+`--offline` behavior, or runtime-offline render/diff contract.
 
 The action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z` inputs. `latest` is
 resolved from the latest GitHub Release before download. Bare versions are
@@ -72,7 +72,7 @@ Pinned example:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.7
+    version: v0.1.9
     install-dir: /usr/local/bin
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,7 +72,7 @@ Pinned example:
 ```yaml
 - uses: sholdee/drydock/setup-action@main
   with:
-    version: v0.1.9
+    version: vX.Y.Z
     install-dir: /usr/local/bin
 ```
 

--- a/docs/reports/live-integration-design-gate.md
+++ b/docs/reports/live-integration-design-gate.md
@@ -12,7 +12,7 @@ cluster, Argo CD server, `kubectl`, `argocd`, Helm/Kustomize command-line
 tools, or any external render service to analyze desired state or produce pull
 request diffs.
 
-This offline-runtime contract is separate from network source acquisition.
+This runtime-offline contract is separate from network source acquisition.
 Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources may be fetched
 into explicit caches unless `--offline` is set. Future live behavior may be
 researched only behind an explicit design update, and that work must not weaken
@@ -42,7 +42,7 @@ Live runtime access changes the threat model and correctness model:
 - Argo CD server-side diff behavior is coupled to repo-server, cluster cache,
   Kubernetes discovery, and Argo CD settings.
 
-The offline-runtime engine should report these as outside its boundary rather
+The runtime-offline engine should report these as outside its boundary rather
 than silently approximating them.
 
 ## Exception Guardrails
@@ -65,7 +65,7 @@ Future live-runtime exceptions must pass these checks before code changes:
 
 ## Default Mode Contract
 
-Default commands and package-level public APIs are offline-runtime
+Default commands and package-level public APIs are runtime-offline
 desired-vs-desired workflows:
 
 - They read the current tree, the baseline tree, and explicit local caches.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-`drydock` is an offline-runtime CLI for Argo CD GitOps repositories. Default
+`drydock` is a runtime-offline CLI for Argo CD GitOps repositories. Default
 commands render and compare desired state from checked-out files plus explicit
 local caches. They do not contact a Kubernetes cluster or Argo CD server, and
 they do not require `kubectl`, `argocd`, Helm CLI, or Kustomize CLI.

--- a/mise.lock
+++ b/mise.lock
@@ -71,6 +71,38 @@ checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e0
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
 provenance = "github-attestations"
 
+[[tools.hugo]]
+version = "0.162.1"
+backend = "aqua:gohugoio/hugo"
+
+[tools.hugo."platforms.linux-arm64"]
+checksum = "sha256:ed2a4dcdc4149b575693b35d0f7220fe5248b70179097bed4cdbf98a238cbdca"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_linux-arm64.tar.gz"
+
+[tools.hugo."platforms.linux-arm64-musl"]
+checksum = "sha256:ed2a4dcdc4149b575693b35d0f7220fe5248b70179097bed4cdbf98a238cbdca"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_linux-arm64.tar.gz"
+
+[tools.hugo."platforms.linux-x64"]
+checksum = "sha256:4bfcdb092d0306586f1b72e5687787ead053faab2d71f09951d3c5fecde66873"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_linux-amd64.tar.gz"
+
+[tools.hugo."platforms.linux-x64-musl"]
+checksum = "sha256:4bfcdb092d0306586f1b72e5687787ead053faab2d71f09951d3c5fecde66873"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_linux-amd64.tar.gz"
+
+[tools.hugo."platforms.macos-arm64"]
+checksum = "sha256:869eedf30c7aeede11060f130b803a72d06b88b598c8f26a408b64edd268b818"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_darwin-universal.pkg"
+
+[tools.hugo."platforms.macos-x64"]
+checksum = "sha256:869eedf30c7aeede11060f130b803a72d06b88b598c8f26a408b64edd268b818"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_darwin-universal.pkg"
+
+[tools.hugo."platforms.windows-x64"]
+checksum = "sha256:c0f4ffa937218cc1781aa9d422d14570b5054e7254a10d0b7a0844b2d4ba14f4"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_0.162.1_windows-amd64.zip"
+
 [[tools.lefthook]]
 version = "2.1.9"
 backend = "aqua:evilmartians/lefthook"

--- a/mise.toml
+++ b/mise.toml
@@ -84,4 +84,4 @@ run = "lefthook install"
 
 [tasks.ci]
 description = "Run the main local CI checks"
-depends = ["mod-verify", "mod-tidy-check", "test-race", "vet", "lint", "markdownlint", "actionlint", "shellcheck", "zizmor", "whitespace"]
+depends = ["mod-verify", "mod-tidy-check", "test-race", "vet", "lint", "markdownlint", "docs-check", "actionlint", "shellcheck", "zizmor", "whitespace"]

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ golangci-lint = "2.12.2"
 lefthook = "2.1.9"
 shellcheck = "0.11.0"
 zizmor = "1.25.2"
+hugo = "0.162.1"
 
 [tasks.fmt]
 description = "Run go fmt against Go code"
@@ -60,6 +61,18 @@ run = "go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./..."
 [tasks.whitespace]
 description = "Check for whitespace errors in changed lines"
 run = "git diff --check"
+
+[tasks.docs-serve]
+description = "Serve the Hugo documentation site locally"
+run = "hugo server --source site --disableFastRender"
+
+[tasks.docs-build]
+description = "Build the Hugo documentation site into site/public"
+run = "hugo --source site --destination public"
+
+[tasks.docs-check]
+description = "Build the Hugo documentation site into a temporary directory"
+run = "hugo --source site --destination /tmp/drydock-docs-site --cleanDestinationDir --minify"
 
 [tasks.zizmor]
 description = "Audit GitHub Actions workflow security"

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -365,12 +365,13 @@ a:hover {
 }
 
 .doc-content pre {
+  position: relative;
   overflow-x: auto;
   border: 1px solid #213149;
   border-radius: 8px;
   background: var(--code-bg);
   color: var(--code-ink);
-  padding: 1rem;
+  padding: 2.65rem 1rem 1rem;
 }
 
 .doc-content pre code {
@@ -378,6 +379,45 @@ a:hover {
   background: transparent;
   color: inherit;
   padding: 0;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.7rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: rgba(20, 33, 51, 0.94);
+  color: var(--navy-deep);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.25rem 0.5rem;
+}
+
+.copy-button:hover {
+  border-color: var(--rust-bright);
+  color: var(--link-hover);
+}
+
+.highlight .c,
+.highlight .c1,
+.highlight .cm,
+.highlight .cp,
+.highlight .cs {
+  color: #a7b3c2 !important;
+}
+
+.highlight .k,
+.highlight .kc,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .nt,
+.highlight .o {
+  color: #ff92b2 !important;
 }
 
 .doc-content blockquote {
@@ -409,6 +449,41 @@ a:hover {
 .doc-index a:hover {
   border-color: var(--rust);
   background: rgba(209, 115, 66, 0.12);
+}
+
+.next-links {
+  border-top: 1px solid var(--line);
+  padding: clamp(1.2rem, 4vw, 2.75rem);
+}
+
+.next-links p {
+  margin: 0 0 0.7rem;
+  color: var(--rust-bright);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.next-links div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.next-links a {
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--teal);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--navy-deep);
+  font-weight: 800;
+  padding: 0.72rem 0.9rem;
+  text-decoration: none;
+}
+
+.next-links a:hover {
+  border-color: var(--teal);
+  background: rgba(105, 215, 194, 0.1);
 }
 
 .site-footer {
@@ -455,7 +530,7 @@ a:hover {
     position: static;
     border-bottom: 1px solid var(--line);
     background: rgba(8, 17, 29, 0.94);
-    padding: 1rem;
+    padding: 0.85rem 1rem;
   }
 
   .docs-nav {
@@ -465,12 +540,21 @@ a:hover {
 
   .docs-nav ul {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: 0.25rem;
   }
 
   .nav-section + .nav-section {
-    margin-top: 0.85rem;
+    margin-top: 0.65rem;
+  }
+
+  .docs-nav a {
+    font-size: 0.86rem;
+    padding: 0.34rem 0.42rem;
+  }
+
+  .nav-heading {
+    margin-bottom: 0.45rem;
   }
 
   .docs-nav li + li {

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -1,0 +1,460 @@
+:root {
+  color-scheme: light;
+  --ink: #172033;
+  --muted: #4a5568;
+  --quiet: #667085;
+  --line: #cad5e1;
+  --line-strong: #8fa1b7;
+  --paper: #f7fafc;
+  --surface: #ffffff;
+  --surface-cool: #edf4f8;
+  --navy: #263244;
+  --navy-deep: #172033;
+  --rust: #a84a22;
+  --rust-bright: #c45a2c;
+  --focus: #0b63ce;
+  --code-bg: #111827;
+  --code-ink: #f8fafc;
+  --max-width: 1480px;
+  --header-height: 72px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  scroll-padding-top: calc(var(--header-height) + 1rem);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(rgba(38, 50, 68, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(38, 50, 68, 0.045) 1px, transparent 1px),
+    linear-gradient(180deg, #f8fbfd 0%, #edf4f8 100%);
+  background-size: 32px 32px, 32px 32px, auto;
+}
+
+a {
+  color: #174f9a;
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  color: var(--rust);
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: 1rem;
+  z-index: 20;
+  transform: translateY(-160%);
+  border: 2px solid var(--navy-deep);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--navy-deep);
+  padding: 0.6rem 0.8rem;
+  font-weight: 700;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+}
+
+.header-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: var(--header-height);
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0.7rem clamp(1rem, 3vw, 2rem);
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.brand-link img {
+  display: block;
+  width: clamp(142px, 18vw, 180px);
+  height: auto;
+}
+
+.header-links {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.header-links a {
+  border-radius: 6px;
+  color: var(--navy-deep);
+  font-size: 0.92rem;
+  font-weight: 700;
+  padding: 0.45rem 0.62rem;
+  text-decoration: none;
+}
+
+.header-links a:hover {
+  background: var(--surface-cool);
+  color: var(--rust);
+}
+
+.site-shell {
+  display: grid;
+  grid-template-columns: minmax(180px, 250px) minmax(0, 1fr) minmax(170px, 230px);
+  gap: clamp(1rem, 2vw, 2rem);
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.site-shell.no-toc {
+  grid-template-columns: minmax(180px, 250px) minmax(0, 1fr);
+}
+
+.site-sidebar,
+.site-toc {
+  align-self: start;
+  position: sticky;
+  top: calc(var(--header-height) + 1rem);
+}
+
+.docs-nav,
+.toc-panel {
+  border-left: 3px solid var(--line-strong);
+  padding-left: 0.9rem;
+}
+
+.nav-heading,
+.section-label {
+  margin: 0 0 0.65rem;
+  color: var(--rust);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.docs-nav ul,
+.toc-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-nav li + li,
+.toc-panel li + li {
+  margin-top: 0.16rem;
+}
+
+.docs-nav a,
+.toc-panel a {
+  display: block;
+  border-radius: 6px;
+  color: var(--navy);
+  font-size: 0.92rem;
+  line-height: 1.3;
+  padding: 0.42rem 0.5rem;
+  text-decoration: none;
+}
+
+.docs-nav a:hover,
+.toc-panel a:hover {
+  background: rgba(202, 213, 225, 0.42);
+  color: var(--rust);
+}
+
+.docs-nav a.is-active {
+  background: var(--navy);
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.toc-panel nav > ul > li > ul {
+  margin-top: 0.15rem;
+  padding-left: 0.7rem;
+}
+
+.toc-panel nav > ul > li > ul a {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.site-main {
+  min-width: 0;
+}
+
+.doc-page {
+  border: 1px solid var(--line);
+  border-top: 4px solid var(--navy);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 16px 40px rgba(23, 32, 51, 0.08);
+}
+
+.home-page {
+  position: relative;
+}
+
+.home-mark {
+  border-bottom: 1px solid var(--line);
+  background:
+    repeating-linear-gradient(90deg, transparent 0 18px, rgba(38, 50, 68, 0.08) 18px 19px),
+    linear-gradient(135deg, #f8fbfd 0%, #edf4f8 100%);
+  padding: 1.25rem clamp(1.1rem, 4vw, 2.5rem);
+}
+
+.home-mark img {
+  display: block;
+  width: min(320px, 100%);
+  height: auto;
+}
+
+.doc-header {
+  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(90deg, rgba(168, 74, 34, 0.09), transparent 42%),
+    var(--surface-cool);
+  padding: clamp(1.35rem, 4vw, 2.5rem) clamp(1.1rem, 4vw, 2.75rem);
+}
+
+.doc-header h1 {
+  margin: 0;
+  color: var(--navy-deep);
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.05;
+}
+
+.lead {
+  max-width: 64ch;
+  margin: 0.9rem 0 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+}
+
+.doc-content {
+  max-width: 82ch;
+  padding: clamp(1.2rem, 4vw, 2.75rem);
+}
+
+.doc-content > :first-child {
+  margin-top: 0;
+}
+
+.doc-content > :last-child {
+  margin-bottom: 0;
+}
+
+.doc-content h1,
+.doc-content h2,
+.doc-content h3,
+.doc-content h4 {
+  color: var(--navy-deep);
+  line-height: 1.2;
+}
+
+.doc-content h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.15rem, 5vw, 3.8rem);
+  line-height: 1.05;
+}
+
+.doc-content h2 {
+  border-top: 1px solid var(--line);
+  margin-top: 2.2rem;
+  padding-top: 1.3rem;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+}
+
+.doc-content h3 {
+  margin-top: 1.65rem;
+  font-size: 1.2rem;
+}
+
+.doc-content p,
+.doc-content li {
+  color: var(--ink);
+}
+
+.doc-content strong {
+  color: var(--navy-deep);
+}
+
+.doc-content table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.doc-content th,
+.doc-content td {
+  border: 1px solid var(--line);
+  padding: 0.6rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-content th {
+  background: var(--surface-cool);
+  color: var(--navy-deep);
+}
+
+.doc-content code {
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: #eef3f7;
+  color: #243044;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+  padding: 0.08rem 0.28rem;
+}
+
+.doc-content pre {
+  overflow-x: auto;
+  border-radius: 8px;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  padding: 1rem;
+}
+
+.doc-content pre code {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.doc-content blockquote {
+  margin-left: 0;
+  border-left: 4px solid var(--rust-bright);
+  background: #fff7f2;
+  padding: 0.65rem 1rem;
+}
+
+.doc-index {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.7rem;
+  border-top: 1px solid var(--line);
+  padding: clamp(1.2rem, 4vw, 2.75rem);
+}
+
+.doc-index a {
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--rust);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--navy-deep);
+  font-weight: 800;
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+}
+
+.doc-index a:hover {
+  border-color: var(--rust);
+  background: #fff7f2;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem clamp(1rem, 3vw, 2rem) 2rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1120px) {
+  .site-shell {
+    grid-template-columns: minmax(180px, 235px) minmax(0, 1fr);
+  }
+
+  .site-toc {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  :root {
+    --header-height: 104px;
+  }
+
+  .header-nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .header-links {
+    justify-content: flex-start;
+  }
+
+  .site-shell {
+    display: block;
+    padding: 0;
+  }
+
+  .site-sidebar {
+    position: static;
+    border-bottom: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.96);
+    padding: 1rem;
+  }
+
+  .docs-nav {
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .docs-nav ul {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+    gap: 0.25rem;
+  }
+
+  .docs-nav li + li {
+    margin-top: 0;
+  }
+
+  .doc-page {
+    border-left: 0;
+    border-right: 0;
+    box-shadow: none;
+  }
+
+  .site-footer {
+    display: block;
+  }
+
+  .site-footer span {
+    display: block;
+  }
+}

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -1,20 +1,25 @@
 :root {
-  color-scheme: light;
-  --ink: #172033;
-  --muted: #4a5568;
-  --quiet: #667085;
-  --line: #cad5e1;
-  --line-strong: #8fa1b7;
-  --paper: #f7fafc;
-  --surface: #ffffff;
-  --surface-cool: #edf4f8;
-  --navy: #263244;
-  --navy-deep: #172033;
-  --rust: #a84a22;
-  --rust-bright: #c45a2c;
-  --focus: #0b63ce;
-  --code-bg: #111827;
-  --code-ink: #f8fafc;
+  color-scheme: dark;
+  --ink: #e7edf5;
+  --muted: #a5b4c6;
+  --quiet: #8190a3;
+  --line: #26354a;
+  --line-strong: #45617f;
+  --paper: #07111d;
+  --surface: #101b29;
+  --surface-raised: #142133;
+  --surface-cool: #17263a;
+  --navy: #c6d4e3;
+  --navy-deep: #f3f7fb;
+  --rust: #d17342;
+  --rust-bright: #f08a51;
+  --teal: #69d7c2;
+  --focus: #69b8ff;
+  --link: #8ec8ff;
+  --link-hover: #ffad73;
+  --code-bg: #050b12;
+  --code-ink: #edf5ff;
+  --shadow: rgba(0, 0, 0, 0.32);
   --max-width: 1480px;
   --header-height: 72px;
 }
@@ -32,22 +37,33 @@ html {
 }
 
 body {
+  position: relative;
+  isolation: isolate;
   margin: 0;
   min-height: 100vh;
-  background:
-    linear-gradient(rgba(38, 50, 68, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(38, 50, 68, 0.045) 1px, transparent 1px),
-    linear-gradient(180deg, #f8fbfd 0%, #edf4f8 100%);
-  background-size: 32px 32px, 32px 32px, auto;
+  background: linear-gradient(180deg, #07111d 0%, #0a1421 46%, #101827 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1440' height='960' viewBox='0 0 1440 960'%3E%3Cg fill='none' stroke-linecap='round'%3E%3Cg stroke='%2369d7c2' stroke-opacity='.12' stroke-width='1.8'%3E%3Cpath d='M-120 110C28 42 156 30 282 88s224 82 358 8 250-108 390-32 264 100 530 28'/%3E%3Cpath d='M-132 158C22 76 168 76 310 138s236 74 382-4 266-112 424-28 270 96 468 22'/%3E%3Cpath d='M-140 218C38 118 194 112 342 176s246 86 396 4 282-126 446-34 264 112 396 54'/%3E%3Cpath d='M-96 374C54 298 192 286 326 348s246 78 404-22 308-118 482-30 286 92 404 18'/%3E%3Cpath d='M-118 466C36 386 198 398 352 462s286 58 438-34 300-108 480-18 280 92 398 24'/%3E%3Cpath d='M-128 548C48 434 214 438 368 510s292 54 438-52 296-116 476-20 280 86 390 6'/%3E%3Cpath d='M-150 744C20 636 188 614 360 704s318 88 496-20 310-140 500-46 270 118 420 48'/%3E%3Cpath d='M-116 888C58 806 232 810 394 872s304 42 454-46 310-88 486-18 286 72 420 10'/%3E%3C/g%3E%3Cg stroke='%23d17342' stroke-opacity='.065' stroke-width='1.4'%3E%3Cpath d='M-100 164C58 94 196 100 334 156s242 60 386-18 266-82 418-8 286 74 424 2'/%3E%3Cpath d='M-126 296C40 220 198 228 348 290s278 54 426-32 292-92 460-14 274 84 420 18'/%3E%3Cpath d='M-116 456C42 382 204 382 358 450s286 52 438-36 298-92 468-10 272 78 390 10'/%3E%3Cpath d='M-120 820C46 746 210 742 376 812s316 58 486-24 308-100 480-24 274 84 426 16'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: cover;
+  opacity: 0.62;
 }
 
 a {
-  color: #174f9a;
+  color: var(--link);
   text-underline-offset: 0.18em;
 }
 
 a:hover {
-  color: var(--rust);
+  color: var(--link-hover);
 }
 
 :focus-visible {
@@ -61,9 +77,9 @@ a:hover {
   top: 1rem;
   z-index: 20;
   transform: translateY(-160%);
-  border: 2px solid var(--navy-deep);
+  border: 2px solid var(--rust-bright);
   border-radius: 6px;
-  background: var(--surface);
+  background: var(--surface-raised);
   color: var(--navy-deep);
   padding: 0.6rem 0.8rem;
   font-weight: 700;
@@ -78,7 +94,7 @@ a:hover {
   top: 0;
   z-index: 10;
   border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(8, 17, 29, 0.92);
   backdrop-filter: blur(10px);
 }
 
@@ -115,7 +131,7 @@ a:hover {
 
 .header-links a {
   border-radius: 6px;
-  color: var(--navy-deep);
+  color: var(--muted);
   font-size: 0.92rem;
   font-weight: 700;
   padding: 0.45rem 0.62rem;
@@ -123,8 +139,8 @@ a:hover {
 }
 
 .header-links a:hover {
-  background: var(--surface-cool);
-  color: var(--rust);
+  background: rgba(105, 215, 194, 0.09);
+  color: var(--navy-deep);
 }
 
 .site-shell {
@@ -156,7 +172,7 @@ a:hover {
 .nav-heading,
 .section-label {
   margin: 0 0 0.65rem;
-  color: var(--rust);
+  color: var(--rust-bright);
   font-size: 0.76rem;
   font-weight: 800;
   text-transform: uppercase;
@@ -178,7 +194,7 @@ a:hover {
 .toc-panel a {
   display: block;
   border-radius: 6px;
-  color: var(--navy);
+  color: var(--muted);
   font-size: 0.92rem;
   line-height: 1.3;
   padding: 0.42rem 0.5rem;
@@ -187,13 +203,13 @@ a:hover {
 
 .docs-nav a:hover,
 .toc-panel a:hover {
-  background: rgba(202, 213, 225, 0.42);
-  color: var(--rust);
+  background: rgba(105, 215, 194, 0.08);
+  color: var(--navy-deep);
 }
 
 .docs-nav a.is-active {
-  background: var(--navy);
-  color: #ffffff;
+  background: linear-gradient(90deg, rgba(209, 115, 66, 0.28), rgba(105, 215, 194, 0.14));
+  color: var(--navy-deep);
   font-weight: 800;
 }
 
@@ -213,9 +229,9 @@ a:hover {
 
 .doc-page {
   border: 1px solid var(--line);
-  border-top: 4px solid var(--navy);
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 16px 40px rgba(23, 32, 51, 0.08);
+  border-top: 4px solid var(--rust);
+  background: rgba(16, 27, 41, 0.94);
+  box-shadow: 0 18px 48px var(--shadow);
 }
 
 .home-page {
@@ -225,21 +241,21 @@ a:hover {
 .home-mark {
   border-bottom: 1px solid var(--line);
   background:
-    repeating-linear-gradient(90deg, transparent 0 18px, rgba(38, 50, 68, 0.08) 18px 19px),
-    linear-gradient(135deg, #f8fbfd 0%, #edf4f8 100%);
-  padding: 1.25rem clamp(1.1rem, 4vw, 2.5rem);
+    linear-gradient(135deg, rgba(209, 115, 66, 0.16), rgba(105, 215, 194, 0.06) 52%, transparent),
+    var(--surface-raised);
+  padding: 1.35rem clamp(1.1rem, 4vw, 2.5rem);
 }
 
 .home-mark img {
   display: block;
-  width: min(320px, 100%);
+  width: min(380px, 100%);
   height: auto;
 }
 
 .doc-header {
   border-bottom: 1px solid var(--line);
   background:
-    linear-gradient(90deg, rgba(168, 74, 34, 0.09), transparent 42%),
+    linear-gradient(90deg, rgba(209, 115, 66, 0.16), transparent 44%),
     var(--surface-cool);
   padding: clamp(1.35rem, 4vw, 2.5rem) clamp(1.1rem, 4vw, 2.75rem);
 }
@@ -247,7 +263,7 @@ a:hover {
 .doc-header h1 {
   margin: 0;
   color: var(--navy-deep);
-  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-size: 2.35rem;
   line-height: 1.05;
 }
 
@@ -281,7 +297,7 @@ a:hover {
 
 .doc-content h1 {
   margin: 0 0 1rem;
-  font-size: clamp(2.15rem, 5vw, 3.8rem);
+  font-size: 2.15rem;
   line-height: 1.05;
 }
 
@@ -289,7 +305,7 @@ a:hover {
   border-top: 1px solid var(--line);
   margin-top: 2.2rem;
   padding-top: 1.3rem;
-  font-size: clamp(1.45rem, 3vw, 2rem);
+  font-size: 1.55rem;
 }
 
 .doc-content h3 {
@@ -329,8 +345,8 @@ a:hover {
 .doc-content code {
   border: 1px solid var(--line);
   border-radius: 5px;
-  background: #eef3f7;
-  color: #243044;
+  background: rgba(5, 11, 18, 0.72);
+  color: #dcecff;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 0.92em;
   padding: 0.08rem 0.28rem;
@@ -338,6 +354,7 @@ a:hover {
 
 .doc-content pre {
   overflow-x: auto;
+  border: 1px solid #213149;
   border-radius: 8px;
   background: var(--code-bg);
   color: var(--code-ink);
@@ -354,7 +371,7 @@ a:hover {
 .doc-content blockquote {
   margin-left: 0;
   border-left: 4px solid var(--rust-bright);
-  background: #fff7f2;
+  background: rgba(209, 115, 66, 0.11);
   padding: 0.65rem 1rem;
 }
 
@@ -370,7 +387,7 @@ a:hover {
   border: 1px solid var(--line);
   border-left: 4px solid var(--rust);
   border-radius: 8px;
-  background: var(--surface);
+  background: var(--surface-raised);
   color: var(--navy-deep);
   font-weight: 800;
   padding: 0.85rem 1rem;
@@ -379,7 +396,7 @@ a:hover {
 
 .doc-index a:hover {
   border-color: var(--rust);
-  background: #fff7f2;
+  background: rgba(209, 115, 66, 0.12);
 }
 
 .site-footer {
@@ -425,7 +442,7 @@ a:hover {
   .site-sidebar {
     position: static;
     border-bottom: 1px solid var(--line);
-    background: rgba(255, 255, 255, 0.96);
+    background: rgba(8, 17, 29, 0.94);
     padding: 1rem;
   }
 
@@ -457,4 +474,22 @@ a:hover {
   .site-footer span {
     display: block;
   }
+
+  .doc-header h1 {
+    font-size: 1.85rem;
+  }
+
+  .doc-content h1 {
+    font-size: 1.75rem;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -178,6 +178,18 @@ a:hover {
   text-transform: uppercase;
 }
 
+.nav-section + .nav-section {
+  margin-top: 1rem;
+}
+
+.nav-section-heading {
+  margin: 0 0 0.22rem;
+  color: var(--quiet);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
 .docs-nav ul,
 .toc-panel ul {
   list-style: none;
@@ -455,6 +467,10 @@ a:hover {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
     gap: 0.25rem;
+  }
+
+  .nav-section + .nav-section {
+    margin-top: 0.85rem;
   }
 
   .docs-nav li + li {

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -1,0 +1,26 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".doc-content pre").forEach((block, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "copy-button";
+    button.textContent = "Copy";
+    button.setAttribute("aria-label", `Copy code block ${index + 1}`);
+
+    button.addEventListener("click", async () => {
+      const code = block.querySelector("code");
+      if (!code || !navigator.clipboard) {
+        return;
+      }
+
+      await navigator.clipboard.writeText(code.innerText);
+      button.textContent = "Copied";
+      button.setAttribute("aria-label", `Copied code block ${index + 1}`);
+      window.setTimeout(() => {
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", `Copy code block ${index + 1}`);
+      }, 1500);
+    });
+
+    block.append(button);
+  });
+});

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,7 @@
+---
+title: drydock
+---
+
+# drydock
+
+Offline desired-state analysis for Argo CD GitOps repositories.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -12,13 +12,13 @@ running Argo CD instance or Kubernetes cluster.
 
 ## Start Here
 
-- [Getting started](getting-started/) covers the first local commands and the
+- [Getting started](/getting-started/) covers the first local commands and the
   runtime-offline model.
-- [GitHub Actions](workflows/github-actions/) shows the current setup and pull
+- [GitHub Actions](/workflows/github-actions/) shows the current setup and pull
   request actions for CI.
-- [Local diffs](workflows/local-diffs/) covers local tree and Git ref
+- [Local diffs](/workflows/local-diffs/) covers local tree and Git ref
   comparisons.
-- [Troubleshooting](troubleshooting/) maps common operator symptoms to the
+- [Troubleshooting](/troubleshooting/) maps common operator symptoms to the
   first commands to run.
 
 ## Core Workflows

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -12,12 +12,14 @@ running Argo CD instance or Kubernetes cluster.
 
 ## Start Here
 
-- [Usage](docs/usage/) covers discovery, rendering, diffs, image reports,
-  diagnostics, and local verification commands.
-- [GitHub Actions](docs/github-actions/) shows the setup action and pull
-  request action inputs, permissions, comments, and outputs.
-- [Compatibility](docs/compatibility/) defines the supported Argo CD behavior
-  and runtime boundary.
+- [Getting started](getting-started/) covers the first local commands and the
+  runtime-offline model.
+- [GitHub Actions](workflows/github-actions/) shows the current setup and pull
+  request actions for CI.
+- [Local diffs](workflows/local-diffs/) covers local tree and Git ref
+  comparisons.
+- [Troubleshooting](troubleshooting/) maps common operator symptoms to the
+  first commands to run.
 
 ## Core Workflows
 
@@ -31,7 +33,11 @@ drydock diag --path ./gitops
 
 ## Operating Model
 
-drydock is built for offline desired-state inspection. It can fetch declared
-Git, Helm, OCI Helm, and remote Kustomize sources into explicit caches unless
-`--offline` is set, but default analysis does not depend on live Kubernetes or
-Argo CD APIs.
+drydock is runtime-offline: render, test, diff, image, and diagnostic commands
+do not call live Kubernetes or Argo CD. Declared Git, HTTP Helm, OCI Helm, and
+remote Kustomize sources can still be fetched into explicit caches unless
+`--offline` is set.
+
+Use these curated pages for day-to-day operation. Use the mounted reference
+docs when you need dense details such as full compatibility notes, action
+inputs, source acquisition flags, or plugin policy schema.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -5,3 +5,33 @@ title: drydock
 # drydock
 
 Offline desired-state analysis for Argo CD GitOps repositories.
+
+drydock discovers Argo CD Applications, renders desired manifests, compares
+Git refs, inspects image changes, and reports diagnostics without requiring a
+running Argo CD instance or Kubernetes cluster.
+
+## Start Here
+
+- [Usage](docs/usage/) covers discovery, rendering, diffs, image reports,
+  diagnostics, and local verification commands.
+- [GitHub Actions](docs/github-actions/) shows the setup action and pull
+  request action inputs, permissions, comments, and outputs.
+- [Compatibility](docs/compatibility/) defines the supported Argo CD behavior
+  and runtime boundary.
+
+## Core Workflows
+
+```bash
+drydock get apps --path ./gitops
+drydock test apps --path ./gitops
+drydock diff apps --repo . --ref main --ref-orig HEAD~1
+drydock diff images --repo . --ref main --ref-orig HEAD~1
+drydock diag --path ./gitops
+```
+
+## Operating Model
+
+drydock is built for offline desired-state inspection. It can fetch declared
+Git, Helm, OCI Helm, and remote Kustomize sources into explicit caches unless
+`--offline` is set, but default analysis does not depend on live Kubernetes or
+Argo CD APIs.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,18 +2,20 @@
 title: drydock
 ---
 
-Offline desired-state analysis for Argo CD GitOps repositories.
+Validate Argo CD pull requests before they sync.
 
-drydock discovers Argo CD Applications, renders desired manifests, compares
-Git refs, inspects image changes, and reports diagnostics without requiring a
-running Argo CD instance or Kubernetes cluster.
+drydock renders desired manifests before Argo CD sees them, catches render
+failures early, reviews manifest and image diffs, and runs in CI without
+Kubernetes credentials.
+
+**[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 
 ## Start Here
 
-- [Getting started](/getting-started/) covers the first local commands and the
-  runtime-offline model.
-- [GitHub Actions](/workflows/github-actions/) shows the current setup and pull
-  request actions for CI.
+- [Getting started](/getting-started/) installs drydock and runs the first
+  local render test.
+- [GitHub Actions](/workflows/github-actions/) sets up pull request checks
+  without Kubernetes or Argo CD credentials.
 - [Local diffs](/workflows/local-diffs/) covers local tree and Git ref
   comparisons.
 - [Troubleshooting](/troubleshooting/) maps common operator symptoms to the

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,11 +2,16 @@
 title: drydock
 ---
 
-Validate Argo CD pull requests before they sync.
+Inspect your Argo CD fleet without getting wet.
 
-drydock renders desired manifests before Argo CD sees them, catches render
-failures early, reviews manifest and image diffs, and runs in CI without
-Kubernetes credentials.
+drydock is a fast, single static Go binary and embeddable Go module for
+runtime-offline Argo CD desired-state analysis. It discovers, renders, tests,
+diffs, and diagnoses GitOps Applications with native Go renderers, no live
+cluster, no Argo CD server, and no default shellouts.
+
+Use it locally or in CI to review rendered manifest diffs, catch render
+failures, inspect image changes, and validate GitOps repositories before Argo CD
+syncs them.
 
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -29,11 +29,11 @@ syncs them.
 ## Core Workflows
 
 ```bash
-drydock get apps --path ./gitops
-drydock test apps --path ./gitops
-drydock diff apps --repo . --ref main --ref-orig HEAD~1
-drydock diff images --repo . --ref main --ref-orig HEAD~1
-drydock diag --path ./gitops
+drydock get apps --path .
+drydock test apps --path .
+drydock diff apps --repo . --ref HEAD --ref-orig main
+drydock diff images --repo . --ref HEAD --ref-orig main
+drydock diag --path .
 ```
 
 ## Operating Model
@@ -43,6 +43,6 @@ do not call live Kubernetes or Argo CD. Declared Git, HTTP Helm, OCI Helm, and
 remote Kustomize sources can still be fetched into explicit caches unless
 `--offline` is set.
 
-Use these curated pages for day-to-day operation. Use the mounted reference
-docs when you need dense details such as full compatibility notes, action
-inputs, source acquisition flags, or plugin policy schema.
+Use these curated pages for day-to-day operation. Use the reference docs when
+you need dense details such as full compatibility notes, action inputs, source
+acquisition flags, or plugin policy schema.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,8 +2,6 @@
 title: drydock
 ---
 
-# drydock
-
 Offline desired-state analysis for Argo CD GitOps repositories.
 
 drydock discovers Argo CD Applications, renders desired manifests, compares

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -3,8 +3,8 @@ title: Compatibility
 ---
 
 drydock targets Argo CD desired-state analysis that can run without live Argo
-CD or Kubernetes. It supports the common offline paths operators need for pull
-request validation and local inspection.
+CD or Kubernetes. It supports the common runtime-offline paths operators need
+for local inspection, CI validation, and pull request review.
 
 ## Supported At A Glance
 

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -1,0 +1,31 @@
+---
+title: Compatibility
+---
+
+drydock targets Argo CD desired-state analysis that can run without live Argo
+CD or Kubernetes. It supports the common offline paths operators need for pull
+request validation and local inspection.
+
+## Supported At A Glance
+
+- Direct Argo CD `Application` resources.
+- Single-source and multi-source Applications.
+- Supported local ApplicationSet generators and fixture-backed provider
+  generators.
+- Desired-vs-desired manifest and image diffs.
+- Native directory, Kustomize, local Helm, remote Helm, and remote Kustomize
+  rendering paths.
+- Structured JSON and YAML output where commands support it.
+- Markdown manifest and image diff output for review comments.
+- Stable diagnostics in CLI and public API output.
+
+## Runtime Boundary
+
+drydock does not reproduce live cluster or Argo CD server behavior such as API
+defaulting, admission mutation, server-side diff, live managed-fields
+ownership, live Application health aggregation, sync windows, source signature
+verification, or full RBAC simulation.
+
+Use this page for the shape of support. Use the canonical
+[Argo CD compatibility notes](/docs/compatibility/) when you need the detailed
+matrix and exact boundaries.

--- a/site/content/concepts/changed-only.md
+++ b/site/content/concepts/changed-only.md
@@ -1,0 +1,42 @@
+---
+title: Changed-Only Diffs
+---
+
+Multi-Application diffs use changed-only selection by default. drydock maps
+changed files to Application inputs and renders only the affected Applications
+when ownership is clear.
+
+If any changed file is unowned or ambiguous, non-strict mode warns and renders
+all Applications. This preserves correctness at the cost of a broader diff.
+
+## Commands
+
+Use the default behavior:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main
+```
+
+Render everything explicitly:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main --changed-only=false
+```
+
+Fail when ownership cannot be proven:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main --strict-changed-only
+```
+
+`diff app` selects one requested Application directly and does not use
+changed-only Git path filtering.
+
+## Mental Model
+
+Changed-only behavior is Argo Application-aware. Shared resources from
+different Applications remain separate diff identities; drydock does not
+collapse overlapping Applications into one owner.
+
+For detailed diff semantics and exit codes, see the [CLI usage guide](/docs/usage/)
+and [compatibility notes](/docs/compatibility/).

--- a/site/content/concepts/runtime-offline.md
+++ b/site/content/concepts/runtime-offline.md
@@ -1,0 +1,41 @@
+---
+title: Runtime Offline
+---
+
+Runtime-offline means drydock does not need live Argo CD or Kubernetes runtime
+access to discover, render, test, diff, inspect images, or report diagnostics.
+It renders desired state from repository contents, explicit mappings, and
+drydock caches.
+
+Runtime-offline does not mean every source network request is disabled.
+Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources can still be
+fetched into explicit caches unless `--offline` is set.
+
+## What drydock Does Not Call
+
+- Live Kubernetes APIs.
+- Live Argo CD APIs.
+- Argo CD server-side diff.
+- Kubernetes defaulting or admission webhooks.
+- Live managed-fields ownership data.
+- Live Application health aggregation.
+
+Those behaviors stay runtime-boundary diagnostics or documented gaps; drydock
+does not silently approximate them from live state.
+
+## When To Use `--offline`
+
+Use `--offline` when a command must be source-offline as well as
+runtime-offline:
+
+```bash
+drydock test apps --path . --offline
+drydock diff apps --path . --path-orig ../baseline --offline
+```
+
+With `--offline`, source resolution must use local files, `--repo-map`, or
+existing cache entries.
+
+For the complete support boundary, see the canonical
+[compatibility notes](/docs/compatibility/) and the
+[live runtime design gate](/docs/reports/live-integration-design-gate/).

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -1,0 +1,53 @@
+---
+title: Source Acquisition
+---
+
+drydock renders from local files and explicit source caches. It may fetch
+declared Git, HTTP Helm, OCI Helm, and remote Kustomize inputs unless
+`--offline` is set.
+
+## Resolution Order
+
+For repository sources, drydock resolves deterministically:
+
+1. Explicit `--repo-map URL=PATH`.
+2. Existing local source path under the selected repository tree.
+3. Declared Git cache or fetch behavior for unmapped external repositories.
+4. Clear failure.
+
+`--repo-map` wins over local fallback and network fetching. Use it for adjacent
+local checkouts or CI jobs that prepare dependencies explicitly:
+
+```bash
+drydock test apps --path . \
+  --repo-map https://github.com/example/platform-config=../platform-config
+```
+
+## Caches And Offline Runs
+
+Render-time Git, chart, and remote-resource caches must stay outside the
+current and baseline repository trees. Populate caches with a non-offline run,
+then use `--offline` for cache-only validation:
+
+```bash
+drydock test apps --path .
+drydock test apps --path . --offline
+```
+
+Cache lifecycle commands are local filesystem operations only:
+
+```bash
+drydock cache path
+drydock cache list -o json
+drydock cache prune --older-than 720h --dry-run
+```
+
+## Credentials
+
+Credentials are explicit and non-interactive. drydock does not read ambient Git
+credential helpers, ambient Helm registry config, or credential fields from
+discovered repository Secrets.
+
+Use the canonical [source acquisition guide](/docs/source-acquisition/) for
+the complete flag list, Helm dependency behavior, remote Kustomize forms, and
+credential details.

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -41,6 +41,7 @@ next.
 Compare the current tree against a baseline worktree:
 
 ```bash
+git worktree add ../baseline main
 drydock diff apps --path . --path-orig ../baseline
 drydock diff images --path . --path-orig ../baseline -o markdown
 ```

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -1,0 +1,54 @@
+---
+title: Getting Started
+---
+
+Use drydock when you want to inspect Argo CD desired state from repository
+contents before a controller sees it. The default commands do not call a live
+Argo CD server or Kubernetes cluster.
+
+## First Commands
+
+Run these from the GitOps repository you want to inspect:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diag --path .
+```
+
+`get apps` shows discovered Applications. `test apps` renders them without
+printing manifest bodies. `diag` uses the same discovery and render validation
+path, then reports repository diagnostics.
+
+## Compare Changes
+
+Compare the current tree against a baseline worktree:
+
+```bash
+drydock diff apps --path . --path-orig ../baseline
+drydock diff images --path . --path-orig ../baseline -o markdown
+```
+
+Or compare local Git refs without creating a second checkout:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main
+drydock diff images --repo . --ref HEAD --ref-orig main -o markdown
+```
+
+## Runtime Offline Does Not Mean Source Offline
+
+drydock is runtime-offline: it does not depend on live Kubernetes or Argo CD.
+Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources may still be
+fetched into explicit caches during render commands.
+
+Use `--offline` when a run must use only local files, repo maps, and existing
+cache entries:
+
+```bash
+drydock test apps --path . --offline
+drydock diff apps --path . --path-orig ../baseline --offline
+```
+
+For full command coverage, see the [CLI usage guide](/docs/usage/). For source
+fetching, cache, and auth details, see [Source acquisition](/docs/source-acquisition/).

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -6,19 +6,34 @@ Use drydock when you want to inspect Argo CD desired state from repository
 contents before a controller sees it. The default commands do not call a live
 Argo CD server or Kubernetes cluster.
 
+## Install
+
+Install the CLI locally with Go:
+
+```bash
+go install github.com/sholdee/drydock/cmd/drydock@latest
+```
+
+For CI installs, use the drydock setup action in GitHub Actions instead of
+installing by hand in each workflow.
+
 ## First Commands
 
 Run these from the GitOps repository you want to inspect:
 
 ```bash
-drydock get apps --path .
 drydock test apps --path .
+drydock get apps --path .
 drydock diag --path .
 ```
 
-`get apps` shows discovered Applications. `test apps` renders them without
-printing manifest bodies. `diag` uses the same discovery and render validation
-path, then reports repository diagnostics.
+Start with `drydock test apps --path .`. It discovers Applications and renders
+them without printing manifest bodies, which makes it the fastest first check
+for render failures. `get apps` shows discovered Applications. `diag` uses the
+same discovery and render validation path, then reports repository diagnostics.
+
+If you are setting this up for CI, go to [GitHub Actions](/workflows/github-actions/)
+next.
 
 ## Compare Changes
 

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -4,7 +4,8 @@ title: Getting Started
 
 Use drydock when you want to inspect Argo CD desired state from repository
 contents before a controller sees it. The default commands do not call a live
-Argo CD server or Kubernetes cluster.
+Argo CD server or Kubernetes cluster, and use native renderers for the common
+directory, Kustomize, Helm, and Jsonnet paths.
 
 ## Install
 

--- a/site/content/plugin-policy/_index.md
+++ b/site/content/plugin-policy/_index.md
@@ -1,0 +1,43 @@
+---
+title: Plugin Policy
+---
+
+drydock plugin policy is the trusted, drydock-specific gate for config
+management plugin compatibility. It is not Argo CD sidecar auto-discovery, and
+it does not make arbitrary discovered commands safe to execute.
+
+Operators usually do not need policy for Kustomize wrapper plugins. If drydock
+discovers a config management plugin command that safely normalizes to
+`kustomize build`, it uses the native Kustomize renderer without shelling out.
+
+## Use Policy For
+
+- Deterministic argocd-vault-plugin placeholder redaction with
+  `engine: avp-compat`.
+- Explicit native Kustomize overrides with `engine: native-kustomize`.
+- Trusted shellout compatibility with `engine: exec` and `--enable-plugins`.
+
+## Exec Gate
+
+The CLI and default Go client run plugin commands only when all of these are
+true:
+
+- The Application source names a plugin that matches a drydock policy entry.
+- The matched entry uses `engine: exec`.
+- The caller passes `--enable-plugins`.
+- The exec policy comes from trusted policy provenance.
+
+For a single-tree command, use an explicit trusted ref:
+
+```bash
+drydock test apps --path . --plugin-policy-ref main --enable-plugins
+```
+
+For pull request diffs, drydock loads policy from the trusted baseline side:
+
+```bash
+drydock diff apps --path-orig ../baseline --path . --enable-plugins
+```
+
+For schema, provenance rules, native engines, and exec security controls, see
+the canonical [plugin policy guide](/docs/plugin-policy/).

--- a/site/content/reference/_index.md
+++ b/site/content/reference/_index.md
@@ -1,0 +1,31 @@
+---
+title: Reference
+---
+
+Use these canonical pages for dense details. The curated site pages link here
+instead of copying long matrices or full flag inventories.
+
+## Operator Guides
+
+- [CLI usage](/docs/usage/): commands, outputs, diff flags, diagnostics, and
+  local verification.
+- [GitHub Actions](/docs/github-actions/): setup action, PR action, inputs,
+  permissions, comments, outputs, and caches.
+- [Source acquisition](/docs/source-acquisition/): Git, Helm, remote
+  Kustomize, caches, offline behavior, and auth.
+- [Plugin policy](/docs/plugin-policy/): trusted policy provenance, engines,
+  schema, and exec security.
+- [Compatibility](/docs/compatibility/): supported Argo CD behavior and
+  runtime-boundary status.
+
+## Design And Maintenance
+
+- [Design](/docs/design/): architecture and behavior model.
+- [ApplicationSets](/docs/applicationsets/): supported generators, fixtures,
+  and template parameters.
+- [Documentation index](/docs/): documentation ownership and anti-sprawl
+  rules.
+- [Release notes](/docs/release/): release process and Argo CD dependency
+  upgrade notes.
+- [Live runtime design gate](/docs/reports/live-integration-design-gate/):
+  required context before proposing live runtime behavior.

--- a/site/content/reference/_index.md
+++ b/site/content/reference/_index.md
@@ -2,8 +2,10 @@
 title: Reference
 ---
 
-Use these canonical pages for dense details. The curated site pages link here
-instead of copying long matrices or full flag inventories.
+Use these mounted `/docs/...` pages as the full reference and canonical detail
+set. They are for dense behavior, flag, compatibility, and maintenance details,
+not the beginner path. Start with [Getting started](/getting-started/) for the
+first local run.
 
 ## Operator Guides
 

--- a/site/content/reference/_index.md
+++ b/site/content/reference/_index.md
@@ -2,10 +2,10 @@
 title: Reference
 ---
 
-Use these mounted `/docs/...` pages as the full reference and canonical detail
-set. They are for dense behavior, flag, compatibility, and maintenance details,
-not the beginner path. Start with [Getting started](/getting-started/) for the
-first local run.
+Use these `/docs/...` pages as the full reference and canonical detail set.
+They are for dense behavior, flag, compatibility, and maintenance details, not
+the beginner path. Start with [Getting started](/getting-started/) for the first
+local run.
 
 ## Operator Guides
 
@@ -25,7 +25,7 @@ first local run.
 - [Design](/docs/design/): architecture and behavior model.
 - [ApplicationSets](/docs/applicationsets/): supported generators, fixtures,
   and template parameters.
-- [Documentation index](/docs/): documentation ownership and anti-sprawl
+- [Documentation index](/docs/readme/): documentation ownership and anti-sprawl
   rules.
 - [Release notes](/docs/release/): release process and Argo CD dependency
   upgrade notes.

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -1,0 +1,70 @@
+---
+title: Troubleshooting
+---
+
+Start with the command that exercises the same path as the failing workflow:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diag --path .
+```
+
+Add `--strict` when warnings should fail the run, and use `-o json` or
+`-o yaml` when you need stable machine-readable diagnostics.
+
+## No Applications Discovered
+
+Check that the selected `--path` points at the GitOps repository root or pass
+the directory that contains Argo CD objects. If the repository stores bootstrap
+inputs as Kustomize rather than committed inflated objects, add an explicit
+entrypoint:
+
+```bash
+drydock get apps --path . --discover-kustomize clusters/prod/argocd
+```
+
+## Render Fails In CI But Works Locally
+
+Confirm whether CI has the same source access and caches. Default runs may
+fetch declared Git, Helm, OCI Helm, and remote Kustomize sources into drydock
+caches. `--offline` disables those source network fetches and requires local
+files, repo maps, or existing cache entries.
+
+```bash
+drydock test apps --path . --offline
+drydock diag --path . --cache-events
+```
+
+## Changed-Only Falls Back To All Apps
+
+Multi-Application diffs use changed-only selection by default. If a changed
+file cannot be safely mapped to Application inputs, non-strict mode warns and
+renders all Applications. Use strict mode when ambiguous ownership should fail:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main --strict-changed-only
+```
+
+## Plugin Source Fails Closed
+
+The CLI and default Go client do not execute config management plugin commands
+by default. Safe Kustomize wrapper plugins may render natively. Other plugin
+sources need trusted drydock plugin policy, and exec policy also needs
+`--enable-plugins`.
+
+```bash
+drydock test apps --path . --plugin-policy-ref main --enable-plugins
+```
+
+See [Plugin policy](/plugin-policy/) for the operator gate.
+
+## Diff Noise Is Hiding Or Showing Too Much
+
+drydock hides common Helm chart/version labels and pod-template checksum
+annotations by default. Use `--show-ignored-fields` to inspect them, or
+`--strip-attr KEY` to remove additional label or annotation keys before
+comparison.
+
+For deeper reference, see the [CLI usage guide](/docs/usage/), [Compatibility](/compatibility/),
+and [Source acquisition](/concepts/source-acquisition/).

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -1,0 +1,104 @@
+---
+title: GitHub Actions
+---
+
+drydock publishes two repository-local composite actions:
+
+- `sholdee/drydock/setup-action`: install a released drydock binary.
+- `sholdee/drydock/pr-action`: install drydock, run PR validation, upload
+  artifacts, and optionally maintain sticky PR comments.
+
+Use `setup-action` when you want to own the CLI commands. Use `pr-action` when
+you want the standard render test, manifest diff, image diff, source cache, and
+comment workflow.
+
+## Manual CLI Workflow
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: sholdee/drydock/setup-action@main
+      - run: drydock test apps --path .
+      - run: drydock diff apps --repo . --ref HEAD --ref-orig origin/${{ github.base_ref }}
+      - run: >-
+          drydock diff images --repo . --ref HEAD
+          --ref-orig origin/${{ github.base_ref }} -o markdown
+```
+
+## Pull Request Action
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sholdee/drydock/pr-action@main
+        with:
+          comment-mode: both
+          skip-secrets: "true"
+```
+
+The PR action checks out the pull request, fetches the base ref, runs
+`drydock test apps`, runs manifest and image diffs, writes artifacts when
+differences are found, and comments in trusted same-repository pull requests.
+Fork pull requests skip comments and source-cache save by default.
+
+## Image Diff Comment Shape
+
+The action uses drydock markdown output for image comments. A typical comment
+looks like this:
+
+```markdown
+## drydock image diff
+
+**Summary:** 1 added, 1 removed.
+
+| Change | Image |
+| --- | --- |
+| added | `registry.example.com/app:v2` |
+| removed | `registry.example.com/app:v1` |
+```
+
+For a no-change image diff, the comment stays compact:
+
+```markdown
+## drydock image diff
+
+**Summary:** 0 added, 0 removed.
+
+No rendered image differences detected.
+```
+
+Use `-o markdown` directly when building a custom workflow, or let `pr-action`
+produce the comment:
+
+```bash
+drydock diff images --repo . --ref HEAD --ref-orig origin/main -o markdown
+```
+
+For all inputs, outputs, permissions, token behavior, and cache details, see
+the canonical [GitHub Actions guide](/docs/github-actions/).

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -74,7 +74,7 @@ The manifest diff comment is the main PR review surface. It summarizes changed
 Applications and resources, then expands each affected Application into a
 reviewable rendered diff:
 
-````text
+````markdown
 ## drydock desired state diff
 
 **Summary:** 1 app, 2 resources, +4/-2.

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -63,14 +63,47 @@ jobs:
 ```
 
 The PR action checks out the pull request, fetches the base ref, runs
-`drydock test apps`, runs manifest and image diffs, writes artifacts when
-differences are found, and comments in trusted same-repository pull requests.
-Fork pull requests skip comments and source-cache save by default.
+`drydock test apps`, renders the desired-state manifest diff, writes full diff
+artifacts when differences are found, and comments in trusted same-repository
+pull requests. Image diff comments are available as a companion signal. Fork
+pull requests skip comments and source-cache save by default.
 
-## Image Diff Comment Shape
+## Manifest Diff Comment Shape
 
-The action uses drydock markdown output for image comments. A typical comment
-looks like this:
+The manifest diff comment is the main PR review surface. It summarizes changed
+Applications and resources, then expands each affected Application into a
+reviewable rendered diff:
+
+````text
+## drydock desired state diff
+
+**Summary:** 1 app, 2 resources, +4/-2.
+
+<details open>
+<summary>renovate (+4/-2, 2 resources)</summary>
+
+```diff
+--- Application: renovate apps/Deployment: renovate/renovate-operator
++++ Application: renovate apps/Deployment: renovate/renovate-operator
+@@ -47,7 +47,7 @@
+-          image: ghcr.io/example/renovate:1.0.0
++          image: ghcr.io/example/renovate:1.1.0
+```
+
+</details>
+````
+
+Use markdown output directly when building a custom workflow, or let
+`pr-action` produce the comment:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig origin/main -o markdown
+```
+
+## Image Diff Companion Comment
+
+Image comments can be enabled alongside the manifest diff. They are useful for
+quickly scanning added and removed rendered image references:
 
 ```text
 ## drydock image diff
@@ -83,17 +116,7 @@ looks like this:
 | removed | `registry.example.com/app:v1` |
 ```
 
-For a no-change image diff, the comment keeps the same heading and stays
-compact:
-
-```text
-**Summary:** 0 added, 0 removed.
-
-No rendered image differences detected.
-```
-
-Use `-o markdown` directly when building a custom workflow, or let `pr-action`
-produce the comment:
+Run image diff markdown directly when building a custom workflow:
 
 ```bash
 drydock diff images --repo . --ref HEAD --ref-orig origin/main -o markdown

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -72,7 +72,7 @@ Fork pull requests skip comments and source-cache save by default.
 The action uses drydock markdown output for image comments. A typical comment
 looks like this:
 
-```markdown
+```text
 ## drydock image diff
 
 **Summary:** 1 added, 1 removed.
@@ -83,11 +83,10 @@ looks like this:
 | removed | `registry.example.com/app:v1` |
 ```
 
-For a no-change image diff, the comment stays compact:
+For a no-change image diff, the comment keeps the same heading and stays
+compact:
 
-```markdown
-## drydock image diff
-
+```text
 **Summary:** 0 added, 0 removed.
 
 No rendered image differences detected.

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -1,0 +1,64 @@
+---
+title: Local Diffs
+---
+
+Use local diffs to compare desired state before opening or merging a pull
+request. drydock renders both sides and compares desired manifests; it does not
+ask live Argo CD or Kubernetes for current state.
+
+## Compare Two Trees
+
+```bash
+git worktree add ../baseline main
+drydock diff apps --path . --path-orig ../baseline
+drydock diff images --path . --path-orig ../baseline -o markdown
+```
+
+Use this when you already have a separate baseline checkout or want to inspect
+uncommitted changes in the current working tree.
+
+## Compare Git Refs
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main
+drydock diff images --repo . --ref HEAD --ref-orig main -o json
+```
+
+`--repo` is a local Git repository path. `--ref-orig` selects the baseline
+snapshot, and `--ref` selects the current snapshot. Top-level remote `--repo`
+URLs are not supported.
+
+## Useful Diff Flags
+
+- `--changed-only=false` renders all discovered Applications.
+- `--strict-changed-only` fails if changed-file ownership is incomplete.
+- `--skip-secrets` omits Secret resources from output and diffs.
+- `--skip-crds` omits CRDs from output and diffs.
+- `--show-ignored-fields` shows drydock default ignored metadata fields.
+- `--exit-code=false` keeps the command successful when differences exist.
+
+## Markdown For Reviews
+
+Manifest and image diffs support markdown output:
+
+```bash
+drydock diff apps --path . --path-orig ../baseline -o markdown
+drydock diff images --path . --path-orig ../baseline -o markdown
+```
+
+Image markdown is comment-facing and omits unchanged images by default:
+
+```markdown
+## drydock image diff
+
+**Summary:** 2 added, 1 removed.
+
+| Change | Image |
+| --- | --- |
+| added | `registry.example.com/api:v2` |
+| added | `registry.example.com/worker:v2` |
+| removed | `registry.example.com/api:v1` |
+```
+
+For the full diff behavior, output formats, ignore rules, and exit codes, see
+the [CLI usage guide](/docs/usage/).

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -3,8 +3,9 @@ title: Local Diffs
 ---
 
 Use local diffs to compare desired state before opening or merging a pull
-request. drydock renders both sides and compares desired manifests; it does not
-ask live Argo CD or Kubernetes for current state.
+request, or any time you want to inspect repository changes before Argo CD sees
+them. drydock renders both sides and compares desired manifests; it does not ask
+live Argo CD or Kubernetes for current state.
 
 ## Compare Two Trees
 
@@ -46,19 +47,29 @@ drydock diff apps --path . --path-orig ../baseline -o markdown
 drydock diff images --path . --path-orig ../baseline -o markdown
 ```
 
-Image markdown is comment-facing and omits unchanged images by default:
+Manifest markdown is the primary review surface:
 
-```markdown
-## drydock image diff
+````markdown
+## drydock desired state diff
 
-**Summary:** 2 added, 1 removed.
+**Summary:** 1 app, 2 resources, +4/-2.
 
-| Change | Image |
-| --- | --- |
-| added | `registry.example.com/api:v2` |
-| added | `registry.example.com/worker:v2` |
-| removed | `registry.example.com/api:v1` |
+<details open>
+<summary>renovate (+4/-2, 2 resources)</summary>
+
+```diff
+--- Application: renovate apps/Deployment: renovate/renovate-operator
++++ Application: renovate apps/Deployment: renovate/renovate-operator
+@@ -47,7 +47,7 @@
+-          image: ghcr.io/example/renovate:1.0.0
++          image: ghcr.io/example/renovate:1.1.0
 ```
+
+</details>
+````
+
+Image markdown is a companion view for scanning rendered image reference
+changes, and omits unchanged images by default.
 
 For the full diff behavior, output formats, ignore rules, and exit codes, see
 the [CLI usage guide](/docs/usage/).

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,0 +1,21 @@
+baseURL: "https://sholdee.github.io/drydock/"
+title: "drydock"
+locale: "en-US"
+disableKinds:
+  - taxonomy
+  - term
+
+module:
+  mounts:
+    - source: content
+      target: content
+    - source: ../docs
+      target: content/docs
+    - source: layouts
+      target: layouts
+    - source: assets
+      target: assets
+    - source: static
+      target: static
+    - source: ../docs/logo
+      target: static/logo

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -12,36 +12,58 @@ menus:
   docs:
     - name: Overview
       url: /
+      params:
+        group: Start
       weight: 10
     - name: Getting Started
       url: /getting-started/
+      params:
+        group: Start
       weight: 20
-    - name: GitHub Actions
-      url: /workflows/github-actions/
-      weight: 30
-    - name: Local Diffs
-      url: /workflows/local-diffs/
-      weight: 40
     - name: Troubleshooting
       url: /troubleshooting/
+      params:
+        group: Start
+      weight: 30
+    - name: GitHub Actions
+      url: /workflows/github-actions/
+      params:
+        group: Workflows
+      weight: 40
+    - name: Local Diffs
+      url: /workflows/local-diffs/
+      params:
+        group: Workflows
       weight: 50
     - name: Runtime Offline
       url: /concepts/runtime-offline/
+      params:
+        group: Concepts
       weight: 60
     - name: Source Acquisition
       url: /concepts/source-acquisition/
+      params:
+        group: Concepts
       weight: 70
     - name: Changed-Only Diffs
       url: /concepts/changed-only/
+      params:
+        group: Concepts
       weight: 80
     - name: Compatibility
       url: /compatibility/
+      params:
+        group: Reference
       weight: 90
     - name: Plugin Policy
       url: /plugin-policy/
+      params:
+        group: Reference
       weight: 100
     - name: Reference
       url: /reference/
+      params:
+        group: Reference
       weight: 110
 
 markup:

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -13,35 +13,35 @@ menus:
     - name: Overview
       url: /
       weight: 10
-    - name: Usage
-      url: /docs/usage/
+    - name: Getting Started
+      url: /getting-started/
       weight: 20
     - name: GitHub Actions
-      url: /docs/github-actions/
+      url: /workflows/github-actions/
       weight: 30
-    - name: ApplicationSets
-      url: /docs/applicationsets/
+    - name: Local Diffs
+      url: /workflows/local-diffs/
       weight: 40
-    - name: Source Acquisition
-      url: /docs/source-acquisition/
+    - name: Troubleshooting
+      url: /troubleshooting/
       weight: 50
-    - name: Plugin Policy
-      url: /docs/plugin-policy/
+    - name: Runtime Offline
+      url: /concepts/runtime-offline/
       weight: 60
-    - name: Compatibility
-      url: /docs/compatibility/
+    - name: Source Acquisition
+      url: /concepts/source-acquisition/
       weight: 70
-    - name: Design
-      url: /docs/design/
+    - name: Changed-Only Diffs
+      url: /concepts/changed-only/
       weight: 80
-    - name: Release Notes
-      url: /docs/release/
+    - name: Compatibility
+      url: /compatibility/
       weight: 90
-    - name: Documentation Index
-      url: /docs/
+    - name: Plugin Policy
+      url: /plugin-policy/
       weight: 100
-    - name: Live Runtime Boundary
-      url: /docs/reports/live-integration-design-gate/
+    - name: Reference
+      url: /reference/
       weight: 110
 
 markup:
@@ -64,3 +64,5 @@ module:
       target: static
     - source: ../docs/logo
       target: static/logo
+    - source: ../schemas
+      target: static/schemas

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -6,7 +6,7 @@ disableKinds:
   - term
 
 params:
-  description: "Offline desired-state analysis for Argo CD GitOps repositories."
+  description: "Runtime-offline desired-state analysis for Argo CD GitOps repositories."
 
 menus:
   docs:

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -5,6 +5,51 @@ disableKinds:
   - taxonomy
   - term
 
+params:
+  description: "Offline desired-state analysis for Argo CD GitOps repositories."
+
+menus:
+  docs:
+    - name: Overview
+      url: /
+      weight: 10
+    - name: Usage
+      url: /docs/usage/
+      weight: 20
+    - name: GitHub Actions
+      url: /docs/github-actions/
+      weight: 30
+    - name: ApplicationSets
+      url: /docs/applicationsets/
+      weight: 40
+    - name: Source Acquisition
+      url: /docs/source-acquisition/
+      weight: 50
+    - name: Plugin Policy
+      url: /docs/plugin-policy/
+      weight: 60
+    - name: Compatibility
+      url: /docs/compatibility/
+      weight: 70
+    - name: Design
+      url: /docs/design/
+      weight: 80
+    - name: Release Notes
+      url: /docs/release/
+      weight: 90
+    - name: Documentation Index
+      url: /docs/
+      weight: 100
+    - name: Live Runtime Boundary
+      url: /docs/reports/live-integration-design-gate/
+      weight: 110
+
+markup:
+  tableOfContents:
+    startLevel: 2
+    endLevel: 3
+    ordered: false
+
 module:
   mounts:
     - source: content

--- a/site/layouts/_default/_markup/render-link.html
+++ b/site/layouts/_default/_markup/render-link.html
@@ -1,14 +1,27 @@
 {{- $destination := .Destination -}}
 {{- $url := urls.Parse $destination -}}
 {{- $href := $destination -}}
-{{- if and (not $url.Scheme) (not $url.Host) (not (strings.HasPrefix $destination "/")) (strings.HasSuffix $url.Path ".md") -}}
-  {{- $path := strings.TrimSuffix ".md" $url.Path -}}
-  {{- $path = strings.TrimPrefix "./" $path -}}
-  {{- $clean := path.Clean (printf "%s/%s" .Page.File.Dir $path) -}}
-  {{- if eq $clean "." -}}
-    {{- $clean = "" -}}
+{{- if and (not $url.Scheme) (not $url.Host) $url.Path -}}
+  {{- if strings.HasPrefix $url.Path "/" -}}
+    {{- $href = relURL (strings.TrimPrefix "/" $url.Path) -}}
+  {{- else -}}
+    {{- $path := $url.Path -}}
+    {{- if strings.HasSuffix $path ".md" -}}
+      {{- $path = strings.TrimSuffix ".md" $path -}}
+    {{- end -}}
+    {{- $path = strings.TrimPrefix "./" $path -}}
+    {{- $clean := path.Clean (printf "%s/%s" .Page.File.Dir $path) -}}
+    {{- if eq $clean "." -}}
+      {{- $clean = "" -}}
+    {{- end -}}
+    {{- if or (strings.HasSuffix $url.Path ".md") (strings.HasSuffix $url.Path "/") -}}
+      {{- $clean = printf "%s/" $clean -}}
+    {{- end -}}
+    {{- $href = relURL $clean -}}
   {{- end -}}
-  {{- $href = relURL (printf "%s/" $clean) -}}
+  {{- with $url.RawQuery -}}
+    {{- $href = printf "%s?%s" $href . -}}
+  {{- end -}}
   {{- with $url.Fragment -}}
     {{- $href = printf "%s#%s" $href . -}}
   {{- end -}}

--- a/site/layouts/_default/_markup/render-link.html
+++ b/site/layouts/_default/_markup/render-link.html
@@ -1,0 +1,16 @@
+{{- $destination := .Destination -}}
+{{- $url := urls.Parse $destination -}}
+{{- $href := $destination -}}
+{{- if and (not $url.Scheme) (not $url.Host) (not (strings.HasPrefix $destination "/")) (strings.HasSuffix $url.Path ".md") -}}
+  {{- $path := strings.TrimSuffix ".md" $url.Path -}}
+  {{- $path = strings.TrimPrefix "./" $path -}}
+  {{- $clean := path.Clean (printf "%s/%s" .Page.File.Dir $path) -}}
+  {{- if eq $clean "." -}}
+    {{- $clean = "" -}}
+  {{- end -}}
+  {{- $href = relURL (printf "%s/" $clean) -}}
+  {{- with $url.Fragment -}}
+    {{- $href = printf "%s#%s" $href . -}}
+  {{- end -}}
+{{- end -}}
+<a href="{{ $href | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="{{ site.Language.Locale | default "en" }}">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    {{ partial "header.html" . }}
+    {{- $hasToc := gt (len .Fragments.Headings) 0 -}}
+    <div class="site-shell{{ if not $hasToc }} no-toc{{ end }}">
+      <aside class="site-sidebar" aria-label="Documentation navigation">
+        {{ partial "sidebar.html" . }}
+      </aside>
+      <main id="main-content" class="site-main" tabindex="-1">
+        {{ block "main" . }}{{ end }}
+      </main>
+      {{ if $hasToc }}
+        <aside class="site-toc" aria-label="Page table of contents">
+          {{ partial "toc.html" . }}
+        </aside>
+      {{ end }}
+    </div>
+    <footer class="site-footer">
+      <span>drydock documentation</span>
+      <span>Offline Argo CD desired-state analysis</span>
+    </footer>
+  </body>
+</html>

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -22,7 +22,7 @@
     </div>
     <footer class="site-footer">
       <span>drydock documentation</span>
-      <span>Offline Argo CD desired-state analysis</span>
+      <span>Runtime-offline Argo CD desired-state analysis</span>
     </footer>
   </body>
 </html>

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+  <article class="doc-page">
+    <header class="doc-header">
+      <p class="section-label">Documentation</p>
+      <h1>{{ partial "title.html" . }}</h1>
+      {{ with site.Params.description }}
+        <p class="lead">{{ . }}</p>
+      {{ end }}
+    </header>
+    {{ with .Content }}
+      <div class="doc-content">
+        {{ . }}
+      </div>
+    {{ end }}
+    <nav class="doc-index" aria-label="Documentation pages">
+      {{ range site.Menus.docs }}
+        {{ if ne .URL "/" }}
+          <a href="{{ relURL .URL }}">
+            <span>{{ .Name }}</span>
+          </a>
+        {{ end }}
+      {{ end }}
+    </nav>
+  </article>
+{{ end }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -9,5 +9,6 @@
     <div class="doc-content">
       {{ .Content }}
     </div>
+    {{ partial "next-links.html" . }}
   </article>
 {{ end }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+  <article class="doc-page">
+    {{ if .Title }}
+      <header class="doc-header">
+        <p class="section-label">Documentation</p>
+        <h1>{{ .Title }}</h1>
+      </header>
+    {{ end }}
+    <div class="doc-content">
+      {{ .Content }}
+    </div>
+  </article>
+{{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -7,5 +7,6 @@
     <div class="doc-content">
       {{ .Content }}
     </div>
+    {{ partial "next-links.html" . }}
   </article>
 {{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+  <article class="doc-page home-page">
+    <div class="home-mark">
+      <img src="{{ "logo/drydock-display.svg" | relURL }}" alt="drydock" width="480" height="128">
+    </div>
+    <div class="doc-content">
+      {{ .Content }}
+    </div>
+  </article>
+{{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,7 +1,8 @@
 {{ define "main" }}
   <article class="doc-page home-page">
+    <h1 class="visually-hidden">{{ .Title }}</h1>
     <div class="home-mark">
-      <img src="{{ "logo/drydock-display.svg" | relURL }}" alt="drydock" width="480" height="128">
+      <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="480" height="128">
     </div>
     <div class="doc-content">
       {{ .Content }}

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,9 +1,11 @@
 {{- $pageTitle := partial "title.html" . -}}
 {{- $description := site.Params.description | default "drydock documentation" -}}
 {{- $styles := resources.Get "css/site.css" | minify | fingerprint -}}
+{{- $script := resources.Get "js/site.js" | minify | fingerprint -}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ $description }}">
 <title>{{ if .IsHome }}{{ site.Title }} documentation{{ else }}{{ $pageTitle }} | {{ site.Title }}{{ end }}</title>
 <link rel="icon" type="image/svg+xml" href="{{ "logo/drydock-logo.svg" | relURL }}">
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+<script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}" defer></script>

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,0 +1,9 @@
+{{- $pageTitle := partial "title.html" . -}}
+{{- $description := site.Params.description | default "drydock documentation" -}}
+{{- $styles := resources.Get "css/site.css" | minify | fingerprint -}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="{{ $description }}">
+<title>{{ if .IsHome }}{{ site.Title }} documentation{{ else }}{{ $pageTitle }} | {{ site.Title }}{{ end }}</title>
+<link rel="icon" type="image/svg+xml" href="{{ "logo/drydock-logo.svg" | relURL }}">
+<link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header class="site-header">
   <nav class="header-nav" aria-label="Primary">
     <a class="brand-link" href="{{ site.Home.RelPermalink }}" aria-label="drydock documentation home">
-      <img src="{{ "logo/drydock-display.svg" | relURL }}" alt="drydock" width="180" height="48">
+      <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="180" height="48">
     </a>
     <div class="header-links">
       <a href="{{ site.Home.RelPermalink }}">Overview</a>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,0 +1,13 @@
+<header class="site-header">
+  <nav class="header-nav" aria-label="Primary">
+    <a class="brand-link" href="{{ site.Home.RelPermalink }}" aria-label="drydock documentation home">
+      <img src="{{ "logo/drydock-display.svg" | relURL }}" alt="drydock" width="180" height="48">
+    </a>
+    <div class="header-links">
+      <a href="{{ site.Home.RelPermalink }}">Overview</a>
+      <a href="{{ relURL "docs/usage/" }}">Usage</a>
+      <a href="{{ relURL "docs/github-actions/" }}">Actions</a>
+      <a href="https://github.com/sholdee/drydock">GitHub</a>
+    </div>
+  </nav>
+</header>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -5,8 +5,9 @@
     </a>
     <div class="header-links">
       <a href="{{ site.Home.RelPermalink }}">Overview</a>
-      <a href="{{ relURL "docs/usage/" }}">Usage</a>
-      <a href="{{ relURL "docs/github-actions/" }}">Actions</a>
+      <a href="{{ relURL "getting-started/" }}">Getting Started</a>
+      <a href="{{ relURL "workflows/github-actions/" }}">PR Checks</a>
+      <a href="{{ relURL "reference/" }}">Reference</a>
       <a href="https://github.com/sholdee/drydock">GitHub</a>
     </div>
   </nav>

--- a/site/layouts/partials/next-links.html
+++ b/site/layouts/partials/next-links.html
@@ -1,0 +1,71 @@
+{{- $links := slice -}}
+{{- if .IsHome -}}
+  {{- $links = slice
+    (dict "label" "Get Started" "url" "/getting-started/")
+    (dict "label" "Set Up PR Checks" "url" "/workflows/github-actions/")
+  -}}
+{{- else -}}
+  {{- $current := .RelPermalink -}}
+  {{- if eq $current (relURL "getting-started/") -}}
+    {{- $links = slice
+      (dict "label" "Set Up PR Checks" "url" "/workflows/github-actions/")
+      (dict "label" "Compare Local Diffs" "url" "/workflows/local-diffs/")
+    -}}
+  {{- else if eq $current (relURL "workflows/github-actions/") -}}
+    {{- $links = slice
+      (dict "label" "Compare Local Diffs" "url" "/workflows/local-diffs/")
+      (dict "label" "Troubleshoot" "url" "/troubleshooting/")
+    -}}
+  {{- else if eq $current (relURL "workflows/local-diffs/") -}}
+    {{- $links = slice
+      (dict "label" "Understand Changed-Only" "url" "/concepts/changed-only/")
+      (dict "label" "Source Acquisition" "url" "/concepts/source-acquisition/")
+    -}}
+  {{- else if eq $current (relURL "troubleshooting/") -}}
+    {{- $links = slice
+      (dict "label" "Compatibility" "url" "/compatibility/")
+      (dict "label" "Full Reference" "url" "/reference/")
+    -}}
+  {{- else if eq $current (relURL "concepts/runtime-offline/") -}}
+    {{- $links = slice
+      (dict "label" "Source Acquisition" "url" "/concepts/source-acquisition/")
+      (dict "label" "Compatibility" "url" "/compatibility/")
+    -}}
+  {{- else if eq $current (relURL "concepts/source-acquisition/") -}}
+    {{- $links = slice
+      (dict "label" "Changed-Only Diffs" "url" "/concepts/changed-only/")
+      (dict "label" "Full Source Reference" "url" "/docs/source-acquisition/")
+    -}}
+  {{- else if eq $current (relURL "concepts/changed-only/") -}}
+    {{- $links = slice
+      (dict "label" "Local Diffs" "url" "/workflows/local-diffs/")
+      (dict "label" "Full CLI Reference" "url" "/docs/usage/")
+    -}}
+  {{- else if eq $current (relURL "compatibility/") -}}
+    {{- $links = slice
+      (dict "label" "Plugin Policy" "url" "/plugin-policy/")
+      (dict "label" "Full Compatibility Notes" "url" "/docs/compatibility/")
+    -}}
+  {{- else if eq $current (relURL "plugin-policy/") -}}
+    {{- $links = slice
+      (dict "label" "Full Plugin Policy" "url" "/docs/plugin-policy/")
+      (dict "label" "Reference" "url" "/reference/")
+    -}}
+  {{- else if eq $current (relURL "reference/") -}}
+    {{- $links = slice
+      (dict "label" "CLI Usage" "url" "/docs/usage/")
+      (dict "label" "Compatibility" "url" "/docs/compatibility/")
+    -}}
+  {{- end -}}
+{{- end -}}
+{{- with $links -}}
+  <nav class="next-links" aria-label="Next steps">
+    <p>Next</p>
+    <div>
+      {{- range . -}}
+        {{- $url := strings.TrimPrefix "/" .url -}}
+        <a href="{{ relURL $url }}">{{ .label }}</a>
+      {{- end -}}
+    </div>
+  </nav>
+{{- end -}}

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,14 +1,22 @@
 <nav class="docs-nav">
   <p class="nav-heading">Docs</p>
-  <ul>
-    {{ range site.Menus.docs }}
-      {{- $entryURL := relURL .URL -}}
-      {{- $active := eq $entryURL $.RelPermalink -}}
-      <li>
-        <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
-          {{ .Name }}
-        </a>
-      </li>
-    {{ end }}
-  </ul>
+  {{ $groups := slice "Start" "Workflows" "Concepts" "Reference" }}
+  {{ range $group := $groups }}
+    <div class="nav-section">
+      <p class="nav-section-heading">{{ $group }}</p>
+      <ul>
+        {{ range site.Menus.docs }}
+          {{ if eq (.Params.group | default "Reference") $group }}
+            {{- $entryURL := relURL .URL -}}
+            {{- $active := eq $entryURL $.RelPermalink -}}
+            <li>
+              <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
+                {{ .Name }}
+              </a>
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+  {{ end }}
 </nav>

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,0 +1,14 @@
+<nav class="docs-nav">
+  <p class="nav-heading">Docs</p>
+  <ul>
+    {{ range site.Menus.docs }}
+      {{- $entryURL := relURL .URL -}}
+      {{- $active := eq $entryURL $.RelPermalink -}}
+      <li>
+        <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
+          {{ .Name }}
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+</nav>

--- a/site/layouts/partials/title.html
+++ b/site/layouts/partials/title.html
@@ -1,0 +1,17 @@
+{{- $title := .Title -}}
+{{- if not $title -}}
+  {{- range site.Menus.docs -}}
+    {{- if eq (relURL .URL) $.RelPermalink -}}
+      {{- $title = .Name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $title -}}
+  {{- with .File -}}
+    {{- $title = replace .TranslationBaseName "-" " " | title -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $title -}}
+  {{- $title = site.Title -}}
+{{- end -}}
+{{- return $title -}}

--- a/site/layouts/partials/toc.html
+++ b/site/layouts/partials/toc.html
@@ -1,0 +1,6 @@
+{{- with .Fragments.Headings -}}
+  <div class="toc-panel">
+    <p class="nav-heading">On This Page</p>
+    {{ $.TableOfContents }}
+  </div>
+{{- end -}}


### PR DESCRIPTION
## Summary
- add a Hugo-based GitHub Pages documentation site with a custom drydock visual theme
- add curated operator pages for getting started, workflows, runtime-offline behavior, source acquisition, compatibility, and plugin policy
- wire docs-site build checks into CI and add a Pages deployment workflow
- refresh README, AGENTS, and docs wording around runtime-offline/native/no-default-shellout architecture

## Review
- final spec review: approved, no blocking issues
- final quality review: approved, no blocking issues

## Validation
- mise run ci
- reviewer Hugo build/link check found 0 missing internal links across generated pages

## Notes
- GitHub Pages must use Settings -> Pages -> Source: GitHub Actions before the deploy workflow can publish