### PR TITLE
fix: improve diag success and trash handling

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -246,9 +246,13 @@ Not supported:
 
 Supported:
 
-- `diag --path` repository diagnostics through the render validation path.
+- `diag --path` repository diagnostics through static discovery, ApplicationSet
+  expansion, and settings metadata.
+- `diag --render` render-backed diagnostic reports.
 - `diag -o json|yaml` structured diagnostic reports.
-- `diag --cache-events` optional cache acquisition event reporting.
+- `diag --cache-events` optional render-backed cache acquisition event
+  reporting.
+- `diag --plugin-executions` optional render-backed plugin execution metadata.
 - `diag --settings -o json|yaml` redacted settings summaries for parsed Argo
   CD settings metadata.
 - Local AppProject manifest discovery.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -444,10 +444,19 @@ Run repository diagnostics without printing rendered manifests:
 drydock diag --path .
 ```
 
-`diag` uses the same discovery, ApplicationSet expansion, source resolution,
-and render validation path as `build apps`. It prints diagnostics to stderr and
-returns an error when runtime failures or error-severity diagnostics are found.
-Use `--strict` to promote warnings to errors.
+By default, `diag` uses static repository discovery, ApplicationSet expansion,
+and settings metadata without rendering Applications. It prints diagnostics to
+stderr and returns an error when runtime failures or error-severity diagnostics
+are found. Use `--strict` to promote warnings to errors.
+
+`diag` refuses broad roots such as the filesystem root or the current user's
+home directory. Run it from the GitOps repository root or pass `--path` to that
+repository.
+
+Use `--render` when the diagnostic report should include render-backed
+diagnostics. `--cache-events` and `--plugin-executions` also opt into the
+render-backed path so source-acquisition and plugin execution metadata reflect
+Application rendering.
 
 Structured diagnostic output can include a redacted settings summary:
 
@@ -461,13 +470,15 @@ metadata such as action names, `useOpenLibs`, and SHA-256 hashes for
 health/action Lua. It does not print raw Lua bodies, embedded secret-looking
 strings, or any live-cluster state.
 
-When local `AppProject` manifests are present, `diag`, `build`, `test`, `diff`,
-and the Go API report source repository and destination validation diagnostics
-from those manifests. RBAC roles and policies are parsed and reported as
-metadata only; Argo CD authorization is not simulated. Repository credential
-matching diagnostics use discovered repository Secret metadata only and never
-read secret credential fields. Cluster Secret diagnostics likewise use only
-`name`, `server`, `namespaces`, `clusterResources`, and `project` metadata;
+When local `AppProject` manifests are present, `build`, `test`, `diff`, and the
+Go API report source repository and destination validation diagnostics from
+those manifests. `diag --render` includes the same render-backed project
+diagnostics; default `diag` reports project and repository metadata discovered
+without rendering every Application. RBAC roles and policies are parsed and
+reported as metadata only; Argo CD authorization is not simulated. Repository
+credential matching diagnostics use discovered repository Secret metadata only
+and never read secret credential fields. Cluster Secret diagnostics likewise use
+only `name`, `server`, `namespaces`, `clusterResources`, and `project` metadata;
 credential/config fields are not decoded, retained, or printed.
 
 `argocd-cmd-params-cm` settings are parsed as runtime-boundary metadata when

--- a/internal/app/discovery_paths.go
+++ b/internal/app/discovery_paths.go
@@ -153,7 +153,12 @@ func sourceRootHasLocalChart(root string) bool {
 }
 
 func shouldSkipDiscoveryCandidateDir(name string) bool {
-	return name == ".git" || name == ".out" || strings.HasPrefix(name, ".cache")
+	switch name {
+	case ".git", ".out", ".Trash", ".Trashes", ".Spotlight-V100", ".DocumentRevisions-V100", ".TemporaryItems", ".fseventsd":
+		return true
+	default:
+		return strings.HasPrefix(name, ".cache")
+	}
 }
 
 func isDiscoveryCandidateYAML(path string) bool {

--- a/internal/app/discovery_paths_test.go
+++ b/internal/app/discovery_paths_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPathMayContainDiscoveryObjectsSkipsUnreadableTrashDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".Trash", "app.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ignored
+`)
+	trash := filepath.Join(root, ".Trash")
+	if err := os.Chmod(trash, 0); err != nil {
+		t.Fatalf("chmod trash directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(trash, 0o700)
+	})
+
+	found, err := pathMayContainDiscoveryObjects(root)
+	if err != nil {
+		t.Fatalf("pathMayContainDiscoveryObjects() error = %v", err)
+	}
+	if found {
+		t.Fatal("pathMayContainDiscoveryObjects() = true, want false for skipped trash directory")
+	}
+}

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -57,50 +59,134 @@ type diagResourceActions struct {
 
 func newDiagCommand(deps Dependencies) *cobra.Command {
 	flags := defaultCommonFlags()
-	includeSettings := false
+	options := diagCommandOptions{}
 	cmd := &cobra.Command{
 		Use:   "diag",
 		Short: "Report repository diagnostics",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			output, parseErr := parseDiagOutput(flags.output)
-			if parseErr != nil {
-				return parseErr
-			}
-			repoMaps, err := parseRepoMaps(flags.repoMaps)
-			if err != nil {
-				return err
-			}
-			request := buildRequestFromFlags(cmd, flags, repoMaps)
-			request.RecordCacheEvents = flags.cacheEvents
-			result, err := deps.Orchestrator.Diag(context.Background(), request)
-			result.Diagnostics = diagnostic.WithStableCodes(result.Diagnostics)
-			report := diagReport{
-				Diagnostics:      result.Diagnostics,
-				CacheEvents:      result.CacheEvents,
-				PluginExecutions: result.PluginExecutions,
-			}
-			if includeSettings {
-				report.Settings = settingsSummary(result.Settings)
-			}
-			switch output {
-			case "text":
-				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); renderErr != nil {
-					return renderErr
-				}
-			case "json", "yaml":
-				if renderErr := writeStructuredOutput(cmd.OutOrStdout(), output, report); renderErr != nil {
-					return renderErr
-				}
-			default:
-				return fmt.Errorf("unsupported output %q for diag", output)
-			}
-			return err
+			return runDiagCommand(cmd, deps, flags, options)
 		},
 	}
 	bindCommonFlags(cmd, &flags)
