### PR TITLE
feat: add changed-only path filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ drydock diff apps --path . --path-orig ../baseline
 
 Diff commands use changed-only selection by default. Use
 `--changed-only=false` when you want to render and compare every discovered
-Application.
+Application. Use repeatable `--changed-only-include` and
+`--changed-only-ignore` globs when CI should ignore known non-GitOps paths
+before changed-only ownership is evaluated.
 
 You can also compare against committed Git refs without creating a baseline
 worktree:

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -193,6 +193,14 @@ replaces `--path`, and `--repo` defaults to `--path`. Do not add shellouts,
 `git worktree add`, checkout mutation, or top-level remote `--repo` URL
 support without an approved design update.
 
+Changed-only include and ignore globs apply before ownership mapping for
+`diff apps` and `diff images`. Patterns are repository-relative and
+slash-normalized; ignore wins over include. No include globs means all changed
+paths are considered. If filtering leaves zero paths, return an empty diff
+without rendering. Strict changed-only diagnostics apply only to the remaining
+considered paths. Do not auto-load implicit policy files without a design
+update; explicit CLI/API/action policy is intentional.
+
 Manifest diff output supports unified diff, markdown, JSON, and YAML. Image
 diff output supports unified diff, markdown, JSON, and YAML for `added`,
 `removed`, and `unchanged` image lists. Image markdown output is comment-facing

--- a/docs/design.md
+++ b/docs/design.md
@@ -197,6 +197,14 @@ be mapped, only affected Applications render. If any path is unowned,
 non-strict mode warns and renders all Applications; `--strict-changed-only`
 fails instead.
 
+Operators can scope the changed path set with explicit include and ignore
+globs before ownership is evaluated. Include globs define the considered path
+universe; ignore globs remove paths from that universe and take precedence. If
+no paths remain after filtering, no Applications render and the diff is empty.
+This is intentionally CLI/API/action-provided policy, not an automatically
+loaded ignore file, so hidden repository policy cannot silently change local
+diff semantics.
+
 Argo CD permits overlapping Applications, so drydock keeps every affected
 Application instead of collapsing ownership to one most-specific owner.
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -157,6 +157,8 @@ the repository under test.
 | `strict` | `false` | Promote diagnostics to errors. |
 | `strict-changed-only` | `false` | Fail ambiguous changed-only ownership. |
 | `changed-only` | drydock default | Override changed-only with `true` or `false`. |
+| `changed-only-include` | unset | Newline-delimited changed-only include globs. |
+| `changed-only-ignore` | unset | Newline-delimited changed-only ignore globs. |
 | `show-ignored-fields` | `false` | Show default ignored diff fields. |
 | `comment-mode` | `both` | One of `none`, `diff`, `images`, or `both`. |
 | `fail-on-diff` | `false` | Fail when manifest differences are detected. |
@@ -164,11 +166,18 @@ the repository under test.
 
 Newline-delimited inputs are passed as repeated drydock flags:
 
+- `changed-only-include`
+- `changed-only-ignore`
 - `discover-kustomize`
 - `repo-map`
 - `extra-test-args`
 - `extra-diff-args`
 - `extra-image-diff-args`
+
+`changed-only-include` and `changed-only-ignore` apply only to `diff apps` and
+`diff images`; `test apps` still validates the selected repository path. Use
+them to keep non-GitOps workflow churn from forcing full-fleet diffs, while
+keeping patterns narrow enough that real render inputs are not hidden.
 
 Only use `extra-*` inputs with trusted workflow configuration. The action
 passes them as arguments without `eval`, but they still change drydock behavior.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,6 +285,26 @@ renders all Applications.
 Use `--changed-only=false` to render all Applications explicitly, or
 `--strict-changed-only` to fail on incomplete input ownership.
 
+Use repeatable `--changed-only-include GLOB` and `--changed-only-ignore GLOB`
+to scope the changed paths considered by changed-only selection before
+Application ownership is evaluated:
+
+```bash
+drydock diff apps \
+  --path . \
+  --ref-orig main \
+  --changed-only-include 'apps/**' \
+  --changed-only-ignore 'apps/**/README.md'
+```
+
+Globs are repository-relative and slash-normalized. When no include globs are
+provided, every changed path is considered. Ignore globs remove paths after
+include filtering, so ignore wins. If filtering removes every changed path, the
+diff is empty and no Applications render. `--strict-changed-only` applies only
+to the remaining considered paths. Broad ignores can hide real render inputs in
+plugin-heavy or unconventional repositories, so prefer narrow patterns owned by
+the workflow.
+
 ### Git Ref Diffs
 
 Diff commands can compare local Git refs without creating a separate baseline
@@ -412,6 +432,9 @@ changes print no names but still return the diff exit code unless
 image lists. Diagnostics remain on stderr so stdout stays valid JSON or YAML.
 Text image diffs use the same `--color=auto|always|never` behavior as manifest
 diffs.
