### PR TITLE
fix: accept core resource customization split keys

### DIFF
--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -473,6 +473,53 @@ func TestOrchestratorDiffAppsHonorsSplitGlobalResourceCustomizationJSONPointers(
 	}
 }
 
+func TestOrchestratorDiffAppsHonorsSplitCoreResourceCustomizationJSONPointers(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writePersistentVolumeClaimApp(t, left, "left-pv")
+	writePersistentVolumeClaimApp(t, right, "right-pv")
+
+	baseline, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:  left,
+		RightPath: right,
+		Unified:   3,
+	})
+	if err != nil {
+		t.Fatalf("baseline DiffApps() error = %v", err)
+	}
+	if len(baseline.Diagnostics) != 0 {
+		t.Fatalf("baseline diagnostics = %#v, want none", baseline.Diagnostics)
+	}
+	if len(baseline.Results) != 1 {
+		t.Fatalf("baseline len(Results) = %d, want volumeName diff: %#v", len(baseline.Results), baseline.Results)
+	}
+	baselineDiff := diffResultText(baseline.Results)
+	if !strings.Contains(baselineDiff, "left-pv") || !strings.Contains(baselineDiff, "right-pv") {
+		t.Fatalf("baseline diff missing volumeName values:\n%s", baselineDiff)
+	}
+
+	writeGlobalCustomization(t, right, `resource.customizations.ignoreDifferences._PersistentVolumeClaim: |
+    jsonPointers:
+      - /spec/volumeName
+`)
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:  left,
+		RightPath: right,
+		Unified:   3,
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if len(result.Results) != 0 {
+		t.Fatalf("len(Results) = %d, want volumeName-only diff ignored: %#v", len(result.Results), result.Results)
+	}
+}
+
 func TestOrchestratorDiffAppliesKnownTypeFields(t *testing.T) {
 	left := t.TempDir()
 	right := t.TempDir()
@@ -1826,6 +1873,37 @@ metadata:
       containers:
         - name: app
           image: example/app:v1
+`)
+}
+
+func writePersistentVolumeClaimApp(t *testing.T, root, volumeName string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "pvc.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pvc
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/pvc
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "pvc", "pvc.yaml"), `apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+  namespace: demo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: `+volumeName+`
 `)
 }
 

--- a/internal/config/provider_split_resource_customizations.go
+++ b/internal/config/provider_split_resource_customizations.go
@@ -147,7 +147,7 @@ func splitResourceCustomizationKey(suffix string, provenance diagnostic.Provenan
 		return "", invalidSplitResourceCustomizationKeyDiagnostic(provenance)
 	}
 	if idx := strings.Index(suffix, "_"); idx >= 0 {
-		if idx == 0 || idx == len(suffix)-1 {
+		if idx == len(suffix)-1 {
 			return "", invalidSplitResourceCustomizationKeyDiagnostic(provenance)
 		}
 		return suffix[:idx] + "/" + suffix[idx+1:], nil

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -480,6 +480,9 @@ func TestLoadHelmValuesResourceSettings(t *testing.T) {
     resource.customizations.ignoreDifferences.apps_Deployment: |
       jsonPointers:
         - /spec/replicas
+    resource.customizations.ignoreDifferences._PersistentVolumeClaim: |
+      jsonPointers:
+        - /spec/volumeName
 `), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
@@ -497,6 +500,10 @@ func TestLoadHelmValuesResourceSettings(t *testing.T) {
 	customization := settings.ResourceCustomizations["apps/Deployment"]
 	if len(customization.IgnoreDifferences.JSONPointers) != 1 || customization.IgnoreDifferences.JSONPointers[0] != "/spec/replicas" {
 		t.Fatalf("Deployment customization = %#v", customization)
+	}
+	pvcCustomization := settings.ResourceCustomizations["/PersistentVolumeClaim"]
+	if len(pvcCustomization.IgnoreDifferences.JSONPointers) != 1 || pvcCustomization.IgnoreDifferences.JSONPointers[0] != "/spec/volumeName" {
+		t.Fatalf("PersistentVolumeClaim customization = %#v", pvcCustomization)
 	}
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -1216,6 +1216,62 @@ data:
 	}
 }
 