-	cmd.Flags().BoolVar(&includeSettings, "settings", false, "include redacted Argo CD settings summary in structured diagnostic output")
+	cmd.Flags().BoolVar(&options.includeSettings, "settings", false, "include redacted Argo CD settings summary in structured diagnostic output")
+	cmd.Flags().BoolVar(&options.includeRender, "render", false, "include render-backed diagnostics by rendering Applications")
+	cmd.Flags().BoolVar(&options.includePluginExecutions, "plugin-executions", false, "include plugin execution metadata in structured diagnostic output; renders Applications")
 	return cmd
+}
+
+type diagCommandOptions struct {
+	includeSettings         bool
+	includeRender           bool
+	includePluginExecutions bool
+}
+
+func runDiagCommand(cmd *cobra.Command, deps Dependencies, flags commonFlags, options diagCommandOptions) error {
+	output, parseErr := parseDiagOutput(flags.output)
+	if parseErr != nil {
+		return parseErr
+	}
+	repoMaps, err := parseRepoMaps(flags.repoMaps)
+	if err != nil {
+		return err
+	}
+	request := buildRequestFromFlags(cmd, flags, repoMaps)
+	if err := rejectBroadDiagPath(request.Path); err != nil {
+		return err
+	}
+	request.RecordCacheEvents = flags.cacheEvents
+	result, err := runDiag(context.Background(), deps.Orchestrator, request, diagMode{
+		Render: options.includeRender || flags.cacheEvents || options.includePluginExecutions,
+	})
+	result.Diagnostics = diagnostic.WithStableCodes(result.Diagnostics)
+	if err != nil && len(result.Diagnostics) == 0 {
+		return err
+	}
+	report := diagReport{
+		Diagnostics: nonNilDiagnostics(result.Diagnostics),
+	}
+	if flags.cacheEvents {
+		report.CacheEvents = result.CacheEvents
+	}
+	if options.includePluginExecutions {
+		report.PluginExecutions = result.PluginExecutions
+	}
+	if options.includeSettings {
+		report.Settings = settingsSummary(result.Settings)
+	}
+	return renderDiagCommandResult(cmd, output, report, result.Diagnostics, err)
+}
+
+func renderDiagCommandResult(cmd *cobra.Command, output string, report diagReport, diagnostics []diagnostic.Diagnostic, runErr error) error {
+	switch output {
+	case "text":
+		if renderErr := renderDiagnostics(cmd.ErrOrStderr(), diagnostics); renderErr != nil {
+			return renderErr
+		}
+		if runErr == nil && len(diagnostics) == 0 {
+			if _, renderErr := fmt.Fprintln(cmd.OutOrStdout(), "No diagnostics found."); renderErr != nil {
+				return renderErr
+			}
+		}
+	case "json", "yaml":
+		if renderErr := writeStructuredOutput(cmd.OutOrStdout(), output, report); renderErr != nil {
+			return renderErr
+		}
+	default:
+		return fmt.Errorf("unsupported output %q for diag", output)
+	}
+	return runErr
+}
+
+func rejectBroadDiagPath(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	abs = filepath.Clean(abs)
+	if filepath.Dir(abs) == abs {
+		return fmt.Errorf("refusing to recursively scan filesystem root %q; pass --path to a GitOps repository directory", abs)
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		homeAbs, homeErr := filepath.Abs(home)
+		if homeErr == nil && sameCleanPath(abs, homeAbs) {
+			return fmt.Errorf("refusing to recursively scan home directory %q; run from a GitOps repository root or pass --path to that repository", abs)
+		}
+	}
+	return nil
+}
+
+func sameCleanPath(left, right string) bool {
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+type diagMode struct {
+	Render bool
+}
+
+func runDiag(ctx context.Context, orchestrator Orchestrator, request app.DiagRequest, mode diagMode) (app.DiagResult, error) {
+	if mode.Render {
+		return orchestrator.Diag(ctx, request)
+	}
+	request.DiscoveryMode = app.DiscoveryModeStatic
+	request.MaxDiscoveryDepth = 0
+	request.MaxDiscoveryDepthSet = true
+	result, err := orchestrator.ListApplications(ctx, request)
+	diagResult := app.DiagResult{
+		Applications: result.Applications,
+		Diagnostics:  result.Diagnostics,
+		Settings:     result.Settings,
+		CacheEvents:  result.CacheEvents,
+	}
+	return diagResult, err
+}
+
+func nonNilDiagnostics(diagnostics []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	if diagnostics == nil {
+		return []diagnostic.Diagnostic{}
+	}
+	return diagnostics
 }
 
 func settingsSummary(settings config.ArgoSettings) *diagSettingsSummary {

--- a/internal/cli/diag_test.go
+++ b/internal/cli/diag_test.go
@@ -21,7 +21,7 @@ type diagCommandParameterJSON struct {
 	Classification string `json:"classification"`
 }
 
-func TestDiagCleanRepositoryPrintsNoManifests(t *testing.T) {
+func TestDiagCleanRepositoryReportsNoDiagnostics(t *testing.T) {
 	root := t.TempDir()
 	writeSimpleAppForCLI(t, root, "ok")
 
@@ -35,11 +35,86 @@ func TestDiagCleanRepositoryPrintsNoManifests(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	if got, want := stdout.String(), "No diagnostics found.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestDiagJSONCleanRepositoryUsesEmptyDiagnosticsArray(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "ok")
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"diag", "--path", root, "-o", "json"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty for structured diag output", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"diagnostics": []`) {
+		t.Fatalf("stdout = %q, want empty diagnostics array", stdout.String())
+	}
+}
+
+func TestDiagStructuredFatalErrorDoesNotWritePartialReport(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing")
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"diag", "--path", missing, "-o", "json", "--settings"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing path error")
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty on fatal prediagnostic error", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestDiagRejectsHomeDirectoryPathBeforeScanning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	orchestrator := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: orchestrator})
+	cmd.SetArgs([]string{"diag", "--path", ".", "--settings", "-o", "json"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	t.Chdir(home)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want broad home directory path error")
+	}
+	if !strings.Contains(err.Error(), "refusing to recursively scan home directory") {
+		t.Fatalf("Execute() error = %v, want home directory refusal", err)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty on broad path error", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if len(orchestrator.listRequests) != 0 || len(orchestrator.diagRequests) != 0 {
+		t.Fatalf("orchestrator called: list=%d diag=%d", len(orchestrator.listRequests), len(orchestrator.diagRequests))
 	}
 }
 
@@ -71,7 +146,7 @@ func TestDiagReportsPluginSourceFailure(t *testing.T) {
 	writePluginCLIApplication(t, root, "cue", "directory")
 
 	cmd := NewRootCommand(VersionInfo{})
-	cmd.SetArgs([]string{"diag", "--path", root})
+	cmd.SetArgs([]string{"diag", "--path", root, "--render"})
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -92,6 +167,28 @@ func TestDiagReportsPluginSourceFailure(t *testing.T) {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
 		}
+	}
+}
+
+func TestDiagDefaultDoesNotRenderApplications(t *testing.T) {
+	root := t.TempDir()
+	writePluginCLIApplication(t, root, "cue", "directory")
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"diag", "--path", root})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if got, want := stdout.String(), "No diagnostics found.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -457,7 +554,7 @@ func TestDiagJSONOutputIncludesPluginExecutions(t *testing.T) {
 		},
 	}
 	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: orchestrator})
