### PR TITLE
fix: compact docs header navigation

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -99,14 +99,14 @@ a:hover {
 }
 
 .header-nav {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(220px, 340px);
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  gap: clamp(0.75rem, 1.6vw, 1.2rem);
   min-height: var(--header-height);
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 0.7rem clamp(1rem, 3vw, 2rem);
+  padding: 0.55rem clamp(1rem, 3vw, 2rem);
 }
 
 .brand-link {
@@ -123,8 +123,8 @@ a:hover {
 
 .site-search {
   position: relative;
-  flex: 1 1 220px;
-  max-width: 360px;
+  width: 100%;
+  min-width: 0;
 }
 
 .site-search input {
@@ -208,7 +208,14 @@ a:hover {
   align-items: center;
   justify-content: flex-end;
   gap: 0.35rem;
-  flex-wrap: wrap;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.header-links::-webkit-scrollbar {
+  display: none;
 }
 
 .header-links a {
@@ -851,6 +858,31 @@ a.workflow-heading:hover {
 }
 
 @media (max-width: 1120px) {
+  :root {
+    --header-height: 104px;
+  }
+
+  .header-nav {
+    grid-template-columns: auto minmax(210px, 320px);
+    grid-template-areas:
+      "brand search"
+      "links links";
+    row-gap: 0.35rem;
+  }
+
+  .brand-link {
+    grid-area: brand;
+  }
+
+  .site-search {
+    grid-area: search;
+  }
+
+  .header-links {
+    grid-area: links;
+    justify-content: flex-start;
+  }
+
   .site-shell {
     grid-template-columns: minmax(180px, 235px) minmax(0, 1fr);
   }
@@ -862,12 +894,25 @@ a.workflow-heading:hover {
 
 @media (max-width: 760px) {
   :root {
-    --header-height: 104px;
+    --header-height: 132px;
+  }
+
+  html {
+    scroll-padding-top: 1rem;
+  }
+
+  .site-header {
+    position: static;
   }
 
   .header-nav {
-    align-items: flex-start;
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "brand"
+      "search"
+      "links";
+    align-items: start;
+    row-gap: 0.5rem;
   }
 
   .header-links {

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -3,6 +3,18 @@
     <a class="brand-link" href="{{ site.Home.RelPermalink }}" aria-label="drydock documentation home">
       <img src="{{ "logo/drydock-display-dark.svg" | relURL }}" alt="drydock" width="180" height="48">
     </a>
+    <div class="header-links">
+      <a href="{{ site.Home.RelPermalink }}">Overview</a>
+      <a href="{{ relURL "getting-started/" }}">Getting Started</a>
+      <a href="{{ relURL "workflows/github-actions/" }}">PR Checks</a>
+      <a href="{{ relURL "reference/" }}">Reference</a>
+      <a class="github-link" href="https://github.com/sholdee/drydock">
+        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
+    </div>
     <form class="site-search" role="search" data-search-index="{{ "index.search.json" | relURL }}">
       <label class="visually-hidden" for="site-search-input">Search documentation</label>
       <input
@@ -18,17 +30,5 @@
         <ul id="site-search-results" role="listbox" aria-label="Search results"></ul>
       </div>
     </form>
-    <div class="header-links">
-      <a href="{{ site.Home.RelPermalink }}">Overview</a>
-      <a href="{{ relURL "getting-started/" }}">Getting Started</a>
-      <a href="{{ relURL "workflows/github-actions/" }}">PR Checks</a>
-      <a href="{{ relURL "reference/" }}">Reference</a>
-      <a class="github-link" href="https://github.com/sholdee/drydock">
-        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
-          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
-        </svg>
-        <span>GitHub</span>
-      </a>
-    </div>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- compact desktop docs header with a grid layout so nav links and search stay grouped
- move tablet navigation into a controlled second row
- make the mobile header non-sticky and reset anchor scroll padding

## Validation
- mise run docs-check
- mise run markdownlint
- git diff --check