### PR TITLE
fix: polish operator-facing CLI and release UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,6 +483,7 @@ jobs:
 
           {
             printf "\n---\n\n"
+            printf "**Validation:** Argo CD render parity smoke passed for release artifacts.\n"
             printf "**Container image:** \`%s:%s\`\n" "${FULL_IMAGE}" "${TAG}"
             printf "**Checksums:** \`checksums.txt\`\n"
           } >> release-notes.md
@@ -734,6 +735,7 @@ jobs:
 
           {
             printf "\n---\n\n"
+            printf "**Validation:** Argo CD render parity smoke passed for release artifacts.\n"
             printf "**Container image:** \`%s:%s@%s\`\n" "${FULL_IMAGE}" "${TAG}" "${DIGEST}"
             printf "**Checksums:** \`checksums.txt\`\n"
           } >> release-notes.md

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -108,6 +108,16 @@ also skip PR comments by default. Set `cache-untrusted-restore: "true"` only if
 restoring cache contents into fork PR runs is acceptable for that repository.
 Cache save remains disabled for fork PRs.
 
+### Reporting and gating
+
+By default, `pr-action` fails render errors and reports manifest or image diffs
+through comments and artifacts without failing the workflow. To make diffs a
+gate, set `strict`, `strict-changed-only`, `fail-on-diff`, and optionally
+`fail-on-image-diff`.
+
+Keep `changed-only-include` and `changed-only-ignore` narrow; ignored paths
+cannot trigger Application renders.
+
 ## Authentication
 
 The action accepts either a normal token or GitHub App credentials:

--- a/docs/release.md
+++ b/docs/release.md
@@ -108,7 +108,8 @@ flowchart TD
   Merge --> Version[Read manifest version]
   Version --> Checks[Run source checks]
   Checks --> Build[Build archives and container]
-  Build --> Draft[Create draft immutable GitHub Release]
+  Build --> Parity[Run Argo CD render parity smoke]
+  Parity --> Draft[Create draft immutable GitHub Release]
   Draft --> PushImage[Push and sign GHCR image tags]
   PushImage --> TapAuth[Verify Homebrew tap write access]
   TapAuth --> Publish[Publish release and mark latest]
@@ -118,7 +119,9 @@ flowchart TD
 
 This preserves the normal operator workflow of marking the release PR ready,
 waiting for CI, and merging it. The publishing workflow then builds, signs, and
-checks all release artifacts before it creates a public GitHub Release.
+checks all release artifacts before it creates a public GitHub Release. It also
+runs the Argo CD render parity smoke against the release archive before
+publication.
 
 If the manifest version already has a matching remote tag and published GitHub
 Release, the publish workflow exits without creating another release. If the

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -10,7 +10,6 @@ import (
 )
 
 func newBuildCommand(deps Dependencies) *cobra.Command {
-	flags := defaultCommonFlags()
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Render Applications",
@@ -19,7 +18,6 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 			return fmt.Errorf("%s requires a subcommand", cmd.CommandPath())
 		},
 	}
-	bindCommonFlags(cmd, &flags)
 
 	appsFlags := defaultCommonFlags()
 	apps := &cobra.Command{

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -92,15 +92,14 @@ func bindCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 	bindPluginFlags(cmd, flags)
 	bindApplicationSetFixtureFlags(cmd, flags)
 	bindFilterFlags(cmd, flags)
-	bindStrictExitFlags(cmd, flags)
-	bindOutputDiffFormattingFlags(cmd, flags)
+	bindStrictFlag(cmd, flags)
+	bindOutputFlags(cmd, flags)
 	bindDiagnosticsCacheEventFlags(cmd, flags)
 	bindParallelismFlags(cmd, flags)
 }
 
 func bindPathDiscoveryFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVar(&flags.path, "path", flags.path, "repository path to inspect")
-	cmd.Flags().StringVar(&flags.pathOrig, "path-orig", flags.pathOrig, "baseline repository path for diffs")
 	cmd.Flags().StringVarP(&flags.selector, "selector", "l", flags.selector, "label selector for Applications")
 	cmd.Flags().StringVar(&flags.discoveryMode, "discovery-mode", flags.discoveryMode, "Application discovery mode: fleet or static")
 	cmd.Flags().IntVar(&flags.maxDiscoveryDepth, "max-discovery-depth", flags.maxDiscoveryDepth, "maximum recursive rendered Application discovery depth")
