### PR TITLE
docs: explain render parity strategy

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,6 +8,24 @@ diagnose local Argo CD desired state without contacting live Argo CD or
 Kubernetes runtime. Declared sources may be fetched into explicit caches unless
 `--offline` is set.
 
+## Render Parity Validation
+
+Argo CD remains the semantic reference for generated desired manifests. drydock
+keeps normal commands runtime-offline, then validates compatibility work with
+an isolated Argo CD render parity smoke.
+
+The smoke installs the pinned Argo CD version into kind, serves the
+`testdata/argocd-parity` fixture repository to Argo CD, renders the same
+Applications with drydock, and compares generated desired manifests. It runs
+manually for maintainer validation and selectively in CI when render parity
+fixtures or semantic-rendering dependencies change. See `docs/release.md` for
+maintainer workflow details.
+
+This check is scoped to generated desired state. Live-only runtime behavior
+such as Kubernetes defaulting, admission mutation, server-side diff, managed
+fields, health aggregation, sync behavior, and controller state remains outside
+drydock's runtime-offline boundary.
+
 ## Runtime Model
 
 Supported:

--- a/docs/design.md
+++ b/docs/design.md
@@ -30,6 +30,27 @@ intentional product boundaries:
 Future live-runtime work must remain explicitly opt-in and pass the design gate
 in `docs/reports/live-integration-design-gate.md`.
 
+## Argo CD As Semantic Reference
+
+Argo CD is the semantic reference for generated desired manifests. drydock does
+not treat Argo CD rendering behavior as trivial or static; it implements a
+runtime-offline renderer so operators can get fast local and CI feedback
+without standing up Argo CD for every render, test, diff, image, or diagnostic
+command.
+
+Compatibility work is validated against upstream Argo CD through the render
+parity smoke. That smoke installs the pinned Argo CD version into an isolated
+kind cluster, serves the fixture repository to Argo CD, renders the same inputs
+with drydock, and compares the generated desired manifests. The smoke is
+manual maintainer validation and a selective CI gate for render parity fixture
+changes or semantic-rendering dependency changes. It is not a runtime
+dependency for normal drydock commands.
+
+The parity smoke is scoped to desired-state generation. Kubernetes API
+defaulting, admission mutation, server-side diff, managed fields, health
+aggregation, sync behavior, and controller state remain live-runtime
+boundaries.
+
 ## Architecture
 
 The production path is a native local engine using Argo CD API types and

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,6 +11,11 @@ Use it locally or in CI to answer operator questions that are hard to review in
 raw Git: which Applications render, which desired resources changed, which
 images moved, and which repository inputs need attention.
 
+Argo CD remains the semantic reference for generated desired state. drydock
+front-loads that validation into an isolated render parity smoke for covered
+fixtures and semantic-rendering changes, while normal operator commands stay
+runtime-offline from Argo CD and Kubernetes.
+
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 
 ## Start Here

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -34,6 +34,10 @@ and supported chart-only Helm sources. Config management plugin execution is
 disabled by default; trusted plugin policy and explicit opt-in are required for
 exec plugins.
 
+Argo CD remains the semantic reference for generated desired manifests. drydock
+keeps this rendering path runtime-offline, then validates covered fixture
+semantics against real Argo CD through the render parity smoke.
+
 ## Normalization
 
 Rendered manifests pass through Argo-aware normalization before diff and image

--- a/site/content/concepts/runtime-offline.md
+++ b/site/content/concepts/runtime-offline.md
@@ -11,6 +11,21 @@ Runtime-offline does not mean every source network request is disabled.
 Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources can still be
 fetched into explicit caches unless `--offline` is set.
 
+## Why Not Call Argo CD Every Time?
+
+Argo CD is the semantic reference for generated desired manifests, but calling
+it for every local render, PR diff, or diagnostic run requires a running Argo
+CD instance, Kubernetes access, runtime credentials, and more CI setup.
+
+drydock chooses a different tradeoff. Normal commands stay runtime-offline and
+fast, while maintainer validation compares covered fixture output against real
+Argo CD through an isolated render parity smoke. That front-loads compatibility
+checks without making every operator command depend on live runtime services.
+
+This does not change source acquisition behavior. Runtime-offline commands may
+still fetch declared Git, Helm, OCI, or remote Kustomize sources unless
+`--offline` is set.
+
 ## What drydock Does Not Call
 
 - Live Kubernetes APIs.


### PR DESCRIPTION
## Summary
- document Argo CD as drydock's semantic reference for generated desired manifests
- explain the render parity smoke and its runtime-offline boundary
- add concise operator-facing docs site wording for the validation strategy

## Review
- spec review approved
- quality review approved
- final implementation review approved

## Validation
- mise run docs-check
- mise run markdownlint
- git diff --check