-	cmd.SetArgs([]string{"diag", "--path", "ignored", "-o", "json"})
+	cmd.SetArgs([]string{"diag", "--path", "ignored", "-o", "json", "--plugin-executions"})
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -484,6 +581,67 @@ func TestDiagJSONOutputIncludesPluginExecutions(t *testing.T) {
 	execution := report.PluginExecutions[0]
 	if execution.AppName != "plugin-app" || execution.PluginName != "exec-renderer" || execution.Phase != "generate" || execution.Command != "argocd-vault-plugin" || execution.Duration != "12ms" {
 		t.Fatalf("pluginExecutions[0] = %#v, want exec metadata", execution)
+	}
+}
+
+func TestDiagDefaultUsesApplicationListing(t *testing.T) {
+	orchestrator := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: orchestrator})
+	cmd.SetArgs([]string{"diag", "--path", "repo"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if len(orchestrator.listRequests) != 1 {
+		t.Fatalf("list requests = %d, want 1", len(orchestrator.listRequests))
+	}
+	request := orchestrator.listRequests[0]
+	if request.DiscoveryMode != app.DiscoveryModeStatic || request.MaxDiscoveryDepth != 0 || !request.MaxDiscoveryDepthSet {
+		t.Fatalf("list request discovery = mode=%q depth=%d set=%t, want static depth 0", request.DiscoveryMode, request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet)
+	}
+	if len(orchestrator.diagRequests) != 0 {
+		t.Fatalf("diag requests = %d, want 0", len(orchestrator.diagRequests))
+	}
+}
+
+func TestDiagRenderBackedFlagsUseDiag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "render", args: []string{"diag", "--path", "repo", "--render"}},
+		{name: "cache events", args: []string{"diag", "--path", "repo", "--cache-events"}},
+		{name: "plugin executions", args: []string{"diag", "--path", "repo", "--plugin-executions"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orchestrator := &recordingCLIOrchestrator{}
+			cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: orchestrator})
+			cmd.SetArgs(tt.args)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			}
+			if len(orchestrator.diagRequests) != 1 {
+				t.Fatalf("diag requests = %d, want 1", len(orchestrator.diagRequests))
+			}
+			request := orchestrator.diagRequests[0]
+			if request.DiscoveryMode != app.DiscoveryModeFleet {
+				t.Fatalf("diag request discovery mode = %q, want fleet", request.DiscoveryMode)
+			}
+			if len(orchestrator.listRequests) != 0 {
+				t.Fatalf("list requests = %d, want 0", len(orchestrator.listRequests))
+			}
+		})
 	}
 }
 

