### PR TITLE
docs: add community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What happened?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: drydock version
+      placeholder: drydock version
+    validations:
+      required: false
+
+  - type: input
+    id: argocd-version
+    attributes:
+      label: Argo CD version, if relevant
+      placeholder: v3.4.3
+    validations:
+      required: false
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: The drydock command you ran.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reproducible repository shape, fixture, or manifests you can share.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect drydock to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What did drydock do instead?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: repo-shape
+    attributes:
+      label: Repository shape
+      description: Select any areas that may be involved.
+      options:
+        - label: ApplicationSet generation
+        - label: Multi-source Application
+        - label: Helm or OCI chart source
+        - label: Kustomize or remote Kustomize source
+        - label: Jsonnet source
+        - label: Config management plugin or PluginPolicy
+        - label: Private Git, Helm, OCI, or remote source
+        - label: Git ref or path diff
+        - label: GitHub Action or PR comment
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Output or logs
+      description: Redact credentials, tokens, Secret values, and private URLs.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sholdee/drydock/security/advisories/new
+    about: Report security vulnerabilities privately. Do not open public security issues.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What operator problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What shape should the feature take?
+    validations:
+      required: false
+
+  - type: textarea
+    id: runtime-boundary
+    attributes:
+      label: Runtime, offline, or security considerations
+      description: Does this require live Argo CD, Kubernetes, external commands, credentials, or network access?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changed, and what is the operator-facing impact? -->
+
+## Validation
+
+<!-- List checks run. Use N/A or skipped with a reason when appropriate. -->
+
+## Impact
+
+- Runtime-offline contract:
+- Default shellouts or live runtime dependency:
+- Performance:
+- Documentation:
+
+## Checklist
+
+- [ ] GitHub Actions are pinned by commit SHA with version comments, if modified
+- [ ] Dependencies are tidy and intentional, if modified

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[https://github.com/sholdee](https://github.com/sholdee).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thanks for your interest in drydock. Pull requests are welcome for focused bug
+fixes, compatibility improvements, documentation, and features that preserve
+the runtime-offline product contract.
+
+## Setup
+
+Install the pinned toolchain with mise:
+
+```bash
+mise install
+```
+
+Useful local checks:
+
+```bash
+mise run test
+mise run test-race
+mise run lint
+mise run markdownlint
+mise run docs-check
+mise run ci
+```
+
+Use the smallest check that proves your change. Run `mise run ci` before larger
+or risky pull requests.
+
+## Pull Request Guidelines
+
+- Keep pull requests focused and explain the operator-facing impact.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for
+  commit messages.
+- Update documentation when changing CLI behavior, compatibility, output,
+  actions, source acquisition, plugin policy, or release behavior.
+- Run `go mod tidy` when changing Go dependencies.
+- Pin GitHub Actions by commit SHA with a version comment when workflows
+  change.
+- Do not add default shellouts to `kubectl`, `argocd`, Helm, Kustomize, or
+  config management plugins.
+- Do not add live Argo CD or Kubernetes runtime requirements to default render,
+  test, diff, image, or diagnostic paths.
+- Keep credentials, repository auth, Secret values, and credential-bearing URLs
+  redacted from logs and diagnostics.
+
+## Runtime-Offline Contract
+
+drydock's default workflows analyze Argo CD desired state without a running
+Argo CD instance or Kubernetes cluster. Source acquisition can still fetch
+declared Git, HTTP Helm, OCI Helm, or remote Kustomize inputs unless
+`--offline` is set.
+
+Changes that alter this boundary need explicit design discussion before
+implementation. Start with the design and compatibility docs:
+
+- [Design](docs/design.md)
+- [Compatibility](docs/compatibility.md)
+- [Source acquisition](docs/source-acquisition.md)
+- [Plugin policy](docs/plugin-policy.md)
+
+## Maintainer Workflows
+
+release-please manages releases from Conventional Commit history. The
+documentation site deploys through GitHub Pages. The Argo CD render parity
+smoke is manual maintainer validation and a selective CI gate for render parity
+fixtures or semantic-rendering dependency changes.
+
+These workflows are described in [release notes](docs/release.md) and the
+repository workflows.
+
+## References
+
+- See [SECURITY.md](SECURITY.md) for vulnerability reporting.
+- See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
+- See the documentation site for operator workflows and reference material.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ change reaches the cluster. Pull request diffing is a key workflow, but
 the same native engine also supports render validation, image inventory,
 repository diagnostics, cache inspection, and Go API embedding.
 
-Full documentation is available at
-[sholdee.github.io/drydock](https://sholdee.github.io/drydock/).
+**Full documentation:** [sholdee.github.io/drydock](https://sholdee.github.io/drydock/).
 
 Core properties:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please use GitHub's private vulnerability reporting feature to report security
+issues:
+
+Repository > Security tab > Advisories > Report a vulnerability
+
+Do not open public issues for security vulnerabilities.
+
+## Scope
+
+The following areas are in scope for vulnerability reports:
+
+- Credential redaction and source authentication handling.
+- Repository, Helm, OCI, remote Kustomize, and cache acquisition behavior.
+- Trusted plugin policy, opt-in exec plugin behavior, and plugin sandbox
+  boundaries.
+- Cache path containment, symlink handling, and filesystem safety.
+- GitHub Actions, setup action, PR action, release artifacts, and container
+  image distribution.
+- Dependency supply chain for Go modules, tools, actions, and container base
+  images.
+
+## Dependency Management
+
+[Renovate](https://docs.renovatebot.com/) automates dependency updates for Go
+modules, tools, container images, and GitHub Actions. GitHub Actions are pinned
+by commit SHA with version comments, and release artifacts are built through
+the repository release workflows.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING, SECURITY, and CODE_OF_CONDUCT community files
- add bug and feature issue forms with blank issues enabled
- add a concise pull request template with validation and drydock impact prompts

## Validation
- mise run markdownlint
- mise run docs-check
- git diff --check
- CODE_OF_CONDUCT.md matches crd-schema-publisher source