@@ -154,6 +153,13 @@ func bindFilterFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringArrayVar(&flags.skipKinds, "skip-kind", flags.skipKinds, "rendered resource kind to omit from output and diffs")
 	cmd.Flags().BoolVar(&flags.skipCRDs, "skip-crds", flags.skipCRDs, "omit CustomResourceDefinition resources from output and diffs")
 	cmd.Flags().BoolVar(&flags.skipSecrets, "skip-secrets", flags.skipSecrets, "omit Secret resources from output and diffs")
+}
+
+func bindDiffPathFlag(cmd *cobra.Command, flags *commonFlags) {
+	cmd.Flags().StringVar(&flags.pathOrig, "path-orig", flags.pathOrig, "baseline repository path for diffs")
+}
+
+func bindChangedOnlyFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.changedOnly, "changed-only", flags.changedOnly, "limit work to Applications affected by changed files")
 	cmd.Flags().BoolVar(&flags.strictChangedOnly, "strict-changed-only", flags.strictChangedOnly, "fail when changed-only input ownership is ambiguous or incomplete")
 }
@@ -163,16 +169,22 @@ func bindChangedOnlyPathFilterFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringArrayVar(&flags.changedOnlyIgnores, "changed-only-ignore", flags.changedOnlyIgnores, "repository-relative glob ignored by changed-only selection")
 }
 
-func bindStrictExitFlags(cmd *cobra.Command, flags *commonFlags) {
+func bindStrictFlag(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.strict, "strict", flags.strict, "promote diagnostics to errors")
+}
+
+func bindDiffExitFlag(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.exitCode, "exit-code", flags.exitCode, "return exit code 1 when a diff is found")
 }
 
-func bindOutputDiffFormattingFlags(cmd *cobra.Command, flags *commonFlags) {
+func bindOutputFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVarP(&flags.output, "output", "o", flags.output, "output format")
+	cmd.Flags().IntVar(&flags.limitBytes, "limit-bytes", flags.limitBytes, "maximum bytes of rendered output per object")
+}
+
+func bindDiffFormattingFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().IntVarP(&flags.unified, "unified", "u", flags.unified, "number of unified diff context lines")
 	cmd.Flags().StringArrayVar(&flags.stripAttrs, "strip-attr", flags.stripAttrs, "metadata label or annotation key to strip before diffing")
-	cmd.Flags().IntVar(&flags.limitBytes, "limit-bytes", flags.limitBytes, "maximum bytes of rendered output per object")
 }
 
 func bindDiagnosticsCacheEventFlags(cmd *cobra.Command, flags *commonFlags) {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -21,7 +21,6 @@ const (
 )
 
 func newDiffCommand(deps Dependencies) *cobra.Command {
-	flags := defaultCommonFlags()
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Diff rendered desired manifests",
@@ -30,7 +29,6 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 			return fmt.Errorf("%s requires a subcommand", cmd.CommandPath())
 		},
 	}
-	bindCommonFlags(cmd, &flags)
 
 	cmd.AddCommand(newDiffAppsCommand(deps), newDiffAppCommand(deps), newDiffImagesCommand(deps))
 	return cmd
@@ -75,6 +73,10 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 	bindCommonFlags(apps, &appsFlags)
+	bindDiffPathFlag(apps, &appsFlags)
+	bindChangedOnlyFlags(apps, &appsFlags)
+	bindDiffExitFlag(apps, &appsFlags)
+	bindDiffFormattingFlags(apps, &appsFlags)
 	bindDiffRefFlags(apps, &appsFlags)
 	bindChangedOnlyPathFilterFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
@@ -125,6 +127,10 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 	bindCommonFlags(appCmd, &appFlags)
+	bindDiffPathFlag(appCmd, &appFlags)
+	bindChangedOnlyFlags(appCmd, &appFlags)
+	bindDiffExitFlag(appCmd, &appFlags)
+	bindDiffFormattingFlags(appCmd, &appFlags)
 	bindDiffRefFlags(appCmd, &appFlags)
 	bindShowIgnoredFieldsFlag(appCmd, &appFlags)
 	bindDiffColorFlag(appCmd, &appColor)
