### PR TITLE
docs: clarify render parity and README routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,13 @@ change reaches the cluster. Pull request diffing is a key workflow, but
 the same native engine also supports render validation, image inventory,
 repository diagnostics, cache inspection, and Go API embedding.
 
+Default commands use native Go renderers and do not shell out to `kubectl`,
+`argocd`, Helm CLI, Kustomize CLI, or repo-server wrappers. Runtime-offline
+does not mean network-disconnected: declared Git, HTTP Helm, OCI Helm, and
+remote Kustomize sources may still be fetched into explicit drydock caches
+unless `--offline` is set.
+
 **Full documentation:** [sholdee.github.io/drydock](https://sholdee.github.io/drydock/).
-
-Core properties:
-
-- Single static Go binary for local use and CI.
-- Native Go renderers and public Go APIs; no repo-server wrapper.
-- No default shellouts to `kubectl`, `argocd`, Helm, Kustomize, or config
-  management plugin commands.
-- Runtime-offline analysis: no running cluster or Argo CD server is required.
-- Cache-backed source acquisition for fast repeatable validation.
-
-Runtime-offline does not mean network-disconnected. Declared Git, HTTP Helm,
-OCI Helm, and remote Kustomize sources may be fetched into explicit drydock
-caches when needed. Use `--offline` to require local files, repo maps, local
-charts, or existing cache hits only.
 
 ## Install
 
@@ -46,6 +38,13 @@ brew install sholdee/tap/drydock
 ```
 
 Homebrew installs shell completions automatically.
+
+For GitOps repository and CI pinning, use `mise` with the GitHub backend:
+
+```toml
+[tools]
+"github:sholdee/drydock[exe=drydock]" = "vX.Y.Z"
+```
 
 <details>
 <summary>Install Script</summary>
@@ -74,13 +73,6 @@ curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/instal
 Use `--no-completions` when completions should be installed manually.
 
 </details>
-
-For GitOps repository and CI pinning, use `mise` with the GitHub backend:
-
-```toml
-[tools]
-"github:sholdee/drydock[exe=drydock]" = "vX.Y.Z"
-```
 
 <details>
 <summary>GitHub Actions</summary>
@@ -170,6 +162,12 @@ drydock completion fish
 
 Run drydock from the root of an Argo CD GitOps repository.
 
+List discovered Applications:
+
+```bash
+drydock get apps --path .
+```
+
 Test every discovered Application without printing rendered manifests:
 
 ```bash
@@ -242,85 +240,49 @@ full command reference.
 
 ## What It Supports
 
-drydock discovers and renders local Argo CD desired state, including:
+drydock covers the common Argo CD GitOps repository shapes operators need to
+inspect locally and in CI:
 
-- Static `Application` resources, supported `ApplicationSet` generators, and
-  rendered child `Application`, `ApplicationSet`, `AppProject`, and settings
-  objects from app-of-apps/bootstrap sources.
-- Optional additional rendered discovery from explicit local Kustomize
-  entrypoints with `--discover-kustomize`.
-- Single-source and multi-source Applications.
-- Directory, Kustomize, local Helm chart, remote Helm chart, and remote
-  Kustomize sources.
-- Discovered safe Kustomize build config management plugins rendered through
-  drydock's native Kustomize adapter, without executing plugin commands.
-- Trusted plugin policy entries for native `avp-compat` placeholder redaction
-  and native plugin overrides.
-- Explicit trusted exec plugin policy support with `--enable-plugins` for
-  operators who need shellout CMP compatibility, including policy-defined
-  post-renderer chains.
-- Declared Git, HTTP Helm, OCI Helm, and remote Kustomize source acquisition
-  into local caches.
-- Fast cache-backed repeated runs for local development and CI.
-- Repository maps with `--repo-map URL=PATH` for adjacent local checkouts.
-- Changed-only desired-vs-desired PR diffs, with strict diagnostics available
-  when a safe ownership decision cannot be made.
-- Default diff noise filtering for common Helm chart/version labels and
-  pod-template checksum annotations, with `--show-ignored-fields` when those
-  fields need inspection.
-- Argo CD diff customizations such as `ignoreDifferences`,
-  `knownTypeFields`, selected compare options, and resource filters.
-- Per-Application render test status as `PASS`, `FAIL`, or `SKIPPED`, including
-  structured JSON and YAML output.
-- Offline validation of configured custom health Lua during render tests.
-- Redacted diagnostics for settings, source repositories, AppProjects, and
-  cache acquisition events.
-- Cache lifecycle commands for Git, chart, and remote Kustomize caches.
+- **Application discovery:** committed Applications, supported ApplicationSets,
+  rendered app-of-apps/bootstrap children, explicit Kustomize discovery
+  entrypoints, AppProjects, and settings objects.
+- **Rendering:** directory, Kustomize, Helm, Jsonnet, single-source and
+  multi-source Applications, Kustomize Helm charts, remote Helm charts, and
+  remote Kustomize sources.
+- **Source acquisition:** declared Git, HTTP Helm, OCI Helm, and remote
+  Kustomize inputs through explicit drydock caches, plus `--repo-map` for
+  adjacent local checkouts.
+- **Diffs and images:** desired-vs-desired manifest and image diffs,
+  changed-only selection, default noisy-field filtering, and structured or
+  markdown output.
+- **Plugins:** native safe Kustomize compatibility, `avp-compat` placeholder
+  redaction, native policy overrides, and explicit trusted exec policy with
+  `--enable-plugins`.
+- **Diagnostics:** render status, custom health Lua validation, redacted
+  settings/repository/AppProject checks, source acquisition diagnostics, and
+  cache lifecycle commands.
 
-See the [compatibility notes](https://sholdee.github.io/drydock/docs/compatibility/)
-for the detailed Argo CD support matrix. See
-[ApplicationSets](https://sholdee.github.io/drydock/docs/applicationsets/) for
-generator details and
-[source acquisition](https://sholdee.github.io/drydock/docs/source-acquisition/)
-for remote source, cache, and auth behavior.
+See the [compatibility overview](https://sholdee.github.io/drydock/compatibility/)
+for the support matrix and links to detailed reference docs.
 
 ## Offline Runtime Model
 
-drydock is desired-vs-desired analysis. It renders the desired Kubernetes
-manifests from a current tree and, for diff commands, a baseline tree. It does
-not ask a live cluster or Argo CD server what is currently running. Network
-source acquisition, when enabled, is limited to populating explicit drydock
-caches for declared repository, chart, and remote Kustomize inputs.
+drydock performs desired-vs-desired analysis. It renders Kubernetes manifests
+from repository inputs, explicit mappings, and drydock caches. Diff commands
+compare a current snapshot to a baseline snapshot.
 
-Default commands do not reproduce:
+Default commands do not ask a live Kubernetes cluster or Argo CD server what is
+currently running. They also do not reproduce runtime behavior such as API
+defaulting, admission mutation, server-side diff, live health aggregation,
+managed-fields ownership, or full RBAC authorization.
 
-- Kubernetes API defaulting or admission mutation.
-- Argo CD server-side diff.
-- Live Argo CD Application health aggregation.
-- Live-only managed-field ownership.
-- Full Argo CD RBAC authorization.
-- CLI config management plugin execution or shellout plugin adapters unless an
-  explicit trusted exec plugin policy is enabled.
+This boundary is intentional: normal workflows stay fast, deterministic, and
+safe for local use and CI. Source acquisition may still fetch declared Git,
+Helm, OCI, or remote Kustomize inputs unless `--offline` is set.
 
-Plugin command execution fails closed unless an embedding caller injects an
-in-process renderer or a trusted drydock exec plugin policy matches the plugin
-name. Discovered safe Kustomize build CMP definitions and native policy
-engines do not execute plugin commands. Exec policy requires trusted
-provenance and `--enable-plugins`. See
-the [plugin policy guide](https://sholdee.github.io/drydock/docs/plugin-policy/)
-for the policy schema, provenance rules, CMP compatibility model, and exec
-security controls.
-
-These behaviors are not silently approximated. The no-live-runtime boundary is
-an intentional product decision so the default cache-backed workflow stays
-deterministic and safe for CI.
-
-Structured outputs keep stdout machine-parseable. Diagnostics and failure
-summaries are written to stderr where appropriate, and drydock avoids printing
-Secret values, repository credentials, tokens, SSH private keys, passphrases,
-registry credentials, or credential-bearing URLs. Repository and cluster Secret
-diagnostics use non-sensitive metadata only, and `argocd-cmd-params-cm` is
-reported as runtime-boundary metadata rather than a render-behavior override.
+See [Runtime Offline](https://sholdee.github.io/drydock/concepts/runtime-offline/)
+and [Argo CD Render Parity](https://sholdee.github.io/drydock/concepts/argocd-render-parity/)
+for the design model and validation strategy.
 
 ## How It Works
 
@@ -361,9 +323,8 @@ manifests, diagnostics, and per-Application statuses from the partial build.
 
 ## Community
 
-drydock is independently implemented, but its offline GitOps desired-state workflow
-was inspired by [home-operations/flate](https://github.com/home-operations/flate)
-and the home-operations community.
+drydock is inspired by [Flate](https://github.com/home-operations/flate), a
+Flux resource inflator, and the home-operations community.
 
 Join the home-operations Discord at <https://discord.gg/home-operations>.
 
@@ -371,20 +332,24 @@ Join the home-operations Discord at <https://discord.gg/home-operations>.
 
 - [Documentation site](https://sholdee.github.io/drydock/): curated operator
   docs and full reference pages.
-- [Getting started](https://sholdee.github.io/drydock/getting-started/): first
-  local render test and comparison commands.
+- [Getting started](https://sholdee.github.io/drydock/getting-started/):
+  first local discovery, render test, and comparison commands.
 - [GitHub Actions](https://sholdee.github.io/drydock/workflows/github-actions/):
   setup action, PR action, comments, artifacts, and caches.
-- [CLI usage](https://sholdee.github.io/drydock/docs/usage/): command
-  workflows, outputs, diagnostics, and diff flags.
+- [Local diffs](https://sholdee.github.io/drydock/workflows/local-diffs/):
+  terminal manifest and image diff workflows.
 - [Compatibility](https://sholdee.github.io/drydock/compatibility/): supported
   Argo CD behavior and intentional runtime boundaries.
+- [Runtime Offline](https://sholdee.github.io/drydock/concepts/runtime-offline/):
+  what drydock does without live Argo CD or Kubernetes.
+- [Argo CD Render Parity](https://sholdee.github.io/drydock/concepts/argocd-render-parity/):
+  how covered render semantics are validated against real Argo CD.
 - [Plugin policy](https://sholdee.github.io/drydock/plugin-policy/): trusted
   policy engines, schema, CMP compatibility, and exec security.
 - [Source acquisition](https://sholdee.github.io/drydock/concepts/source-acquisition/):
   Git, Helm, remote Kustomize, cache, and auth behavior.
-- [Release notes](https://sholdee.github.io/drydock/docs/release/): release
-  and Argo CD dependency upgrade notes.
+- [Reference](https://sholdee.github.io/drydock/reference/): full command and
+  behavior reference.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ copying the same rule into multiple files.
 | `docs/logo/` | Project logo assets. |
 | `docs/reports/live-integration-design-gate.md` | No-live-runtime boundary and gate for exceptions. |
 | `site/` | Hugo docs site source, curated operator pages, local layouts, and GitHub Pages configuration. |
+| `site/content/concepts/argocd-render-parity.md` | Curated operator explanation of Argo CD render parity and drydock's validation strategy. |
 
 ## Anti-Sprawl Rules
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -42,7 +42,7 @@ drydock diag --path .
 | --- | --- | --- |
 | Confirm the fleet renders | `drydock test apps --path .` | [Getting started](/getting-started/) |
 | Review manifest changes | `drydock diff apps --repo . --ref HEAD --ref-orig main -o markdown` | [GitHub Actions](/workflows/github-actions/) |
-| Scan image movement | `drydock diff images --repo . --ref HEAD --ref-orig main -o markdown` | [Local diffs](/workflows/local-diffs/) |
+| Scan image movement | `drydock diff images --repo . --ref HEAD --ref-orig main` | [Local diffs](/workflows/local-diffs/) |
 | Explain warnings or failures | `drydock diag --path . --cache-events` | [Troubleshooting](/troubleshooting/) |
 | Validate cache-only operation | `drydock test apps --path . --offline` | [Source acquisition](/concepts/source-acquisition/) |
 

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -73,8 +73,12 @@ Rendering intentionally does not call live Argo CD, Kubernetes, `kubectl`,
 `argocd`, Helm CLI, or Kustomize CLI. That keeps local and CI analysis fast,
 portable, and reproducible.
 
-See [source acquisition](/docs/source-acquisition/) and
-[runtime-offline design](/concepts/runtime-offline/).
+Covered rendering semantics are validated against real Argo CD through the
+[render parity smoke](/concepts/argocd-render-parity/).
+
+See [source acquisition](/docs/source-acquisition/),
+[runtime-offline design](/concepts/runtime-offline/), and
+[Argo CD render parity](/concepts/argocd-render-parity/).
 
 ### Plugins
 

--- a/site/content/concepts/argocd-render-parity.md
+++ b/site/content/concepts/argocd-render-parity.md
@@ -1,0 +1,67 @@
+---
+title: Argo CD Render Parity
+---
+
+Argo CD is the semantic reference for generated desired manifests. drydock
+keeps normal render, test, diff, image, and diagnostic commands
+runtime-offline, then validates covered rendering semantics against real Argo
+CD in isolated maintainer smoke tests.
+
+The goal is not to replace Argo CD as the source of truth. The goal is to make
+repository analysis fast, portable, and repeatable without requiring every
+local command or pull request check to stand up Argo CD and Kubernetes.
+
+## Why Not Call Argo CD Every Time?
+
+Calling Argo CD for every diff can be accurate, but it makes each run depend on
+a live Argo CD installation, Kubernetes access, runtime credentials, API
+availability, controller readiness, and more CI setup.
+
+drydock takes a different tradeoff. Maintainer validation proves covered
+rendering semantics against real Argo CD, while normal operator workflows use
+the native runtime-offline engine.
+
+## What This Buys Operators
+
+- **Performance:** normal commands avoid live Argo CD startup, controller, API,
+  and cluster costs.
+- **Portability:** one static binary works locally and in CI without `kubectl`,
+  `argocd`, Helm CLI, Kustomize CLI, or repo-server wrappers.
+- **Repeatability:** results come from repository inputs, explicit source maps,
+  and drydock caches instead of live runtime state.
+- **Lower CI burden:** consuming repositories can run fast offline checks while
+  drydock maintainers front-load Argo CD semantic validation.
+
+## How Validation Works
+
+The render parity smoke starts a kind cluster, installs the pinned Argo CD
+version, serves a fixture Git repository to Argo CD, and applies fixture
+`Application` and `ApplicationSet` objects.
+
+For each fixture Application, the smoke captures Argo CD rendered manifests,
+renders the same Application with drydock, canonicalizes both manifest streams
+by Kubernetes resource identity, and compares the results. A mismatch is
+treated as a rendering regression for the covered fixture set.
+
+## Covered Areas
+
+| Area | Covered examples |
+| --- | --- |
+| Directory | recurse, include/exclude handling, skip files |
+| Helm | release name and namespace, values, parameters, file parameters, capabilities, value-file globs, skip CRDs/tests |
+| Kustomize | base rendering, namespace, images, replicas, labels, annotations, components, patches, Helm charts |
+| Jsonnet | ext vars, top-level arguments, code mode, libraries |
+| Multi-source | `$ref` values, ref-only sources, source precedence, last-wins resources |
+| ApplicationSet | git directories, git files, list, matrix, merge, Go templates, `missingkey=error`, selectors, generator template overrides, `templatePatch` |
+| Tracking and resources | Argo CD tracking metadata, repeated-resource behavior |
+
+The source of truth for the active fixture inventory is the parity smoke script;
+this table summarizes the covered semantics rather than enumerating every
+fixture name.
+
+## How To Read The Coverage
+
+The parity smoke is not a proof that every possible Argo CD repository shape is
+identical. It is a regression harness for the rendering semantics drydock
+implements. If a semantic gap is found, the fix should add or extend a parity
+fixture.

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -36,7 +36,9 @@ exec plugins.
 
 Argo CD remains the semantic reference for generated desired manifests. drydock
 keeps this rendering path runtime-offline, then validates covered fixture
-semantics against real Argo CD through the render parity smoke.
+semantics against real Argo CD through the render parity smoke. See
+[Argo CD Render Parity](/concepts/argocd-render-parity/) for the validation
+strategy.
 
 ## Normalization
 

--- a/site/content/concepts/runtime-offline.md
+++ b/site/content/concepts/runtime-offline.md
@@ -11,22 +11,10 @@ Runtime-offline does not mean every source network request is disabled.
 Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources can still be
 fetched into explicit caches unless `--offline` is set.
 
-## Why Not Call Argo CD Every Time?
+## Runtime Boundary
 
-Argo CD is the semantic reference for generated desired manifests, but calling
-it for every local render, PR diff, or diagnostic run requires a running Argo
-CD instance, Kubernetes access, runtime credentials, and more CI setup.
-
-drydock chooses a different tradeoff. Normal commands stay runtime-offline and
-fast, while maintainer validation compares covered fixture output against real
-Argo CD through an isolated render parity smoke. That front-loads compatibility
-checks without making every operator command depend on live runtime services.
-
-This does not change source acquisition behavior. Runtime-offline commands may
-still fetch declared Git, Helm, OCI, or remote Kustomize sources unless
-`--offline` is set.
-
-## What drydock Does Not Call
+Runtime-offline describes the live services drydock does not need while a
+command runs. It does not call:
 
 - Live Kubernetes APIs.
 - Live Argo CD APIs.
@@ -37,6 +25,9 @@ still fetch declared Git, Helm, OCI, or remote Kustomize sources unless
 
 Those behaviors stay runtime-boundary diagnostics or documented gaps; drydock
 does not silently approximate them from live state.
+
+For how covered render output is validated against real Argo CD, see
+[Argo CD Render Parity](/concepts/argocd-render-parity/).
 
 ## When To Use `--offline`
 

--- a/site/content/concepts/topologies.md
+++ b/site/content/concepts/topologies.md
@@ -21,9 +21,10 @@ drydock get apps --path .
 drydock test apps --path .
 ```
 
-Fleet commands render bootstrap Applications to discover rendered child
-Applications and settings. Add `--discovery-mode static` when only committed
-objects should count.
+By default, fleet commands recursively render bootstrap Applications and
+app-of-apps sources to discover rendered `Application`, `ApplicationSet`,
+`AppProject`, and Argo CD settings objects until discovery converges. Add
+`--discovery-mode static` when only committed objects should count.
 
 ## Kustomize Bootstrap
 

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -17,6 +17,13 @@ brew install sholdee/tap/drydock
 
 Homebrew installs shell completions automatically.
 
+For GitOps repository and CI pinning, use `mise` with the GitHub backend:
+
+```toml
+[tools]
+"github:sholdee/drydock[exe=drydock]" = "vX.Y.Z"
+```
+
 {{< details summary="Install Script" >}}
 
 ```bash
@@ -43,13 +50,6 @@ curl -fsSL https://raw.githubusercontent.com/sholdee/drydock/main/scripts/instal
 Use `--no-completions` when completions should be installed manually.
 
 {{< /details >}}
-
-For GitOps repository and CI pinning, use `mise` with the GitHub backend:
-
-```toml
-[tools]
-"github:sholdee/drydock[exe=drydock]" = "vX.Y.Z"
-```
 
 {{< details summary="GitHub Actions" >}}
 
@@ -104,15 +104,13 @@ drydock completion fish
 Run these from the GitOps repository you want to inspect:
 
 ```bash
-drydock test apps --path .
 drydock get apps --path .
-drydock diag --path .
+drydock test apps --path .
 ```
 
-Start with `drydock test apps --path .`. It discovers Applications and renders
-them without printing manifest bodies, which makes it the fastest first check
-for render failures. `get apps` shows discovered Applications. `diag` uses the
-same discovery and render validation path, then reports repository diagnostics.
+Start with `drydock get apps --path .` to confirm which Applications drydock
+discovers. Then run `drydock test apps --path .` to render them without
+printing manifest bodies and surface warnings or errors.
 
 If you are setting this up for CI, go to [GitHub Actions](/workflows/github-actions/)
 next.
@@ -124,15 +122,19 @@ Compare the current tree against a baseline worktree:
 ```bash
 git worktree add ../baseline main
 drydock diff apps --path . --path-orig ../baseline
-drydock diff images --path . --path-orig ../baseline -o markdown
+drydock diff images --path . --path-orig ../baseline
 ```
 
 Or compare local Git refs without creating a second checkout:
 
 ```bash
 drydock diff apps --repo . --ref HEAD --ref-orig main
-drydock diff images --repo . --ref HEAD --ref-orig main -o markdown
+drydock diff images --repo . --ref HEAD --ref-orig main
 ```
+
+Default diff output is intended for terminal review and uses TTY-appropriate
+color and syntax highlighting when available. Use markdown output for pull
+request comments.
 
 ## Runtime Offline Does Not Mean Source Offline
 

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -12,18 +12,20 @@ inputs alone.
 ```bash
 git worktree add ../baseline main
 drydock diff apps --path . --path-orig ../baseline
-drydock diff images --path . --path-orig ../baseline -o markdown
+drydock diff images --path . --path-orig ../baseline
 ```
 
 Use this when you already have a separate baseline checkout or want to inspect
 uncommitted changes in the current working tree. Add `--offline` when the
 review must use only local files, repo maps, and existing drydock cache entries.
+Default output is intended for terminal review and uses TTY-appropriate
+color and syntax highlighting when available.
 
 ## Compare Git Refs
 
 ```bash
 drydock diff apps --repo . --ref HEAD --ref-orig main
-drydock diff images --repo . --ref HEAD --ref-orig main -o json
+drydock diff images --repo . --ref HEAD --ref-orig main
 ```
 
 `--repo` is a local Git repository path. `--ref-orig` selects the baseline
@@ -45,9 +47,9 @@ Changed-only filters are repository-relative and repeatable. They are useful
 when local commits include known non-GitOps files, but they should stay narrow:
 ignored files cannot trigger an Application render.
 
-## Markdown For Reviews
+## Markdown For Pull Request Comments
 
-Manifest and image diffs support markdown output:
+Manifest and image diffs support markdown output for pull request comments:
 
 ```bash
 drydock diff apps --path . --path-orig ../baseline -o markdown

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -64,6 +64,11 @@ menus:
       params:
         group: Concepts
       weight: 60
+    - name: Argo CD Render Parity
+      url: /concepts/argocd-render-parity/
+      params:
+        group: Concepts
+      weight: 62
     - name: How It Works
       url: /concepts/how-it-works/
       params:


### PR DESCRIPTION
## Summary
- add an Argo CD render parity concept page
- clarify runtime-offline and local diff docs routing
- tighten README support/runtime sections and documentation links

## Validation
- mise run markdownlint
- mise run docs-check