### PR TITLE
feat: add HTML diff artifact review UI

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -99,8 +99,13 @@ By default the action:
 - writes image diff comments with drydock markdown output, including removed
   image references when present;
 - uses drydock source caches under the runner temp directory;
-- uploads full diff artifacts when differences are found;
+- uploads full raw diff and browser-openable HTML diff artifacts when manifest
+  differences are found;
 - writes sticky PR comments for trusted same-repository pull requests.
+
+The manifest diff comment links to the HTML diff report artifact when artifact
+upload is enabled. The raw unified diff artifact remains available for scripts
+and archival workflows.
 
 Fork pull requests do not restore or save drydock source caches by default,
 because source caches can contain private repository or chart material. They
@@ -201,5 +206,7 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | `has-image-diff` | Any image difference was detected, including removed-only diffs. |
 | `render-status` | `passed`, `failed`, or `skipped`. |
 | `diff-path` | Local path to the rendered manifest diff file. |
+| `diff-html-path` | Local path to the rendered manifest diff HTML report. |
 | `images-path` | Local path to the current-only image list. |
+| `diff-html-artifact-name` | Filename used for the rendered manifest diff HTML artifact. |
 | `trusted-context` | Whether cache save and PR comments were allowed. |

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sholdee/drydock/internal/app"
 	cliformat "github.com/sholdee/drydock/internal/format"
 	"github.com/sholdee/drydock/internal/report"
+	"github.com/sholdee/drydock/internal/report/diffhtml"
 	"github.com/sholdee/drydock/internal/source"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,7 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	appsColor := diffColorAuto
 	appsMarkdownMaxBytes := report.DefaultMaxBytes
 	appsRawOutputFile := ""
+	appsHTMLOutputFile := ""
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Diff all Applications",
@@ -69,7 +71,7 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor, appsRawOutputFile, appsMarkdownMaxBytes)
+			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor, appsRawOutputFile, appsHTMLOutputFile, appsMarkdownMaxBytes)
 		},
 	}
 	bindCommonFlags(apps, &appsFlags)
@@ -81,7 +83,7 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	bindChangedOnlyPathFilterFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
 	bindDiffColorFlag(apps, &appsColor)
-	bindDiffMarkdownFlags(apps, &appsMarkdownMaxBytes, &appsRawOutputFile)
+	bindDiffReportFileFlags(apps, &appsMarkdownMaxBytes, &appsRawOutputFile, &appsHTMLOutputFile)
 
 	return apps
 }
@@ -91,6 +93,7 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	appColor := diffColorAuto
 	appMarkdownMaxBytes := report.DefaultMaxBytes
 	appRawOutputFile := ""
+	appHTMLOutputFile := ""
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Diff one Application",
@@ -123,7 +126,7 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor, appRawOutputFile, appMarkdownMaxBytes)
+			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor, appRawOutputFile, appHTMLOutputFile, appMarkdownMaxBytes)
 		},
 	}
 	bindCommonFlags(appCmd, &appFlags)
@@ -134,7 +137,7 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	bindDiffRefFlags(appCmd, &appFlags)
 	bindShowIgnoredFieldsFlag(appCmd, &appFlags)
 	bindDiffColorFlag(appCmd, &appColor)
-	bindDiffMarkdownFlags(appCmd, &appMarkdownMaxBytes, &appRawOutputFile)
+	bindDiffReportFileFlags(appCmd, &appMarkdownMaxBytes, &appRawOutputFile, &appHTMLOutputFile)
 
 	return appCmd
 }
@@ -203,9 +206,10 @@ func bindDiffColorFlag(cmd *cobra.Command, colorMode *string) {
 	cmd.Flags().StringVar(colorMode, "color", *colorMode, "color diff output: auto, always, or never")
 }
 
-func bindDiffMarkdownFlags(cmd *cobra.Command, markdownMaxBytes *int, rawOutputFile *string) {
+func bindDiffReportFileFlags(cmd *cobra.Command, markdownMaxBytes *int, rawOutputFile, htmlOutputFile *string) {
 	bindDiffMarkdownMaxBytesFlag(cmd, markdownMaxBytes)
 	cmd.Flags().StringVar(rawOutputFile, "raw-output-file", *rawOutputFile, "write full uncolored unified diff output to this file")
+	cmd.Flags().StringVar(htmlOutputFile, "html-output-file", *htmlOutputFile, "write full static HTML diff report to this file")
 }
 
 func bindDiffMarkdownMaxBytesFlag(cmd *cobra.Command, markdownMaxBytes *int) {
@@ -250,9 +254,19 @@ func shouldColorDiffOutput(mode string, deps Dependencies, w io.Writer) bool {
 	}
 }
 
-func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile string, markdownMaxBytes int) error {
+func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile, htmlOutputFile string, markdownMaxBytes int) error {
+	if err := writeDiffSideOutputs(cmd.ErrOrStderr(), result, output, diagnosticColor, rawOutputFile, htmlOutputFile); err != nil {
+		return err
+	}
+	if err := writeDiffCommandOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes); err != nil {
+		return err
+	}
+	return diffResultExitError(result, disableDiffExitCode)
+}
+
+func writeDiffSideOutputs(stderr io.Writer, result app.DiffResult, output string, diagnosticColor bool, rawOutputFile, htmlOutputFile string) error {
 	if output != diffOutputMarkdown {
-		if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
+		if err := renderDiagnosticsWithColor(stderr, result.Diagnostics, diagnosticColor); err != nil {
 			return err
 		}
 	}
@@ -261,31 +275,56 @@ func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExit
 			return fmt.Errorf("write raw diff output: %w", err)
 		}
 	}