@@ -171,6 +177,10 @@ func newDiffImagesCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 	bindCommonFlags(images, &imagesFlags)
+	bindDiffPathFlag(images, &imagesFlags)
+	bindChangedOnlyFlags(images, &imagesFlags)
+	bindDiffExitFlag(images, &imagesFlags)
+	bindDiffFormattingFlags(images, &imagesFlags)
 	bindDiffRefFlags(images, &imagesFlags)
 	bindChangedOnlyPathFilterFlags(images, &imagesFlags)
 	bindDiffColorFlag(images, &imagesColor)

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -17,7 +17,6 @@ import (
 )
 
 func newGetCommand(deps Dependencies) *cobra.Command {
-	flags := defaultCommonFlags()
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "List discovered Argo CD objects",
@@ -26,7 +25,6 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 			return fmt.Errorf("%s requires a subcommand", cmd.CommandPath())
 		},
 	}
-	bindCommonFlags(cmd, &flags)
 
 	appsFlags := defaultCommonFlags()
 	appsFlags.output = string(cliformat.OutputTable)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -33,6 +33,57 @@ func TestRootHelp(t *testing.T) {
 	}
 }
 
+func TestNonDiffLeafHelpOmitsDiffOnlyFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"test", "apps", "--help"},
+		{"get", "apps", "--help"},
+	} {
+		result := runCLI(t, args...)
+		assertStdoutExcludesAll(t, result,
+			"--path-orig",
+			"--changed-only",
+			"--strict-changed-only",
+			"--exit-code",
+			"--strip-attr",
+			"--unified",
+			"--show-ignored-fields",
+			"--color",
+			"--markdown-max-bytes",
+			"--raw-output-file",
+			"--ref-orig",
+		)
+	}
+}
+
+func TestSubcommandParentHelpOmitsOperationalFlags(t *testing.T) {
+	result := runCLI(t, "test", "--help")
+	assertStdoutExcludesAll(t, result,
+		"--path",
+		"--offline",
+		"--output",
+		"--path-orig",
+		"--changed-only",
+		"--exit-code",
+	)
+}
+
+func TestDiffAppsHelpIncludesDiffFlags(t *testing.T) {
+	result := runCLI(t, "diff", "apps", "--help")
+	assertStdoutContainsAll(t, result,
+		"--path-orig",
+		"--changed-only",
+		"--strict-changed-only",
+		"--exit-code",
+		"--strip-attr",
+		"--unified",
+		"--show-ignored-fields",
+		"--color",
+		"--markdown-max-bytes",
+		"--raw-output-file",
+		"--ref-orig",
+	)
+}
+
 func TestVersionCommand(t *testing.T) {
 	cmd := NewRootCommand(VersionInfo{
 		Version:            "test",

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -16,8 +16,6 @@ import (
 
 //nolint:gocyclo // CLI flag binding and output-mode branching stay together for command readability.
 func newTestCommand(deps Dependencies) *cobra.Command {
-	flags := defaultCommonFlags()
-	flags.output = testOutputText
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Test whether Applications render",
@@ -26,7 +24,6 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 			return fmt.Errorf("%s requires a subcommand", cmd.CommandPath())
 		},
 	}
-	bindCommonFlags(cmd, &flags)
 
 	appsFlags := defaultCommonFlags()
 	appsFlags.output = testOutputText

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -72,9 +72,17 @@ artifacts when differences are found, and comments in trusted same-repository
 pull requests. Image diff comments are available as a companion signal. Fork
 pull requests skip comments and source-cache restore/save by default.
 
+## Reporting And Gating
+
+By default, `pr-action` fails render errors and reports manifest or image diffs
+through comments and artifacts without failing the workflow. To make diffs a
+gate, set `strict`, `strict-changed-only`, `fail-on-diff`, and optionally
+`fail-on-image-diff`.
+
 `changed-only-include` and `changed-only-ignore` are optional newline-delimited
 globs passed to manifest and image diffs. They keep known non-GitOps paths from
-forcing a full-fleet changed-only fallback. They do not affect `test apps`.
+forcing a full-fleet changed-only fallback. Keep them narrow; ignored paths
+cannot trigger Application renders. They do not affect `test apps`.
 
 ## Manifest Diff Comment Shape
 


### PR DESCRIPTION
## Summary
- clarify PR action reporting/gating and release parity smoke docs
- scope CLI help flags so non-diff commands no longer show diff-only options
- add release-note validation text after Argo CD render parity smoke succeeds

## Validation
- mise run markdownlint
- mise run docs-check
- go test ./cmd/drydock ./internal/cli
- mise run actionlint