+func TestLoadConfigMapSplitResourceCustomizationKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		suffix  string
+		want    string
+		wantErr bool
+	}{
+		{name: "all", suffix: "all", want: "*/*"},
+		{name: "bare kind", suffix: "ConfigMap", want: "ConfigMap"},
+		{name: "group kind", suffix: "apps_Deployment", want: "apps/Deployment"},
+		{name: "core group kind", suffix: "_PersistentVolumeClaim", want: "/PersistentVolumeClaim"},
+		{name: "empty", suffix: "", wantErr: true},
+		{name: "empty kind", suffix: "apps_", wantErr: true},
+		{name: "extra separator", suffix: "apps_Deployment_extra", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "argocd-cm.yaml")
+			if err := os.WriteFile(path, []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  resource.customizations.ignoreDifferences.`+tc.suffix+`: |
+    jsonPointers:
+      - /spec/test
+`), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			settings, diags, err := LoadFromConfigMap(path)
+			if err != nil {
+				t.Fatalf("LoadFromConfigMap() error = %v", err)
+			}
+			if tc.wantErr {
+				if len(diags) != 1 || diags[0].Severity != "error" {
+					t.Fatalf("diagnostics = %#v, want one error", diags)
+				}
+				if len(settings.ResourceCustomizations) != 0 {
+					t.Fatalf("ResourceCustomizations = %#v, want none", settings.ResourceCustomizations)
+				}
+				return
+			}
+			if len(diags) != 0 {
+				t.Fatalf("diagnostics = %#v, want none", diags)
+			}
+			customization, ok := settings.ResourceCustomizations[tc.want]
+			if !ok {
+				t.Fatalf("ResourceCustomizations missing key %q: %#v", tc.want, settings.ResourceCustomizations)
+			}
+			if len(customization.IgnoreDifferences.JSONPointers) != 1 || customization.IgnoreDifferences.JSONPointers[0] != "/spec/test" {
+				t.Fatalf("customization = %#v, want /spec/test pointer", customization)
+			}
+		})
+	}
+}
+
 func TestLoadRepositorySecretIgnoresCredentials(t *testing.T) {
 	settings, diags, err := LoadRepositorySecret(filepath.Join("..", "..", "testdata", "settings", "repo-secret.yaml"))
 	if err != nil {

--- a/internal/luahealth/evaluator_test.go
+++ b/internal/luahealth/evaluator_test.go
@@ -83,6 +83,38 @@ func TestEvaluatorReportsRuntimeErrorForMatchingResource(t *testing.T) {
 	assertMessageContains(t, diags[0], "runtime error")
 }
 
+func TestEvaluatorMatchesCoreResourceHealthLuaByBareKind(t *testing.T) {
+	evaluator := New(config.ArgoSettings{ResourceCustomizations: map[string]config.ResourceCustomization{
+		"Secret": {
+			HasHealthLua: true,
+			HealthLua:    `error("bare core key matched")`,
+		},
+	}})
+
+	diags := evaluator.Validate(context.Background(), Request{
+		Application: ApplicationRef{Name: "demo", Namespace: "argocd"},
+		Manifests:   []render.Manifest{{Object: object("v1", "Secret", "default", "demo")}},
+	})
+	assertOneHealthDiagnostic(t, diags, "health.lua-failed", "health Lua failed for Application argocd/demo resource Secret default/demo")
+}
+
+func TestEvaluatorDoesNotMatchSlashPrefixedCoreResourceHealthLua(t *testing.T) {
+	evaluator := New(config.ArgoSettings{ResourceCustomizations: map[string]config.ResourceCustomization{
+		"/Secret": {
+			HasHealthLua: true,
+			HealthLua:    `error("slash-prefixed core key should not match Argo CD lua health key")`,
+		},
+	}})
+
+	diags := evaluator.Validate(context.Background(), Request{
+		Application: ApplicationRef{Name: "demo", Namespace: "argocd"},
+		Manifests:   []render.Manifest{{Object: object("v1", "Secret", "default", "demo")}},
+	})
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v, want slash-prefixed core key not to match", diags)
+	}
+}
+
 func TestEvaluatorReportsInvalidReturnType(t *testing.T) {
 	evaluator := New(config.ArgoSettings{ResourceCustomizations: map[string]config.ResourceCustomization{
 		"example.com/Widget": {


### PR DESCRIPTION
## Summary
- Accept Argo CD split resource customization keys for core resources such as _PersistentVolumeClaim.
- Add loader and diff regressions for core split-key ignoreDifferences behavior.
- Document Lua health core-resource matching behavior with tests aligned to Argo CD v3.4.3.

## Test Plan
- go test ./internal/config ./internal/app ./internal/luahealth -count=1
- git diff --check origin/main..HEAD
- go run ./cmd/drydock test apps