### PR TITLE
docs: render Mermaid diagrams on docs site

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -401,6 +401,26 @@ a:hover {
   color: var(--link-hover);
 }
 
+.mermaid-figure {
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  border: 1px solid #213149;
+  border-radius: 8px;
+  background: rgba(5, 11, 18, 0.7);
+  padding: 1rem;
+}
+
+.mermaid-figure .mermaid {
+  min-width: min(680px, 100%);
+}
+
+.mermaid-figure svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
 .highlight .c,
 .highlight .c1,
 .highlight .cm,

--- a/site/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/site/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,6 @@
+{{- .Page.Store.Set "hasMermaid" true -}}
+<figure class="mermaid-figure">
+  <div class="mermaid">
+{{ .Inner | htmlEscape | safeHTML }}
+  </div>
+</figure>

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -24,5 +24,6 @@
       <span>drydock documentation</span>
       <span>Runtime-offline Argo CD desired-state analysis</span>
     </footer>
+    {{ partial "mermaid.html" . }}
   </body>
 </html>

--- a/site/layouts/partials/mermaid.html
+++ b/site/layouts/partials/mermaid.html
@@ -1,6 +1,6 @@
 {{- if .Store.Get "hasMermaid" -}}
 <script type="module">
-  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.10.1/dist/mermaid.esm.min.mjs";
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";
 
   mermaid.initialize({
     startOnLoad: false,

--- a/site/layouts/partials/mermaid.html
+++ b/site/layouts/partials/mermaid.html
@@ -1,0 +1,17 @@
+{{- if .Store.Get "hasMermaid" -}}
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.10.1/dist/mermaid.esm.min.mjs";
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "dark"
+  });
+
+  try {
+    await mermaid.run({ querySelector: ".mermaid" });
+  } catch (error) {
+    console.error("Failed to render Mermaid diagrams", error);
+  }
+</script>
+{{- end -}}


### PR DESCRIPTION
## Summary
- render fenced Mermaid code blocks as diagrams on the docs site
- load pinned Mermaid 11.15.0 ESM from jsDelivr only on pages that contain Mermaid diagrams
- style rendered diagrams for the dark docs theme

## Validation
- mise run docs-check
- mise run markdownlint
- git diff --check
- verified generated docs/design and docs/release pages use Mermaid containers instead of language-mermaid code blocks
- verified generated design/release pages reference Mermaid 11.15.0
- verified the pinned jsDelivr Mermaid 11.15.0 module returns HTTP 200