--- a/internal/cli/git_source_test.go
+++ b/internal/cli/git_source_test.go
@@ -64,8 +64,8 @@ data:
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	if got, want := stdout.String(), "No diagnostics found.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -126,8 +126,8 @@ data:
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 	}
-	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	if got, want := stdout.String(), "No diagnostics found.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())

--- a/internal/cli/parallelism_test.go
+++ b/internal/cli/parallelism_test.go
@@ -128,7 +128,7 @@ func TestNonTestCommandsDoNotRequestStatusOnlyBuild(t *testing.T) {
 			name: "diag",
 			args: []string{"diag"},
 			statusOnly: func(recorder *recordingCLIOrchestrator) bool {
-				return recorder.diagRequests[0].StatusOnly
+				return recorder.listRequests[0].StatusOnly
 			},
 		},
 	}
@@ -225,8 +225,8 @@ func TestDiagParallelismFlag(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}
 	executeParallelismCommand(t, recorder, "diag", "--parallelism", "7")
 
-	if got := recorder.diagRequests[0].Parallelism; got != 7 {
-		t.Fatalf("DiagRequest.Parallelism = %d, want 7", got)
+	if got := recorder.listRequests[0].Parallelism; got != 7 {
+		t.Fatalf("ListApplications BuildRequest.Parallelism = %d, want 7", got)
 	}
 }
 
