### PR TITLE
ci: parallelize release validation

### DIFF
--- a/.github/workflows/argocd-parity-smoke.yml
+++ b/.github/workflows/argocd-parity-smoke.yml
@@ -4,7 +4,27 @@ name: Argo CD Render Parity Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      drydock_archive_name:
+        description: Release archive inside the artifact to smoke test.
+        required: false
+        default: drydock_linux-amd64.tar.gz
+      drydock_artifact_name:
+        description: Optional uploaded artifact containing release archives.
+        required: false
+        default: ""
   workflow_call:
+    inputs:
+      drydock_archive_name:
+        description: Release archive inside the artifact to smoke test.
+        required: false
+        type: string
+        default: drydock_linux-amd64.tar.gz
+      drydock_artifact_name:
+        description: Optional uploaded artifact containing release archives.
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: argocd-parity-smoke-${{ github.ref }}
@@ -43,12 +63,60 @@ jobs:
           wait: 120s
 
       - name: Build drydock
+        if: inputs.drydock_artifact_name == ''
         run: go build -trimpath -o dist/drydock ./cmd/drydock
 
+      - name: Download release artifacts
+        if: inputs.drydock_artifact_name != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.drydock_artifact_name }}
+          path: dist/
+
+      - name: Extract release drydock
+        if: inputs.drydock_artifact_name != ''
+        id: release-binary
+        env:
+          ARCHIVE: ${{ inputs.drydock_archive_name }}
+        shell: bash
+        run: |
+          archive_path="dist/${ARCHIVE}"
+          checksums_path="dist/checksums.txt"
+          binary_dir="${RUNNER_TEMP}/drydock-release-binary"
+          binary_path="${binary_dir}/drydock"
+
+          if [[ ! -f "${archive_path}" ]]; then
+            echo "Release archive not found: ${archive_path}" >&2
+            exit 1
+          fi
+          if [[ ! -f "${checksums_path}" ]]; then
+            echo "Release checksum manifest not found: ${checksums_path}" >&2
+            exit 1
+          fi
+
+          checksum="$(awk -v archive="${ARCHIVE}" '$2 == archive { print $1 }' "${checksums_path}")"
+          if [[ -z "${checksum}" ]]; then
+            echo "checksums.txt does not contain ${ARCHIVE}" >&2
+            exit 1
+          fi
+          printf '%s  %s\n' "${checksum}" "${archive_path}" | sha256sum --check --status
+
+          mkdir -p "${binary_dir}"
+          tar -xzf "${archive_path}" -C "${binary_dir}" drydock
+          if [[ ! -x "${binary_path}" ]]; then
+            echo "Extracted drydock binary is missing or not executable: ${binary_path}" >&2
+            exit 1
+          fi
+
+          echo "path=${binary_path}" >> "${GITHUB_OUTPUT}"
+
       - name: Run Argo CD render parity smoke
+        env:
+          RELEASE_BINARY: ${{ steps.release-binary.outputs.path }}
+        shell: bash
         run: >-
           scripts/argocd-parity-smoke.sh
-          --binary ./dist/drydock
+          --binary "${RELEASE_BINARY:-./dist/drydock}"
           --out "${RUNNER_TEMP}/argocd-parity-smoke"
           --cluster-name drydock-argocd-parity-smoke
           --existing-cluster

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
             echo "tag=${tag}"
           } >> "${GITHUB_OUTPUT}"
 
-  source-checks:
+  source-go-test:
     needs:
       - release-meta
     if: needs.release-meta.outputs.publish == 'true'
@@ -116,17 +116,132 @@ jobs:
       - name: Vet
         run: mise run vet
 
+  source-go-lint:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
       - name: Lint Go
         run: mise run lint
 
+  source-markdownlint:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
       - name: Lint Markdown
         run: mise run markdownlint
+
+  source-docs-site:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Build documentation site
+        run: mise run docs-check
+
+  source-workflow-lint:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
 
       - name: Lint GitHub Actions
         run: mise run actionlint
 
       - name: Audit GitHub Actions security
         run: mise run zizmor
+
+  source-shellcheck:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Lint shell scripts
+        run: mise run shellcheck
+
+  source-whitespace:
+    needs:
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Diff check
         shell: bash
@@ -144,10 +259,57 @@ jobs:
             fi
           fi
 
+  source-checks:
+    needs:
+      - release-meta
+      - source-docs-site
+      - source-go-lint
+      - source-go-test
+      - source-markdownlint
+      - source-shellcheck
+      - source-whitespace
+      - source-workflow-lint
+    if: always() && needs.release-meta.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify source checks
+        env:
+          SOURCE_DOCS_SITE: ${{ needs.source-docs-site.result }}
+          SOURCE_GO_LINT: ${{ needs.source-go-lint.result }}
+          SOURCE_GO_TEST: ${{ needs.source-go-test.result }}
+          SOURCE_MARKDOWNLINT: ${{ needs.source-markdownlint.result }}
+          SOURCE_SHELLCHECK: ${{ needs.source-shellcheck.result }}
+          SOURCE_WHITESPACE: ${{ needs.source-whitespace.result }}
+          SOURCE_WORKFLOW_LINT: ${{ needs.source-workflow-lint.result }}
+        shell: bash
+        run: |
+          failed="false"
+          for check in \
+            "source-docs-site=${SOURCE_DOCS_SITE}" \
+            "source-go-lint=${SOURCE_GO_LINT}" \
+            "source-go-test=${SOURCE_GO_TEST}" \
+            "source-markdownlint=${SOURCE_MARKDOWNLINT}" \
+            "source-shellcheck=${SOURCE_SHELLCHECK}" \
+            "source-whitespace=${SOURCE_WHITESPACE}" \
+            "source-workflow-lint=${SOURCE_WORKFLOW_LINT}"; do
+            name="${check%%=*}"
+            result="${check#*=}"
+            echo "${name}: ${result}"
+            if [[ "${result}" != "success" ]]; then
+              failed="true"
+            fi
+          done
+
+          if [[ "${failed}" == "true" ]]; then
+            echo "One or more release source checks failed." >&2
+            exit 1
+          fi
+
   binaries:
     needs:
       - release-meta