+
+`diff images` uses the same changed-only defaults and
+`--changed-only-include` / `--changed-only-ignore` path filters as `diff apps`.
 
 ## Diagnostics
 

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -27,12 +27,14 @@ type DiffRequest struct {
 	Ref       string
 	RefOrig   string
 	DiscoveryOptions
-	ChangedOnly       bool
-	StrictChangedOnly bool
-	Strict            bool
-	Unified           int
-	StripAttrs        []string
-	ShowIgnoredFields bool
+	ChangedOnly             bool
+	StrictChangedOnly       bool
+	ChangedOnlyIncludeGlobs []string
+	ChangedOnlyIgnoreGlobs  []string
+	Strict                  bool
+	Unified                 int
+	StripAttrs              []string
+	ShowIgnoredFields       bool
 	AcquisitionOptions
 	PluginOptions
 	ExecutionOptions
@@ -425,6 +427,9 @@ func validateDiffPaths(request DiffRequest) error {
 	if request.RightPath == "" {
 		return fmt.Errorf("--path is required")
 	}
+	if _, err := changedOnlyPathFilter(request); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -485,6 +490,14 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 
 	var diagnostics []diagnostic.Diagnostic
 	if request.ChangedOnly {
+		changedPaths, err := filteredChangedOnlyPaths(request)
+		if err != nil {
+			return BuildResult{}, BuildResult{}, diagnostics, err
+		}
+		if len(changedPaths) == 0 {
+			return BuildResult{}, BuildResult{}, diagnostics, nil
+		}
+
 		leftList, err := o.ListApplications(ctx, leftBuildRequest)
 		diagnostics = append(diagnostics, leftList.Diagnostics...)
 		if err != nil {
@@ -500,14 +513,6 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 		rightBuildRequest.renderCache = rightList.renderCache
 		rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
 
-		changedPaths := request.changedPaths
-		if changedPaths == nil {
-			var err error
-			changedPaths, err = change.Detect(request.LeftPath, request.RightPath)
-			if err != nil {
-				return BuildResult{}, BuildResult{}, diagnostics, err
-			}
-		}
 		leftSelected, leftUnowned := SelectChangedApplicationInputs(leftList.ApplicationInputs, changedPaths)
 		rightSelected, rightUnowned := SelectChangedApplicationInputs(rightList.ApplicationInputs, changedPaths)
 		unowned := unownedByNeitherSide(leftUnowned, rightUnowned)
@@ -540,6 +545,28 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 		return leftBuild, rightBuild, diagnostics, err
 	}
 	return leftBuild, rightBuild, diagnostics, nil
+}
+
+func filteredChangedOnlyPaths(request DiffRequest) ([]string, error) {
+	filter, err := changedOnlyPathFilter(request)
+	if err != nil {
+		return nil, err
+	}
+	changedPaths := request.changedPaths
+	if changedPaths == nil {
+		changedPaths, err = change.Detect(request.LeftPath, request.RightPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return filter.Apply(changedPaths).Paths, nil
+}
+
+func changedOnlyPathFilter(request DiffRequest) (change.PathFilter, error) {
+	return change.NewPathFilter(change.PathFilterConfig{
+		Includes: request.ChangedOnlyIncludeGlobs,
+		Ignores:  request.ChangedOnlyIgnoreGlobs,
+	})
 }
 
 func unownedByNeitherSide(leftUnowned, rightUnowned []string) []string {

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -1179,6 +1179,142 @@ func TestOrchestratorDiffAppsChangedOnlyFallsBackOnUnownedCurrentPath(t *testing
 	}
 }
 
+func TestOrchestratorDiffAppsChangedOnlyIgnoresUnownedPaths(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleApp(t, left, "old")
+	writeSimpleApp(t, right, "new")
+	writeTestFile(t, filepath.Join(left, "README.md"), "left\n")
+	writeTestFile(t, filepath.Join(right, "README.md"), "right\n")
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:               left,
+		RightPath:              right,
+		ChangedOnly:            true,
+		StrictChangedOnly:      true,
+		ChangedOnlyIgnoreGlobs: []string{"README.md"},
+		Unified:                3,
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("len(Results) = %d, want 1", len(result.Results))
+	}
+}
+
+func TestOrchestratorDiffAppsChangedOnlyIncludesConsideredPaths(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleApp(t, left, "old")
+	writeSimpleApp(t, right, "new")
+	writeTestFile(t, filepath.Join(left, "README.md"), "left\n")
+	writeTestFile(t, filepath.Join(right, "README.md"), "right\n")
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:                left,
+		RightPath:               right,
+		ChangedOnly:             true,
+		StrictChangedOnly:       true,
+		ChangedOnlyIncludeGlobs: []string{"manifests/**"},
+		Unified:                 3,
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("len(Results) = %d, want 1", len(result.Results))
+	}
+}
+
+func TestOrchestratorDiffAppsChangedOnlyAllPathsFilteredReturnsEmptyDiff(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeTestFile(t, filepath.Join(left, "README.md"), "left\n")
+	writeTestFile(t, filepath.Join(right, "README.md"), "right\n")
+	writeTestFile(t, filepath.Join(left, "apps", "broken.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+`)
+	writeTestFile(t, filepath.Join(right, "apps", "broken.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+`)
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:                left,
+		RightPath:               right,
+		ChangedOnly:             true,
+		StrictChangedOnly:       true,
+		ChangedOnlyIncludeGlobs: []string{"apps/**"},
+		Unified:                 3,
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if len(result.Results) != 0 {
+		t.Fatalf("Results = %#v, want none", result.Results)
+	}
+}
+
+func TestOrchestratorDiffImagesHonorsChangedOnlyFilters(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleApp(t, left, "same")
+	writeSimpleApp(t, right, "same")
+	writeTestFile(t, filepath.Join(left, "README.md"), "left\n")
+	writeTestFile(t, filepath.Join(right, "README.md"), "right\n")
+
+	result, err := Orchestrator{}.DiffImages(context.Background(), DiffRequest{
+		LeftPath:               left,
+		RightPath:              right,
+		ChangedOnly:            true,
+		StrictChangedOnly:      true,
+		ChangedOnlyIgnoreGlobs: []string{"README.md"},
+	})
+	if err != nil {
+		t.Fatalf("DiffImages() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorDiffAppsChangedOnlyRejectsInvalidFilterGlob(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleApp(t, left, "old")
+	writeSimpleApp(t, right, "new")
+
+	_, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:                left,
+		RightPath:               right,
+		ChangedOnly:             true,
+		ChangedOnlyIncludeGlobs: []string{"apps/["},
+		Unified:                 3,
+	})
+	if err == nil {
+		t.Fatal("DiffApps() error = nil, want invalid glob error")
+	}
+	if !strings.Contains(err.Error(), "changed-only include glob") {
+		t.Fatalf("DiffApps() error = %v, want changed-only include glob message", err)
+	}
+}
+
 func TestOrchestratorDiffAppsStrictChangedOnlyOwnsApplicationManifestChanges(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, "left")

--- a/internal/change/filter.go
+++ b/internal/change/filter.go
@@ -1,0 +1,102 @@
+package change
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+type PathFilter struct {
+	includes []string
+	ignores  []string
+}
+
+type PathFilterConfig struct {
+	Includes []string
+	Ignores  []string
+}
+
+type FilterResult struct {
+	Paths    []string
+	Included []string
+	Ignored  []string
+}
+
+func NewPathFilter(config PathFilterConfig) (PathFilter, error) {
+	includes, err := normalizePatterns(config.Includes, "include")
+	if err != nil {
+		return PathFilter{}, err
+	}
+	ignores, err := normalizePatterns(config.Ignores, "ignore")
+	if err != nil {
+		return PathFilter{}, err
+	}
+	return PathFilter{includes: includes, ignores: ignores}, nil
+}
+
+func (filter PathFilter) Apply(paths []string) FilterResult {
+	result := FilterResult{Paths: make([]string, 0, len(paths))}
+	for _, inputPath := range paths {
+		normalized := normalizeFilterPath(inputPath)
+		if !filter.included(normalized) {
+			continue
+		}
+		result.Included = append(result.Included, normalized)
+		if filter.ignored(normalized) {
+			result.Ignored = append(result.Ignored, normalized)
+			continue
+		}
+		result.Paths = append(result.Paths, normalized)
+	}
+	return result
+}
+
+func (filter PathFilter) included(inputPath string) bool {
+	if len(filter.includes) == 0 {
+		return true
+	}
+	for _, pattern := range filter.includes {
+		if doublestar.MatchUnvalidated(pattern, inputPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func (filter PathFilter) ignored(inputPath string) bool {
+	for _, pattern := range filter.ignores {
+		if doublestar.MatchUnvalidated(pattern, inputPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePatterns(patterns []string, label string) ([]string, error) {
+	out := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		normalized := normalizeFilterPath(pattern)
+		if normalized == "" {
+			return nil, fmt.Errorf("changed-only %s glob must not be blank", label)
+		}
+		if !doublestar.ValidatePattern(normalized) {
+			return nil, fmt.Errorf("changed-only %s glob %q is invalid", label, pattern)
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func normalizeFilterPath(input string) string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(input), "\\", "/")
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	cleaned := path.Clean(strings.Trim(normalized, "/"))
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
+}

--- a/internal/change/index_test.go
+++ b/internal/change/index_test.go
@@ -88,6 +88,117 @@ func TestIndexRootInputOwnsAllChangedPaths(t *testing.T) {
 	}
 }
 
+func TestPathFilterEmptyIncludesKeepsAllPaths(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{"apps/a/cm.yaml", "docs/readme.md"})
+
+	want := []string{"apps/a/cm.yaml", "docs/readme.md"}
+	if !equal(got.Paths, want) {
+		t.Fatalf("Paths = %v, want %v", got.Paths, want)
+	}
+}
+
+func TestPathFilterIncludesMatchingPaths(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{Includes: []string{"apps/**"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{"apps/a/cm.yaml", "docs/readme.md"})
+
+	want := []string{"apps/a/cm.yaml"}
+	if !equal(got.Paths, want) {
+		t.Fatalf("Paths = %v, want %v", got.Paths, want)
+	}
+	wantIncluded := []string{"apps/a/cm.yaml"}
+	if !equal(got.Included, wantIncluded) {
+		t.Fatalf("Included = %v, want %v", got.Included, wantIncluded)
+	}
+}
+
+func TestPathFilterIgnoresMatchingPaths(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{Ignores: []string{".github/**", "mise.lock"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{"apps/a/cm.yaml", ".github/workflows/ci.yaml", "mise.lock"})
+
+	want := []string{"apps/a/cm.yaml"}
+	if !equal(got.Paths, want) {
+		t.Fatalf("Paths = %v, want %v", got.Paths, want)
+	}
+	wantIgnored := []string{".github/workflows/ci.yaml", "mise.lock"}
+	if !equal(got.Ignored, wantIgnored) {
+		t.Fatalf("Ignored = %v, want %v", got.Ignored, wantIgnored)
+	}
+}
+
+func TestPathFilterIgnoreWinsOverInclude(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{
+		Includes: []string{"apps/**"},
+		Ignores:  []string{"apps/generated/**"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{"apps/a/cm.yaml", "apps/generated/cm.yaml"})
+
+	want := []string{"apps/a/cm.yaml"}
+	if !equal(got.Paths, want) {
+		t.Fatalf("Paths = %v, want %v", got.Paths, want)
+	}
+}
+
+func TestPathFilterNormalizesPatternsAndChangedPaths(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{Includes: []string{`.\apps\**`}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{`.\apps\a\cm.yaml`, "./docs/readme.md"})
+
+	want := []string{"apps/a/cm.yaml"}
+	if !equal(got.Paths, want) {
+		t.Fatalf("Paths = %v, want %v", got.Paths, want)
+	}
+}
+
+func TestPathFilterRejectsInvalidPatterns(t *testing.T) {
+	_, err := NewPathFilter(PathFilterConfig{Includes: []string{"apps/["}})
+	if err == nil {
+		t.Fatal("NewPathFilter() error = nil, want invalid glob error")
+	}
+}
+
+func TestPathFilterRejectsBlankPatterns(t *testing.T) {
+	_, err := NewPathFilter(PathFilterConfig{Ignores: []string{"  "}})
+	if err == nil {
+		t.Fatal("NewPathFilter() error = nil, want blank glob error")
+	}
+}
+
+func TestPathFilterRepresentsNoRemainingPaths(t *testing.T) {
+	filter, err := NewPathFilter(PathFilterConfig{Includes: []string{"apps/**"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := filter.Apply([]string{".github/workflows/ci.yaml"})
+
+	if len(got.Paths) != 0 {
+		t.Fatalf("Paths = %v, want none", got.Paths)
+	}
+	if len(got.Included) != 0 {
+		t.Fatalf("Included = %v, want none", got.Included)
+	}
+}
+
 func TestDetectChangedPaths(t *testing.T) {
 	base := t.TempDir()
 	current := t.TempDir()

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -56,6 +56,8 @@ type commonFlags struct {
 	skipSecrets              bool
 	skipLuaHealth            bool
 	changedOnly              bool
+	changedOnlyIncludes      []string
+	changedOnlyIgnores       []string
 	strictChangedOnly        bool
 	strict                   bool
 	exitCode                 bool
@@ -156,6 +158,11 @@ func bindFilterFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.strictChangedOnly, "strict-changed-only", flags.strictChangedOnly, "fail when changed-only input ownership is ambiguous or incomplete")
 }
 
+func bindChangedOnlyPathFilterFlags(cmd *cobra.Command, flags *commonFlags) {
+	cmd.Flags().StringArrayVar(&flags.changedOnlyIncludes, "changed-only-include", flags.changedOnlyIncludes, "repository-relative glob for changed paths considered by changed-only selection")
+	cmd.Flags().StringArrayVar(&flags.changedOnlyIgnores, "changed-only-ignore", flags.changedOnlyIgnores, "repository-relative glob ignored by changed-only selection")
+}
+
 func bindStrictExitFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.strict, "strict", flags.strict, "promote diagnostics to errors")
 	cmd.Flags().BoolVar(&flags.exitCode, "exit-code", flags.exitCode, "return exit code 1 when a diff is found")
@@ -242,6 +249,8 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		MaxDiscoveryDepthSet:           flags.maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), flags.discoverKustomize...),
 		ChangedOnly:                    &flags.changedOnly,
+		ChangedOnlyIncludes:            append([]string(nil), flags.changedOnlyIncludes...),
+		ChangedOnlyIgnores:             append([]string(nil), flags.changedOnlyIgnores...),
 		StrictChangedOnly:              flags.strictChangedOnly,
 		Strict:                         flags.strict,
 		Unified:                        flags.unified,

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -76,6 +76,7 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	}
 	bindCommonFlags(apps, &appsFlags)
 	bindDiffRefFlags(apps, &appsFlags)
+	bindChangedOnlyPathFilterFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
 	bindDiffColorFlag(apps, &appsColor)
 	bindDiffMarkdownFlags(apps, &appsMarkdownMaxBytes, &appsRawOutputFile)
@@ -171,6 +172,7 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 	}
 	bindCommonFlags(images, &imagesFlags)
 	bindDiffRefFlags(images, &imagesFlags)
+	bindChangedOnlyPathFilterFlags(images, &imagesFlags)
 	bindDiffColorFlag(images, &imagesColor)
 	bindDiffMarkdownMaxBytesFlag(images, &imagesMarkdownMaxBytes)
 

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -774,6 +774,84 @@ func TestDiffImagesColorAlwaysColorsImageDiff(t *testing.T) {
 	assertStderrEmpty(t, result)
 }
 
+func TestDiffAppsChangedOnlyPathFilterFlags(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder},
+		"diff", "apps",
+		"--path-orig", "left",
+		"--path", "right",
+		"--changed-only-include", "apps/**",
+		"--changed-only-include", "clusters/**",
+		"--changed-only-ignore", ".github/**",
+		"--exit-code=false",
+	)
+	assertStderrEmpty(t, result)
+	if len(recorder.diffAppsRequests) != 1 {
+		t.Fatalf("DiffApps requests = %#v, want one request", recorder.diffAppsRequests)
+	}
+	request := recorder.diffAppsRequests[0]
+	assertStringSliceEqual(t, request.ChangedOnlyIncludeGlobs, []string{"apps/**", "clusters/**"})
+	assertStringSliceEqual(t, request.ChangedOnlyIgnoreGlobs, []string{".github/**"})
+}
+
+func TestDiffImagesChangedOnlyPathFilterFlags(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder},
+		"diff", "images",
+		"--path-orig", "left",
+		"--path", "right",
+		"--changed-only-include", "apps/**",
+		"--changed-only-ignore", ".github/**",
+		"--exit-code=false",
+	)
+	assertStderrEmpty(t, result)
+	if len(recorder.diffImagesRequests) != 1 {
+		t.Fatalf("DiffImages requests = %#v, want one request", recorder.diffImagesRequests)
+	}
+	request := recorder.diffImagesRequests[0]
+	assertStringSliceEqual(t, request.ChangedOnlyIncludeGlobs, []string{"apps/**"})
+	assertStringSliceEqual(t, request.ChangedOnlyIgnoreGlobs, []string{".github/**"})
+}
+
+func TestDiffAppDoesNotExposeChangedOnlyPathFilterFlags(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: recorder})
+	cmd.SetArgs([]string{"diff", "app", "demo", "--path-orig", "left", "--path", "right", "--changed-only-include", "apps/**"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unknown flag error")
+	}
+	if !strings.Contains(err.Error(), "unknown flag: --changed-only-include") {
+		t.Fatalf("error = %v, want unknown changed-only include flag", err)
+	}
+	if len(recorder.diffAppRequests) != 0 {
+		t.Fatalf("DiffApp requests = %#v, want none", recorder.diffAppRequests)
+	}
+}
+
+func TestNonDiffCommandsDoNotExposeChangedOnlyPathFilterFlags(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: recorder})
+	cmd.SetArgs([]string{"test", "apps", "--path", "repo", "--changed-only-ignore", ".github/**"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unknown flag error")
+	}
+	if !strings.Contains(err.Error(), "unknown flag: --changed-only-ignore") {
+		t.Fatalf("error = %v, want unknown changed-only ignore flag", err)
+	}
+}
+
 func TestDiffImagesMarkdownOutput(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{
 		diffImagesResult: app.ImageDiffResult{

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -23,6 +23,8 @@ type Options struct {
 	MaxDiscoveryDepthSet           bool
 	DiscoverKustomizePaths         []string
 	ChangedOnly                    *bool
+	ChangedOnlyIncludes            []string
+	ChangedOnlyIgnores             []string
 	StrictChangedOnly              bool
 	Strict                         bool
 	ValidateLuaHealth              bool
@@ -79,23 +81,25 @@ func (options Options) Diff() app.DiffRequest {
 		changedOnly = *options.ChangedOnly
 	}
 	return app.DiffRequest{
-		LeftPath:              options.LeftPath,
-		RightPath:             options.RightPath,
-		Repo:                  options.Repo,
-		Ref:                   options.Ref,
-		RefOrig:               options.RefOrig,
-		DiscoveryOptions:      options.discoveryOptions(),
-		ChangedOnly:           changedOnly,
-		StrictChangedOnly:     options.StrictChangedOnly,
-		Strict:                options.Strict,
-		Unified:               options.Unified,
-		StripAttrs:            append([]string(nil), options.StripAttrs...),
-		ShowIgnoredFields:     options.ShowIgnoredFields,
-		AcquisitionOptions:    options.acquisitionOptions(),
-		PluginOptions:         options.pluginOptions(),
-		ExecutionOptions:      options.executionOptions(),
-		FilterOptions:         options.filterOptions(),
-		ApplicationSetOptions: options.applicationSetOptions(),
+		LeftPath:                options.LeftPath,
+		RightPath:               options.RightPath,
+		Repo:                    options.Repo,
+		Ref:                     options.Ref,
+		RefOrig:                 options.RefOrig,
+		DiscoveryOptions:        options.discoveryOptions(),
+		ChangedOnly:             changedOnly,
+		ChangedOnlyIncludeGlobs: append([]string(nil), options.ChangedOnlyIncludes...),
+		ChangedOnlyIgnoreGlobs:  append([]string(nil), options.ChangedOnlyIgnores...),
+		StrictChangedOnly:       options.StrictChangedOnly,
+		Strict:                  options.Strict,
+		Unified:                 options.Unified,
+		StripAttrs:              append([]string(nil), options.StripAttrs...),
+		ShowIgnoredFields:       options.ShowIgnoredFields,
+		AcquisitionOptions:      options.acquisitionOptions(),
+		PluginOptions:           options.pluginOptions(),
+		ExecutionOptions:        options.executionOptions(),
+		FilterOptions:           options.filterOptions(),
+		ApplicationSetOptions:   options.applicationSetOptions(),
 	}
 }
 

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -75,6 +75,8 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "MaxDiscoveryDepthSet", request.MaxDiscoveryDepthSet, true)
 	assertDeepEqual(t, "DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
 	assertDeepEqual(t, "ChangedOnly", request.ChangedOnly, true)
+	assertDeepEqual(t, "ChangedOnlyIncludeGlobs", request.ChangedOnlyIncludeGlobs, []string{"apps/**"})
+	assertDeepEqual(t, "ChangedOnlyIgnoreGlobs", request.ChangedOnlyIgnoreGlobs, []string{".github/**"})
 	assertDeepEqual(t, "StrictChangedOnly", request.StrictChangedOnly, true)
 	assertDeepEqual(t, "Strict", request.Strict, true)
 	assertDeepEqual(t, "Unified", request.Unified, 0)
@@ -110,6 +112,8 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 
 	mutateOptions(&options)
 	assertDeepEqual(t, "copied DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
+	assertDeepEqual(t, "copied ChangedOnlyIncludeGlobs", request.ChangedOnlyIncludeGlobs, []string{"apps/**"})
+	assertDeepEqual(t, "copied ChangedOnlyIgnoreGlobs", request.ChangedOnlyIgnoreGlobs, []string{".github/**"})
 	assertDeepEqual(t, "copied StripAttrs", request.StripAttrs, []string{"metadata.annotations.checksum/config"})
 	assertDeepEqual(t, "copied RepoMaps", request.RepoMaps, []source.RepoMap{{URL: "https://example.test/repo.git", Path: "/repo"}})
 	assertDeepEqual(t, "copied SkipKinds", request.SkipKinds, []string{"Secret"})
@@ -137,6 +141,8 @@ func fixtureOptions() Options {
 		MaxDiscoveryDepth:            2,
 		MaxDiscoveryDepthSet:         true,
 		DiscoverKustomizePaths:       []string{"argocd/overlays/prod"},
+		ChangedOnlyIncludes:          []string{"apps/**"},
+		ChangedOnlyIgnores:           []string{".github/**"},
 		StrictChangedOnly:            true,
 		Strict:                       true,
 		StripAttrs:                   []string{"metadata.annotations.checksum/config"},
@@ -185,6 +191,8 @@ func providerDataFixture() appset.ProviderData {
 func mutateOptions(options *Options) {
 	options.StripAttrs[0] = "mutated"
 	options.DiscoverKustomizePaths[0] = "mutated"
+	options.ChangedOnlyIncludes[0] = "mutated"
+	options.ChangedOnlyIgnores[0] = "mutated"
 	options.RepoMaps[0].Path = "/mutated"
 	options.RemoteResourceForbiddenRoots[0] = "/mutated"
 	options.SkipKinds[0] = "ConfigMap"

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -57,6 +57,8 @@ type Config struct {
 	ApplicationSetProviderFixtures []string
 	ApplicationSetProviderData     ApplicationSetProviderData
 	ChangedOnly                    *bool
+	ChangedOnlyIncludes            []string
+	ChangedOnlyIgnores             []string
 	StrictChangedOnly              bool
 	Unified                        int
 	StripAttrs                     []string
@@ -192,6 +194,8 @@ func (client *Client) requestOptions() requestopts.Options {
 		MaxDiscoveryDepthSet:           maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), client.config.DiscoverKustomizePaths...),
 		ChangedOnly:                    client.config.ChangedOnly,
+		ChangedOnlyIncludes:            append([]string(nil), client.config.ChangedOnlyIncludes...),
+		ChangedOnlyIgnores:             append([]string(nil), client.config.ChangedOnlyIgnores...),
 		StrictChangedOnly:              client.config.StrictChangedOnly,
 		Strict:                         client.config.Strict,
 		Unified:                        unified,

--- a/pkg/drydock/drydock_diff_test.go
+++ b/pkg/drydock/drydock_diff_test.go
@@ -2,6 +2,7 @@ package drydock
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,30 @@ func TestDiffApplications(t *testing.T) {
 	}
 	if result.Results[0].Change != "modified" {
 		t.Fatalf("Change = %q, want modified", result.Results[0].Change)
+	}
+}
+
+func TestDiffApplicationsChangedOnlyPathFilters(t *testing.T) {
+	left, right := writeDiffTrees(t, "v1", "v2")
+	writeAPIFile(t, filepath.Join(left, "README.md"), "left\n")
+	writeAPIFile(t, filepath.Join(right, "README.md"), "right\n")
+
+	result, err := DiffApplications(context.Background(), Config{
+		PathOrig:            left,
+		Path:                right,
+		ChangedOnly:         new(true),
+		StrictChangedOnly:   true,
+		ChangedOnlyIncludes: []string{"manifests/**"},
+		ChangedOnlyIgnores:  []string{"README.md"},
+	})
+	if err != nil {
+		t.Fatalf("DiffApplications() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("Results = %d, want 1", len(result.Results))
 	}
 }
 

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -95,6 +95,12 @@ inputs:
   changed-only:
     description: Override changed-only behavior with true or false. Leave empty for drydock defaults.
     required: false
+  changed-only-include:
+    description: Newline-delimited repository-relative glob patterns that define changed paths considered by changed-only selection.
+    required: false
+  changed-only-ignore:
+    description: Newline-delimited repository-relative glob patterns ignored by changed-only selection.
+    required: false
   show-ignored-fields:
     description: Show drydock default ignored diff fields.
     required: false
@@ -390,6 +396,8 @@ runs:
         DRYDOCK_DIFF_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-artifact-name }}
         DRYDOCK_IMAGE_ARTIFACT_NAME: ${{ steps.prepare.outputs.image-artifact-name }}
         DRYDOCK_INPUT_CHANGED_ONLY: ${{ inputs.changed-only }}
+        DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE: ${{ inputs.changed-only-include }}
+        DRYDOCK_INPUT_CHANGED_ONLY_IGNORE: ${{ inputs.changed-only-ignore }}
         DRYDOCK_INPUT_COMMENT_EMPTY: ${{ inputs.comment-empty }}
         DRYDOCK_INPUT_COMMENT_MODE: ${{ inputs.comment-mode }}
         DRYDOCK_INPUT_DIFF_MAX_BYTES: ${{ inputs.diff-max-bytes }}

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -101,7 +101,7 @@ capture_image_diff_json() {
   local stderr_file="$1"
   local -a image_args
 
-  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${diff_common_args[@]}")
   append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
   image_args+=(-o json --exit-code=false)
   if capture_command_quiet "${images_json_path}" "${stderr_file}" "${image_args[@]}"; then
@@ -340,6 +340,10 @@ if [[ -n "${DRYDOCK_INPUT_CHANGED_ONLY}" ]]; then
   common_args+=("--changed-only=${DRYDOCK_INPUT_CHANGED_ONLY}")
 fi
 
+diff_common_args=("${common_args[@]}")
+append_lines diff_common_args "${DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE}" "--changed-only-include"
+append_lines diff_common_args "${DRYDOCK_INPUT_CHANGED_ONLY_IGNORE}" "--changed-only-ignore"
+
 render_status="skipped"
 has_diff="false"
 has_images="false"
@@ -365,7 +369,7 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
     echo "A base ref is required when run-diff is true." >&2
     exit 1
   fi
-  diff_args=("${drydock_bin}" diff apps --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+  diff_args=("${drydock_bin}" diff apps --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${diff_common_args[@]}")
   append_bool_flag diff_args "${DRYDOCK_INPUT_SHOW_IGNORED_FIELDS}" "--show-ignored-fields"
   append_extra_lines diff_args "${DRYDOCK_INPUT_EXTRA_DIFF_ARGS}"
   diff_args+=(
@@ -393,7 +397,7 @@ if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
     echo "A base ref is required when run-image-diff is true." >&2
     exit 1
   fi
-  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+  image_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${diff_common_args[@]}")
   append_extra_lines image_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
   image_args+=(-o name)
   if capture_command_quiet "${images_path}" "${images_stderr}" "${image_args[@]}"; then
@@ -475,7 +479,7 @@ fi
 
 if [[ "${images_comment}" == "true" ]]; then
   if [[ "${DRYDOCK_INPUT_RUN_IMAGE_DIFF}" == "true" ]]; then
-    image_comment_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${common_args[@]}")
+    image_comment_args=("${drydock_bin}" diff images --repo "${repo}" --ref "${head_ref}" --ref-orig "${base_compare_ref}" "${diff_common_args[@]}")
     append_extra_lines image_comment_args "${DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS}"
     image_comment_args+=(
       -o markdown

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -17,6 +17,8 @@ func TestRunFallsBackToJSONWhenImageNameOutputIsUnsupported(t *testing.T) {
 	tmp := t.TempDir()
 	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
 set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
 
 if [[ "$*" == *"diff images"* && "$*" == *"-o name"* ]]; then
   echo "name output is not supported for diff images" >&2
@@ -61,6 +63,8 @@ esac
 	cmd.Dir = "."
 	cmd.Env = append(defaultRunEnv(tmp, workDir, outputPath),
 		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
+		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE=apps/**",
+		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE=.github/**",
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -88,6 +92,13 @@ esac
 	for _, want := range []string{"has-images=true", "has-image-diff=true"} {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("GITHUB_OUTPUT = %q, want %q", output, want)
+		}
+	}
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	for _, want := range []string{"-o name", "-o json", "--changed-only-include apps/**", "--changed-only-ignore .github/**"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("drydock args = %q, want %q", args, want)
 		}
 	}
 }
@@ -282,6 +293,45 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 	}
 }
 
+func TestRunPassesChangedOnlyPathFiltersOnlyToDiffCommands(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode:        "both",
+		diffOutput:         true,
+		imageOutput:        true,
+		runTest:            true,
+		changedOnlyInclude: "apps/**\nclusters/**",
+		changedOnlyIgnore:  ".github/**\nmise.lock",
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	lines := strings.Split(strings.TrimSpace(args), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
+	}
+	for _, line := range lines {
+		hasFilters := strings.Contains(line, "--changed-only-include apps/**") &&
+			strings.Contains(line, "--changed-only-include clusters/**") &&
+			strings.Contains(line, "--changed-only-ignore .github/**") &&
+			strings.Contains(line, "--changed-only-ignore mise.lock")
+		switch {
+		case strings.Contains(line, "test apps"):
+			if hasFilters {
+				t.Fatalf("test apps received diff-only changed path filters:\n%s", line)
+			}
+		case strings.Contains(line, "diff apps") || strings.Contains(line, "diff images"):
+			if !hasFilters {
+				t.Fatalf("diff command missing changed path filters:\n%s", line)
+			}
+		default:
+			t.Fatalf("unexpected drydock invocation:\n%s", line)
+		}
+	}
+}
+
 func TestRunImageCommentsUseMarkdownAfterExtraImageArgs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -435,8 +485,11 @@ type commentScenario struct {
 	imageMarkdownDisabled bool
 	imageJSONDisabled     bool
 	skipImageDiff         bool
+	runTest               bool
 	extraDiffArgs         string
 	extraImageArgs        string
+	changedOnlyInclude    string
+	changedOnlyIgnore     string
 }
 
 func runCommentScenario(t *testing.T, scenario commentScenario) string {
@@ -455,8 +508,11 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 		"DRYDOCK_INPUT_COMMENT_MODE="+commentMode,
 		"DRYDOCK_INPUT_EXTRA_DIFF_ARGS="+scenario.extraDiffArgs,
 		"DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS="+scenario.extraImageArgs,
+		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE="+scenario.changedOnlyInclude,
+		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE="+scenario.changedOnlyIgnore,
 		"DRYDOCK_INPUT_RUN_DIFF=true",
 		"DRYDOCK_INPUT_RUN_IMAGE_DIFF="+boolString(!scenario.skipImageDiff),
+		"DRYDOCK_INPUT_RUN_TEST="+boolString(scenario.runTest),
 		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS="+boolString(scenario.uploadArtifacts),
 		"DRYDOCK_INPUT_COMMENT_EMPTY="+boolString(scenario.commentEmpty),
 		"GITHUB_SERVER_URL=",
@@ -509,6 +565,10 @@ func writeCommentScenarioDrydock(t *testing.T, path string, scenario commentScen
 set -euo pipefail
 mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
 printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+
+if [[ "$*" == *"test apps"* ]]; then
+  exit 0
+fi
 
 if [[ "$*" == *"diff apps"* ]]; then
   `+diffOutput+`
@@ -683,6 +743,8 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_DIFF_ARTIFACT_NAME=diff",
 		"DRYDOCK_IMAGE_ARTIFACT_NAME=images",
 		"DRYDOCK_INPUT_CHANGED_ONLY=",
+		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE=",
+		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE=",
 		"DRYDOCK_INPUT_COMMENT_EMPTY=false",
 		"DRYDOCK_INPUT_COMMENT_MODE=none",
 		"DRYDOCK_INPUT_DIFF_MAX_BYTES=60000",

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,11 +11,6 @@ Use it locally or in CI to answer operator questions that are hard to review in
 raw Git: which Applications render, which desired resources changed, which
 images moved, and which repository inputs need attention.
 
-Argo CD remains the semantic reference for generated desired state. drydock
-front-loads that validation into an isolated render parity smoke for covered
-fixtures and semantic-rendering changes, while normal operator commands stay
-runtime-offline from Argo CD and Kubernetes.
-
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 
 ## Start Here

--- a/site/content/concepts/changed-only.md
+++ b/site/content/concepts/changed-only.md
@@ -29,6 +29,22 @@ Fail when ownership cannot be proven:
 drydock diff apps --repo . --ref HEAD --ref-orig main --strict-changed-only
 ```
 
+Scope the changed paths considered by ownership mapping:
+
+```bash
+drydock diff apps \
+  --repo . \
+  --ref HEAD \
+  --ref-orig main \
+  --changed-only-include 'apps/**' \
+  --changed-only-ignore '.github/**'
+```
+
+Include and ignore globs are repository-relative. If no include globs are set,
+all changed paths are considered. Ignore globs are applied after includes, so
+ignore wins. When every changed path is filtered out, drydock reports an empty
+diff instead of rendering the fleet.
+
 `diff app` selects one requested Application directly and does not use
 changed-only Git path filtering.
 
@@ -37,6 +53,10 @@ changed-only Git path filtering.
 Changed-only behavior is Argo Application-aware. Shared resources from
 different Applications remain separate diff identities; drydock does not
 collapse overlapping Applications into one owner.
+
+Path filters are explicit command or workflow policy. Keep filters narrow in
+repositories that use plugins or unusual generation paths, because an ignored
+file is no longer eligible to trigger a render.
 
 For detailed diff semantics and exit codes, see the [CLI usage guide](/docs/usage/)
 and [compatibility notes](/docs/compatibility/).

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -60,6 +60,10 @@ jobs:
         with:
           comment-mode: both
           skip-secrets: "true"
+          changed-only-include: |
+            apps/**
+          changed-only-ignore: |
+            .github/**
 ```
 
 The PR action checks out the pull request, fetches the base ref, runs
@@ -67,6 +71,10 @@ The PR action checks out the pull request, fetches the base ref, runs
 artifacts when differences are found, and comments in trusted same-repository
 pull requests. Image diff comments are available as a companion signal. Fork
 pull requests skip comments and source-cache restore/save by default.
+
+`changed-only-include` and `changed-only-ignore` are optional newline-delimited
+globs passed to manifest and image diffs. They keep known non-GitOps paths from
+forcing a full-fleet changed-only fallback. They do not affect `test apps`.
 
 ## Manifest Diff Comment Shape
 

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -34,10 +34,16 @@ URLs are not supported.
 
 - `--changed-only=false` renders all discovered Applications.
 - `--strict-changed-only` fails if changed-file ownership is incomplete.
+- `--changed-only-include 'apps/**'` considers only matching changed paths.
+- `--changed-only-ignore '.github/**'` removes matching paths before ownership.
 - `--skip-secrets` omits Secret resources from output and diffs.
 - `--skip-crds` omits CRDs from output and diffs.
 - `--show-ignored-fields` shows drydock default ignored metadata fields.
 - `--exit-code=false` keeps the command successful when differences exist.
+
+Changed-only filters are repository-relative and repeatable. They are useful
+when local commits include known non-GitOps files, but they should stay narrow:
+ignored files cannot trigger an Application render.
 
 ## Markdown For Reviews
 


### PR DESCRIPTION
## Summary
- add explicit changed-only include/ignore glob filters for diff apps and diff images
- expose filters through CLI, Go API, and pr-action inputs without affecting test apps
- document operator semantics and keep the docs overview focused on day-to-day use

## Test Plan
- go test ./...
- mise run lint
- mise run docs-check
- mise run markdownlint
- mise run shellcheck
- mise run actionlint
- git diff --check

## Review
- spec review: approved
- quality review: approved