### PR TITLE
docs: polish operator documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # drydock
 
-Inspect your Argo CD fleet without getting wet.
+Inspect your Argo CD fleet without getting wet
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/sholdee/drydock)](https://goreportcard.com/report/github.com/sholdee/drydock)
 [![CI](https://github.com/sholdee/drydock/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sholdee/drydock/actions/workflows/ci.yml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,6 @@
-# Documentation Index
+---
+title: Documentation Index
+---
 
 This page owns documentation routing. Update the canonical owner instead of
 copying the same rule into multiple files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ copying the same rule into multiple files.
 | `docs/agent-reference.md` | Task-specific agent constraints and code-area notes. |
 | `docs/design.md` | Product architecture and behavior model. |
 | `docs/usage.md` | Operator CLI workflows and high-value command examples. |
+| `docs/topologies.md` | Repository topology guidance and command patterns. |
 | `docs/applicationsets.md` | ApplicationSet generator behavior, fixture schema, and template parameters. |
 | `docs/source-acquisition.md` | Git, Helm, remote Kustomize, cache, and auth behavior. |
 | `docs/plugin-policy.md` | Trusted plugin policy provenance, editor schema, CMP compatibility, and exec security. |

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -1,4 +1,6 @@
-# Agent Reference
+---
+title: Agent Reference
+---
 
 This file contains task-specific drydock agent guidance. Read `AGENTS.md`
 first; load this file only for the sections relevant to the work in front of

--- a/docs/applicationsets.md
+++ b/docs/applicationsets.md
@@ -1,4 +1,6 @@
-# ApplicationSet Reference
+---
+title: ApplicationSet Reference
+---
 
 `drydock` expands a deterministic local subset of Argo CD `ApplicationSet`
 generators. Unsupported generators emit diagnostics; non-strict commands keep

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,4 +1,6 @@
-# Argo CD Compatibility Notes
+---
+title: Argo CD Compatibility Notes
+---
 
 `drydock` tracks Argo CD compatibility for runtime-offline desired-state
 analysis. Default commands discover, render, test, diff, inspect images, and

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,6 @@
-# drydock Design
+---
+title: drydock Design
+---
 
 `drydock` is an independent Go CLI and embeddable library for Argo CD GitOps
 repository analysis. It discovers Argo CD Applications, renders desired
@@ -35,18 +37,7 @@ selected reusable helpers where they are decoupled from live runtime services.
 drydock owns discovery, source planning, cache use, rendering orchestration,
 diagnostics, and output shaping.
 
-```mermaid
-flowchart LR
-  Repo[Checked-out repository] --> Discover[Discover Applications, ApplicationSets, settings]
-  Discover --> Plan[Plan sources and inputs]
-  Plan --> Acquire[Acquire declared sources into caches]
-  Acquire --> Render[Render desired manifests with Go libraries]
-  Render --> Normalize[Apply Argo-aware normalization]
-  Normalize --> Diffs[Manifest diffs]
-  Normalize --> Images[Image diffs and inventory]
-  Render --> Tests[Render tests and Lua health validation]
-  Render --> Diag[Diagnostics]
-```
+{{< workflow name="architecture" >}}
 
 Primary packages:
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,4 +1,6 @@
-# GitHub Actions
+---
+title: GitHub Actions
+---
 
 drydock publishes two repository-local composite actions:
 

--- a/docs/plugin-policy.md
+++ b/docs/plugin-policy.md
@@ -1,4 +1,6 @@
-# Plugin Policy
+---
+title: Plugin Policy
+---
 
 `drydock` plugin policy is the trusted, drydock-specific contract for Argo CD
 config management plugin (CMP) compatibility beyond drydock's built-in native

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,4 +1,6 @@
-# Release And Upgrade Notes
+---
+title: Release And Upgrade Notes
+---
 
 `drydock` is a single static Go binary and embeddable Go module. Release
 artifacts should preserve the runtime-offline core contract: render and diff

--- a/docs/reports/live-integration-design-gate.md
+++ b/docs/reports/live-integration-design-gate.md
@@ -1,4 +1,6 @@
-# Live Runtime Boundary
+---
+title: Live Runtime Boundary
+---
 
 Date: 2026-05-24
 

--- a/docs/source-acquisition.md
+++ b/docs/source-acquisition.md
@@ -1,4 +1,6 @@
-# Source Acquisition
+---
+title: Source Acquisition
+---
 
 `drydock` renders from local files and explicit source caches. Declared Git,
 HTTP Helm, OCI Helm, and remote Kustomize sources may be fetched into those

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -1,0 +1,158 @@
+# Repository Topologies
+
+This page helps operators map common GitOps repository shapes to drydock
+commands. It is not a second behavior spec; detailed command, source,
+ApplicationSet, and plugin rules live in the linked canonical docs.
+
+## Start With The Repository Root
+
+For a repository that commits Argo CD `Application` manifests, run from the
+repository root:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diff apps --repo . --ref HEAD --ref-orig main
+```
+
+`get apps`, `test apps`, and `diff apps` discover Applications, render desired
+state, and report diagnostics without contacting live Argo CD or Kubernetes.
+The operator command flow, output formats, selectors, diff behavior, and exit
+codes are owned by [`usage.md`](usage.md).
+
+## App-Of-Apps And Rendered Discovery
+
+If the repository commits a bootstrap Application or Helm app-of-apps source,
+fleet commands recursively render discovered Applications to find additional
+Argo CD objects until discovery converges:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+```
+
+Use this topology when committed bootstrap inputs render child `Application`,
+`ApplicationSet`, `AppProject`, or Argo CD settings objects. Use
+`--discovery-mode static` when you want committed static discovery only, or
+`--max-discovery-depth 0` when you want normal static discovery while disabling
+recursive rendered fleet discovery. These flags and precedence rules are owned
+by [`usage.md`](usage.md).
+
+## Kustomize Bootstrap Inputs
+
+Some repositories store Argo CD bootstrap objects behind Kustomize overlays
+instead of committing inflated manifests. Add each local Kustomize entrypoint
+explicitly:
+
+```bash
+drydock get apps --path . --discover-kustomize clusters/prod/argocd
+drydock test apps --path . --discover-kustomize clusters/prod/argocd
+```
+
+`--discover-kustomize` paths are relative to `--path`, must stay under that
+repository tree, and are rendered with drydock's native Kustomize renderer.
+Rendered discovery behavior is owned by [`usage.md`](usage.md); Kustomize
+source acquisition and remote reference behavior are owned by
+[`source-acquisition.md`](source-acquisition.md).
+
+## Multi-Repository Sources
+
+Applications can reference sources outside the selected repository. Prefer
+explicit local mappings in developer workstations and CI jobs:
+
+```bash
+drydock test apps --path . \
+  --repo-map https://github.com/example/platform-config=../platform-config
+```
+
+Repository source resolution prefers `--repo-map`, then an existing local
+source path, then declared Git cache or fetch behavior, then a clear failure.
+Use `--offline` when the command must use only local files, repo maps, and
+existing cache entries:
+
+```bash
+drydock test apps --path . --offline
+drydock diff apps --path . --path-orig ../baseline --offline
+```
+
+Git, Helm, remote Kustomize, cache, auth, and `--offline` behavior are owned by
+[`source-acquisition.md`](source-acquisition.md).
+
+## ApplicationSet Fleets
+
+Repositories that commit `ApplicationSet` manifests can use the same fleet
+commands:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+```
+
+Local deterministic generators are expanded offline. Provider-backed
+generators use explicit local fixture files:
+
+```bash
+drydock get apps --path . \
+  --appset-provider-fixture fixtures/appset-providers.yaml
+```
+
+Supported generators, fixture schema, template parameters, and strict-mode
+diagnostics are owned by [`applicationsets.md`](applicationsets.md).
+
+## Config Management Plugin Sources
+
+For repositories that rely on Argo CD config management plugins, start with a
+normal render test:
+
+```bash
+drydock test apps --path .
+```
+
+Safe Kustomize wrapper plugins may render through drydock's native Kustomize
+path. Other plugin sources fail closed unless a drydock plugin policy matches
+the plugin. Trusted exec policy also requires `--enable-plugins`:
+
+```bash
+drydock test apps --path . --plugin-policy-ref main --enable-plugins
+drydock diff apps --path-orig ../baseline --path . --enable-plugins
+```
+
+Plugin policy provenance, native plugin compatibility, and exec security
+controls are owned by [`plugin-policy.md`](plugin-policy.md).
+
+## Pull Request Topologies
+
+For one local repository, compare Git refs without mutating the checkout:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main
+drydock diff images --repo . --ref HEAD --ref-orig main -o markdown
+```
+
+For two prepared trees, compare explicit paths:
+
+```bash
+drydock diff apps --path ./current --path-orig ../baseline
+drydock diff images --path ./current --path-orig ../baseline -o markdown
+```
+
+Changed-only selection, manifest and image outputs, ignore rules,
+resource-filter flags, and diff exit codes are owned by [`usage.md`](usage.md).
+Source cache placement and source-network behavior during PR checks are owned
+by [`source-acquisition.md`](source-acquisition.md).
+
+## What To Verify Per Topology
+
+Run the command that matches the operator workflow first:
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diag --path .
+```
+
+Use `get apps` to confirm discovery, `test apps` to prove render health without
+manifest output, and `diag` to inspect diagnostics and settings summaries. For
+source-heavy repositories, add `--offline` after caches and repo maps are in
+place so cache-only behavior is exercised. For plugin-heavy repositories, add
+the same plugin policy flags used by CI.

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -1,4 +1,6 @@
-# Repository Topologies
+---
+title: Repository Topologies
+---
 
 This page helps operators map common GitOps repository shapes to drydock
 commands. It is not a second behavior spec; detailed command, source,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,6 @@
-# Usage
+---
+title: Usage
+---
 
 `drydock` is a runtime-offline CLI for Argo CD GitOps repositories. Default
 commands render and compare desired state from checked-out files plus explicit

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -302,9 +302,16 @@ uncommitted changes, against committed `main`. `--repo . --ref feature
 are not supported yet; clone the repository locally and pass the local path.
 
 Manifest diffs default to unified diff output. `diff apps` and `diff app` also
-support `-o json` and `-o yaml`, which serialize the structured `[]diff.Result`
-payload. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
-`-o name` is not supported for manifest diffs.
+support `-o markdown`, `-o json`, and `-o yaml`. Markdown output is intended for
+review comments: it includes a summary plus expandable per-Application rendered
+manifest patches, and embeds successful diagnostics in the document. JSON and
+YAML serialize the structured `[]diff.Result` payload. Diagnostics remain on
+stderr for unified, JSON, and YAML output so stdout stays parseable. `-o name`
+is not supported for manifest diffs.
+
+```bash
+drydock diff apps --path ./current --path-orig ../base -o markdown
+```
 
 Unified diff output supports git-style ANSI color with
 `--color=auto|always|never`. The default, `auto`, colors only when writing to a
@@ -398,10 +405,11 @@ whose key is exactly `image`. It does not scan arbitrary string content, Secret
 manifests, top-level metadata/status, or ConfigMap data payloads. Use `-o name`
 to print current-only added image references, one per line. Removed-only image
 changes print no names but still return the diff exit code unless
-`--exit-code=false` is set. Use `-o json` or `-o yaml` for machine-readable
-`added`, `removed`, and `unchanged` image lists. Diagnostics remain on stderr so
-stdout stays valid JSON or YAML. Text image diffs use the same
-`--color=auto|always|never` behavior as manifest diffs.
+`--exit-code=false` is set. Use `-o markdown` for pull request comments, or
+`-o json` / `-o yaml` for machine-readable `added`, `removed`, and `unchanged`
+image lists. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
+Text image diffs use the same `--color=auto|always|never` behavior as manifest
+diffs.
 
 ## Diagnostics
 

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -265,6 +265,38 @@ a:hover {
   text-transform: uppercase;
 }
 
+.nav-reference-index {
+  margin-top: 0.35rem;
+}
+
+.nav-reference-index summary {
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1.3;
+  padding: 0.42rem 0.5rem;
+}
+
+.nav-reference-index summary:hover {
+  background: rgba(105, 215, 194, 0.08);
+  color: var(--navy-deep);
+}
+
+.nav-reference-index[open] summary {
+  color: var(--navy-deep);
+}
+
+.docs-nav .nav-reference-index ul {
+  margin-top: 0.2rem;
+  padding-left: 0.65rem;
+}
+
+.docs-nav .nav-reference-index a {
+  font-size: 0.84rem;
+}
+
 .docs-nav ul,
 .toc-panel ul {
   list-style: none;

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -212,12 +212,23 @@ a:hover {
 }
 
 .header-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   border-radius: 6px;
   color: var(--muted);
   font-size: 0.92rem;
   font-weight: 700;
+  line-height: 1.2;
   padding: 0.45rem 0.62rem;
   text-decoration: none;
+}
+
+.header-links svg {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
 }
 
 .header-links a:hover {

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -196,6 +196,13 @@ a:hover {
   -webkit-line-clamp: 2;
 }
 
+.search-match {
+  border-radius: 3px;
+  background: rgba(240, 138, 81, 0.28);
+  color: var(--navy-deep);
+  padding: 0 0.08em;
+}
+
 .header-links {
   display: flex;
   align-items: center;
@@ -238,6 +245,12 @@ a:hover {
   top: calc(var(--header-height) + 1rem);
 }
 
+.site-sidebar {
+  max-height: calc(100vh - var(--header-height) - 2rem);
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
 .docs-nav,
 .toc-panel {
   border-left: 3px solid var(--line-strong);
@@ -265,43 +278,65 @@ a:hover {
   text-transform: uppercase;
 }
 
-.nav-reference-index {
-  margin-top: 0.35rem;
-}
-
-.nav-reference-index summary {
-  border-radius: 6px;
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 0.86rem;
-  font-weight: 800;
-  line-height: 1.3;
-  padding: 0.42rem 0.5rem;
-}
-
-.nav-reference-index summary:hover {
-  background: rgba(105, 215, 194, 0.08);
-  color: var(--navy-deep);
-}
-
-.nav-reference-index[open] summary {
-  color: var(--navy-deep);
-}
-
-.docs-nav .nav-reference-index ul {
-  margin-top: 0.2rem;
-  padding-left: 0.65rem;
-}
-
-.docs-nav .nav-reference-index a {
-  font-size: 0.84rem;
-}
-
 .docs-nav ul,
 .toc-panel ul {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.nav-reference-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+}
+
+.nav-reference-row a {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.nav-reference-toggle {
+  border: 0;
+  border-bottom-right-radius: 6px;
+  border-top-right-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 800;
+  min-width: 2.1rem;
+  padding: 0.42rem 0.5rem;
+}
+
+.nav-reference-toggle::before {
+  content: "+";
+}
+
+.nav-reference-toggle[aria-expanded="true"]::before {
+  content: "-";
+}
+
+.nav-reference-row:hover a,
+.nav-reference-row:hover .nav-reference-toggle,
+.nav-reference-toggle:hover {
+  background: rgba(105, 215, 194, 0.08);
+  color: var(--navy-deep);
+}
+
+.docs-nav .nav-reference-index {
+  display: block;
+  margin-top: 0.2rem;
+  padding-left: 0.65rem;
+}
+
+.docs-nav .nav-reference-index[hidden] {
+  display: none;
+}
+
+.docs-nav .nav-reference-index a {
+  font-size: 0.84rem;
 }
 
 .docs-nav li + li,
@@ -369,6 +404,14 @@ a:hover {
   display: block;
   width: min(380px, 100%);
   height: auto;
+}
+
+.home-tagline {
+  max-width: 34rem;
+  margin: 0.35rem 0 0 clamp(0.35rem, 1vw, 0.85rem);
+  color: var(--quiet);
+  font-size: 0.98rem;
+  font-weight: 650;
 }
 
 .doc-header {
@@ -549,7 +592,9 @@ a:hover {
 }
 
 .mermaid-figure {
+  display: inline-block;
   overflow-x: auto;
+  max-width: 100%;
   margin: 1.5rem 0;
   border: 1px solid #213149;
   border-radius: 8px;
@@ -565,7 +610,106 @@ a:hover {
   display: block;
   max-width: 100%;
   height: auto;
-  margin: 0 auto;
+  margin: 0;
+}
+
+.workflow-map {
+  max-width: 58rem;
+  margin: 1.6rem 0 2rem;
+}
+
+.workflow-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.workflow-step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.workflow-step + .workflow-step {
+  margin-top: 0.65rem;
+}
+
+.workflow-step::before {
+  content: "";
+  position: absolute;
+  top: 2.45rem;
+  bottom: -0.85rem;
+  left: 1.08rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(105, 215, 194, 0.52), rgba(209, 115, 66, 0.22));
+}
+
+.workflow-step:last-child::before {
+  display: none;
+}
+
+.workflow-node {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 1px solid rgba(105, 215, 194, 0.58);
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--teal);
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.workflow-copy {
+  min-width: 0;
+  padding: 0.04rem 0 0.5rem;
+}
+
+.workflow-heading {
+  display: inline-block;
+  margin: 0;
+  color: var(--navy-deep);
+  font-size: 1rem;
+  font-weight: 850;
+  line-height: 1.25;
+  text-decoration: none;
+}
+
+a.workflow-heading:hover {
+  color: var(--link-hover);
+}
+
+.workflow-copy p:not(.workflow-heading) {
+  margin: 0.18rem 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.workflow-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.55rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.workflow-tags li {
+  border: 1px solid rgba(105, 215, 194, 0.28);
+  border-radius: 999px;
+  background: rgba(105, 215, 194, 0.08);
+  color: var(--navy-deep);
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.2;
+  padding: 0.22rem 0.48rem;
 }
 
 .highlight .c,
@@ -731,6 +875,8 @@ a:hover {
 
   .site-sidebar {
     position: static;
+    max-height: none;
+    overflow: visible;
     border-bottom: 1px solid var(--line);
     background: rgba(8, 17, 29, 0.94);
     padding: 0.85rem 1rem;

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -121,6 +121,81 @@ a:hover {
   height: auto;
 }
 
+.site-search {
+  position: relative;
+  flex: 1 1 220px;
+  max-width: 360px;
+}
+
+.site-search input {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: rgba(5, 11, 18, 0.78);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.92rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.site-search input::placeholder {
+  color: var(--quiet);
+}
+
+.search-panel {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: 0;
+  z-index: 30;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  box-shadow: 0 16px 42px var(--shadow);
+}
+
+.search-panel ul {
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+}
+
+.search-panel li + li {
+  margin-top: 0.15rem;
+}
+
+.search-panel a {
+  display: block;
+  border-radius: 6px;
+  color: var(--ink);
+  padding: 0.55rem 0.65rem;
+  text-decoration: none;
+}
+
+.search-panel li[aria-selected="true"] a,
+.search-panel a:hover {
+  background: rgba(105, 215, 194, 0.1);
+  color: var(--navy-deep);
+}
+
+.search-panel span {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.search-panel small {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .header-links {
   display: flex;
   align-items: center;
@@ -279,6 +354,28 @@ a:hover {
   line-height: 1.05;
 }
 
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.page-actions a {
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  color: var(--navy-deep);
+  font-size: 0.82rem;
+  font-weight: 800;
+  padding: 0.38rem 0.56rem;
+  text-decoration: none;
+}
+
+.page-actions a:hover {
+  border-color: var(--rust-bright);
+  color: var(--link-hover);
+}
+
 .lead {
   max-width: 64ch;
   margin: 0.9rem 0 0;
@@ -323,6 +420,24 @@ a:hover {
 .doc-content h3 {
   margin-top: 1.65rem;
   font-size: 1.2rem;
+}
+
+.heading-permalink {
+  opacity: 0;
+  color: var(--quiet);
+  font-size: 0.82em;
+  text-decoration: none;
+}
+
+.doc-content h2:hover .heading-permalink,
+.doc-content h2:focus-within .heading-permalink,
+.doc-content h3:hover .heading-permalink,
+.doc-content h3:focus-within .heading-permalink {
+  opacity: 1;
+}
+
+.heading-permalink:focus-visible {
+  opacity: 1;
 }
 
 .doc-content p,
@@ -447,6 +562,37 @@ a:hover {
   padding: 0.65rem 1rem;
 }
 
+.doc-content blockquote p:first-child {
+  margin-top: 0;
+}
+
+.doc-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.doc-content details {
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--teal);
+  border-radius: 8px;
+  background: rgba(20, 33, 51, 0.78);
+  margin: 1rem 0;
+  padding: 0.8rem 1rem;
+}
+
+.doc-content summary {
+  color: var(--navy-deep);
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.doc-content details[open] summary {
+  margin-bottom: 0.65rem;
+}
+
+.doc-content details > :last-child {
+  margin-bottom: 0;
+}
+
 .doc-index {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -539,6 +685,11 @@ a:hover {
 
   .header-links {
     justify-content: flex-start;
+  }
+
+  .site-search {
+    width: 100%;
+    max-width: none;
   }
 
   .site-shell {

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -4,6 +4,15 @@ document.addEventListener("DOMContentLoaded", () => {
     initSearch(searchForm);
   }
 
+  document.querySelectorAll(".nav-reference-toggle").forEach((button) => {
+    initNavReferenceToggle(button);
+  });
+
+  const sidebar = document.querySelector(".site-sidebar");
+  if (sidebar) {
+    initSidebarPersistence(sidebar);
+  }
+
   document.querySelectorAll(".doc-content pre").forEach((block, index) => {
     const button = document.createElement("button");
     button.type = "button";
@@ -39,6 +48,63 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
+function initNavReferenceToggle(button) {
+  const storageKey = "drydock.nav.reference.expanded";
+  const targetID = button.getAttribute("aria-controls");
+  if (!targetID) {
+    return;
+  }
+  const target = document.getElementById(targetID);
+  if (!target) {
+    return;
+  }
+
+  const referenceContext = button.dataset.referenceContext === "true";
+  const storedExpanded = referenceContext ? null : storageGet("localStorage", storageKey);
+  if (storedExpanded !== null) {
+    setNavReferenceExpanded(button, target, storedExpanded === "true");
+  }
+
+  button.addEventListener("click", () => {
+    const expanded = button.getAttribute("aria-expanded") === "true";
+    const nextExpanded = !expanded;
+    setNavReferenceExpanded(button, target, nextExpanded);
+    storageSet("localStorage", storageKey, String(nextExpanded));
+  });
+}
+
+function setNavReferenceExpanded(button, target, expanded) {
+  button.setAttribute("aria-expanded", expanded ? "true" : "false");
+  target.hidden = !expanded;
+}
+
+function initSidebarPersistence(sidebar) {
+  const storageKey = "drydock.sidebar.scrollTop";
+  const storedScrollTop = Number.parseInt(storageGet("sessionStorage", storageKey) || "", 10);
+
+  if (Number.isFinite(storedScrollTop) && storedScrollTop > 0) {
+    window.requestAnimationFrame(() => {
+      sidebar.scrollTop = storedScrollTop;
+    });
+  }
+
+  let scheduled = false;
+  sidebar.addEventListener(
+    "scroll",
+    () => {
+      if (scheduled) {
+        return;
+      }
+      scheduled = true;
+      window.requestAnimationFrame(() => {
+        scheduled = false;
+        storageSet("sessionStorage", storageKey, String(Math.round(sidebar.scrollTop)));
+      });
+    },
+    { passive: true },
+  );
+}
+
 function initSearch(form) {
   const input = form.querySelector("input[type='search']");
   const panel = form.querySelector(".search-panel");
@@ -70,6 +136,12 @@ function initSearch(form) {
     activeIndex = -1;
   };
 
+  const clearSearch = () => {
+    input.value = "";
+    resultsList.replaceChildren();
+    closeResults();
+  };
+
   const setActive = (nextIndex) => {
     const items = Array.from(resultsList.querySelectorAll("[role='option']"));
     if (items.length === 0) {
@@ -85,16 +157,21 @@ function initSearch(form) {
     input.setAttribute("aria-activedescendant", items[activeIndex].id);
   };
 
-  const renderResults = (matches) => {
+  const renderResults = (matches, terms) => {
     resultsList.replaceChildren();
-    matches.forEach((page, index) => {
+    matches.forEach((match, index) => {
+      const page = match.page;
       const item = document.createElement("li");
       const link = document.createElement("a");
+      const title = document.createElement("span");
+      const snippet = document.createElement("small");
       item.id = `site-search-result-${index}`;
       item.setAttribute("role", "option");
       item.setAttribute("aria-selected", "false");
       link.href = page.url;
-      link.innerHTML = `<span>${escapeHTML(page.title)}</span><small>${escapeHTML(page.summary || page.section || "")}</small>`;
+      appendHighlightedText(title, page.title || "", terms);
+      appendHighlightedText(snippet, match.snippet || page.summary || page.section || "", terms);
+      link.append(title, snippet);
       item.append(link);
       resultsList.append(item);
     });
@@ -124,18 +201,34 @@ function initSearch(form) {
             return null;
           }
           const score = terms.reduce((total, term) => total + (title.includes(term) ? 3 : 1), 0);
-          return { page, score };
+          return { page, score, snippet: searchSnippet(page, terms) };
         })
         .filter(Boolean)
         .sort((left, right) => right.score - left.score || left.page.title.localeCompare(right.page.title))
-        .slice(0, 8)
-        .map((match) => match.page);
+        .slice(0, 8);
 
-      renderResults(matches);
+      renderResults(matches, terms);
     } catch {
       closeResults();
     }
   };
+
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+    if (event.key === "/" && !isEditable(event.target)) {
+      event.preventDefault();
+      input.focus();
+      input.select();
+      runSearch();
+      return;
+    }
+    if (event.key === "Escape" && (document.activeElement === input || input.value || !panel.hidden)) {
+      event.preventDefault();
+      clearSearch();
+    }
+  });
 
   input.addEventListener("input", runSearch);
   input.addEventListener("focus", runSearch);
@@ -153,7 +246,8 @@ function initSearch(form) {
   input.addEventListener("keydown", (event) => {
     const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
     if (event.key === "Escape") {
-      closeResults();
+      event.preventDefault();
+      clearSearch();
       return;
     }
     if (event.key === "ArrowDown" && items.length > 0) {
@@ -179,10 +273,101 @@ function initSearch(form) {
   });
 }
 
-function escapeHTML(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
+function appendHighlightedText(parent, value, terms) {
+  const text = String(value);
+  const pattern = highlightPattern(terms);
+  if (!pattern) {
+    parent.textContent = text;
+    return;
+  }
+
+  let offset = 0;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index > offset) {
+      parent.append(document.createTextNode(text.slice(offset, match.index)));
+    }
+    const mark = document.createElement("mark");
+    mark.className = "search-match";
+    mark.textContent = match[0];
+    parent.append(mark);
+    offset = match.index + match[0].length;
+  }
+  if (offset < text.length) {
+    parent.append(document.createTextNode(text.slice(offset)));
+  }
+}
+
+function highlightPattern(terms) {
+  const uniqueTerms = Array.from(new Set(terms.filter(Boolean))).sort((left, right) => right.length - left.length);
+  if (uniqueTerms.length === 0) {
+    return null;
+  }
+  return new RegExp(uniqueTerms.map(escapeRegExp).join("|"), "gi");
+}
+
+function searchSnippet(page, terms) {
+  const source = normalizeSearchText(page.content || page.summary || page.section || "");
+  if (!source) {
+    return page.section || "";
+  }
+
+  const lowerSource = source.toLowerCase();
+  const firstIndex = terms.reduce((best, term) => {
+    const index = lowerSource.indexOf(term);
+    if (index < 0) {
+      return best;
+    }
+    return best < 0 ? index : Math.min(best, index);
+  }, -1);
+
+  if (firstIndex < 0) {
+    return truncateSnippet(source, 180);
+  }
+
+  const context = 84;
+  const start = Math.max(0, firstIndex - context);
+  const end = Math.min(source.length, firstIndex + context);
+  const prefix = start > 0 ? "... " : "";
+  const suffix = end < source.length ? " ..." : "";
+  return `${prefix}${source.slice(start, end).trim()}${suffix}`;
+}
+
+function normalizeSearchText(value) {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function truncateSnippet(value, length) {
+  const text = normalizeSearchText(value);
+  if (text.length <= length) {
+    return text;
+  }
+  return `${text.slice(0, length).trim()} ...`;
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isEditable(target) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return target.isContentEditable || tagName === "input" || tagName === "textarea" || tagName === "select";
+}
+
+function storageGet(storageName, key) {
+  try {
+    return window[storageName].getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(storageName, key, value) {
+  try {
+    window[storageName].setItem(key, value);
+  } catch {
+    // Storage can be disabled by browser privacy settings. The site still works without it.
+  }
 }

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -1,4 +1,9 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const searchForm = document.querySelector(".site-search");
+  if (searchForm) {
+    initSearch(searchForm);
+  }
+
   document.querySelectorAll(".doc-content pre").forEach((block, index) => {
     const button = document.createElement("button");
     button.type = "button";
@@ -23,4 +28,161 @@ document.addEventListener("DOMContentLoaded", () => {
 
     block.append(button);
   });
+
+  document.querySelectorAll(".doc-content h2[id], .doc-content h3[id]").forEach((heading) => {
+    const link = document.createElement("a");
+    link.className = "heading-permalink";
+    link.href = `#${heading.id}`;
+    link.setAttribute("aria-label", `Link to ${heading.textContent}`);
+    link.textContent = "#";
+    heading.append(" ", link);
+  });
 });
+
+function initSearch(form) {
+  const input = form.querySelector("input[type='search']");
+  const panel = form.querySelector(".search-panel");
+  const resultsList = form.querySelector("#site-search-results");
+  const indexUrl = form.dataset.searchIndex;
+  let pages = [];
+  let activeIndex = -1;
+
+  if (!input || !panel || !resultsList || !indexUrl) {
+    return;
+  }
+
+  const loadIndex = async () => {
+    if (pages.length > 0) {
+      return pages;
+    }
+    const response = await fetch(indexUrl, { credentials: "same-origin" });
+    if (!response.ok) {
+      throw new Error(`Search index unavailable: ${response.status}`);
+    }
+    pages = await response.json();
+    return pages;
+  };
+
+  const closeResults = () => {
+    panel.hidden = true;
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const setActive = (nextIndex) => {
+    const items = Array.from(resultsList.querySelectorAll("[role='option']"));
+    if (items.length === 0) {
+      activeIndex = -1;
+      input.removeAttribute("aria-activedescendant");
+      return;
+    }
+
+    activeIndex = (nextIndex + items.length) % items.length;
+    items.forEach((item, index) => {
+      item.setAttribute("aria-selected", index === activeIndex ? "true" : "false");
+    });
+    input.setAttribute("aria-activedescendant", items[activeIndex].id);
+  };
+
+  const renderResults = (matches) => {
+    resultsList.replaceChildren();
+    matches.forEach((page, index) => {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      item.id = `site-search-result-${index}`;
+      item.setAttribute("role", "option");
+      item.setAttribute("aria-selected", "false");
+      link.href = page.url;
+      link.innerHTML = `<span>${escapeHTML(page.title)}</span><small>${escapeHTML(page.summary || page.section || "")}</small>`;
+      item.append(link);
+      resultsList.append(item);
+    });
+
+    panel.hidden = matches.length === 0;
+    input.setAttribute("aria-expanded", matches.length === 0 ? "false" : "true");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const runSearch = async () => {
+    const query = input.value.trim().toLowerCase();
+    if (query.length < 2) {
+      closeResults();
+      resultsList.replaceChildren();
+      return;
+    }
+
+    try {
+      const terms = query.split(/\s+/).filter(Boolean);
+      const loadedPages = await loadIndex();
+      const matches = loadedPages
+        .map((page) => {
+          const title = (page.title || "").toLowerCase();
+          const haystack = `${title} ${page.section || ""} ${page.summary || ""} ${page.content || ""}`.toLowerCase();
+          if (!terms.every((term) => haystack.includes(term))) {
+            return null;
+          }
+          const score = terms.reduce((total, term) => total + (title.includes(term) ? 3 : 1), 0);
+          return { page, score };
+        })
+        .filter(Boolean)
+        .sort((left, right) => right.score - left.score || left.page.title.localeCompare(right.page.title))
+        .slice(0, 8)
+        .map((match) => match.page);
+
+      renderResults(matches);
+    } catch {
+      closeResults();
+    }
+  };
+
+  input.addEventListener("input", runSearch);
+  input.addEventListener("focus", runSearch);
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].click();
+      return;
+    }
+    if (items[0]) {
+      items[0].click();
+    }
+  });
+  input.addEventListener("keydown", (event) => {
+    const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
+    if (event.key === "Escape") {
+      closeResults();
+      return;
+    }
+    if (event.key === "ArrowDown" && items.length > 0) {
+      event.preventDefault();
+      setActive(activeIndex + 1);
+      return;
+    }
+    if (event.key === "ArrowUp" && items.length > 0) {
+      event.preventDefault();
+      setActive(activeIndex - 1);
+      return;
+    }
+    if (event.key === "Enter" && activeIndex >= 0 && items[activeIndex]) {
+      event.preventDefault();
+      items[activeIndex].click();
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!form.contains(event.target)) {
+      closeResults();
+    }
+  });
+}
+
+function escapeHTML(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,16 +2,18 @@
 title: drydock
 ---
 
+Review Argo CD repository changes before they become controller work.
+
 Inspect your Argo CD fleet without getting wet.
 
 drydock is a fast, single static Go binary and embeddable Go module for
 runtime-offline Argo CD desired-state analysis. It discovers, renders, tests,
-diffs, and diagnoses GitOps Applications with native Go renderers, no live
-cluster, no Argo CD server, and no default shellouts.
+diffs, and diagnoses GitOps Applications with native Go renderers, no Argo CD
+server, no Kubernetes credentials, and no default shellouts.
 
-Use it locally or in CI to review rendered manifest diffs, catch render
-failures, inspect image changes, and validate GitOps repositories before Argo CD
-syncs them.
+Use it locally or in CI to answer operator questions that are hard to review in
+raw Git: which Applications render, which desired resources changed, which
+images moved, and which repository inputs need attention.
 
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 
@@ -23,6 +25,8 @@ syncs them.
   without Kubernetes or Argo CD credentials.
 - [Local diffs](/workflows/local-diffs/) covers local tree and Git ref
   comparisons.
+- [How it works](/concepts/how-it-works/) explains discovery, source
+  acquisition, rendering, normalization, and reporting.
 - [Troubleshooting](/troubleshooting/) maps common operator symptoms to the
   first commands to run.
 
@@ -36,13 +40,34 @@ drydock diff images --repo . --ref HEAD --ref-orig main
 drydock diag --path .
 ```
 
+## Choose Your Workflow
+
+| Need | Start with | Read next |
+| --- | --- | --- |
+| Confirm the fleet renders | `drydock test apps --path .` | [Getting started](/getting-started/) |
+| Review manifest changes | `drydock diff apps --repo . --ref HEAD --ref-orig main -o markdown` | [GitHub Actions](/workflows/github-actions/) |
+| Scan image movement | `drydock diff images --repo . --ref HEAD --ref-orig main -o markdown` | [Local diffs](/workflows/local-diffs/) |
+| Explain warnings or failures | `drydock diag --path . --cache-events` | [Troubleshooting](/troubleshooting/) |
+| Validate cache-only operation | `drydock test apps --path . --offline` | [Source acquisition](/concepts/source-acquisition/) |
+
+## What It Covers
+
+| Capability | Result |
+| --- | --- |
+| Discover | Find committed and supported generated Argo CD Applications. |
+| Render | Inflate directory, Kustomize, Helm, Jsonnet, and supported remote sources. |
+| Test | Prove Applications render before Argo CD syncs them. |
+| Diff | Compare rendered desired manifests across paths or Git refs. |
+| Inspect images | Report rendered image reference additions and removals. |
+| Diagnose | Surface repository, project, source, cache, plugin, and settings issues. |
+
 ## Operating Model
 
 drydock is runtime-offline: render, test, diff, image, and diagnostic commands
-do not call live Kubernetes or Argo CD. Declared Git, HTTP Helm, OCI Helm, and
+do not call Kubernetes or Argo CD APIs. Declared Git, HTTP Helm, OCI Helm, and
 remote Kustomize sources can still be fetched into explicit caches unless
 `--offline` is set.
 
-Use these curated pages for day-to-day operation. Use the reference docs when
-you need dense details such as full compatibility notes, action inputs, source
-acquisition flags, or plugin policy schema.
+Use these curated pages for day-to-day operation. Use the reference docs for
+full compatibility notes, action inputs, source acquisition flags, and plugin
+policy schema.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,10 +2,6 @@
 title: drydock
 ---
 
-Review Argo CD repository changes before they become controller work.
-
-Inspect your Argo CD fleet without getting wet.
-
 drydock is a fast, single static Go binary and embeddable Go module for
 runtime-offline Argo CD desired-state analysis. It discovers, renders, tests,
 diffs, and diagnoses GitOps Applications with native Go renderers, no Argo CD

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -6,14 +6,7 @@ drydock turns repository inputs into reviewable Argo CD desired-state reports.
 It uses the same pipeline for `get`, `test`, `diff`, image inspection, and
 diagnostics, with two repository snapshots for diff commands.
 
-```mermaid
-flowchart LR
-  repo[Repository tree or local Git ref] --> discover[Discover Applications and settings]
-  discover --> acquire[Resolve declared sources and caches]
-  acquire --> render[Render desired manifests with native Go renderers]
-  render --> normalize[Normalize resources and apply filters]
-  normalize --> report[Report tests, diffs, images, and diagnostics]
-```
+{{< workflow name="how-it-works" >}}
 
 ## Discovery
 
@@ -40,6 +33,13 @@ Jsonnet, Kustomize, Helm, Kustomize `helmCharts`, remote Kustomize resources,
 and supported chart-only Helm sources. Config management plugin execution is
 disabled by default; trusted plugin policy and explicit opt-in are required for
 exec plugins.
+
+## Normalization
+
+Rendered manifests pass through Argo-aware normalization before diff and image
+inspection. drydock applies supported resource filters, ignore settings, known
+type handling, repeated-resource behavior, and default noise suppression for
+common chart metadata.
 
 ## Reporting
 

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -1,0 +1,54 @@
+---
+title: How It Works
+---
+
+drydock turns repository inputs into reviewable Argo CD desired-state reports.
+It uses the same pipeline for `get`, `test`, `diff`, image inspection, and
+diagnostics, with two repository snapshots for diff commands.
+
+```mermaid
+flowchart LR
+  repo[Repository tree or local Git ref] --> discover[Discover Applications and settings]
+  discover --> acquire[Resolve declared sources and caches]
+  acquire --> render[Render desired manifests with native Go renderers]
+  render --> normalize[Normalize resources and apply filters]
+  normalize --> report[Report tests, diffs, images, and diagnostics]
+```
+
+## Discovery
+
+drydock scans repository YAML for Argo CD `Application`, supported
+`ApplicationSet`, `AppProject`, and settings objects. It can also render
+explicit Kustomize discovery entrypoints when bootstrap inputs are not committed
+as inflated Argo CD objects.
+
+Supported ApplicationSet generators expand offline from local files, lists,
+matrix and merge combinations, or explicit provider fixtures. Unsupported
+generators produce diagnostics instead of guessing.
+
+## Source Resolution
+
+Application sources resolve from repo maps, local paths, declared Git sources,
+Helm chart sources, remote Kustomize resources, and drydock caches. Default
+runs may fetch declared Git, HTTP Helm, OCI Helm, and remote Kustomize inputs
+into explicit caches. `--offline` makes those source lookups cache-only.
+
+## Rendering
+
+drydock renders desired manifests with native Go renderers for directory,
+Jsonnet, Kustomize, Helm, Kustomize `helmCharts`, remote Kustomize resources,
+and supported chart-only Helm sources. Config management plugin execution is
+disabled by default; trusted plugin policy and explicit opt-in are required for
+exec plugins.
+
+## Reporting
+
+`test` reports whether selected Applications render. `diff apps` compares
+desired manifests between two snapshots. `diff images` projects rendered image
+references from those manifests. `diag` reports repository, source, settings,
+and compatibility issues without printing manifest bodies.
+
+Diagnostics and structured outputs are kept separate so JSON, YAML, and name
+outputs remain machine-parseable. Markdown diff output is intended for pull
+request comments and includes the review summary with expandable rendered
+manifest changes.

--- a/site/content/concepts/topologies.md
+++ b/site/content/concepts/topologies.md
@@ -1,0 +1,73 @@
+---
+title: Repository Topologies
+---
+
+Match the command to the shape of the repository before tuning flags.
+
+## Committed Applications
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diff apps --repo . --ref HEAD --ref-orig main
+```
+
+Use this when Argo CD `Application` manifests are committed directly.
+
+## App-Of-Apps
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+```
+
+Fleet commands render bootstrap Applications to discover rendered child
+Applications and settings. Add `--discovery-mode static` when only committed
+objects should count.
+
+## Kustomize Bootstrap
+
+```bash
+drydock get apps --path . --discover-kustomize clusters/prod/argocd
+drydock test apps --path . --discover-kustomize clusters/prod/argocd
+```
+
+Use this when Argo CD objects live behind Kustomize overlays instead of
+committed inflated YAML.
+
+## Multi-Repository Sources
+
+```bash
+drydock test apps --path . \
+  --repo-map https://github.com/example/platform-config=../platform-config
+drydock test apps --path . --offline
+```
+
+Use repo maps for adjacent checkouts and `--offline` for cache-only runs.
+
+## ApplicationSets
+
+```bash
+drydock get apps --path .
+drydock get apps --path . \
+  --appset-provider-fixture fixtures/appset-providers.yaml
+```
+
+Local generators expand offline. Provider-backed generators need explicit
+fixture files.
+
+## Plugin Sources
+
+```bash
+drydock test apps --path .
+drydock test apps --path . --plugin-policy-ref main --enable-plugins
+```
+
+Start without plugin execution. Add trusted policy flags only when the
+repository depends on non-native plugin rendering.
+
+For deeper guidance, see the canonical
+[repository topology guide](/docs/topologies/),
+[source acquisition](/docs/source-acquisition/),
+[ApplicationSet reference](/docs/applicationsets/), and
+[plugin policy](/docs/plugin-policy/).

--- a/site/content/cookbook/_index.md
+++ b/site/content/cookbook/_index.md
@@ -1,0 +1,15 @@
+---
+title: Operator Cookbook
+---
+
+Short command recipes for common drydock operations.
+
+## Recipes
+
+- [Pull request checks](pr-checks/)
+- [Source access](source-access/)
+- [Generated Applications](generated-apps/)
+- [Troubleshooting renders](troubleshooting-renders/)
+
+For the full CLI reference, use the [usage guide](/docs/usage/). For choosing
+commands by repository layout, use [repository topologies](/concepts/topologies/).

--- a/site/content/cookbook/generated-apps.md
+++ b/site/content/cookbook/generated-apps.md
@@ -1,0 +1,45 @@
+---
+title: Generated Applications
+---
+
+## List Generated Apps
+
+```bash
+drydock get apps --path .
+```
+
+Use this first for app-of-apps and `ApplicationSet` repositories. It shows the
+Applications drydock can discover before rendering tests or diffs.
+
+## Render Kustomize Bootstrap Objects
+
+```bash
+drydock get apps --path . --discover-kustomize clusters/prod/argocd
+drydock test apps --path . --discover-kustomize clusters/prod/argocd
+```
+
+Use this when committed files are Kustomize inputs that render Argo CD objects.
+
+## Supply Provider Fixtures
+
+```bash
+drydock get apps --path . \
+  --appset-provider-fixture fixtures/appset-providers.yaml
+drydock test apps --path . \
+  --appset-provider-fixture fixtures/appset-providers.yaml
+```
+
+Provider-backed `ApplicationSet` generators are fixture-backed offline. Keep
+fixtures in the repository or prepare them in CI before running drydock.
+
+## Disable Recursive Rendered Discovery
+
+```bash
+drydock get apps --path . --discovery-mode static
+drydock get apps --path . --max-discovery-depth 0
+```
+
+Use static discovery when only committed Argo CD objects should be considered.
+
+Details live in [repository topologies](/docs/topologies/) and the
+[ApplicationSet reference](/docs/applicationsets/).

--- a/site/content/cookbook/pr-checks.md
+++ b/site/content/cookbook/pr-checks.md
@@ -1,0 +1,61 @@
+---
+title: Pull Request Checks
+---
+
+## Use The PR Action
+
+```yaml
+name: drydock
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  drydock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sholdee/drydock/pr-action@main
+        with:
+          version: vX.Y.Z
+          comment-mode: both
+          skip-secrets: "true"
+```
+
+## Own The Commands
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    fetch-depth: 0
+- uses: sholdee/drydock/setup-action@main
+  with:
+    version: vX.Y.Z
+- run: drydock test apps --path .
+- run: >-
+    drydock diff apps --repo . --ref HEAD
+    --ref-orig origin/${{ github.base_ref }}
+- run: >-
+    drydock diff images --repo . --ref HEAD
+    --ref-orig origin/${{ github.base_ref }} -o markdown
+```
+
+## Tighten The Gate
+
+```yaml
+with:
+  strict: "true"
+  strict-changed-only: "true"
+  fail-on-diff: "true"
+```
+
+Use `pr-action` for the standard render test, manifest diff, image diff,
+artifacts, source cache, and sticky comments. Use `setup-action` when workflow
+YAML should own every drydock command.
+
+Full inputs, outputs, permissions, and token behavior are in the
+[GitHub Actions guide](/docs/github-actions/).

--- a/site/content/cookbook/source-access.md
+++ b/site/content/cookbook/source-access.md
@@ -1,0 +1,49 @@
+---
+title: Source Access
+---
+
+## Map Adjacent Repositories
+
+```bash
+drydock test apps --path . \
+  --repo-map https://github.com/example/platform-config=../platform-config
+```
+
+Use `--repo-map` when CI or a developer workstation already checked out a
+source repository.
+
+## Prove Cache-Only Runs
+
+```bash
+drydock test apps --path .
+drydock test apps --path . --offline
+```
+
+The first command can populate drydock caches. The second command requires
+local files, repo maps, or existing cache entries.
+
+## Inspect Cache Events
+
+```bash
+drydock diag --path . --cache-events -o json
+drydock cache list -o json
+```
+
+Use cache events to see which source acquisitions were used during diagnostics,
+then inspect recognized cache entries.
+
+## Pass Explicit Credentials
+
+```bash
+drydock test apps --path . \
+  --git-ssh-key-file ./ci/deploy_key \
+  --git-known-hosts-file ./ci/known_hosts
+drydock test apps --path . \
+  --helm-username "$HELM_USER" \
+  --helm-password "$HELM_PASSWORD"
+drydock test apps --path . --registry-config ./ci/registry-config.json
+```
+
+Credential handling is explicit and non-interactive. Complete cache, auth,
+Helm, Git, and remote Kustomize behavior is in
+[source acquisition](/docs/source-acquisition/).

--- a/site/content/cookbook/troubleshooting-renders.md
+++ b/site/content/cookbook/troubleshooting-renders.md
@@ -1,0 +1,56 @@
+---
+title: Troubleshooting Renders
+---
+
+## Start Narrow
+
+```bash
+drydock get apps --path .
+drydock test apps --path .
+drydock diag --path .
+```
+
+`get apps` checks discovery. `test apps` checks render health without manifest
+output. `diag` reports diagnostics from the same discovery and render path.
+
+## Isolate One Application
+
+```bash
+drydock test app argocd/my-app --path .
+drydock build app argocd/my-app --path .
+```
+
+Use `NAMESPACE/NAME` when names are reused across namespaces.
+
+## Check Source Access
+
+```bash
+drydock test apps --path . --offline
+drydock diag --path . --cache-events -o json
+```
+
+If offline mode fails, add repo maps or populate caches before expecting
+cache-only CI runs to pass.
+
+## Check Plugins
+
+```bash
+drydock test apps --path .
+drydock test apps --path . --plugin-policy-ref main --enable-plugins
+```
+
+Run without plugin execution first. Add trusted plugin policy flags only when
+the failing source requires them.
+
+## Remove Diff Noise
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main --show-ignored-fields
+drydock diff apps --repo . --ref HEAD --ref-orig main --strip-attr checksum/config
+```
+
+Use `--show-ignored-fields` to inspect default ignored fields, and
+`--strip-attr` for extra label or annotation noise.
+
+For symptom-based routing, see [Troubleshooting](/troubleshooting/). For full
+command behavior, see the [usage guide](/docs/usage/).

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -2,7 +2,9 @@
 title: Troubleshooting
 ---
 
-Start with the command that exercises the same path as the failing workflow:
+Start with the symptom. Run the smallest command that exercises the failing
+path, then add `--strict` when warnings should fail the run or `-o json` /
+`-o yaml` when another tool needs stable diagnostics.
 
 ```bash
 drydock get apps --path .
@@ -10,10 +12,7 @@ drydock test apps --path .
 drydock diag --path .
 ```
 
-Add `--strict` when warnings should fail the run, and use `-o json` or
-`-o yaml` when you need stable machine-readable diagnostics.
-
-## No Applications Discovered
+## Symptom: No Applications Discovered
 
 Check that the selected `--path` points at the GitOps repository root or pass
 the directory that contains Argo CD objects. If the repository stores bootstrap
@@ -24,7 +23,10 @@ entrypoint:
 drydock get apps --path . --discover-kustomize clusters/prod/argocd
 ```
 
-## Render Fails In CI But Works Locally
+If the repository uses ApplicationSet providers, make sure the workflow passes
+the same fixture inputs used for local verification.
+
+## Symptom: Render Fails In CI But Works Locally
 
 Confirm whether CI has the same source access and caches. Default runs may
 fetch declared Git, Helm, OCI Helm, and remote Kustomize sources into drydock
@@ -36,7 +38,7 @@ drydock test apps --path . --offline
 drydock diag --path . --cache-events
 ```
 
-## Changed-Only Falls Back To All Apps
+## Symptom: Changed-Only Falls Back To All Apps
 
 Multi-Application diffs use changed-only selection by default. If a changed
 file cannot be safely mapped to Application inputs, non-strict mode warns and
@@ -46,7 +48,7 @@ renders all Applications. Use strict mode when ambiguous ownership should fail:
 drydock diff apps --repo . --ref HEAD --ref-orig main --strict-changed-only
 ```
 
-## Plugin Source Fails Closed
+## Symptom: Plugin Source Fails Closed
 
 The CLI and default Go client do not execute config management plugin commands
 by default. Safe Kustomize wrapper plugins may render natively. Other plugin
@@ -59,12 +61,25 @@ drydock test apps --path . --plugin-policy-ref main --enable-plugins
 
 See [Plugin policy](/plugin-policy/) for the operator gate.
 
-## Diff Noise Is Hiding Or Showing Too Much
+## Symptom: Diff Noise Is Hiding Or Showing Too Much
 
 drydock hides common Helm chart/version labels and pod-template checksum
 annotations by default. Use `--show-ignored-fields` to inspect them, or
 `--strip-attr KEY` to remove additional label or annotation keys before
 comparison.
+
+## Symptom: PR Comment Is Too Large Or Hard To Scan
+
+Use markdown output for the review surface and keep full artifacts for deeper
+inspection:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig main -o markdown
+drydock diff images --repo . --ref HEAD --ref-orig main -o markdown
+```
+
+For sensitive or noisy resource classes, use explicit filters such as
+`--skip-secrets`, `--skip-crds`, or repeatable `--strip-attr KEY`.
 
 For deeper reference, see the [CLI usage guide](/docs/usage/), [Compatibility](/compatibility/),
 and [Source acquisition](/concepts/source-acquisition/).

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -9,8 +9,8 @@ drydock publishes two repository-local composite actions:
   artifacts, and optionally maintain sticky PR comments.
 
 Use `setup-action` when you want to own the CLI commands. Use `pr-action` when
-you want the standard render test, manifest diff, image diff, source cache, and
-comment workflow.
+you want the standard render test, markdown manifest diff, image diff, source
+cache, artifacts, and pull request comment workflow.
 
 ## Manual CLI Workflow
 
@@ -66,7 +66,7 @@ The PR action checks out the pull request, fetches the base ref, runs
 `drydock test apps`, renders the desired-state manifest diff, writes full diff
 artifacts when differences are found, and comments in trusted same-repository
 pull requests. Image diff comments are available as a companion signal. Fork
-pull requests skip comments and source-cache save by default.
+pull requests skip comments and source-cache restore/save by default.
 
 ## Manifest Diff Comment Shape
 
@@ -77,17 +77,20 @@ reviewable rendered diff:
 ````markdown
 ## drydock desired state diff
 
-**Summary:** 1 app, 2 resources, +4/-2.
+**Summary:** 2 apps, 3 resources, +12/-5.
 
 <details open>
-<summary>renovate (+4/-2, 2 resources)</summary>
+<summary>payments-api (+9/-3, 2 resources)</summary>
 
 ```diff
---- Application: renovate apps/Deployment: renovate/renovate-operator
-+++ Application: renovate apps/Deployment: renovate/renovate-operator
-@@ -47,7 +47,7 @@
--          image: ghcr.io/example/renovate:1.0.0
-+          image: ghcr.io/example/renovate:1.1.0
+--- Application: payments-api apps/Deployment: payments/payments-api
++++ Application: payments-api apps/Deployment: payments/payments-api
+@@ -31,7 +31,7 @@
+-        app.kubernetes.io/version: 2026.05.0
++        app.kubernetes.io/version: 2026.05.1
+@@ -48,7 +48,7 @@
+-          image: registry.example.com/payments-api:2026.05.0
++          image: registry.example.com/payments-api:2026.05.1
 ```
 
 </details>
@@ -112,8 +115,8 @@ quickly scanning added and removed rendered image references:
 
 | Change | Image |
 | --- | --- |
-| added | `registry.example.com/app:v2` |
-| removed | `registry.example.com/app:v1` |
+| added | `registry.example.com/payments-api:2026.05.1` |
+| removed | `registry.example.com/payments-api:2026.05.0` |
 ```
 
 Run image diff markdown directly when building a custom workflow:

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -2,10 +2,10 @@
 title: Local Diffs
 ---
 
-Use local diffs to compare desired state before opening or merging a pull
-request, or any time you want to inspect repository changes before Argo CD sees
-them. drydock renders both sides and compares desired manifests; it does not ask
-live Argo CD or Kubernetes for current state.
+Use local diffs to review desired-state changes before opening or merging a
+pull request. drydock renders both sides and compares Argo CD desired
+manifests, so operators can review resource and image changes from repository
+inputs alone.
 
 ## Compare Two Trees
 
@@ -16,7 +16,8 @@ drydock diff images --path . --path-orig ../baseline -o markdown
 ```
 
 Use this when you already have a separate baseline checkout or want to inspect
-uncommitted changes in the current working tree.
+uncommitted changes in the current working tree. Add `--offline` when the
+review must use only local files, repo maps, and existing drydock cache entries.
 
 ## Compare Git Refs
 
@@ -47,29 +48,34 @@ drydock diff apps --path . --path-orig ../baseline -o markdown
 drydock diff images --path . --path-orig ../baseline -o markdown
 ```
 
-Manifest markdown is the primary review surface:
+Manifest markdown is the primary review surface. It keeps the operator summary
+near the top and puts rendered resource patches behind per-Application details:
 
 ````markdown
 ## drydock desired state diff
 
-**Summary:** 1 app, 2 resources, +4/-2.
+**Summary:** 2 apps, 3 resources, +12/-5.
 
 <details open>
-<summary>renovate (+4/-2, 2 resources)</summary>
+<summary>payments-api (+9/-3, 2 resources)</summary>
 
 ```diff
---- Application: renovate apps/Deployment: renovate/renovate-operator
-+++ Application: renovate apps/Deployment: renovate/renovate-operator
-@@ -47,7 +47,7 @@
--          image: ghcr.io/example/renovate:1.0.0
-+          image: ghcr.io/example/renovate:1.1.0
+--- Application: payments-api apps/Deployment: payments/payments-api
++++ Application: payments-api apps/Deployment: payments/payments-api
+@@ -31,7 +31,7 @@
+-        app.kubernetes.io/version: 2026.05.0
++        app.kubernetes.io/version: 2026.05.1
+@@ -48,7 +48,7 @@
+-          image: registry.example.com/payments-api:2026.05.0
++          image: registry.example.com/payments-api:2026.05.1
 ```
 
 </details>
 ````
 
 Image markdown is a companion view for scanning rendered image reference
-changes, and omits unchanged images by default.
+changes. It omits unchanged images by default so the comment stays focused on
+added and removed references.
 
 For the full diff behavior, output formats, ignore rules, and exit codes, see
 the [CLI usage guide](/docs/usage/).

--- a/site/content/workflows/output.md
+++ b/site/content/workflows/output.md
@@ -1,0 +1,51 @@
+---
+title: Output Controls
+---
+
+drydock keeps stdout machine-parseable for structured output. Diagnostics and
+failure summaries go to stderr unless status text is the primary output.
+
+## Formats
+
+Use `-o` or `--output` to select the format supported by each command:
+
+| Command area | Output formats |
+| --- | --- |
+| `get apps`, `get images` | `table`, `name`, `json`, `yaml` |
+| `test apps`, `test app` | `text`, `json`, `yaml` |
+| `diff apps`, `diff app` | `unified`, `markdown`, `json`, `yaml` |
+| `diff images` | `unified`, `markdown`, `json`, `yaml`, `name` |
+| `diag` | `text`, `json`, `yaml` |
+
+`-o name` is intended for list-style output. It is not supported for manifest
+diffs, and removed-only image changes print no names while still counting as a
+diff for exit-code behavior.
+
+## Diff Controls
+
+Unified manifest and image diffs support terminal color with
+`--color=auto|always|never`. The default `auto` colors only when stdout is a
+terminal. JSON and YAML outputs never include ANSI color.
+
+Use markdown output when the result will be read in a pull request comment:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig origin/main -o markdown
+drydock diff images --repo . --ref HEAD --ref-orig origin/main -o markdown
+```
+
+## Exit Codes
+
+Diff commands use fixed exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success, no diff |
+| `1` | Success, diff found |
+| `2` | Runtime, config, or render error |
+
+Use `--exit-code=false` for local inspection when a diff should not fail the
+command.
+
+For the full command reference, see the [CLI usage guide](/docs/usage/). For
+action outputs and PR comment controls, see the [GitHub Actions guide](/docs/github-actions/).

--- a/site/data/workflows/architecture.yaml
+++ b/site/data/workflows/architecture.yaml
@@ -1,0 +1,21 @@
+title: drydock architecture path
+steps:
+  - title: Repository
+    text: Read a checked-out GitOps repository or a temporary Git ref snapshot.
+  - title: Discovery
+    text: Build the local Application, ApplicationSet, settings, project, repository, and cluster metadata model.
+  - title: Source Planning
+    text: Apply Argo CD source precedence, multi-source ordering, repo maps, refs, and cache policy.
+  - title: Acquisition
+    text: Fetch or reuse declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources according to offline policy.
+  - title: Rendering
+    text: Render desired manifests with Go libraries and explicit plugin policy hooks.
+    outputs:
+      - Render tests
+      - Lua health validation
+      - Diagnostics
+  - title: Normalization
+    text: Apply compare settings, resource filters, repeated-resource behavior, and default diff noise suppression.
+    outputs:
+      - Manifest diffs
+      - Image reports

--- a/site/data/workflows/how-it-works.yaml
+++ b/site/data/workflows/how-it-works.yaml
@@ -1,0 +1,19 @@
+title: drydock render pipeline
+steps:
+  - title: Repository Input
+    text: Start from a checked-out repository, local path, or Git ref snapshot.
+  - title: Discovery
+    href: "#discovery"
+    text: Find Argo CD Applications, ApplicationSets, AppProjects, settings, repository metadata, and cluster metadata.
+  - title: Source Resolution
+    href: "#source-resolution"
+    text: Resolve local paths, repo maps, Git sources, Helm chart sources, remote Kustomize inputs, and caches.
+  - title: Rendering
+    href: "#rendering"
+    text: Inflate desired manifests with native Go renderers for directory, Kustomize, Helm, Jsonnet, and supported plugin policy flows.
+  - title: Normalization
+    href: "#normalization"
+    text: Apply Argo-aware normalization, resource filters, ignore settings, and diff noise controls.
+  - title: Reporting
+    href: "#reporting"
+    text: Return render tests, desired-state diffs, image movement, cache events, and diagnostics.

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -7,6 +7,20 @@ disableKinds:
 
 params:
   description: "Runtime-offline desired-state analysis for Argo CD GitOps repositories."
+  repositoryURL: "https://github.com/sholdee/drydock"
+  editBranch: "main"
+
+outputs:
+  home:
+    - html
+    - search
+
+outputFormats:
+  search:
+    mediaType: application/json
+    baseName: index.search
+    isPlainText: true
+    notAlternative: true
 
 menus:
   docs:
@@ -25,6 +39,11 @@ menus:
       params:
         group: Start
       weight: 30
+    - name: Operator Cookbook
+      url: /cookbook/
+      params:
+        group: Cookbook
+      weight: 35
     - name: GitHub Actions
       url: /workflows/github-actions/
       params:
@@ -35,11 +54,21 @@ menus:
       params:
         group: Workflows
       weight: 50
+    - name: Output Controls
+      url: /workflows/output/
+      params:
+        group: Workflows
+      weight: 55
     - name: Runtime Offline
       url: /concepts/runtime-offline/
       params:
         group: Concepts
       weight: 60
+    - name: How It Works
+      url: /concepts/how-it-works/
+      params:
+        group: Concepts
+      weight: 65
     - name: Source Acquisition
       url: /concepts/source-acquisition/
       params:
@@ -50,6 +79,11 @@ menus:
       params:
         group: Concepts
       weight: 80
+    - name: Repository Topologies
+      url: /concepts/topologies/
+      params:
+        group: Concepts
+      weight: 85
     - name: Compatibility
       url: /compatibility/
       params:

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,9 +1,13 @@
 {{ define "main" }}
   <article class="doc-page">
-    {{ if .Title }}
+    {{- $actions := partial "page-actions.html" . -}}
+    {{ if or .Title $actions }}
       <header class="doc-header">
-        <p class="section-label">Documentation</p>
-        <h1>{{ .Title }}</h1>
+        {{ if .Title }}
+          <p class="section-label">Documentation</p>
+          <h1>{{ .Title }}</h1>
+        {{ end }}
+        {{ $actions }}
       </header>
     {{ end }}
     <div class="doc-content">

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,11 +1,12 @@
 {{ define "main" }}
   <article class="doc-page">
+    {{- $title := partial "title.html" . -}}
     {{- $actions := partial "page-actions.html" . -}}
-    {{ if or .Title $actions }}
+    {{ if or $title $actions }}
       <header class="doc-header">
-        {{ if .Title }}
+        {{ if $title }}
           <p class="section-label">Documentation</p>
-          <h1>{{ .Title }}</h1>
+          <h1>{{ $title }}</h1>
         {{ end }}
         {{ $actions }}
       </header>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -3,7 +3,7 @@
     <h1 class="visually-hidden">{{ .Title }}</h1>
     <div class="home-mark">
       <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="480" height="128">
-      <p class="home-tagline">Inspect your Argo CD fleet without getting wet.</p>
+      <p class="home-tagline">Inspect your Argo CD fleet without getting wet</p>
     </div>
     <div class="doc-content">
       {{ .Content }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -3,6 +3,7 @@
     <h1 class="visually-hidden">{{ .Title }}</h1>
     <div class="home-mark">
       <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="480" height="128">
+      <p class="home-tagline">Inspect your Argo CD fleet without getting wet.</p>
     </div>
     <div class="doc-content">
       {{ .Content }}

--- a/site/layouts/index.search.json
+++ b/site/layouts/index.search.json
@@ -1,0 +1,15 @@
+{{- $pages := slice -}}
+{{- range site.RegularPages -}}
+  {{- if in .RelPermalink "/docs/agent-reference/" -}}
+    {{- continue -}}
+  {{- end -}}
+  {{- $title := partial "title.html" . -}}
+  {{- $pages = $pages | append (dict
+    "title" ($title | plainify)
+    "url" .RelPermalink
+    "section" (.Section | plainify)
+    "summary" (.Summary | plainify | htmlUnescape)
+    "content" (.Plain | plainify | htmlUnescape | truncate 4000)
+  ) -}}
+{{- end -}}
+{{- $pages | jsonify -}}

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -3,6 +3,21 @@
     <a class="brand-link" href="{{ site.Home.RelPermalink }}" aria-label="drydock documentation home">
       <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="180" height="48">
     </a>
+    <form class="site-search" role="search" data-search-index="{{ "index.search.json" | relURL }}">
+      <label class="visually-hidden" for="site-search-input">Search documentation</label>
+      <input
+        id="site-search-input"
+        name="q"
+        type="search"
+        autocomplete="off"
+        placeholder="Search docs"
+        aria-controls="site-search-results"
+        aria-expanded="false"
+      >
+      <div class="search-panel" hidden>
+        <ul id="site-search-results" role="listbox" aria-label="Search results"></ul>
+      </div>
+    </form>
     <div class="header-links">
       <a href="{{ site.Home.RelPermalink }}">Overview</a>
       <a href="{{ relURL "getting-started/" }}">Getting Started</a>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -23,7 +23,12 @@
       <a href="{{ relURL "getting-started/" }}">Getting Started</a>
       <a href="{{ relURL "workflows/github-actions/" }}">PR Checks</a>
       <a href="{{ relURL "reference/" }}">Reference</a>
-      <a href="https://github.com/sholdee/drydock">GitHub</a>
+      <a class="github-link" href="https://github.com/sholdee/drydock">
+        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
     </div>
   </nav>
 </header>

--- a/site/layouts/partials/page-actions.html
+++ b/site/layouts/partials/page-actions.html
@@ -1,0 +1,19 @@
+{{- $repoURL := strings.TrimSuffix "/" (site.Params.repositoryURL | default "") -}}
+{{- $branch := site.Params.editBranch | default "main" -}}
+{{- $sourcePath := "" -}}
+{{- with .File -}}
+  {{- $filename := replace .Filename "\\" "/" -}}
+  {{- if in $filename "/site/content/" -}}
+    {{- $sourcePath = printf "site/content/%s" (index (last 1 (split $filename "/site/content/")) 0) -}}
+  {{- else if in $filename "/docs/" -}}
+    {{- $sourcePath = printf "docs/%s" (index (last 1 (split $filename "/docs/")) 0) -}}
+  {{- end -}}
+{{- end -}}
+{{- if and $repoURL $sourcePath (not (in $sourcePath "site/public/")) -}}
+  {{- $sourceURL := printf "%s/blob/%s/%s" $repoURL $branch $sourcePath -}}
+  {{- $editURL := printf "%s/edit/%s/%s" $repoURL $branch $sourcePath -}}
+  <nav class="page-actions" aria-label="Page actions">
+    <a href="{{ $editURL }}">Edit this page</a>
+    <a href="{{ $sourceURL }}">View source</a>
+  </nav>
+{{- end -}}

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,6 +1,6 @@
 <nav class="docs-nav">
   <p class="nav-heading">Docs</p>
-  {{ $groups := slice "Start" "Workflows" "Concepts" "Reference" }}
+  {{ $groups := slice "Start" "Workflows" "Cookbook" "Concepts" "Reference" }}
   {{ range $group := $groups }}
     <div class="nav-section">
       <p class="nav-section-heading">{{ $group }}</p>

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -25,29 +25,40 @@
             {{- $entryURL := relURL .URL -}}
             {{- $active := eq $entryURL $.RelPermalink -}}
             <li>
-              <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
-                {{ .Name }}
-              </a>
+              {{ if and (eq $group "Reference") (eq .Name "Reference") }}
+                <div class="nav-reference-row">
+                  <a href="{{ $entryURL }}"{{ if or $active $isReferenceContext }} class="is-active"{{ end }}{{ if $active }} aria-current="page"{{ end }}>
+                    {{ .Name }}
+                  </a>
+                  <button
+                    type="button"
+                    class="nav-reference-toggle"
+                    aria-label="Toggle reference index"
+                    aria-controls="nav-reference-index"
+                    aria-expanded="{{ if $isReferenceContext }}true{{ else }}false{{ end }}"
+                    data-reference-context="{{ if $isReferenceContext }}true{{ else }}false{{ end }}"
+                  ></button>
+                </div>
+                <ul id="nav-reference-index" class="nav-reference-index"{{ if not $isReferenceContext }} hidden{{ end }}>
+                  {{ range $referencePages }}
+                    {{- $referenceEntryURL := relURL .url -}}
+                    {{- $referenceActive := eq $referenceEntryURL $.RelPermalink -}}
+                    <li>
+                      <a href="{{ $referenceEntryURL }}"{{ if $referenceActive }} class="is-active" aria-current="page"{{ end }}>
+                        {{ .name }}
+                      </a>
+                    </li>
+                  {{ end }}
+                </ul>
+              {{ else }}
+                <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
+                  {{ .Name }}
+                </a>
+              {{ end }}
             </li>
           {{ end }}
         {{ end }}
       </ul>
-      {{ if eq $group "Reference" }}
-        <details class="nav-reference-index"{{ if $isReferenceContext }} open{{ end }}>
-          <summary>Full Reference</summary>
-          <ul>
-            {{ range $referencePages }}
-              {{- $entryURL := relURL .url -}}
-              {{- $active := eq $entryURL $.RelPermalink -}}
-              <li>
-                <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
-                  {{ .name }}
-                </a>
-              </li>
-            {{ end }}
-          </ul>
-        </details>
-      {{ end }}
     </div>
   {{ end }}
 </nav>

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -1,6 +1,21 @@
 <nav class="docs-nav">
   <p class="nav-heading">Docs</p>
   {{ $groups := slice "Start" "Workflows" "Cookbook" "Concepts" "Reference" }}
+  {{ $referencePages := slice
+    (dict "name" "Usage" "url" "docs/usage/")
+    (dict "name" "GitHub Actions" "url" "docs/github-actions/")
+    (dict "name" "Source Acquisition" "url" "docs/source-acquisition/")
+    (dict "name" "Repository Topologies" "url" "docs/topologies/")
+    (dict "name" "ApplicationSets" "url" "docs/applicationsets/")
+    (dict "name" "Plugin Policy" "url" "docs/plugin-policy/")
+    (dict "name" "Compatibility" "url" "docs/compatibility/")
+    (dict "name" "Design" "url" "docs/design/")
+    (dict "name" "Release" "url" "docs/release/")
+    (dict "name" "Documentation Index" "url" "docs/readme/")
+    (dict "name" "Live Runtime Gate" "url" "docs/reports/live-integration-design-gate/")
+  }}
+  {{ $referenceURL := relURL "reference/" }}
+  {{ $isReferenceContext := or (eq $.Section "docs") (eq $.RelPermalink $referenceURL) }}
   {{ range $group := $groups }}
     <div class="nav-section">
       <p class="nav-section-heading">{{ $group }}</p>
@@ -17,6 +32,22 @@
           {{ end }}
         {{ end }}
       </ul>
+      {{ if eq $group "Reference" }}
+        <details class="nav-reference-index"{{ if $isReferenceContext }} open{{ end }}>
+          <summary>Full Reference</summary>
+          <ul>
+            {{ range $referencePages }}
+              {{- $entryURL := relURL .url -}}
+              {{- $active := eq $entryURL $.RelPermalink -}}
+              <li>
+                <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
+                  {{ .name }}
+                </a>
+              </li>
+            {{ end }}
+          </ul>
+        </details>
+      {{ end }}
     </div>
   {{ end }}
 </nav>

--- a/site/layouts/shortcodes/workflow.html
+++ b/site/layouts/shortcodes/workflow.html
@@ -1,0 +1,29 @@
+{{- $name := .Get "name" -}}
+{{- $workflow := index hugo.Data.workflows $name -}}
+{{- if not $workflow -}}
+  {{- errorf "workflow shortcode could not find site/data/workflows/%s.yaml" $name -}}
+{{- end -}}
+<section class="workflow-map" aria-label="{{ $workflow.title }}">
+  <ol class="workflow-steps">
+    {{- range $index, $step := $workflow.steps }}
+      <li class="workflow-step">
+        <span class="workflow-node" aria-hidden="true">{{ printf "%02d" (add $index 1) }}</span>
+        <div class="workflow-copy">
+          {{- if $step.href }}
+            <a class="workflow-heading" href="{{ $step.href }}">{{ $step.title }}</a>
+          {{- else }}
+            <p class="workflow-heading">{{ $step.title }}</p>
+          {{- end }}
+          <p>{{ $step.text }}</p>
+          {{- with $step.outputs }}
+            <ul class="workflow-tags" aria-label="{{ $step.title }} outputs">
+              {{- range . }}
+                <li>{{ . }}</li>
+              {{- end }}
+            </ul>
+          {{- end }}
+        </div>
+      </li>
+    {{- end }}
+  </ol>
+</section>


### PR DESCRIPTION
## Summary
- add a GitHub icon to the docs site header without changing header height
- remove the trailing period from the tagline in the README and docs homepage
- keep the docs-site navigation polish from the current branch

## Validation
- mise run docs-check
- mise run markdownlint
- git diff --check

## Review
- Review agent approved the completed docs-site polish with no blockers.