@@ -280,6 +280,8 @@ type recordingCLIOrchestrator struct {
 	diffAppError       error
 	diffImagesResult   app.ImageDiffResult
 	diffImagesError    error
+	listResult         app.BuildResult
+	listError          error
 	diagResult         app.DiagResult
 	diagError          error
 }
@@ -301,7 +303,7 @@ func (orchestrator *recordingCLIOrchestrator) BuildApp(_ context.Context, reques
 
 func (orchestrator *recordingCLIOrchestrator) ListApplications(_ context.Context, request app.BuildRequest) (app.BuildResult, error) {
 	orchestrator.listRequests = append(orchestrator.listRequests, request)
-	return app.BuildResult{}, nil
+	return orchestrator.listResult, orchestrator.listError
 }
 
 func (orchestrator *recordingCLIOrchestrator) DiffApps(_ context.Context, request app.DiffRequest) (app.DiffResult, error) {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -432,7 +432,12 @@ func looksLikeConfigManagementPluginYAML(value string) bool {
 }
 
 func shouldSkipDir(name string) bool {
-	return name == ".git" || name == ".out" || strings.HasPrefix(name, ".cache")
+	switch name {
+	case ".git", ".out", ".Trash", ".Trashes", ".Spotlight-V100", ".DocumentRevisions-V100", ".TemporaryItems", ".fseventsd":
+		return true
+	default:
+		return strings.HasPrefix(name, ".cache")
+	}
 }
 
 func isHelmTemplateYAML(root, path string) bool {

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -85,6 +85,31 @@ func TestScanSkipsInternalDirectories(t *testing.T) {
 	}
 }
 
+func TestScanSkipsUnreadableTrashDirectory(t *testing.T) {
+	root := t.TempDir()
+	fixture := filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml")
+	mustCopy(t, fixture, filepath.Join(root, "visible", "app.yaml"))
+	trash := filepath.Join(root, ".Trash")
+	mustCopy(t, fixture, filepath.Join(trash, "app.yaml"))
+	if err := os.Chmod(trash, 0); err != nil {
+		t.Fatalf("chmod trash directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(trash, 0o700)
+	})
+
+	result, err := Scan(root, Options{})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %d, want 1", len(result.Applications))
+	}
+	if result.Applications[0].Path != filepath.Join("visible", "app.yaml") {
+		t.Fatalf("Path = %s", result.Applications[0].Path)
+	}
+}
+
 func TestScanSkipsSymlinkedYAML(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()

--- a/site/content/cookbook/source-access.md
+++ b/site/content/cookbook/source-access.md
@@ -29,8 +29,8 @@ drydock diag --path . --cache-events -o json
 drydock cache list -o json
 ```
 
-Use cache events to see which source acquisitions were used during diagnostics,
-then inspect recognized cache entries.
+Use cache events to see which source acquisitions were used while rendering
+Applications for diagnostics, then inspect recognized cache entries.
 
 ## Pass Explicit Credentials
 

--- a/site/content/cookbook/troubleshooting-renders.md
+++ b/site/content/cookbook/troubleshooting-renders.md
@@ -11,7 +11,9 @@ drydock diag --path .
 ```
 
 `get apps` checks discovery. `test apps` checks render health without manifest
-output. `diag` reports diagnostics from the same discovery and render path.
+output. `diag` reports repository and settings diagnostics without rendering
+every Application; add `--render` when the diagnostic report needs render-backed
+diagnostics.
 
 ## Isolate One Application
 

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -38,6 +38,9 @@ drydock test apps --path . --offline
 drydock diag --path . --cache-events
 ```
 
+`--cache-events` renders Applications so source-acquisition events match the
+rendering path.
+
 ## Symptom: Changed-Only Falls Back To All Apps
 
 Multi-Application diffs use changed-only selection by default. If a changed


### PR DESCRIPTION
## Summary
- make default diag use lightweight static discovery/settings diagnostics instead of full render-backed analysis
- add explicit render-backed diagnostic opt-ins with --render, --cache-events, and --plugin-executions
- print an explicit clean-state message, emit empty diagnostics arrays in structured output, and avoid partial structured output on fatal prediagnostic errors
- skip common macOS/system trash directories during recursive discovery
- update docs for the new diag UX

## Validation
- go test ./...
- /private/tmp/drydock-diag-ux diag --path . in ~/git/home-ops
- /private/tmp/drydock-diag-ux diag --path . --settings -o json in ~/git/home-ops
- /private/tmp/drydock-diag-ux diag --path . --render in ~/git/home-ops
- unreadable .Trash fixture with diag --settings -o json
- review agent approval