-      - source-checks
     if: needs.release-meta.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -197,7 +359,6 @@ jobs:
   image:
     needs:
       - release-meta
-      - source-checks
     if: needs.release-meta.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -239,11 +400,25 @@ jobs:
           cache-from: type=gha,scope=drydock
           cache-to: type=gha,scope=drydock,mode=max,ignore-error=true
 
+  argocd-render-parity-smoke:
+    needs:
+      - binaries
+      - release-meta
+    if: needs.release-meta.outputs.publish == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/argocd-parity-smoke.yml
+    with:
+      drydock_archive_name: drydock_linux-amd64.tar.gz
+      drydock_artifact_name: release-artifacts
+
   stage-release:
     needs:
+      - argocd-render-parity-smoke
       - binaries
       - image
       - release-meta
+      - source-checks
     if: needs.release-meta.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ charts, or existing cache hits only.
 
 ## Install
 
-Install the latest Linux/macOS release:
+Install the latest Linux/macOS release with Homebrew:
+
+```bash
+brew install sholdee/tap/drydock
+```
+
+Homebrew installs shell completions automatically.
+
+<details>
+<summary>Install Script</summary>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh -o install-drydock.sh
@@ -49,6 +58,22 @@ bash install-drydock.sh --yes
 The script verifies release checksums, verifies Sigstore bundles when
 available, installs the `drydock` binary, and attempts shell completion
 installation. Pin a release with `--version vX.Y.Z`.
+
+Pipe form:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --yes
+```
+
+Pinned pipe form:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --version vX.Y.Z --yes
+```
+
+Use `--no-completions` when completions should be installed manually.
+
+</details>
 
 For GitOps repository and CI pinning, use `mise` with the GitHub backend:
 
@@ -97,36 +122,6 @@ selected archive with the release checksum manifest by default.
 See the [GitHub Actions reference](https://sholdee.github.io/drydock/docs/github-actions/)
 for full action inputs, GitHub App token support, cache behavior, comments,
 artifacts, and outputs.
-
-</details>
-
-<details>
-<summary>Homebrew</summary>
-
-```bash
-brew install sholdee/tap/drydock
-```
-
-Homebrew installs shell completions automatically.
-
-</details>
-
-<details>
-<summary>Install Script Options</summary>
-
-Pipe form:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --yes
-```
-
-Pinned pipe form:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --version vX.Y.Z --yes
-```
-
-Use `--no-completions` when completions should be installed manually.
 
 </details>
 

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -9,7 +9,15 @@ directory, Kustomize, Helm, and Jsonnet paths.
 
 ## Install
 
-Install the latest Linux/macOS release:
+Install the latest Linux/macOS release with Homebrew:
+
+```bash
+brew install sholdee/tap/drydock
+```
+
+Homebrew installs shell completions automatically.
+
+{{< details summary="Install Script" >}}
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh -o install-drydock.sh
@@ -19,6 +27,22 @@ bash install-drydock.sh --yes
 The script verifies release checksums, verifies Sigstore bundles when
 available, installs the `drydock` binary, and attempts shell completion
 installation. Pin a release with `--version vX.Y.Z`.
+
+Pipe form:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --yes
+```
+
+Pinned pipe form:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --version vX.Y.Z --yes
+```
+
+Use `--no-completions` when completions should be installed manually.
+
+{{< /details >}}
 
 For GitOps repository and CI pinning, use `mise` with the GitHub backend:
 
@@ -40,32 +64,6 @@ Use `setup-action` when your workflow owns the drydock commands:
 Use `pr-action` for the standard pull request render test, manifest diff,
 image diff, artifacts, cache, and comment workflow. See
 [GitHub Actions](/workflows/github-actions/) for inputs and permissions.
-
-{{< /details >}}
-
-{{< details summary="Homebrew" >}}
-
-```bash
-brew install sholdee/tap/drydock
-```
-
-Homebrew installs completions automatically.
-
-{{< /details >}}
-
-{{< details summary="Install Script Options" >}}
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --yes
-```
-
-Pinned pipe form:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/install-drydock.sh | bash -s -- --version vX.Y.Z --yes
-```
-
-Use `--no-completions` when completions should be installed manually.
 
 {{< /details >}}
 


### PR DESCRIPTION
## Summary
- split release source checks into parallel jobs with the existing source-checks aggregate gate
- run release binary and image validation earlier while keeping stage-release blocked on all checks
- extend the Argo CD parity smoke workflow to validate the GoReleaser release artifact by checksum before running it
- make Homebrew the default visible install path in README and getting started docs

## Validation
- mise run actionlint
- mise run zizmor
- mise run markdownlint
- mise run docs-check
- git diff --check

## Reviews
- spec review approved
- quality review approved