+	if htmlOutputFile != "" {
+		if err := writeHTMLDiffOutput(htmlOutputFile, result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDiffCommandOutput(w io.Writer, result app.DiffResult, output string, diffColor bool, markdownMaxBytes int) error {
 	switch output {
 	case diffOutputUnified:
-		for _, item := range result.Results {
-			if _, err := fmt.Fprint(cmd.OutOrStdout(), colorizeUnifiedDiff(item.Diff, diffColor)); err != nil {
-				return err
-			}
-		}
+		return writeUnifiedDiffOutput(w, result, diffColor)
 	case diffOutputMarkdown:
-		if _, err := report.WriteDiffMarkdown(cmd.OutOrStdout(), result, report.MarkdownOptions{MaxBytes: markdownMaxBytes}); err != nil {
-			return err
-		}
-	case string(cliformat.OutputJSON):
-		if err := writeStructuredOutput(cmd.OutOrStdout(), output, result.Results); err != nil {
-			return err
-		}
-	case string(cliformat.OutputYAML):
-		if err := writeStructuredOutput(cmd.OutOrStdout(), output, result.Results); err != nil {
-			return err
-		}
+		_, err := report.WriteDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes})
+		return err
+	case string(cliformat.OutputJSON), string(cliformat.OutputYAML):
+		return writeStructuredOutput(w, output, result.Results)
 	default:
 		return fmt.Errorf("unsupported output %q for diff", output)
 	}
+}
+
+func writeUnifiedDiffOutput(w io.Writer, result app.DiffResult, diffColor bool) error {
+	for _, item := range result.Results {
+		if _, err := fmt.Fprint(w, colorizeUnifiedDiff(item.Diff, diffColor)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func diffResultExitError(result app.DiffResult, disableDiffExitCode bool) error {
 	code := exitCode(nil, disableDiffExitCode, len(result.Results) > 0)
 	if code != 0 {
 		return ExitError{Code: code}
+	}
+	return nil
+}
+
+func writeHTMLDiffOutput(path string, result app.DiffResult) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("write HTML diff output: %w", err)
+	}
+	if err := diffhtml.Write(file, result, diffhtml.Options{}); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write HTML diff output: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("write HTML diff output: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -196,6 +196,83 @@ func TestDiffAppsMarkdownRawOutputFilePreservesUnifiedDiff(t *testing.T) {
 	}
 }
 
+func TestDiffAppsHTMLOutputFilePreservesSelectedStdout(t *testing.T) {
+	htmlPath := filepath.Join(t.TempDir(), "diff.html")
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{
+				Parent: diff.Parent{Namespace: "argocd", Name: "demo"},
+				Resource: diff.Resource{
+					Kind:      "ConfigMap",
+					Namespace: "default",
+					Name:      "demo",
+				},
+				Change: diff.ChangeModified,
+				Diff:   sampleUnifiedDiffForCLI(),
+			}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--html-output-file", htmlPath, "--exit-code=false")
+
+	assertStdoutContainsAll(t, result, "## drydock desired state diff", "```diff\n", "-  value: old", "+  value: new")
+	assertStdoutExcludesAll(t, result, "<!doctype html>", `data-view="side-by-side"`)
+	assertHTMLFileContainsAll(t, htmlPath,
+		"<!doctype html>",
+		"<title>drydock desired state diff</title>",
+		"argocd/demo",
+		"ConfigMap default/demo",
+		`data-view="side-by-side"`,
+	)
+}
+
+func TestDiffAppHTMLOutputFile(t *testing.T) {
+	htmlPath := filepath.Join(t.TempDir(), "diff.html")
+	recorder := &recordingCLIOrchestrator{
+		diffAppResult: app.DiffResult{
+			Results: []diff.Result{{
+				Parent: diff.Parent{Namespace: "argocd", Name: "demo"},
+				Resource: diff.Resource{
+					Kind:      "ConfigMap",
+					Namespace: "default",
+					Name:      "demo",
+				},
+				Change: diff.ChangeModified,
+				Diff:   sampleUnifiedDiffForCLI(),
+			}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "app", "demo", "--path-orig", "left", "--path", "right", "--html-output-file", htmlPath, "--exit-code=false")
+
+	assertStdoutContainsAll(t, result, "--- Application: argocd/demo source[0]", "-  value: old", "+  value: new")
+	assertStdoutExcludesAll(t, result, "<!doctype html>")
+	assertHTMLFileContainsAll(t, htmlPath, "ConfigMap default/demo")
+}
+
+func TestDiffAppsHTMLOutputFileWriteError(t *testing.T) {
+	htmlPath := t.TempDir()
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{Diff: sampleUnifiedDiffForCLI()}},
+		},
+	}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: recorder})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"diff", "apps", "--path-orig", "left", "--path", "right", "--html-output-file", htmlPath, "--exit-code=false"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want HTML output write error")
+	}
+	if !strings.Contains(err.Error(), "write HTML diff output") {
+		t.Fatalf("Execute() error = %v, want write HTML diff output", err)
+	}
+}
+
 func TestDiffAppsMarkdownRejectsInvalidMaxBytes(t *testing.T) {
 	for _, maxBytes := range []string{"-1", "1023"} {
 		t.Run(maxBytes, func(t *testing.T) {
@@ -1249,6 +1326,20 @@ func sampleUnifiedDiffForCLI() string {
 		" kind: ConfigMap\n" +
 		"-  value: old\n" +
 		"+  value: new\n"
+}
+
+func assertHTMLFileContainsAll(t *testing.T, path string, wants ...string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	text := string(data)
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML output missing %q:\n%s", want, text)
+		}
+	}
 }
 
 func writeSimpleAppForCLI(t *testing.T, root, value string) {

--- a/internal/report/diffhtml/assets.go
+++ b/internal/report/diffhtml/assets.go
@@ -1,0 +1,386 @@
+package diffhtml
+
+const reviewStyles = `
+:root {
+	color-scheme: dark;
+	font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	--ink: #e7edf5;
+	--muted: #a5b4c6;
+	--quiet: #8190a3;
+	--line: #26354a;
+	--line-strong: #45617f;
+	--paper: #07111d;
+	--surface: #101b29;
+	--surface-raised: #142133;
+	--surface-cool: #17263a;
+	--navy-deep: #f3f7fb;
+	--rust: #d17342;
+	--rust-bright: #f08a51;
+	--teal: #69d7c2;
+	--focus: #69b8ff;
+	--code-bg: #050b12;
+	--shadow: rgba(0, 0, 0, 0.32);
+	background: var(--paper);
+	color: var(--ink);
+}
+body {
+	margin: 0;
+	min-height: 100vh;
+	background: linear-gradient(180deg, #07111d 0%, #0a1421 46%, #101827 100%);
+	color: var(--ink);
+}
+:focus-visible {
+	outline: 3px solid var(--focus);
+	outline-offset: 3px;
+}
+.report-header {
+	position: sticky;
+	top: 0;
+	z-index: 5;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 18px;
+	padding: 12px 22px;
+	border-bottom: 1px solid var(--line);
+	background: rgba(8, 17, 29, 0.94);
+	backdrop-filter: blur(10px);
+}
+.report-header h1 {
+	margin: 0 0 6px;
+	font-size: 20px;
+	line-height: 1.25;
+	color: var(--navy-deep);
+}
+.brand-logo {
+	display: block;
+	width: clamp(132px, 16vw, 180px);
+	height: auto;
+}
+.summary, .resource-meta {
+	margin: 0;
+	color: var(--muted);
+	font-size: 13px;
+}
+.review-layout {
+	display: grid;
+	grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+	min-height: calc(100vh - 73px);
+}
+.tree {
+	border-right: 1px solid var(--line);
+	background: rgba(16, 27, 41, 0.86);
+	padding: 16px;
+	overflow: auto;
+}
+.tree-search {
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0 0 14px;
+	padding: 9px 10px;
+	border: 1px solid var(--line-strong);
+	border-radius: 6px;
+	background: rgba(5, 11, 18, 0.78);
+	color: var(--ink);
+	font: inherit;
+}
+.tree-search::placeholder {
+	color: var(--quiet);
+}
+.tree h2 {
+	margin: 16px 0 6px;
+	font-size: 12px;
+	text-transform: uppercase;
+	color: var(--quiet);
+}
+.tree-resource {
+	display: block;
+	width: 100%;
+	margin: 3px 0;
+	padding: 7px 8px;
+	border: 0;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--ink);
+	font: inherit;
+	font-size: 13px;
+	text-align: left;
+	cursor: pointer;
+}
+.tree-resource[aria-current="true"] {
+	background: rgba(105, 215, 194, 0.12);
+	color: var(--navy-deep);
+}
+.review-main {
+	min-width: 0;
+	padding: 18px 22px 34px;
+	overflow: auto;
+}
+.toolbar {
+	position: sticky;
+	top: 0;
+	z-index: 3;
+	display: flex;
+	gap: 8px;
+	margin: 0 0 16px;
+	padding: 0 0 12px;
+	background: linear-gradient(180deg, #0a1421 70%, rgba(10, 20, 33, 0));
+}
+.toolbar button {
+	padding: 7px 10px;
+	border: 1px solid var(--line-strong);
+	border-radius: 6px;
+	background: var(--surface-raised);
+	color: var(--ink);
+	font: inherit;
+	cursor: pointer;
+}
+.toolbar button[aria-pressed="true"] {
+	background: rgba(105, 215, 194, 0.13);
+	border-color: var(--teal);
+	color: var(--navy-deep);
+}
+.applications {
+	min-width: 0;
+}
+.resource {
+	display: none;
+	margin: 0;
+}
+.resource.is-active {
+	display: block;
+}
+.resource h3 {
+	margin: 0 0 4px;
+	font-size: 18px;
+	color: var(--navy-deep);
+}
+.diff-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 14px;
+	background: var(--code-bg);
+	border: 1px solid var(--line);
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 12px;
+	line-height: 1.5;
+}
+.diff-table th {
+	text-align: left;
+}
+.hunk-header th {
+	padding: 5px 8px;
+	background: rgba(105, 184, 255, 0.13);
+	color: #8ec8ff;
+	font-weight: 600;
+}
+.line-number {
+	width: 1%;
+	min-width: 44px;
+	padding: 2px 8px;
+	border-right: 1px solid var(--line);
+	background: rgba(16, 27, 41, 0.8);
+	color: var(--quiet);
+	text-align: right;
+	user-select: none;
+	vertical-align: top;
+}
+.line-code {
+	padding: 2px 8px;
+	white-space: pre-wrap;
+	word-break: break-word;
+	vertical-align: top;
+}
+.diff-row.added .line-code {
+	background: rgba(63, 185, 80, 0.13);
+}
+.diff-row.removed .line-code {
+	background: rgba(248, 81, 73, 0.13);
+}
+.inline-change {
+	border-radius: 3px;
+	padding: 0 1px;
+}
+.inline-change.added {
+	background: rgba(63, 185, 80, 0.38);
+	box-shadow: 0 0 0 1px rgba(63, 185, 80, 0.2);
+}
+.inline-change.removed {
+	background: rgba(248, 81, 73, 0.38);
+	box-shadow: 0 0 0 1px rgba(248, 81, 73, 0.2);
+}
+body[data-view="side-by-side"] .diff-table.unified,
+body[data-view="unified"] .diff-table.side-by-side {
+	display: none;
+}
+.diagnostics {
+	margin: 28px 0 0;
+	border: 1px solid rgba(209, 115, 66, 0.32);
+	border-radius: 8px;
+	background: rgba(209, 115, 66, 0.08);
+	color: var(--muted);
+}
+.diagnostics summary {
+	cursor: pointer;
+	padding: 10px 12px;
+	color: var(--rust-bright);
+	font-weight: 700;
+}
+.diagnostics ul {
+	margin: 0;
+	padding: 0 14px 12px 30px;
+}
+.diagnostics li + li {
+	margin-top: 6px;
+}
+.severity, .category {
+	color: var(--navy-deep);
+}
+.no-diff {
+	margin: 0;
+	color: var(--muted);
+}
+@media (max-width: 800px) {
+	.report-header {
+		position: static;
+		grid-template-columns: 1fr;
+	}
+	.brand-logo {
+		width: 132px;
+	}
+	.review-layout {
+		grid-template-columns: 1fr;
+	}
+	.tree {
+		max-height: 280px;
+		border-right: 0;
+		border-bottom: 1px solid var(--line);
+	}
+}
+`
+
+const drydockLogo = `<svg class="brand-logo" aria-label="drydock" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 128" width="480" height="128">
+  <defs>
+    <linearGradient id="hull-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#b95a2d"/>
+      <stop offset="100%" stop-color="#e07a3f"/>
+    </linearGradient>
+  </defs>
+  <path d="M16 58 L28 58 L34 102 L94 102 L100 58 L112 58 L106 110 L22 110 Z" fill="#d6e0eb"/>
+  <rect x="59" y="90" width="10" height="12" fill="#8fa1b7"/>
+  <path d="M35 32 L93 32 L93 58 C93 80 77 90 64 90 C51 90 35 80 35 58 Z" fill="url(#hull-grad)"/>
+  <line x1="36" y1="58" x2="92" y2="58" stroke="#ffad73" stroke-width="1.5"/>
+  <path d="M64 12 L87 22 L87 32 L41 32 L41 22 Z" fill="#e6a15f"/>
+  <text x="144" y="76" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="52" font-weight="600" fill="#f3f7fb" letter-spacing="2">drydock</text>
+</svg>`
+
+const drydockFaviconHref = "data:image/svg+xml;base64," +
+	"PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4IiB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9Imh1bGwtZ3JhZCIgeDE9IjAiIHkxPSIwIiB4Mj0iMSIgeTI9IjAiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjYTg0YTIyIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2M0NWEyYyIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPCEtLSBCYXNpbiB3YWxsczogdGFwZXJlZCwgY29udGFpbmluZyBsb3dlciBodWxsIC0tPgogIDxwYXRoIGQ9Ik0xNiA1OCBMMjggNTggTDM0IDEwMiBMOTQgMTAyIEwxMDAgNTggTDExMiA1OCBMMTA2IDExMCBMMjIgMTEwIFoiIGZpbGw9IiMyZDM3NDgiLz4KICA8IS0tIEtlZWwgYmxvY2sgLS0+CiAgPHJlY3QgeD0iNTkiIHk9IjkwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTIiIGZpbGw9IiM0YTU1NjgiLz4KICA8IS0tIEh1bGw6IGdyYWRpZW50IGZvciBzdWJ0bGUgZGVwdGggLS0+CiAgPHBhdGggZD0iTTM1IDMyIEw5MyAzMiBMOTMgNTggQzkzIDgwIDc3IDkwIDY0IDkwIEM1MSA5MCAzNSA4MCAzNSA1OCBaIiBmaWxsPSJ1cmwoI2h1bGwtZ3JhZCkiLz4KICA8IS0tIFdhdGVybGluZSBzdHJpcGUgYXQgYmFzaW4gd2FsbCB0b3BzIC0tPgogIDxsaW5lIHgxPSIzNiIgeTE9IjU4IiB4Mj0iOTIiIHkyPSI1OCIgc3Ryb2tlPSIjOWU0NDIwIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDwhLS0gQXJrIGNhYmluOiBwZWFrZWQgcm9vZiwgZ29sZGVuLW9hayB0b25lIC0tPgogIDxwYXRoIGQ9Ik02NCAxMiBMODcgMjIgTDg3IDMyIEw0MSAzMiBMNDEgMjIgWiIgZmlsbD0iI2NjN2U0NSIvPgo8L3N2Zz4K"
+
+const reviewScript = `
+(() => {
+	const body = document.body;
+	const resources = Array.from(document.querySelectorAll('[data-resource-id]'));
+	const treeButtons = Array.from(document.querySelectorAll('[data-target-resource]'));
+	const viewButtons = Array.from(document.querySelectorAll('.toolbar button[data-view]'));
+	const searchInput = document.querySelector('[data-tree-search]');
+	const isEditable = (target) => {
+		if (!(target instanceof HTMLElement)) {
+			return false;
+		}
+		const tagName = target.tagName.toLowerCase();
+		return target.isContentEditable || tagName === 'input' || tagName === 'textarea' || tagName === 'select';
+	};
+
+	const selectResource = (id) => {
+		resources.forEach((resource) => {
+			resource.classList.toggle('is-active', resource.dataset.resourceId === id);
+		});
+		treeButtons.forEach((button) => {
+			const selected = button.dataset.targetResource === id;
+			button.setAttribute('aria-current', selected ? 'true' : 'false');
+		});
+	};
+
+	treeButtons.forEach((button) => {
+		button.addEventListener('click', () => selectResource(button.dataset.targetResource));
+	});
+
+	viewButtons.forEach((button) => {
+		button.addEventListener('click', () => {
+			body.dataset.view = button.dataset.view;
+			viewButtons.forEach((candidate) => {
+				candidate.setAttribute('aria-pressed', candidate === button ? 'true' : 'false');
+			});
+		});
+	});
+
+	const runSearch = () => {
+		if (!searchInput) {
+			return;
+		}
+		const query = searchInput.value.trim().toLowerCase();
+		document.querySelectorAll('[data-tree-app]').forEach((app) => {
+			let visible = false;
+			app.querySelectorAll('[data-search-text]').forEach((button) => {
+				const matches = !query || button.dataset.searchText.includes(query);
+				button.hidden = !matches;
+				visible = visible || matches;
+			});
+			app.hidden = !visible;
+		});
+	};
+
+	const clearSearch = () => {
+		if (!searchInput) {
+			return;
+		}
+		searchInput.value = '';
+		runSearch();
+	};
+
+	const clearOrBlurSearch = () => {
+		if (!searchInput) {
+			return;
+		}
+		if (searchInput.value) {
+			clearSearch();
+			return;
+		}
+		if (document.activeElement === searchInput) {
+			searchInput.blur();
+		}
+	};
+
+	if (searchInput) {
+		searchInput.addEventListener('input', runSearch);
+		searchInput.addEventListener('keydown', (event) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				event.stopPropagation();
+				clearOrBlurSearch();
+			}
+		});
+		document.addEventListener('keydown', (event) => {
+			if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
+				return;
+			}
+			if (event.key === '/' && !isEditable(event.target)) {
+				event.preventDefault();
+				searchInput.focus();
+				searchInput.select();
+				runSearch();
+				return;
+			}
+			if (event.key === 'Escape' && (document.activeElement === searchInput || searchInput.value)) {
+				event.preventDefault();
+				clearOrBlurSearch();
+			}
+		});
+	}
+
+	if (resources.length > 0) {
+		selectResource(resources[0].dataset.resourceId);
+	}
+})();
+`

--- a/internal/report/diffhtml/hunk.go
+++ b/internal/report/diffhtml/hunk.go
@@ -1,0 +1,114 @@
+package diffhtml
+
+import (
+	"strconv"
+	"strings"
+)
+
+type diffHunk struct {
+	Header string
+	Rows   []diffRow
+}
+
+type diffRow struct {
+	Kind        string
+	LeftNumber  int
+	RightNumber int
+	LeftText    string
+	RightText   string
+}
+
+func parseUnifiedDiff(text string) []diffHunk {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	var hunks []diffHunk
+	var current *diffHunk
+	var leftNumber, rightNumber int
+	var leftRemaining, rightRemaining int
+
+	for line := range strings.SplitSeq(text, "\n") {
+		if strings.HasPrefix(line, "@@ ") {
+			leftNumber, leftRemaining, rightNumber, rightRemaining = parseHunkRange(line)
+			hunks = append(hunks, diffHunk{Header: line})
+			current = &hunks[len(hunks)-1]
+			if hunkConsumed(leftRemaining, rightRemaining) {
+				current = nil
+			}
+			continue
+		}
+		if current == nil || line == "" {
+			continue
+		}
+
+		prefix := line[0]
+		content := line[1:]
+		switch prefix {
+		case ' ':
+			current.Rows = append(current.Rows, diffRow{
+				Kind:        "context",
+				LeftNumber:  leftNumber,
+				RightNumber: rightNumber,
+				LeftText:    content,
+				RightText:   content,
+			})
+			leftNumber++
+			rightNumber++
+			leftRemaining--
+			rightRemaining--
+		case '-':
+			current.Rows = append(current.Rows, diffRow{
+				Kind:       "removed",
+				LeftNumber: leftNumber,
+				LeftText:   content,
+			})
+			leftNumber++
+			leftRemaining--
+		case '+':
+			current.Rows = append(current.Rows, diffRow{
+				Kind:        "added",
+				RightNumber: rightNumber,
+				RightText:   content,
+			})
+			rightNumber++
+			rightRemaining--
+		default:
+			continue
+		}
+		if hunkConsumed(leftRemaining, rightRemaining) {
+			current = nil
+		}
+	}
+
+	return hunks
+}
+
+func parseHunkRange(header string) (int, int, int, int) {
+	fields := strings.Fields(header)
+	if len(fields) < 3 {
+		return 0, 0, 0, 0
+	}
+	leftStart, leftCount := parseRange(fields[1])
+	rightStart, rightCount := parseRange(fields[2])
+	return leftStart, leftCount, rightStart, rightCount
+}
+
+func parseRange(rangeText string) (int, int) {
+	rangeText = strings.TrimPrefix(rangeText, "-")
+	rangeText = strings.TrimPrefix(rangeText, "+")
+	start, countText, hasCount := strings.Cut(rangeText, ",")
+	number, err := strconv.Atoi(start)
+	if err != nil {
+		return 0, 0
+	}
+	if !hasCount {
+		return number, 1
+	}
+	count, err := strconv.Atoi(countText)
+	if err != nil {
+		return number, 0
+	}
+	return number, count
+}
+
+func hunkConsumed(leftRemaining, rightRemaining int) bool {
+	return leftRemaining <= 0 && rightRemaining <= 0
+}

--- a/internal/report/diffhtml/hunk_test.go
+++ b/internal/report/diffhtml/hunk_test.go
@@ -1,0 +1,84 @@
+package diffhtml
+
+import "testing"
+
+func TestParseUnifiedDiffHunksLineNumbers(t *testing.T) {
+	hunks := parseUnifiedDiff("@@ -10,3 +10,4 @@\n context\n-removed\n+added one\n+added two\n")
+
+	if len(hunks) != 1 {
+		t.Fatalf("len(hunks) = %d, want 1", len(hunks))
+	}
+	if hunks[0].Header != "@@ -10,3 +10,4 @@" {
+		t.Fatalf("Header = %q, want %q", hunks[0].Header, "@@ -10,3 +10,4 @@")
+	}
+
+	want := []diffRow{
+		{Kind: "context", LeftNumber: 10, RightNumber: 10, LeftText: "context", RightText: "context"},
+		{Kind: "removed", LeftNumber: 11, LeftText: "removed"},
+		{Kind: "added", RightNumber: 11, RightText: "added one"},
+		{Kind: "added", RightNumber: 12, RightText: "added two"},
+	}
+	assertDiffRows(t, hunks[0].Rows, want)
+}
+
+func TestParseUnifiedDiffMultipleHunks(t *testing.T) {
+	hunks := parseUnifiedDiff("--- old\n+++ new\n@@ -1,1 +1,1 @@\n-old\n+new\n@@ -20,1 +20,1 @@\n-old twenty\n+new twenty\n")
+
+	if len(hunks) != 2 {
+		t.Fatalf("len(hunks) = %d, want 2", len(hunks))
+	}
+	if len(hunks[0].Rows) == 0 {
+		t.Fatal("first hunk has no rows")
+	}
+	if got := hunks[0].Rows[0]; got.Kind != "removed" || got.LeftNumber != 1 {
+		t.Fatalf("first hunk first row = %+v, want removed row at line 1", got)
+	}
+	if len(hunks[1].Rows) == 0 {
+		t.Fatal("second hunk has no rows")
+	}
+	if got := hunks[1].Rows[0]; got.Kind != "removed" || got.LeftNumber != 20 {
+		t.Fatalf("second hunk first row = %+v, want removed row at line 20", got)
+	}
+}
+
+func TestParseUnifiedDiffPreservesRowsThatResembleFileHeaders(t *testing.T) {
+	hunks := parseUnifiedDiff("--- old\n+++ new\n@@ -1,1 +1,1 @@\n---removed\n+++added\n")
+
+	if len(hunks) != 1 {
+		t.Fatalf("len(hunks) = %d, want 1", len(hunks))
+	}
+	want := []diffRow{
+		{Kind: "removed", LeftNumber: 1, LeftText: "--removed"},
+		{Kind: "added", RightNumber: 1, RightText: "++added"},
+	}
+	assertDiffRows(t, hunks[0].Rows, want)
+}
+
+func TestParseUnifiedDiffStopsAtDeclaredHunkRanges(t *testing.T) {
+	hunks := parseUnifiedDiff("--- old\n+++ new\n@@ -1,1 +1,1 @@\n-old\n+new\n--- old2\n+++ new2\n@@ -20,1 +20,1 @@\n-old twenty\n+new twenty\n")
+
+	if len(hunks) != 2 {
+		t.Fatalf("len(hunks) = %d, want 2", len(hunks))
+	}
+	assertDiffRows(t, hunks[0].Rows, []diffRow{
+		{Kind: "removed", LeftNumber: 1, LeftText: "old"},
+		{Kind: "added", RightNumber: 1, RightText: "new"},
+	})
+	assertDiffRows(t, hunks[1].Rows, []diffRow{
+		{Kind: "removed", LeftNumber: 20, LeftText: "old twenty"},
+		{Kind: "added", RightNumber: 20, RightText: "new twenty"},
+	})
+}
+
+func assertDiffRows(t *testing.T, got, want []diffRow) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(rows) = %d, want %d\nrows = %+v", len(got), len(want), got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("row %d = %+v, want %+v", index, got[index], want[index])
+		}
+	}
+}

--- a/internal/report/diffhtml/render.go
+++ b/internal/report/diffhtml/render.go
@@ -1,0 +1,427 @@
+package diffhtml
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/diff"
+)
+
+const defaultTitle = "drydock desired state diff"
+
+type Options struct {
+	Title string
+}
+
+type appGroup struct {
+	id      string
+	entries []groupEntry
+	added   int
+	removed int
+}
+
+type groupEntry struct {
+	index  int
+	result diff.Result
+}
+
+func Render(result app.DiffResult, options Options) ([]byte, error) {
+	title := strings.TrimSpace(options.Title)
+	if title == "" {
+		title = defaultTitle
+	}
+
+	groups := groupedResults(result.Results)
+	added, removed := totalLineChanges(groups)
+
+	var builder bytes.Buffer
+	builder.WriteString("<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n")
+	fmt.Fprintf(&builder, "<title>%s</title>\n", escape(title))
+	fmt.Fprintf(&builder, "<link rel=\"icon\" type=\"image/svg+xml\" href=\"%s\">\n", drydockFaviconHref)
+	builder.WriteString("<style>")
+	builder.WriteString(reviewStyles)
+	builder.WriteString("</style>\n</head>\n<body data-view=\"side-by-side\">\n")
+	builder.WriteString("<header class=\"report-header\">\n")
+	builder.WriteString("<div>\n")
+	fmt.Fprintf(&builder, "<h1>%s</h1>\n", escape(title))
+	renderSummary(&builder, len(groups), len(result.Results), added, removed)
+	builder.WriteString("</div>\n")
+	builder.WriteString(drydockLogo)
+	builder.WriteString("\n")
+	builder.WriteString("</header>\n")
+	builder.WriteString("<div class=\"review-layout\">\n")
+	renderTree(&builder, groups)
+	builder.WriteString("<main class=\"review-main\">\n")
+	if len(groups) == 0 {
+		builder.WriteString("<p class=\"no-diff\">No rendered manifest differences detected.</p>\n")
+	} else {
+		renderToolbar(&builder)
+		renderGroups(&builder, groups)
+	}
+	renderDiagnostics(&builder, result.Diagnostics)
+	builder.WriteString("</main>\n</div>\n<script>")
+	builder.WriteString(reviewScript)
+	builder.WriteString("</script>\n</body>\n</html>\n")
+	return builder.Bytes(), nil
+}
+
+func Write(w io.Writer, result app.DiffResult, options Options) error {
+	data, err := Render(result, options)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func groupedResults(results []diff.Result) []appGroup {
+	byID := make(map[string]*appGroup)
+	for index, result := range results {
+		id := applicationID(result.Parent)
+		group := byID[id]
+		if group == nil {
+			group = &appGroup{id: id}
+			byID[id] = group
+		}
+		group.entries = append(group.entries, groupEntry{index: index, result: result})
+		added, removed := lineChanges(result.Diff)
+		group.added += added
+		group.removed += removed
+	}
+
+	groups := make([]appGroup, 0, len(byID))
+	for _, group := range byID {
+		groups = append(groups, *group)
+	}
+	slices.SortFunc(groups, func(left, right appGroup) int {
+		leftChanged := left.added + left.removed
+		rightChanged := right.added + right.removed
+		if leftChanged != rightChanged {
+			return rightChanged - leftChanged
+		}
+		return strings.Compare(left.id, right.id)
+	})
+	return groups
+}
+
+func applicationID(parent diff.Parent) string {
+	if parent.Namespace != "" {
+		return parent.Namespace + "/" + parent.Name
+	}
+	return parent.Name
+}
+
+func totalLineChanges(groups []appGroup) (int, int) {
+	var added, removed int
+	for _, group := range groups {
+		added += group.added
+		removed += group.removed
+	}
+	return added, removed
+}
+
+func lineChanges(text string) (int, int) {
+	var added, removed int
+	for line := range strings.SplitSeq(text, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+		case strings.HasPrefix(line, "+"):
+			added++
+		case strings.HasPrefix(line, "-"):
+			removed++
+		}
+	}
+	return added, removed
+}
+
+func renderSummary(builder *bytes.Buffer, apps, resources, added, removed int) {
+	fmt.Fprintf(builder, "<p class=\"summary\">%s, %s, +%d/-%d</p>\n",
+		escape(plural(apps, "app", "apps")),
+		escape(plural(resources, "resource", "resources")),
+		added,
+		removed,
+	)
+}
+
+func renderDiagnostics(builder *bytes.Buffer, diagnostics []diagnostic.Diagnostic) {
+	if len(diagnostics) == 0 {
+		return
+	}
+	builder.WriteString("<details class=\"diagnostics\">\n")
+	fmt.Fprintf(builder, "<summary>%s</summary>\n<ul>\n", escape(diagnosticSummary(diagnostics)))
+	for _, diag := range diagnostics {
+		builder.WriteString("<li>")
+		fmt.Fprintf(builder, "<span class=\"severity\">%s</span>", escape(string(diag.Severity)))
+		if diag.Category != "" {
+			fmt.Fprintf(builder, " <span class=\"category\">%s</span>", escape(diag.Category))
+		}
+		fmt.Fprintf(builder, " <span class=\"message\">%s</span>", escape(singleLine(diag.Message)))
+		builder.WriteString("</li>\n")
+	}
+	builder.WriteString("</ul>\n</details>\n")
+}
+
+func renderTree(builder *bytes.Buffer, groups []appGroup) {
+	builder.WriteString("<aside class=\"tree\">\n")
+	builder.WriteString("<input class=\"tree-search\" data-tree-search type=\"search\" placeholder=\"Search changes\" aria-label=\"Search changed resources\">\n")
+	for _, group := range groups {
+		fmt.Fprintf(builder, "<section data-tree-app=\"%s\">\n", escape(group.id))
+		fmt.Fprintf(builder, "<h2>%s</h2>\n", escape(group.id))
+		for _, entry := range group.entries {
+			label := resourceLabel(entry.result.Resource)
+			searchText := strings.ToLower(strings.Join([]string{
+				group.id,
+				label,
+				string(entry.result.Change),
+			}, " "))
+			fmt.Fprintf(builder, "<button class=\"tree-resource\" type=\"button\" data-target-resource=\"resource-%d\" data-search-text=\"%s\">%s</button>\n",
+				entry.index,
+				escape(searchText),
+				escape(label),
+			)
+		}
+		builder.WriteString("</section>\n")
+	}
+	builder.WriteString("</aside>\n")
+}
+
+func renderToolbar(builder *bytes.Buffer) {
+	builder.WriteString("<div class=\"toolbar\" role=\"toolbar\" aria-label=\"Diff view\">\n")
+	builder.WriteString("<button type=\"button\" data-view=\"side-by-side\" aria-pressed=\"true\">Side-by-side</button>\n")
+	builder.WriteString("<button type=\"button\" data-view=\"unified\" aria-pressed=\"false\">Unified</button>\n")
+	builder.WriteString("</div>\n")
+}
+
+func renderGroups(builder *bytes.Buffer, groups []appGroup) {
+	builder.WriteString("<section class=\"applications\">\n")
+	for _, group := range groups {
+		for _, entry := range group.entries {
+			renderResource(builder, group.id, entry)
+		}
+	}
+	builder.WriteString("</section>\n")
+}
+
+func renderResource(builder *bytes.Buffer, appID string, entry groupEntry) {
+	result := entry.result
+	hunks := parseUnifiedDiff(result.Diff)
+	fmt.Fprintf(builder, "<article class=\"resource\" data-resource-id=\"resource-%d\" data-result-index=\"%d\" data-change=\"%s\">\n",
+		entry.index,
+		entry.index,
+		escape(string(result.Change)),
+	)
+	fmt.Fprintf(builder, "<h3>%s</h3>\n", escape(resourceLabel(result.Resource)))
+	fmt.Fprintf(builder, "<p class=\"resource-meta\">%s &middot; %s</p>\n", escape(appID), escape(string(result.Change)))
+	renderSideBySideTable(builder, hunks)
+	renderUnifiedTable(builder, hunks)
+	builder.WriteString("</article>\n")
+}
+
+func renderSideBySideTable(builder *bytes.Buffer, hunks []diffHunk) {
+	builder.WriteString("<table class=\"diff-table side-by-side\">\n<tbody>\n")
+	for _, hunk := range hunks {
+		leftHighlights, rightHighlights := pairedHighlights(hunk.Rows)
+		fmt.Fprintf(builder, "<tr class=\"hunk-header\"><th colspan=\"4\">%s</th></tr>\n", escape(hunk.Header))
+		for index, row := range hunk.Rows {
+			fmt.Fprintf(builder, "<tr class=\"diff-row %s\">", escape(row.Kind))
+			renderLineNumberCell(builder, row.LeftNumber)
+			builder.WriteString("<td class=\"line-code\">")
+			renderHighlightedText(builder, row.LeftText, leftHighlights[index], "removed")
+			builder.WriteString("</td>")
+			renderLineNumberCell(builder, row.RightNumber)
+			builder.WriteString("<td class=\"line-code\">")
+			renderHighlightedText(builder, row.RightText, rightHighlights[index], "added")
+			builder.WriteString("</td>")
+			builder.WriteString("</tr>\n")
+		}
+	}
+	builder.WriteString("</tbody>\n</table>\n")
+}
+
+func renderUnifiedTable(builder *bytes.Buffer, hunks []diffHunk) {
+	builder.WriteString("<table class=\"diff-table unified\">\n<tbody>\n")
+	for _, hunk := range hunks {
+		leftHighlights, rightHighlights := pairedHighlights(hunk.Rows)
+		fmt.Fprintf(builder, "<tr class=\"hunk-header\"><th colspan=\"2\">%s</th></tr>\n", escape(hunk.Header))
+		for index, row := range hunk.Rows {
+			number := row.RightNumber
+			text := row.RightText
+			highlights := rightHighlights[index]
+			highlightClass := "added"
+			if row.Kind == "removed" {
+				number = row.LeftNumber
+				text = row.LeftText
+				highlights = leftHighlights[index]
+				highlightClass = "removed"
+			}
+			fmt.Fprintf(builder, "<tr class=\"diff-row %s\">", escape(row.Kind))
+			renderLineNumberCell(builder, number)
+			builder.WriteString("<td class=\"line-code\">")
+			renderHighlightedText(builder, text, highlights, highlightClass)
+			builder.WriteString("</td>")
+			builder.WriteString("</tr>\n")
+		}
+	}
+	builder.WriteString("</tbody>\n</table>\n")
+}
+
+func renderLineNumberCell(builder *bytes.Buffer, number int) {
+	if number == 0 {
+		builder.WriteString("<td class=\"line-number\"></td>")
+		return
+	}
+	fmt.Fprintf(builder, "<td class=\"line-number\">%d</td>", number)
+}
+
+type highlightRange struct {
+	start int
+	end   int
+}
+
+func pairedHighlights(rows []diffRow) (map[int][]highlightRange, map[int][]highlightRange) {
+	leftHighlights := make(map[int][]highlightRange)
+	rightHighlights := make(map[int][]highlightRange)
+	for index := 0; index < len(rows); {
+		if rows[index].Kind != "removed" {
+			index++
+			continue
+		}
+		removedStart := index
+		for index < len(rows) && rows[index].Kind == "removed" {
+			index++
+		}
+		addedStart := index
+		for index < len(rows) && rows[index].Kind == "added" {
+			index++
+		}
+		removedCount := addedStart - removedStart
+		addedCount := index - addedStart
+		pairCount := min(removedCount, addedCount)
+		for offset := range pairCount {
+			leftIndex := removedStart + offset
+			rightIndex := addedStart + offset
+			left, right := changedRanges(rows[leftIndex].LeftText, rows[rightIndex].RightText)
+			if len(left) > 0 {
+				leftHighlights[leftIndex] = left
+			}
+			if len(right) > 0 {
+				rightHighlights[rightIndex] = right
+			}
+		}
+	}
+	return leftHighlights, rightHighlights
+}
+
+func changedRanges(left, right string) ([]highlightRange, []highlightRange) {
+	leftRunes := []rune(left)
+	rightRunes := []rune(right)
+	if string(leftRunes) == string(rightRunes) {
+		return nil, nil
+	}
+
+	prefix := 0
+	for prefix < len(leftRunes) && prefix < len(rightRunes) && leftRunes[prefix] == rightRunes[prefix] {
+		prefix++
+	}
+
+	suffix := 0
+	for suffix < len(leftRunes)-prefix &&
+		suffix < len(rightRunes)-prefix &&
+		leftRunes[len(leftRunes)-1-suffix] == rightRunes[len(rightRunes)-1-suffix] {
+		suffix++
+	}
+
+	leftEnd := len(leftRunes) - suffix
+	rightEnd := len(rightRunes) - suffix
+	var leftRanges, rightRanges []highlightRange
+	if prefix < leftEnd {
+		leftRanges = append(leftRanges, highlightRange{start: prefix, end: leftEnd})
+	}
+	if prefix < rightEnd {
+		rightRanges = append(rightRanges, highlightRange{start: prefix, end: rightEnd})
+	}
+	return leftRanges, rightRanges
+}
+
+func renderHighlightedText(builder *bytes.Buffer, text string, highlights []highlightRange, class string) {
+	if len(highlights) == 0 {
+		builder.WriteString(escape(text))
+		return
+	}
+	runes := []rune(text)
+	cursor := 0
+	for _, highlight := range highlights {
+		if highlight.start < cursor {
+			highlight.start = cursor
+		}
+		if highlight.end > len(runes) {
+			highlight.end = len(runes)
+		}
+		if highlight.start > cursor {
+			builder.WriteString(escape(string(runes[cursor:highlight.start])))
+		}
+		if highlight.start < highlight.end {
+			fmt.Fprintf(builder, "<span class=\"inline-change %s\">%s</span>",
+				escape(class),
+				escape(string(runes[highlight.start:highlight.end])),
+			)
+			cursor = highlight.end
+		}
+	}
+	if cursor < len(runes) {
+		builder.WriteString(escape(string(runes[cursor:])))
+	}
+}
+
+func resourceLabel(resource diff.Resource) string {
+	var parts []string
+	if resource.Group != "" {
+		parts = append(parts, resource.Group)
+	}
+	if resource.Kind != "" {
+		parts = append(parts, resource.Kind)
+	}
+	name := resource.Name
+	if resource.Namespace != "" {
+		name = resource.Namespace + "/" + name
+	}
+	if name != "" {
+		parts = append(parts, name)
+	}
+	return strings.Join(parts, " ")
+}
+
+func plural(count int, singular, multiple string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, singular)
+	}
+	return fmt.Sprintf("%d %s", count, multiple)
+}
+
+func diagnosticSummary(diagnostics []diagnostic.Diagnostic) string {
+	if len(diagnostics) == 1 {
+		severity := strings.TrimSpace(string(diagnostics[0].Severity))
+		if severity != "" {
+			return "Diagnostics: 1 " + severity
+		}
+		return "Diagnostics: 1 message"
+	}
+	return fmt.Sprintf("Diagnostics: %d messages", len(diagnostics))
+}
+
+func singleLine(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", " ")
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.ReplaceAll(text, "\r", " ")
+	return text
+}
+
+func escape(text string) string {
+	return html.EscapeString(text)
+}

--- a/internal/report/diffhtml/render_test.go
+++ b/internal/report/diffhtml/render_test.go
@@ -1,0 +1,397 @@
+package diffhtml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/diff"
+)
+
+func TestRenderEscapesDynamicContent(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{{
+			Parent: diff.Parent{
+				Namespace: "argocd<script>",
+				Name:      "demo&app",
+			},
+			Resource: diff.Resource{
+				Kind: "ConfigMap",
+				Name: "cm<one>",
+			},
+			Change: diff.ChangeModified,
+			Diff:   "--- <old>\n+++ <new>\n@@ -1,1 +1,1 @@\n-<old>\n+<new>\n",
+		}},
+		Diagnostics: []diagnostic.Diagnostic{{
+			Severity: diagnostic.SeverityWarning,
+			Category: "render<script>",
+			Message:  "message <tag>",
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, raw := range []string{
+		"argocd<script>/demo&app",
+		"render<script>",
+		"cm<one>",
+		"<old>",
+		"<new>",
+		"<tag>",
+	} {
+		if strings.Contains(text, raw) {
+			t.Fatalf("HTML contains unescaped dynamic value %q:\n%s", raw, text)
+		}
+	}
+	for _, escaped := range []string{
+		"argocd&lt;script&gt;/demo&amp;app",
+		"render&lt;script&gt;",
+		"cm&lt;one&gt;",
+		`&lt;<span class="inline-change removed">old</span>&gt;`,
+		`&lt;<span class="inline-change added">new</span>&gt;`,
+		"&lt;tag&gt;",
+	} {
+		if !strings.Contains(text, escaped) {
+			t.Fatalf("HTML missing escaped dynamic value %q:\n%s", escaped, text)
+		}
+	}
+}
+
+func TestRenderGroupsAndSummarizesChanges(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "small", "cm-one", "-old\n+new\n"),
+			diffResult("argocd", "large", "cm-two", "-old\n+new\n-old2\n+new2\n"),
+			diffResult("argocd", "small", "cm-three", " context\n"),
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"<title>drydock desired state diff</title>",
+		"2 apps",
+		"3 resources",
+		"+3/-3",
+		"argocd/large",
+		"argocd/small",
+		"cm-one",
+		"cm-two",
+		"cm-three",
+		`data-change="modified"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Index(text, "argocd/large") > strings.Index(text, "argocd/small") {
+		t.Fatalf("HTML did not sort app groups by changed lines descending:\n%s", text)
+	}
+}
+
+func TestRenderIncludesStaticReviewUI(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{{
+			Parent: diff.Parent{
+				Namespace: "argocd",
+				Name:      "demo",
+			},
+			Resource: diff.Resource{
+				Kind: "ConfigMap",
+				Name: "cm-one",
+			},
+			Change: diff.ChangeModified,
+			Diff:   "--- old\n+++ new\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+		}},
+	}, Options{Title: "Review"})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"<style>",
+		`<body data-view="side-by-side">`,
+		"<header",
+		`class="brand-logo"`,
+		`class="tree"`,
+		`class="tree-search"`,
+		`data-tree-search`,
+		`placeholder="Search changes"`,
+		`aria-label="Search changed resources"`,
+		`data-tree-app`,
+		`data-target-resource="resource-0"`,
+		`data-search-text="argocd/demo configmap cm-one modified"`,
+		`class="toolbar"`,
+		`data-view="side-by-side"`,
+		`data-view="unified"`,
+		`data-resource-id="resource-0"`,
+		`class="diff-table side-by-side"`,
+		`class="diff-table unified"`,
+		`class="line-number"`,
+		`class="line-code"`,
+		`class="inline-change added"`,
+		`[data-resource-id]`,
+		`[data-tree-search]`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderSearchKeyboardContract(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{diffResult("argocd", "demo", "cm-one", "@@ -1,1 +1,1 @@\n-old\n+new\n")},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`const isEditable = (target) => {`,
+		`const clearOrBlurSearch = () => {`,
+		`document.addEventListener('keydown', (event) => {`,
+		`event.key === '/' && !isEditable(event.target)`,
+		`searchInput.focus();`,
+		`searchInput.select();`,
+		`if (searchInput.value) {`,
+		`searchInput.blur();`,
+		`event.stopPropagation();`,
+		`event.key === 'Escape' && (document.activeElement === searchInput || searchInput.value)`,
+		`clearOrBlurSearch();`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing search keyboard contract %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderUsesDarkDocsThemeAndInlineLogo(t *testing.T) {
+	out, err := Render(app.DiffResult{}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`color-scheme: dark;`,
+		`--paper: #07111d;`,
+		`--surface: #101b29;`,
+		`--teal: #69d7c2;`,
+		`--rust-bright: #f08a51;`,
+		`.resource h3 {`,
+		`aria-label="drydock"`,
+		`viewBox="0 0 480 128"`,
+		`>drydock</text>`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderIncludesInlineFavicon(t *testing.T) {
+	out, err := Render(app.DiffResult{}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,`,
+		`PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4IiB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCI+`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing favicon marker %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderDiagnosticsAtBottomCollapsedByDefault(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{diffResult("argocd", "demo", "cm-one", "@@ -1,1 +1,1 @@\n-old\n+new\n")},
+		Diagnostics: []diagnostic.Diagnostic{{
+			Severity: diagnostic.SeverityWarning,
+			Category: "changed-only",
+			Message:  "rendering all Applications",
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	diffIndex := strings.Index(text, `class="applications"`)
+	diagnosticsIndex := strings.Index(text, `<details class="diagnostics">`)
+	if diffIndex == -1 || diagnosticsIndex == -1 {
+		t.Fatalf("HTML missing applications or diagnostics section:\n%s", text)
+	}
+	if diagnosticsIndex < diffIndex {
+		t.Fatalf("diagnostics should render after diff content:\n%s", text)
+	}
+	if strings.Contains(text, `<details class="diagnostics" open>`) {
+		t.Fatalf("diagnostics should be collapsed by default:\n%s", text)
+	}
+	for _, want := range []string{
+		`<summary>Diagnostics: 1 warning</summary>`,
+		`<span class="severity">warning</span>`,
+		`<span class="category">changed-only</span>`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderDiffViewportOnlyContainsResourceArticles(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "one", "cm-one", "@@ -1,1 +1,1 @@\n-old\n+new\n"),
+			diffResult("argocd", "two", "cm-two", "@@ -1,1 +1,1 @@\n-left\n+right\n"),
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, `class="application"`) || strings.Contains(text, `class="app-summary"`) {
+		t.Fatalf("main diff viewport should not render app wrapper headers:\n%s", text)
+	}
+	for _, want := range []string{
+		`<article class="resource" data-resource-id="resource-0"`,
+		`<article class="resource" data-resource-id="resource-1"`,
+		`<p class="resource-meta">argocd/one &middot; modified</p>`,
+		`<p class="resource-meta">argocd/two &middot; modified</p>`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderHighlightsChangedCharactersInsidePairedRows(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{{
+			Parent:   diff.Parent{Name: "demo"},
+			Resource: diff.Resource{Kind: "ConfigMap", Name: "cm-one"},
+			Change:   diff.ChangeModified,
+			Diff:     "--- old\n+++ new\n@@ -1,1 +1,1 @@\n-image: app:v1\n+image: app:v2\n",
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`image: app:v<span class="inline-change removed">1</span>`,
+		`image: app:v<span class="inline-change added">2</span>`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing inline highlight %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderTreeTargetsOriginalResourceIndexesAfterGrouping(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "small", "cm-small", "@@ -1,1 +1,1 @@\n-old\n+new\n"),
+			diffResult("argocd", "large", "cm-large", "@@ -1,2 +1,2 @@\n-old\n+new\n-old2\n+new2\n"),
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	largeIndex := strings.Index(text, `data-tree-app="argocd/large"`)
+	smallIndex := strings.Index(text, `data-tree-app="argocd/small"`)
+	if largeIndex == -1 || smallIndex == -1 {
+		t.Fatalf("HTML missing expected app groups:\n%s", text)
+	}
+	if largeIndex > smallIndex {
+		t.Fatalf("HTML did not render larger app first:\n%s", text)
+	}
+	assertContainsAfter(t, text, largeIndex, `data-target-resource="resource-1"`)
+	assertContainsAfter(t, text, smallIndex, `data-target-resource="resource-0"`)
+	assertCount(t, text, `data-resource-id="resource-0"`, 1)
+	assertCount(t, text, `data-resource-id="resource-1"`, 1)
+}
+
+func TestRenderSideBySideRowsFromHunks(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{{
+			Parent: diff.Parent{Name: "demo"},
+			Resource: diff.Resource{
+				Kind: "ConfigMap",
+				Name: "cm-one",
+			},
+			Change: diff.ChangeModified,
+			Diff:   "--- old\n+++ new\n@@ -10,2 +10,2 @@\n context\n-removed\n+added\n",
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`<tr class="hunk-header"><th colspan="4">@@ -10,2 +10,2 @@</th></tr>`,
+		`<tr class="hunk-header"><th colspan="2">@@ -10,2 +10,2 @@</th></tr>`,
+		`<td class="line-number">10</td><td class="line-code">context</td><td class="line-number">10</td><td class="line-code">context</td>`,
+		`<td class="line-number">11</td><td class="line-code"><span class="inline-change removed">remov</span>ed</td><td class="line-number"></td><td class="line-code"></td>`,
+		`<td class="line-number"></td><td class="line-code"></td><td class="line-number">11</td><td class="line-code"><span class="inline-change added">add</span>ed</td>`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "--- old") || strings.Contains(text, "+++ new") {
+		t.Fatalf("HTML rendered complete unified file headers instead of hunk rows:\n%s", text)
+	}
+}
+
+func TestRenderEmptyDiff(t *testing.T) {
+	out, err := Render(app.DiffResult{}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"0 apps",
+		"0 resources",
+		"+0/-0",
+		"No rendered manifest differences detected.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func assertContainsAfter(t *testing.T, text string, offset int, want string) {
+	t.Helper()
+	if !strings.Contains(text[offset:], want) {
+		t.Fatalf("HTML missing %q after offset %d:\n%s", want, offset, text)
+	}
+}
+
+func assertCount(t *testing.T, text, needle string, want int) {
+	t.Helper()
+	if got := strings.Count(text, needle); got != want {
+		t.Fatalf("strings.Count(%q) = %d, want %d\n%s", needle, got, want, text)
+	}
+}
+
+func diffResult(namespace, appName, resourceName, diffText string) diff.Result {
+	return diff.Result{
+		Parent: diff.Parent{
+			Namespace: namespace,
+			Name:      appName,
+		},
+		Resource: diff.Resource{
+			Kind: "ConfigMap",
+			Name: resourceName,
+		},
+		Change: diff.ChangeModified,
+		Diff:   diffText,
+	}
+}

--- a/internal/report/diffhtml/site_search_test.go
+++ b/internal/report/diffhtml/site_search_test.go
@@ -1,0 +1,31 @@
+package diffhtml
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDocsSiteSearchKeyboardContract(t *testing.T) {
+	script, err := os.ReadFile("../../../site/assets/js/site.js")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(script)
+	for _, want := range []string{
+		`const clearOrBlurSearch = () => {`,
+		`if (input.value) {`,
+		`input.blur();`,
+		`event.key === "/" && !isEditable(event.target)`,
+		`input.focus();`,
+		`input.select();`,
+		`event.key === "Escape" && (document.activeElement === input || input.value || !panel.hidden)`,
+		`event.stopPropagation();`,
+		`clearOrBlurSearch();`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("site search script missing keyboard contract %q", want)
+		}
+	}
+}

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -235,12 +235,18 @@ outputs:
   diff-path:
     description: Local path to the rendered manifest diff file.
     value: ${{ steps.run.outputs.diff-path }}
+  diff-html-path:
+    description: Local path to the rendered manifest diff HTML file.
+    value: ${{ steps.run.outputs.diff-html-path }}
   images-path:
     description: Local path to the current-only image references file.
     value: ${{ steps.run.outputs.images-path }}
   diff-artifact-name:
     description: Rendered manifest diff artifact name.
     value: ${{ steps.run.outputs.diff-artifact-name }}
+  diff-html-artifact-name:
+    description: Rendered manifest diff HTML artifact name.
+    value: ${{ steps.run.outputs.diff-html-artifact-name }}
   image-artifact-name:
     description: Added image artifact name.
     value: ${{ steps.run.outputs.image-artifact-name }}
@@ -394,6 +400,7 @@ runs:
         DRYDOCK_BIN: ${{ inputs.install == 'true' && format('{0}/drydock', steps.setup.outputs.install-dir) || inputs.drydock-bin }}
         DRYDOCK_CACHE_PATH: ${{ steps.prepare.outputs.cache-path }}
         DRYDOCK_DIFF_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-artifact-name }}
+        DRYDOCK_DIFF_HTML_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-html-artifact-name }}
         DRYDOCK_IMAGE_ARTIFACT_NAME: ${{ steps.prepare.outputs.image-artifact-name }}
         DRYDOCK_INPUT_CHANGED_ONLY: ${{ inputs.changed-only }}
         DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE: ${{ inputs.changed-only-include }}
@@ -445,6 +452,27 @@ runs:
         name: ${{ steps.run.outputs.diff-artifact-name }}
         path: ${{ steps.run.outputs.diff-path }}
         retention-days: ${{ inputs.artifact-retention-days }}
+
+    - name: Upload rendered manifest diff HTML
+      id: upload-diff-html
+      if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        path: ${{ steps.run.outputs.diff-html-path }}
+        retention-days: ${{ inputs.artifact-retention-days }}
+        if-no-files-found: error
+        archive: false
+
+    - name: Add rendered manifest diff HTML link
+      if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.diff-comment == 'true' && inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}
+      shell: bash
+      env:
+        DRYDOCK_DIFF_COMMENT_PATH: ${{ steps.run.outputs.diff-comment-path }}
+        DRYDOCK_DIFF_HTML_ARTIFACT_URL: ${{ steps.upload-diff-html.outputs.artifact-url }}
+      run: |
+        if [[ -n "${DRYDOCK_DIFF_HTML_ARTIFACT_URL}" ]]; then
+          printf '%s\n' "- [Full Diff Report](${DRYDOCK_DIFF_HTML_ARTIFACT_URL})" >> "${DRYDOCK_DIFF_COMMENT_PATH}"
+        fi
 
     - name: Comment rendered manifest diff
       if: ${{ github.event_name == 'pull_request' && steps.prepare.outputs.trusted-context == 'true' && steps.run.outputs.diff-comment == 'true' }}

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -1,0 +1,62 @@
+package praction
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestActionUploadsHTMLDiffBeforeCommentAndAppendsURL(t *testing.T) {
+	actionYAMLBytes, err := os.ReadFile("action.yml")
+	if err != nil {
+		t.Fatalf("read action.yml: %v", err)
+	}
+	actionYAML := string(actionYAMLBytes)
+
+	rawUpload := strings.Index(actionYAML, "- name: Upload rendered manifest diff\n")
+	htmlUpload := strings.Index(actionYAML, "- name: Upload rendered manifest diff HTML\n")
+	htmlLink := strings.Index(actionYAML, "- name: Add rendered manifest diff HTML link\n")
+	comment := strings.Index(actionYAML, "- name: Comment rendered manifest diff\n")
+	for name, index := range map[string]int{
+		"raw diff upload":  rawUpload,
+		"HTML diff upload": htmlUpload,
+		"HTML link":        htmlLink,
+		"diff comment":     comment,
+	} {
+		if index == -1 {
+			t.Fatalf("action.yml missing %s step", name)
+		}
+	}
+	if rawUpload >= htmlUpload || htmlUpload >= htmlLink || htmlLink >= comment {
+		t.Fatalf("action.yml step order raw upload=%d html upload=%d html link=%d comment=%d", rawUpload, htmlUpload, htmlLink, comment)
+	}
+
+	htmlUploadBlock := actionYAML[htmlUpload:htmlLink]
+	for _, want := range []string{
+		"id: upload-diff-html",
+		"path: ${{ steps.run.outputs.diff-html-path }}",
+		"archive: false",
+	} {
+		if !strings.Contains(htmlUploadBlock, want) {
+			t.Fatalf("HTML upload block missing %q:\n%s", want, htmlUploadBlock)
+		}
+	}
+
+	linkBlock := actionYAML[htmlLink:comment]
+	for _, want := range []string{
+		"DRYDOCK_DIFF_COMMENT_PATH: ${{ steps.run.outputs.diff-comment-path }}",
+		"DRYDOCK_DIFF_HTML_ARTIFACT_URL: ${{ steps.upload-diff-html.outputs.artifact-url }}",
+		"[Full Diff Report](${DRYDOCK_DIFF_HTML_ARTIFACT_URL})",
+		"artifact-url",
+	} {
+		if !strings.Contains(linkBlock, want) {
+			t.Fatalf("HTML link block missing %q:\n%s", want, linkBlock)
+		}
+	}
+	if strings.Contains(linkBlock, "[${DRYDOCK_DIFF_HTML_ARTIFACT_NAME}]") {
+		t.Fatalf("HTML link block should not use artifact filename as link text:\n%s", linkBlock)
+	}
+	if strings.Contains(linkBlock, "[Full Diff Report](${DRYDOCK_DIFF_HTML_ARTIFACT_URL}).") {
+		t.Fatalf("HTML link block should not append punctuation to link:\n%s", linkBlock)
+	}
+}

--- a/pr-action/prepare.sh
+++ b/pr-action/prepare.sh
@@ -92,6 +92,10 @@ diff_artifact_name="${DRYDOCK_INPUT_DIFF_ARTIFACT_NAME}"
 if [[ -z "${diff_artifact_name}" ]]; then
   diff_artifact_name="drydock-diff-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}"
 fi
+diff_html_artifact_name="${DRYDOCK_INPUT_DIFF_HTML_ARTIFACT_NAME:-}"
+if [[ -z "${diff_html_artifact_name}" ]]; then
+  diff_html_artifact_name="drydock-diff-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}.html"
+fi
 image_artifact_name="${DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME}"
 if [[ -z "${image_artifact_name}" ]]; then
   image_artifact_name="drydock-images-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}"
@@ -105,6 +109,7 @@ fi
   echo "cache-save=${cache_save}"
   echo "trusted-context=${trusted_context}"
   echo "diff-artifact-name=${diff_artifact_name}"
+  echo "diff-html-artifact-name=${diff_html_artifact_name}"
   echo "image-artifact-name=${image_artifact_name}"
   echo "restore-keys<<EOF"
   printf '%s\n' "${restore_keys}"

--- a/pr-action/prepare_test.go
+++ b/pr-action/prepare_test.go
@@ -1,0 +1,58 @@
+package praction
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPrepareOutputsDefaultHTMLDiffArtifactName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	outputPath := filepath.Join(tmp, "github-output")
+	cmd := exec.Command("bash", "prepare.sh")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(),
+		"GITHUB_OUTPUT="+outputPath,
+		"GITHUB_RUN_ID=12345",
+		"GITHUB_RUN_ATTEMPT=2",
+		"GITHUB_EVENT_NAME=pull_request",
+		"GITHUB_REPOSITORY=example/repo",
+		"RUNNER_TEMP="+tmp,
+		"RUNNER_OS=Linux",
+		"RUNNER_ARCH=X64",
+		"DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS=",
+		"DRYDOCK_INPUT_CACHE=true",
+		"DRYDOCK_INPUT_CACHE_KEY=",
+		"DRYDOCK_INPUT_CACHE_KEY_PREFIX=drydock",
+		"DRYDOCK_INPUT_CACHE_KEY_SUFFIX=v1",
+		"DRYDOCK_INPUT_CACHE_PATH=",
+		"DRYDOCK_INPUT_CACHE_RESTORE_KEYS=",
+		"DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE=false",
+		"DRYDOCK_INPUT_COMMENT_CONTINUE_ON_ERROR=false",
+		"DRYDOCK_INPUT_COMMENT_EMPTY=false",
+		"DRYDOCK_INPUT_COMMENT_MODE=both",
+		"DRYDOCK_INPUT_DIFF_ARTIFACT_NAME=",
+		"DRYDOCK_INPUT_DIFF_MAX_BYTES=60000",
+		"DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME=",
+		"DRYDOCK_INPUT_SAVE_CACHE=true",
+		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS=true",
+		"DRYDOCK_PR_HEAD_REPO=example/repo",
+		"DRYDOCK_RESOLVED_VERSION=test",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("prepare.sh failed: %v\n%s", err, out)
+	}
+
+	output := readFile(t, outputPath)
+	if !strings.Contains(output, "diff-html-artifact-name=drydock-diff-12345-2.html") {
+		t.Fatalf("GITHUB_OUTPUT = %q, want default HTML diff artifact name", output)
+	}
+}

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -169,22 +169,6 @@ diff_comment_budget() {
   printf '%s\n' "$((effective - reserve))"
 }
 
-append_diff_artifact_footer() {
-  local comment_file="$1"
-  local max_bytes=60000
-  local footer
-  footer="- Full diff output: [${DRYDOCK_DIFF_ARTIFACT_NAME} artifact](${run_url})."
-  local current footer_bytes
-  current="$(wc -c < "${comment_file}")"
-  footer_bytes="$(printf '\n%s\n' "${footer}" | wc -c)"
-  if [[ $((current + footer_bytes)) -le "${max_bytes}" ]]; then
-    {
-      echo
-      echo "${footer}"
-    } >> "${comment_file}"
-  fi
-}
-
 validate_diff_comment_size() {
   local comment_file="$1"
   local max_bytes=60000
@@ -292,10 +276,15 @@ cache_path="${DRYDOCK_CACHE_PATH:-}"
 if [[ -n "${cache_path}" ]]; then
   mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes"
 fi
+diff_html_artifact_name="${DRYDOCK_DIFF_HTML_ARTIFACT_NAME:-}"
+if [[ -z "${diff_html_artifact_name}" ]]; then
+  diff_html_artifact_name="drydock-diff-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}.html"
+fi
 
 test_stdout="${work_dir}/test.out"
 test_stderr="${work_dir}/test.err"
 diff_path="${work_dir}/diff.txt"
+diff_html_path="${work_dir}/${diff_html_artifact_name}"
 diff_stderr="${work_dir}/diff.err"
 images_path="${work_dir}/added-images.txt"
 images_removed_path="${work_dir}/removed-images.txt"
@@ -376,6 +365,7 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
     -o markdown
     --markdown-max-bytes "$(diff_comment_budget "${DRYDOCK_INPUT_DIFF_MAX_BYTES}")"
     --raw-output-file "${diff_path}"
+    --html-output-file "${diff_html_path}"
     --exit-code=false
   )
   if ! capture_command "${diff_comment_path}" "${diff_stderr}" "${diff_args[@]}"; then
@@ -389,6 +379,7 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
   fi
 else
   : > "${diff_path}"
+  : > "${diff_html_path}"
   : > "${diff_comment_path}"
 fi
 
@@ -471,9 +462,6 @@ if [[ "${diff_comment}" == "true" ]]; then
       echo "No rendered manifest differences detected."
     } > "${diff_comment_path}"
   fi
-  if [[ "${has_diff}" == "true" && "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" == "true" && -n "${run_url}" ]]; then
-    append_diff_artifact_footer "${diff_comment_path}"
-  fi
   validate_diff_comment_size "${diff_comment_path}"
 fi
 
@@ -534,12 +522,14 @@ fi
   echo "has-image-diff=${has_image_diff}"
   echo "render-status=${render_status}"
   echo "diff-path=${diff_path}"
+  echo "diff-html-path=${diff_html_path}"
   echo "images-path=${images_path}"
   echo "diff-comment-path=${diff_comment_path}"
   echo "images-comment-path=${images_comment_path}"
   echo "diff-comment=${diff_comment}"
   echo "images-comment=${images_comment}"
   echo "diff-artifact-name=${DRYDOCK_DIFF_ARTIFACT_NAME}"
+  echo "diff-html-artifact-name=${diff_html_artifact_name}"
   echo "image-artifact-name=${DRYDOCK_IMAGE_ARTIFACT_NAME}"
 } >> "${GITHUB_OUTPUT}"
 

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -116,13 +116,13 @@ func TestRunCommentsLinkWorkflowRunArtifactsWhenUploadEnabled(t *testing.T) {
 	})
 
 	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
-	for _, want := range []string{
-		"Full diff output: [diff artifact](https://github.example.test/example/repo/actions/runs/12345).",
-		"~~~diff",
-	} {
+	for _, want := range []string{"~~~diff"} {
 		if !strings.Contains(diffComment, want) {
 			t.Fatalf("diff comment = %q, want %q", diffComment, want)
 		}
+	}
+	if strings.Contains(diffComment, "Full diff output") || strings.Contains(diffComment, "actions/runs/12345") {
+		t.Fatalf("diff comment contains raw artifact footer from run.sh:\n%s", diffComment)
 	}
 	if strings.Contains(diffComment, "Full output is available from the workflow artifacts") {
 		t.Fatalf("diff comment still has vague artifact text:\n%s", diffComment)
@@ -275,7 +275,7 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 	})
 
 	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
-	for _, want := range []string{"-o json", "--raw-output-file /tmp/ignored", "-o markdown", "--markdown-max-bytes 59488", "--raw-output-file " + filepath.Join(workDir, "diff.txt"), "--exit-code=false"} {
+	for _, want := range []string{"-o json", "--raw-output-file /tmp/ignored", "-o markdown", "--markdown-max-bytes 59488", "--raw-output-file " + filepath.Join(workDir, "diff.txt"), "--html-output-file " + filepath.Join(workDir, "diff.html"), "--exit-code=false"} {
 		if !strings.Contains(args, want) {
 			t.Fatalf("drydock args = %q, want %q", args, want)
 		}
@@ -290,6 +290,36 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
 	if !strings.Contains(diffComment, "## drydock desired state diff") {
 		t.Fatalf("diff comment = %q, want markdown report", diffComment)
+	}
+	if strings.Contains(diffComment, "Full diff output") || strings.Contains(diffComment, "actions/runs/12345") {
+		t.Fatalf("diff comment contains raw artifact footer from run.sh:\n%s", diffComment)
+	}
+}
+
+func TestRunOutputsHTMLDiffArtifactPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		diffOutput:                      true,
+		omitDiffHTMLArtifactNameFromEnv: true,
+	})
+
+	htmlPath := filepath.Join(workDir, "drydock-diff-run-1.html")
+	html := readFile(t, htmlPath)
+	if !strings.Contains(html, "<html><body>drydock diff</body></html>") {
+		t.Fatalf("diff.html = %q, want HTML diff artifact", html)
+	}
+
+	output := readFile(t, filepath.Join(filepath.Dir(workDir), "github-output"))
+	for _, want := range []string{
+		"diff-html-path=" + htmlPath,
+		"diff-html-artifact-name=drydock-diff-run-1.html",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("GITHUB_OUTPUT = %q, want %q", output, want)
+		}
 	}
 }
 
@@ -475,21 +505,22 @@ func TestRunFallsBackToGenericImageCommentWhenLegacyJSONFails(t *testing.T) {
 }
 
 type commentScenario struct {
-	uploadArtifacts       bool
-	githubEnv             bool
-	commentEmpty          bool
-	commentMode           string
-	diffOutput            bool
-	imageOutput           bool
-	imageRemoved          bool
-	imageMarkdownDisabled bool
-	imageJSONDisabled     bool
-	skipImageDiff         bool
-	runTest               bool
-	extraDiffArgs         string
-	extraImageArgs        string
-	changedOnlyInclude    string
-	changedOnlyIgnore     string
+	uploadArtifacts                 bool
+	githubEnv                       bool
+	commentEmpty                    bool
+	commentMode                     string
+	diffOutput                      bool
+	imageOutput                     bool
+	imageRemoved                    bool
+	imageMarkdownDisabled           bool
+	imageJSONDisabled               bool
+	skipImageDiff                   bool
+	runTest                         bool
+	extraDiffArgs                   string
+	extraImageArgs                  string
+	changedOnlyInclude              string
+	changedOnlyIgnore               string
+	omitDiffHTMLArtifactNameFromEnv bool
 }
 
 func runCommentScenario(t *testing.T, scenario commentScenario) string {
@@ -525,6 +556,9 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 			"GITHUB_REPOSITORY=example/repo",
 			"GITHUB_RUN_ID=12345",
 		)
+	}
+	if scenario.omitDiffHTMLArtifactNameFromEnv {
+		env = withoutEnv(env, "DRYDOCK_DIFF_HTML_ARTIFACT_NAME")
 	}
 
 	cmd := exec.Command("bash", "run.sh")
@@ -573,11 +607,16 @@ fi
 if [[ "$*" == *"diff apps"* ]]; then
   `+diffOutput+`
   raw_output_file=""
+  html_output_file=""
   output="diff"
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
       --raw-output-file)
         raw_output_file="$2"
+        shift 2
+        ;;
+      --html-output-file)
+        html_output_file="$2"
         shift 2
         ;;
       -o | --output)
@@ -595,6 +634,9 @@ if [[ "$*" == *"diff apps"* ]]; then
   done
   if [[ -n "${raw_output_file}" ]]; then
     printf '%s' "${diff_body:-}" > "${raw_output_file}"
+  fi
+  if [[ -n "${html_output_file}" ]]; then
+    printf '<html><body>drydock diff</body></html>\n' > "${html_output_file}"
   fi
   if [[ "${output}" == "markdown" ]]; then
     if [[ -n "${diff_body:-}" ]]; then
@@ -704,6 +746,18 @@ func boolString(value bool) string {
 	return "false"
 }
 
+func withoutEnv(env []string, key string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 
@@ -741,6 +795,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_BIN=drydock",
 		"DRYDOCK_CACHE_PATH=",
 		"DRYDOCK_DIFF_ARTIFACT_NAME=diff",
+		"DRYDOCK_DIFF_HTML_ARTIFACT_NAME=diff.html",
 		"DRYDOCK_IMAGE_ARTIFACT_NAME=images",
 		"DRYDOCK_INPUT_CHANGED_ONLY=",
 		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE=",

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -245,6 +245,17 @@ function initSearch(form) {
     closeResults();
   };
 
+  const clearOrBlurSearch = () => {
+    if (input.value) {
+      clearSearch();
+      return;
+    }
+    closeResults();
+    if (document.activeElement === input) {
+      input.blur();
+    }
+  };
+
   const setActive = (nextIndex) => {
     const items = Array.from(resultsList.querySelectorAll("[role='option']"));
     if (items.length === 0) {
@@ -329,7 +340,7 @@ function initSearch(form) {
     }
     if (event.key === "Escape" && (document.activeElement === input || input.value || !panel.hidden)) {
       event.preventDefault();
-      clearSearch();
+      clearOrBlurSearch();
     }
   });
 
@@ -350,7 +361,8 @@ function initSearch(form) {
     const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
     if (event.key === "Escape") {
       event.preventDefault();
-      clearSearch();
+      event.stopPropagation();
+      clearOrBlurSearch();
       return;
     }
     if (event.key === "ArrowDown" && items.length > 0) {


### PR DESCRIPTION
## Summary
- Adds a static HTML diff artifact for rendered manifest diffs.
- Links the clean `Full Diff Report` artifact from PR comments.
- Adds a dark, VS Code-like diff UI with file tree navigation, source panes, syntax-aware diff formatting, inline highlights, search hotkeys, diagnostics placement, and drydock branding.

## Test Plan
- `go test ./...`
- `git diff --check origin/main..HEAD`
- Validated in home-ops e2e run: https://github.com/sholdee/home-ops/actions/runs/26897943704

## Notes
- The branch was squashed to one commit against `origin/main`.
- GitHub comments strip `target` attributes from links, so the comment cannot force the artifact link to open in a new tab.
