### PR TITLE
feat(plugin-policy): support trusted container bootstrap rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ when the user-facing task requires it.
 ## Hard Constraints
 
 - Do not add default shellouts to `helm`, `kustomize`, `kubectl`, `argocd`, or
-  config-management plugins. Exec plugins require trusted policy provenance
-  plus explicit `--enable-plugins`.
+  config-management plugins. Exec and container plugin engines require trusted
+  policy provenance plus explicit `--enable-plugins`.
 - Do not add live Kubernetes or Argo CD server behavior without updating the
   live runtime boundary document and preserving `--offline` behavior.
 - Do not hard-code `home-ops` paths, chart versions, branches, or repository

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ inspect locally and in CI:
   changed-only selection, default noisy-field filtering, and structured or
   markdown output.
 - **Plugins:** native safe Kustomize compatibility, `avp-compat` placeholder
-  redaction, native policy overrides, and explicit trusted exec policy with
-  `--enable-plugins`.
+  redaction, native policy overrides, trusted exec/container policy with
+  `--enable-plugins`, and policy bootstrap entrypoints.
 - **Diagnostics:** render status, custom health Lua validation, redacted
   settings/repository/AppProject checks, source acquisition diagnostics, and
   cache lifecycle commands.
@@ -353,7 +353,8 @@ Join the home-operations Discord at <https://discord.gg/home-operations>.
 - [Argo CD Render Parity](https://sholdee.github.io/drydock/concepts/argocd-render-parity/):
   how covered render semantics are validated against real Argo CD.
 - [Plugin policy](https://sholdee.github.io/drydock/plugin-policy/): trusted
-  policy engines, schema, CMP compatibility, and exec security.
+  policy engines, schema, CMP compatibility, bootstrap discovery, and command
+  security.
 - [Source acquisition](https://sholdee.github.io/drydock/concepts/source-acquisition/):
   Git, Helm, remote Kustomize, cache, and auth behavior.
 - [Reference](https://sholdee.github.io/drydock/reference/): full command and

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ copying the same rule into multiple files.
 | `docs/topologies.md` | Repository topology guidance and command patterns. |
 | `docs/applicationsets.md` | ApplicationSet generator behavior, fixture schema, and template parameters. |
 | `docs/source-acquisition.md` | Git, Helm, remote Kustomize, cache, and auth behavior. |
-| `docs/plugin-policy.md` | Trusted plugin policy provenance, editor schema, CMP compatibility, and exec security. |
+| `docs/plugin-policy.md` | Trusted plugin policy provenance, editor schema, CMP compatibility, bootstrap discovery, and command security. |
 | `schemas/plugin-policy.schema.json` | Editor validation schema for `.drydock/plugins.yaml`; parser remains authoritative. |
 | `docs/compatibility.md` | Supported Argo CD behavior and runtime-boundary status. |
 | `docs/github-actions.md` | Setup action and full PR action usage, permissions, cache, comments, and outputs. |

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -20,8 +20,8 @@ Canonical references:
 - `internal/requestopts` for shared option parsing.
 - `pkg/drydock` for the public embedding API.
 - `docs/design.md` for architecture and behavior contracts.
-- `docs/plugin-policy.md` for trusted plugin policy provenance, schema, and
-  exec security controls.
+- `docs/plugin-policy.md` for trusted plugin policy provenance, schema,
+  bootstrap discovery, and command security controls.
 
 Current command groups are:
 
@@ -58,11 +58,11 @@ Public API rules:
 
 Config management plugin command execution fails closed by default. CLI/default
 paths do not execute plugin commands unless trusted drydock plugin policy
-provenance matches `engine: exec` and the caller explicitly sets
-`--enable-plugins`. Discovered Argo CD CMP definitions that normalize to a safe
-`kustomize build` command may be interpreted through drydock's native
-Kustomize renderer without shelling out. Other native engines must remain
-narrow, in-process compatibility paths with fail-closed validators. Keep
+provenance matches `engine: exec` or `engine: container` and the caller
+explicitly sets `--enable-plugins`. Discovered Argo CD CMP definitions that
+normalize to a safe `kustomize build` command may be interpreted through
+drydock's native Kustomize renderer without shelling out. Other native engines
+must remain narrow, in-process compatibility paths with fail-closed validators. Keep
 detailed policy behavior in `docs/plugin-policy.md`. Public API plugin
 rendering is allowed only through explicit in-process `Config.PluginRenderer`
 or registry injection. Preserve `plugin.unsupported`, `plugin.failed`, and

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -182,7 +182,16 @@ Supported:
   `discover.fileName` or `discover.find.glob` rule matches a native-rendered
   source. drydock does not execute `discover.find.command`.
 - Trusted drydock plugin policy entries for native AVP compatibility, native
-  plugin overrides, and explicitly enabled exec CMP compatibility.
+  plugin overrides, and explicitly enabled exec/container CMP compatibility.
+- Trusted plugin policy bootstrap entrypoints for plugin-rendered Argo CD
+  bootstrap objects.
+- Trusted plugin policy `configManagementPlugin` seeds for static
+  `discover.fileName` / `discover.find.glob` metadata and optional
+  `generate.command` / `generate.args` compatibility metadata. Unnamed
+  Application plugin sources may match these trusted static rules.
+- Trusted exec/container plugin policies that gate Application plugin
+  parameters through `parameters.allow`, including string argv substitution and
+  constrained path parameters.
 - Config management plugin source detection with fail-closed diagnostics in
   the CLI and default Go client.
 - Injectable in-process plugin renderers, named plugin registry dispatch, and
@@ -199,14 +208,16 @@ Documented runtime-offline safety boundary:
 Not supported:
 
 - Arbitrary CLI config management plugin execution outside trusted
-  `engine: exec` policy plus `--enable-plugins`.
+  `engine: exec` or `engine: container` policy plus `--enable-plugins`.
 - Shellout plugin adapters or plugin command execution by default.
 - Argo CD repo-server sidecar plugin discovery.
 - Ambient plugin configuration or environment loading.
+- Untrusted CMP descriptor execution, unallowlisted Application plugin
+  parameters, or Application plugin env for policy-backed native engines.
 - Plugin credential injection.
 
 See `docs/plugin-policy.md` for trusted policy provenance, supported engines,
-schema, and exec security controls.
+schema, and command security controls.
 
 ## Diff, Images, And Output
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -162,14 +162,15 @@ Supported render paths:
 - Discovered Argo CD CMP definitions that normalize to a safe `kustomize
   build` command, interpreted through drydock's native Kustomize renderer.
 - Trusted plugin policy entries for native AVP compatibility, native plugin
-  overrides, and explicitly enabled exec CMP compatibility. Policy provenance,
-  schema, supported engines, and exec security controls are owned by
+  overrides, explicitly enabled exec/container CMP compatibility, and
+  plugin-rendered bootstrap discovery. Policy provenance, schema, supported
+  engines, and command security controls are owned by
   `docs/plugin-policy.md`.
 - Deterministic in-process plugin renderers supplied by embedding callers.
 
 The default CLI and default Go client fail closed for other config management
 plugin sources unless an embedding caller injects a plugin renderer or the
-caller explicitly enables a trusted exec policy.
+caller explicitly enables trusted command-backed policy.
 
 ## Diff Semantics
 

--- a/docs/plugin-policy.md
+++ b/docs/plugin-policy.md
@@ -16,18 +16,23 @@ Use plugin policy for these cases:
 - Deterministic argocd-vault-plugin (AVP) placeholder redaction with
   `engine: avp-compat`.
 - Explicit native Kustomize overrides with `engine: native-kustomize`.
-- Trusted shellout compatibility with `engine: exec` and `--enable-plugins`.
+- Trusted host-process compatibility with `engine: exec` and
+  `--enable-plugins`.
+- Trusted Docker-backed compatibility with `engine: container` and
+  `--enable-plugins`.
+- Plugin-rendered bootstrap discovery with `bootstrap.entrypoints`.
 
-## Runtime Gate
+## Command Execution Gate
 
 The CLI and default Go client do not run plugin commands unless all of these
 are true:
 
 - The Application source names a plugin that matches a drydock plugin policy
-  entry.
-- The matched policy entry uses `engine: exec`.
+  entry, or an unnamed Application plugin source matches trusted static
+  discovery from policy.
+- The matched policy entry uses `engine: exec` or `engine: container`.
 - The caller passes `--enable-plugins`.
-- The exec policy came from trusted policy provenance.
+- The command-backed policy came from trusted policy provenance.
 
 No plugin command execution occurs unless `--enable-plugins` is passed. Native
 rendering paths do not execute plugin commands.
@@ -44,6 +49,34 @@ would be required. This check is intentionally bounded: drydock only evaluates
 `discover.fileName` and `discover.find.glob` against the local Application
 source directory. It never executes or emulates `discover.find.command`.
 
+## Bootstrap Entrypoints
+
+Some repositories keep Argo CD bootstrap objects behind a config management
+plugin rather than committing `Application` or `ApplicationSet` YAML directly.
+Policy bootstrap entrypoints let drydock render those trusted plugin sources
+during fleet discovery so their generated Argo CD objects become normal
+discovered inputs.
+
+Bootstrap discovery runs after committed and explicit Kustomize discovery and
+the first ApplicationSet expansion, then drydock expands any ApplicationSets
+produced by bootstrap output before recursive rendered fleet discovery. It runs
+only in fleet discovery mode. `--discovery-mode static` disables it;
+`--max-discovery-depth 0` does not. Static committed objects take precedence
+over bootstrap-rendered duplicates, and bootstrap-rendered objects take
+precedence over recursive rendered fleet duplicates.
+
+Each bootstrap entrypoint creates an internal, hidden synthetic Application
+with namespace `argocd`, project `default`, destination name `in-cluster`, and
+destination namespace `argocd`. The synthetic Application is used only to
+render and scan the entrypoint output; it is not returned as a discovered
+Application.
+
+Bootstrap entrypoints fail closed. The `sourcePath` must be repository-local,
+exist, be a directory, avoid symlink components, and match the referenced
+plugin's trusted static `match.discover` or `configManagementPlugin.discover`
+rule. Bootstrap render failures are discovery errors rather than skipped
+recursive app-of-apps candidates.
+
 ## Trusted Provenance
 
 The default local policy path is `.drydock/plugins.yaml`. Use
@@ -56,15 +89,17 @@ safe discovered CMP definitions.
 Default local policy is trusted for native policy only. For single-tree
 commands such as `build`, `test`, and `diag`, a policy loaded from the current
 working tree may authorize `avp-compat` and `native-kustomize`. It is not
-trusted to execute `engine: exec` entries. Even with `--enable-plugins`, a
-matching exec entry from the current tree fails closed unless the caller also
-selects trusted policy provenance with `--plugin-policy-ref`.
+trusted to execute `engine: exec` or `engine: container` entries. Even with
+`--enable-plugins`, a matching command-backed entry from the current tree fails
+closed unless the caller also selects trusted policy provenance with
+`--plugin-policy-ref`.
 
 Diff commands load default policy from the left/baseline side, such as
 `--path-orig` or the `--ref-orig` snapshot, and use that one policy for both
-sides of the diff. Exec policy from that baseline provenance may run only when
-`--enable-plugins` is passed. Policy command definitions and post-renderers are
-never sourced from the proposed/current side of a pull request.
+sides of the diff. Command-backed policy from that baseline provenance may run
+only when `--enable-plugins` is passed. Policy command definitions,
+post-renderers, container image references, and bootstrap definitions are never
+sourced from the proposed/current side of a pull request.
 
 `--plugin-policy-ref` means "load the policy from this explicit trusted Git ref
 or source." When `--plugin-policy-repo` is set, drydock resolves the ref in
@@ -72,6 +107,79 @@ that local Git repository; otherwise it uses the selected repository. The ref
 is a trust assertion by the operator or CI job, not an arbitrary escape hatch
 for untrusted working-tree policy. Policy paths remain relative to the policy
 root snapshot and may not escape it.
+
+## Local Validation
+
+For a committed command-backed policy, validate with the trusted policy ref that
+CI will use:
+
+```sh
+drydock get apps \
+  --path . \
+  --enable-plugins \
+  --plugin-policy-ref main
+```
+
+When generated Applications point at the canonical Git remote URL, add a
+repository map so recursive rendering uses the local checkout:
+
+```sh
+drydock test apps \
+  --path . \
+  --enable-plugins \
+  --plugin-policy-ref main \
+  --repo-map https://github.com/example/cluster="$PWD"
+```
+
+To validate an uncommitted policy without making the working tree policy
+trusted directly, copy the policy into a small temporary Git repository and
+trust that repository's `HEAD`:
+
+```sh
+mkdir -p /tmp/drydock-policy-trust/.drydock
+cp .drydock/plugins.yaml /tmp/drydock-policy-trust/.drydock/plugins.yaml
+git -C /tmp/drydock-policy-trust init
+git -C /tmp/drydock-policy-trust add .drydock/plugins.yaml
+git -C /tmp/drydock-policy-trust commit -m "Trust local drydock plugin policy"
+
+drydock test apps \
+  --path . \
+  --enable-plugins \
+  --plugin-policy-ref HEAD \
+  --plugin-policy-repo /tmp/drydock-policy-trust \
+  --repo-map https://github.com/example/cluster="$PWD"
+```
+
+For diff validation, use the same trusted policy source and render all apps
+when there may be no local Git changes:
+
+```sh
+drydock diff apps \
+  --path-orig . \
+  --path . \
+  --enable-plugins \
+  --plugin-policy-ref HEAD \
+  --plugin-policy-repo /tmp/drydock-policy-trust \
+  --repo-map https://github.com/example/cluster="$PWD" \
+  --changed-only=false \
+  --exit-code=false
+```
+
+Common validation failures:
+
+- `requires --enable-plugins`: pass `--enable-plugins`; drydock never runs
+  command-backed policies by default.
+- `untrusted policy source`: use `--plugin-policy-ref`, or run a diff where the
+  policy comes from the trusted baseline side.
+- `no trusted plugin policy match.discover`: ensure the Application plugin name
+  matches a policy key, or add trusted static `match.discover` or
+  `configManagementPlugin.discover` metadata.
+- `Application plugin parameter ... is not allowed`: add a narrow
+  `parameters.allow` entry with the expected type and path allowlist.
+- `container command failed` during `init`: check copied sibling paths,
+  package/cache requirements, and whether the policy needs `network: default`.
+- `network: default` with `--offline`: container network access is rejected in
+  offline mode; use local caches or run without `--offline`.
 
 ## Schema
 
@@ -100,6 +208,22 @@ Top-level fields:
 | `apiVersion` | Yes | None | Must be `drydock.sholdee.dev/v1alpha1`. |
 | `kind` | Yes | None | Must be `PluginPolicy`. |
 | `plugins` | No | `{}` | Mapping from Argo CD plugin name to policy entry. |
+| `bootstrap` | No | None | Plugin-rendered discovery entrypoints for Argo CD bootstrap objects. |
+
+`bootstrap` fields:
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `entrypoints` | Yes | None | Non-empty list of bootstrap entrypoints. |
+
+Bootstrap entrypoint fields:
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | Yes | None | DNS-label-like identifier, maximum 63 characters. |
+| `plugin` | Yes | None | Plugin policy key to render. |
+| `sourcePath` | Yes | None | Repository-relative plugin source path. `.` is allowed. |
+| `parameters` | No | `[]` | Argo-style plugin parameters supplied by trusted policy. |
 
 Each `plugins` key is the `spec.source.plugin.name` value that drydock should
 match. Names are trimmed and must be non-empty and unique after trimming.
@@ -108,21 +232,36 @@ Plugin entry fields:
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `engine` | Yes | None | One of `avp-compat`, `native-kustomize`, or `exec`. |
+| `engine` | Yes | None | One of `avp-compat`, `native-kustomize`, `exec`, or `container`. |
+| `match.discover` | No | None | Trusted static discovery rule for matching unnamed Application plugin sources. |
+| `configManagementPlugin` | No | None | Optional trusted CMP compatibility seed. |
 
-`avp-compat` and `native-kustomize` entries accept only `engine`.
+`avp-compat` and `native-kustomize` entries accept `engine`, optional
+`match`, and optional `configManagementPlugin`.
 
 `exec` entries support:
 
 | Field | Required | Default | Notes |
 | --- | --- | --- | --- |
 | `workdir` | No | `source` | Only `source` is supported. Commands run from a temporary copy of the source path. |
+| `copy.scope` | No | `source` | Use `repository` only when a trusted plugin needs allowlisted sibling repository paths. |
+| `copy.include` | No | `[]` | Repository-relative glob allowlist. Required when `copy.scope: repository`. |
 | `init` | No | None | Optional command run before `generate`. |
 | `generate` | Yes | None | Command that writes Kubernetes manifests to stdout. |
 | `postRenderers` | No | None | Non-empty list when present. Chains stdout through stdin. |
 | `env.allow` | No | `[]` | Up to 64 environment variable names copied from the caller environment. |
+| `parameters.allow` | No | `[]` | Application plugin parameter allowlist for `engine: exec` and `engine: container`. |
 | `output.maxStdoutBytes` | No | `10485760` | Per-command stdout limit. |
 | `output.maxStderrBytes` | No | `65536` | Per-command stderr limit. Stderr is not printed in failure messages. |
+
+`container` entries support the same lifecycle fields as `exec`, plus:
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `runtime` | No | `docker` | Only Docker is supported. |
+| `image` | Yes | None | Fully qualified image reference. Digest required unless `allowMutableImageTag: true`. |
+| `allowMutableImageTag` | No | `false` | Allows tag-only image references for local/trusted workflows. |
+| `network` | No | `none` | `none` or `default`. `default` is rejected when `--offline` is set. |
 
 Command fields:
 
@@ -133,12 +272,48 @@ Command fields:
 
 `timeout` uses Go duration syntax such as `2s`, `500ms`, or `1m30s`.
 
-## Exec Security Model
+## Trusted CMP Compatibility Descriptors
 
-Exec policy is argv-only. `command` must be a YAML sequence of strings; shell
-strings such as `ytt -f .` are rejected. Empty argv tokens are rejected.
+Policy entries may include a small `configManagementPlugin` seed copied from a
+trusted Argo CD `ConfigManagementPlugin` descriptor. This is compatibility
+metadata, not a full Argo CD object. The `plugins` map key is the Argo CD plugin
+name. drydock does not support, parse, or infer `metadata.name` inside the seed.
 
-The command executable may be either:
+The supported seed subset is intentionally narrow:
+
+| Seed field | Notes |
+| --- | --- |
+| `discover.fileName` | Static source-relative file glob. |
+| `discover.find.glob` | Static source-relative find glob. |
+| `generate.command` | Optional argv metadata. |
+| `generate.args` | Optional argv metadata. |
+
+`configManagementPlugin.generate` is optional compatibility metadata and is
+never executed by seed handling. For `engine: exec` and `engine: container`,
+only the top-level trusted policy `generate.command` authorizes execution. A
+seed `generate` block cannot make a command runnable and cannot replace the
+required lifecycle `generate`.
+
+Unnamed Application plugin sources may match trusted static discovery from
+policy. drydock checks `match.discover` first, then
+`configManagementPlugin.discover`. If both forms are present, they must describe
+the same normalized static rule. Only `discover.fileName` and
+`discover.find.glob` are supported; `discover.find.command` is not supported and
+is never executed.
+
+For `engine: native-kustomize`, drydock may use seed `generate.command` plus
+`generate.args` to choose native Kustomize build options. The configured CMP
+command still does not run. For command-backed engines, seed `generate` remains
+metadata only; execution always comes from the top-level trusted lifecycle
+policy.
+
+## Command Security Model
+
+Exec and container policy lifecycle commands are argv-only. `command` must be a
+YAML sequence of strings; shell strings such as `ytt -f .` are rejected. Empty
+argv tokens are rejected.
+
+For `engine: exec`, the command executable may be either:
 
 - A basename resolved on drydock's controlled PATH:
   `/usr/local/bin:/usr/bin:/bin`.
@@ -157,20 +332,68 @@ binaries must not resolve inside protected roots, and command arguments must
 not point back into protected roots except for files inside the temporary
 workdir. Credential-bearing URLs in arguments are rejected.
 
-The environment starts with only drydock's controlled `PATH`. `env.allow` names
-additional caller environment variables that may be copied in. Names must be
-valid environment identifiers, cannot be duplicated, and cannot be reserved
+For `engine: container`, drydock prepares the same temporary source or
+repository-scoped workspace, makes it writable for container users, and mounts
+it into the container at `/work`. Container lifecycle commands run inside the
+configured image with Docker `run --rm --interactive`, the configured network,
+and an env file generated from policy-allowed environment values. The Docker
+client itself runs with a minimal client environment. In offline mode, drydock
+adds `--pull never`, sets Docker client `HOME` and `DOCKER_CONFIG` to an empty
+temporary directory, rejects `network: default`, and rejects caller-provided
+remote Docker client configuration such as non-local `DOCKER_HOST`,
+`DOCKER_CONTEXT`, `DOCKER_CONFIG`, `DOCKER_TLS_VERIFY`, or
+`DOCKER_CERT_PATH`. Timed-out or canceled container commands are removed with
+`docker rm -f` when a container ID is available.
+
+For `engine: exec`, the command environment starts with only drydock's
+controlled `PATH`. `env.allow` names additional caller environment variables
+that may be copied in.
+
+For `engine: container`, the Docker client process uses a minimal controlled
+environment. The process inside the configured image keeps the image-defined
+environment and receives policy-allowed environment values, Argo plugin
+parameter environment values, and drydock extras through `--env-file`.
+
+For both command-backed engines, allowed environment names must be valid
+environment identifiers, cannot be duplicated, and cannot be reserved
 loader/interpreter variables such as `PATH`, `LD_*`, `DYLD_*`, `PYTHONPATH`,
 `NODE_OPTIONS`, or similar runtime injection names. Each copied value is capped
-at 16 KiB. Application-authored plugin env and parameters are rejected for
-policy-backed plugin sources.
+at 16 KiB. Application-authored plugin env is rejected for policy-backed plugin
+sources.
 
-Exec runs keep structured execution metadata per phase: phase name, sanitized
-executable basename, and elapsed duration. Metadata does not include plugin
-stdout, stderr, argv beyond the executable basename, environment values, or
-rendered manifests. If a basename executable is missing from drydock's
-controlled `PATH`, install it there or configure an absolute trusted executable
-path outside protected roots.
+### Application Parameters
+
+Application plugin parameters are accepted only for `engine: exec` and
+`engine: container`, and only when allowlisted by trusted policy. Native engines
+reject Application plugin env and parameters.
+
+`parameters.allow[]` entries:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | Yes | Application plugin parameter name. |
+| `type` | Yes | `string`, `array`, or `map`. |
+| `required` | No | When `true`, the Application must provide the parameter. |
+| `path.base` | No | For string path parameters only. Defaults to `source`; may be `repository`. |
+| `path.allow` | No | Slash-normalized relative glob allowlist for path values. |
+
+String parameters may be substituted into argv tokens with `{{param:name}}`.
+Parameter templates are not allowed in the executable position. Array and map
+parameters are exposed only through Argo-style `PARAM_*` and
+`ARGOCD_APP_PARAMETERS` environment values.
+
+Path parameters may be constrained to paths under the Application source or the
+repository. Repository-scoped path parameters require `copy.scope: repository`.
+Values under the Application source are copied by default; trusted sibling
+repository paths must also match `copy.include`.
+
+Command-backed runs keep structured execution metadata per phase: phase name,
+engine, sanitized command basename, elapsed duration, and for container policy
+the runtime and image. Metadata does not include plugin stdout, stderr, argv
+beyond the command basename, environment values, or rendered manifests. If an
+exec basename executable is missing from drydock's controlled `PATH`, install
+it there or configure an absolute trusted executable path outside protected
+roots.
 
 ## Engines
 
@@ -189,13 +412,17 @@ uses its Go-native Kustomize renderer.
 `postRenderers` commands under the gates and process controls above. It
 supports path-based plugin sources only; chart plugin sources fail closed.
 
+`container` runs the same lifecycle inside a trusted image through the Docker
+runtime. It supports path-based plugin sources only; chart plugin sources fail
+closed.
+
 ## Selective Native Engines
 
 Additional native engines should be added only when they clearly improve speed,
-determinism, security, or setup burden compared with trusted `engine: exec`.
-CUE or Jsonnet are the most plausible next candidates if stable Go APIs and
-real repository demand line up. ytt and Tanka need separate design review
-because their import, environment, and convention surfaces are broader.
+determinism, security, or setup burden compared with trusted command-backed
+engines. CUE or Jsonnet are the most plausible next candidates if stable Go
+APIs and real repository demand line up. ytt and Tanka need separate design
+review because their import, environment, and convention surfaces are broader.
 
 Native engines must remain narrow compatibility paths. drydock may interpret
 discovered CMP definitions only when they map to a known in-process renderer
@@ -213,6 +440,150 @@ plugins:
   avp-directory-include:
     engine: avp-compat
 ```
+
+Native Kustomize compatibility copied from trusted Docker or sidecar CMP
+descriptor metadata:
+
+```yaml
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  kustomize-build-with-helm:
+    engine: native-kustomize
+    configManagementPlugin:
+      discover:
+        fileName: kustomization.yaml
+      generate:
+        command: ["kustomize"]
+        args: ["build", "--enable-helm", "."]
+```
+
+The policy keeps only trusted static descriptor metadata. drydock uses the
+native Kustomize renderer and native option validation; it does not run a Docker
+sidecar, shell wrapper, or the copied CMP command.
+
+Trusted Docker-backed renderer policy:
+
+```yaml
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: container
+    image: registry.example.com/drydock/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    copy:
+      scope: repository
+      include:
+        - packages/**
+        - personal-cluster/**
+    generate:
+      command: ["pkl", "eval", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow:
+              - personal-cluster/**/*.pkl
+```
+
+Plugin-rendered Pkl bootstrap discovery with a trusted container image:
+
+```yaml
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: cluster-root
+      plugin: pkl
+      sourcePath: personal-cluster
+      parameters:
+        - name: path
+          string: index.pkl
+plugins:
+  pkl:
+    engine: container
+    image: registry.example.com/drydock/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    network: default
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    copy:
+      scope: repository
+      include:
+        - packages/**
+        - personal-cluster/**
+    init:
+      command: ["pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"]
+    generate:
+      command: ["pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: source
+            allow:
+              - index.pkl
+              - components/*.pkl
+        - name: pkl_modules
+          type: array
+```
+
+The bootstrap entrypoint renders `personal-cluster` during fleet discovery,
+scans the output for Argo CD `Application`, `ApplicationSet`, `AppProject`, and
+settings objects, then treats those objects like other discovered desired
+state. The referenced source must match the plugin's trusted static discovery
+rule before drydock runs the command-backed plugin. Use repository-scoped copy
+when the plugin source imports sibling directories such as shared Pkl packages.
+Use `network: default` only when trusted package resolution needs network
+access; it is rejected with `--offline`.
+
+Trusted Pkl exec policy using a workdir-relative cache and a repository-scoped
+path parameter:
+
+```yaml
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    copy:
+      scope: repository
+      include:
+        - packages/**
+        - pkl-packages/**
+    init:
+      command: ["pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"]
+    generate:
+      command: ["pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow:
+              - personal-cluster/**/*.pkl
+```
+
+This replaces sidecar patterns such as `/tmp/pkl-cache`, `sh -c`, or Docker
+execution with trusted argv. `configManagementPlugin.generate`, if copied into
+the policy for compatibility metadata, still remains metadata only. The
+top-level exec `generate.command` is the command that runs.
+
+When an Application already supplies source-relative `path` values, use
+`path.base: source` with source-relative `path.allow` patterns instead.
 
 Exec policy for a trusted non-native renderer with a post-renderer:
 
@@ -236,9 +607,10 @@ plugins:
 ```
 
 The checked fixtures in `testdata/plugin-policy/` are parsed and fingerprinted
-by unit tests so these examples do not silently drift.
+by unit tests; keep documentation examples aligned with those parser rules.
 
-For a single-tree command, run exec plugins from an explicit trusted ref:
+For a single-tree command, run command-backed plugins from an explicit trusted
+ref:
 
 ```bash
 drydock test apps --path . --plugin-policy-ref main --enable-plugins

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -112,14 +112,24 @@ drydock test apps --path .
 
 Safe Kustomize wrapper plugins may render through drydock's native Kustomize
 path. Other plugin sources fail closed unless a drydock plugin policy matches
-the plugin. Trusted exec policy also requires `--enable-plugins`:
+the plugin. Trusted exec and container policy also require `--enable-plugins`:
 
 ```bash
 drydock test apps --path . --plugin-policy-ref main --enable-plugins
 drydock diff apps --path-orig ../baseline --path . --enable-plugins
 ```
 
-Plugin policy provenance, native plugin compatibility, and exec security
+For Docker sidecar CMP repositories, copy only safe descriptor metadata into the
+trusted `PluginPolicy`: the plugin name as the policy key, static discovery, and
+optional generate argv metadata. Prefer `engine: native-kustomize` when the
+descriptor is a Kustomize wrapper. Otherwise use `engine: exec` with a direct
+argv command or `engine: container` with a digest-pinned image, explicit
+Application parameter allowlists, and repository-copy includes for any trusted
+sibling paths the plugin must read. If Argo CD bootstrap objects are generated
+by the plugin, add `bootstrap.entrypoints` so fleet discovery can render and
+scan those generated `Application` or `ApplicationSet` objects.
+
+Plugin policy provenance, native plugin compatibility, and command security
 controls are owned by [`plugin-policy.md`](plugin-policy.md).
 
 ## Pull Request Topologies

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,17 +201,20 @@ normalize to a safe `kustomize build` command are interpreted through drydock's
 native Kustomize renderer. Other plugin sources fail closed with
 `plugin.unsupported` unless an embedding caller supplies
 `drydock.Config.PluginRenderer` or a trusted drydock plugin policy matches the
-plugin name. Exec policy requires trusted provenance and `--enable-plugins`;
-native policy engines such as `avp-compat` and `native-kustomize` do not
-execute plugin commands. Embedders can pass a renderer directly or use
-`drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to dispatch
-in-process renderers by `plugin.name`. The public plugin request includes the
-resolved source, `$ref` roots and source metadata, kube version, and API
-versions.
+plugin name or trusted static discovery for an unnamed plugin source. Exec and
+container policy require trusted provenance and `--enable-plugins`; Application
+plugin parameters for command-backed engines must be allowlisted by policy.
+Native policy engines such as `avp-compat` and `native-kustomize` do not
+execute plugin commands and reject Application plugin env and parameters.
+Embedders can pass a renderer directly or
+use `drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to
+dispatch in-process renderers by `plugin.name`. The public plugin request
+includes the resolved source, `$ref` roots and source metadata, kube version,
+and API versions.
 
 See [`plugin-policy.md`](plugin-policy.md) for `--plugin-policy-path`,
 `--plugin-policy-ref`, `--plugin-policy-repo`, `--disable-plugin-policy`, the
-policy schema, CMP compatibility behavior, and exec security model.
+policy schema, CMP compatibility behavior, and command security model.
 
 ## Render Tests
 
@@ -565,10 +568,10 @@ These source paths are outside the current default runtime contract:
 
 - Live provider API calls for cluster, clusterDecisionResource, SCM provider,
   pull-request, and plugin ApplicationSet generators.
-- Arbitrary CLI config management plugin execution outside trusted exec policy
-  plus `--enable-plugins`, Argo CD repo-server sidecar plugin discovery,
-  ambient plugin configuration, ambient plugin environment loading, and plugin
-  credential injection.
+- Arbitrary CLI config management plugin execution outside trusted exec or
+  container policy plus `--enable-plugins`, Argo CD repo-server sidecar plugin
+  discovery, ambient plugin configuration, ambient plugin environment loading,
+  and plugin credential injection.
 - Live cluster and Argo CD API sources.
 - Live destination cluster existence, sync windows, source integrity
   verification, project-scoped cluster Secret enforcement beyond discovered

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.4.3
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-jsonnet v0.22.0
@@ -54,7 +55,6 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -56,6 +56,13 @@ func (o Orchestrator) discoverRepository(ctx context.Context, root string, reque
 		return discovered, allDiags, allEvents, renderCache, "", err
 	}
 
+	discovered, bootstrapDiags, bootstrapEvents, err := o.applyPolicyBootstrapDiscovery(ctx, root, request, discovered, appsetOptions, renderCache, mode)
+	allDiags = append(allDiags, bootstrapDiags...)
+	allEvents = append(allEvents, bootstrapEvents...)
+	if err != nil {
+		return discovered, allDiags, allEvents, renderCache, "", err
+	}
+
 	settings, _, err := loadSettingsFromDiscovery(root, discovered)
 	if err != nil {
 		return discovered, allDiags, allEvents, renderCache, "", err

--- a/internal/app/discovery_bootstrap.go
+++ b/internal/app/discovery_bootstrap.go
@@ -1,0 +1,222 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/appset"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/discovery"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+	"github.com/sholdee/drydock/internal/render"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	policyBootstrapApplicationNamespace = "argocd"
+	policyBootstrapApplicationProject   = "default"
+	policyBootstrapDestinationName      = "in-cluster"
+	policyBootstrapDestinationNamespace = "argocd"
+)
+
+func (o Orchestrator) applyPolicyBootstrapDiscovery(ctx context.Context, root string, request BuildRequest, discovered discovery.Result, appsetOptions appset.Options, renderCache *applicationRenderCache, mode string) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
+	if !policyBootstrapDiscoveryEnabled(request, mode) {
+		return discovered, nil, nil, nil
+	}
+
+	settings, _, err := loadSettingsFromDiscovery(root, discovered)
+	if err != nil {
+		return discovered, nil, nil, err
+	}
+	settingsSig, err := settingsSignature(settings)
+	if err != nil {
+		return discovered, nil, nil, err
+	}
+
+	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
+	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	if err != nil {
+		return discovered, nil, recorder.Events(), err
+	}
+	defer cleanup()
+
+	var rendered discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, entrypoint := range request.pluginPolicy.Bootstrap.Entrypoints {
+		next, diags, err := renderPolicyBootstrapEntrypoint(ctx, root, request, provider, settingsSig, renderCache, entrypoint)
+		allDiags = append(allDiags, diags...)
+		if err != nil {
+			return discovered, allDiags, recorder.Events(), err
+		}
+		var mergeDiags []diagnostic.Diagnostic
+		rendered, mergeDiags = mergeDiscoveryResultsWithDiagnostics(rendered, next)
+		allDiags = append(allDiags, mergeDiags...)
+	}
+
+	next, mergeDiags := mergeDiscoveryResultsWithDiagnostics(discovered, rendered)
+	allDiags = append(allDiags, mergeDiags...)
+	var expansionDiags []diagnostic.Diagnostic
+	next, expansionDiags, err = expandApplicationSetDiscovery(root, request, next, appsetOptions)
+	allDiags = append(allDiags, expansionDiags...)
+	if err != nil {
+		return next, allDiags, recorder.Events(), err
+	}
+	return next, allDiags, recorder.Events(), nil
+}
+
+func policyBootstrapDiscoveryEnabled(request BuildRequest, mode string) bool {
+	return !request.DisablePluginPolicy && len(request.pluginPolicy.Bootstrap.Entrypoints) > 0 && mode == DiscoveryModeFleet
+}
+
+func renderPolicyBootstrapEntrypoint(ctx context.Context, root string, request BuildRequest, provider localProvider, settingsSig string, renderCache *applicationRenderCache, entrypoint pluginpolicy.BootstrapEntrypoint) (discovery.Result, []diagnostic.Diagnostic, error) {
+	sourcePath, err := validatePolicyBootstrapEntrypoint(root, request.pluginPolicy, entrypoint)
+	if err != nil {
+		return discovery.Result{}, nil, fmt.Errorf("plugin policy bootstrap entrypoint %q: %w", entrypoint.Name, err)
+	}
+	application := policyBootstrapEntrypointApplication(entrypoint, sourcePath)
+	rendered, err := renderApplicationCached(renderContext{
+		context:           ctx,
+		provider:          provider,
+		cache:             renderCache,
+		settingsSignature: settingsSig,
+		request:           request,
+	}, application)
+	if err != nil {
+		return discovery.Result{}, rendered.Diagnostics, fmt.Errorf("plugin policy bootstrap entrypoint %q: %w", entrypoint.Name, err)
+	}
+	return scanPolicyBootstrapEntrypointObjects(request, entrypoint, sourcePath, rendered.Manifests)
+}
+
+func validatePolicyBootstrapEntrypoint(root string, policy pluginpolicy.Policy, entrypoint pluginpolicy.BootstrapEntrypoint) (string, error) {
+	plugin, ok := policy.Plugin(entrypoint.Plugin)
+	if !ok {
+		return "", fmt.Errorf("plugin %q is not defined", entrypoint.Plugin)
+	}
+	discover, discoverBy, ok := policyPluginStaticDiscoverRule(plugin)
+	if !ok {
+		return "", fmt.Errorf("plugin %q must define match.discover or configManagementPlugin.discover", entrypoint.Plugin)
+	}
+	sourcePath, err := cleanLocalSourcePath(entrypoint.SourcePath)
+	if err != nil {
+		return "", err
+	}
+	if err := rejectLocalSymlinkComponents(root, sourcePath); err != nil {
+		return "", err
+	}
+	sourceDir := filepath.Join(root, sourcePath)
+	info, err := os.Lstat(sourceDir)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("source path %q is a symlink", sourcePath)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("source path %q must be a directory", sourcePath)
+	}
+	matched, err := policyPluginDiscoverMatch(sourceDir, discover)
+	if err != nil {
+		return "", fmt.Errorf("match %s for plugin %q: %w", discoverBy, entrypoint.Plugin, err)
+	}
+	if !matched {
+		return "", fmt.Errorf("source path %q (sourcePath) did not match plugin %q %s rule", sourcePath, entrypoint.Plugin, discoverBy)
+	}
+	return filepath.ToSlash(sourcePath), nil
+}
+
+func policyBootstrapEntrypointApplication(entrypoint pluginpolicy.BootstrapEntrypoint, sourcePath string) argoappv1.Application {
+	return argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      entrypoint.Name,
+			Namespace: policyBootstrapApplicationNamespace,
+		},
+		Spec: argoappv1.ApplicationSpec{
+			Project: policyBootstrapApplicationProject,
+			Source: &argoappv1.ApplicationSource{
+				Path: sourcePath,
+				Plugin: &argoappv1.ApplicationSourcePlugin{
+					Name:       entrypoint.Plugin,
+					Parameters: policyBootstrapPluginParameters(entrypoint.Parameters),
+				},
+			},
+			Destination: argoappv1.ApplicationDestination{
+				Name:      policyBootstrapDestinationName,
+				Namespace: policyBootstrapDestinationNamespace,
+			},
+		},
+	}
+}
+
+func policyBootstrapPluginParameters(parameters []pluginpolicy.BootstrapParameter) argoappv1.ApplicationSourcePluginParameters {
+	out := make(argoappv1.ApplicationSourcePluginParameters, 0, len(parameters))
+	for _, parameter := range parameters {
+		next := argoappv1.ApplicationSourcePluginParameter{Name: parameter.Name}
+		switch {
+		case parameter.String != nil:
+			value := *parameter.String
+			next.String_ = &value
+		case parameter.Array != nil:
+			next.OptionalArray = &argoappv1.OptionalArray{Array: append([]string(nil), parameter.Array.Values...)}
+		case parameter.Map != nil:
+			values := make(map[string]string, len(parameter.Map.Values))
+			maps.Copy(values, parameter.Map.Values)
+			next.OptionalMap = &argoappv1.OptionalMap{Map: values}
+		}
+		out = append(out, next)
+	}
+	return out
+}
+
+func scanPolicyBootstrapEntrypointObjects(request BuildRequest, entrypoint pluginpolicy.BootstrapEntrypoint, sourcePath string, manifests []render.Manifest) (discovery.Result, []diagnostic.Diagnostic, error) {
+	var out discovery.Result
+	var allDiags []diagnostic.Diagnostic
+	for _, renderedManifest := range manifests {
+		if renderedManifest.Object == nil {
+			continue
+		}
+		displayPath := policyBootstrapObjectDiscoveryPath(entrypoint, renderedManifest)
+		next, err := discovery.ScanObjects(displayPath, []*unstructured.Unstructured{renderedManifest.Object.DeepCopy()})
+		if err != nil {
+			return out, allDiags, fmt.Errorf("discover plugin policy bootstrap entrypoint %q output %q: %w", entrypoint.Name, displayPath, err)
+		}
+		markDiscoveryTier(&next, discovery.SourceTierPolicyBootstrap, policyBootstrapInputPaths(request, sourcePath, renderedManifest))
+		var mergeDiags []diagnostic.Diagnostic
+		out, mergeDiags = mergeDiscoveryResultsWithDiagnostics(out, next)
+		allDiags = append(allDiags, mergeDiags...)
+	}
+	return out, allDiags, nil
+}
+
+func policyBootstrapObjectDiscoveryPath(entrypoint pluginpolicy.BootstrapEntrypoint, renderedManifest render.Manifest) string {
+	base := filepath.ToSlash(filepath.Join("plugin-policy-bootstrap", entrypoint.Name))
+	if renderedManifest.Path == "" {
+		return base
+	}
+	return filepath.ToSlash(filepath.Join(base, renderedManifest.Path))
+}
+
+func policyBootstrapInputPaths(request BuildRequest, sourcePath string, renderedManifest render.Manifest) []string {
+	inputs := []string{policyBootstrapPolicyInputPath(request), filepath.ToSlash(sourcePath)}
+	if renderedManifest.Path != "" {
+		inputs = append(inputs, filepath.ToSlash(renderedManifest.Path))
+	}
+	return uniqueStrings(inputs)
+}
+
+func policyBootstrapPolicyInputPath(request BuildRequest) string {
+	if strings.TrimSpace(request.PluginPolicyPath) == "" {
+		return defaultPluginPolicyPath
+	}
+	clean, err := cleanPluginPolicyPath(request.PluginPolicyPath)
+	if err != nil {
+		return filepath.ToSlash(request.PluginPolicyPath)
+	}
+	return filepath.ToSlash(clean)
+}

--- a/internal/app/discovery_bootstrap_test.go
+++ b/internal/app/discovery_bootstrap_test.go
@@ -1,0 +1,383 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+)
+
+func TestListApplicationsRunsPluginPolicyBootstrapDuringFleetDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	writeTestFile(t, filepath.Join(root, "workloads", "bootstrap-child", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bootstrap-child
+`)
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("bootstrap-child", "workloads/bootstrap-child"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("exec runner calls = %d, want one bootstrap render", runner.calls)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "bootstrap-child" {
+		t.Fatalf("Applications = %#v, want bootstrap-rendered Application", names)
+	}
+	inputs, ok := applicationInputPaths(result.ApplicationInputs, "bootstrap-child")
+	if !ok {
+		t.Fatalf("ApplicationInputs = %#v, missing bootstrap-child", result.ApplicationInputs)
+	}
+	for _, want := range []string{".drydock/plugins.yaml", "bootstrap"} {
+		if !containsPath(inputs, want) {
+			t.Fatalf("bootstrap-child inputs = %#v, missing %q", inputs, want)
+		}
+	}
+}
+
+func TestListApplicationsUsesCustomPluginPolicyPathForBootstrapInputs(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicyAt(t, root, "policy/plugins.yaml", "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("custom-policy", "workloads/custom-policy"))},
+	}
+	options := trustedBootstrapPluginOptionsAt(t, root, "policy/plugins.yaml")
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		PluginOptions: options,
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	inputs, ok := applicationInputPaths(result.ApplicationInputs, "custom-policy")
+	if !ok {
+		t.Fatalf("ApplicationInputs = %#v, missing custom-policy", result.ApplicationInputs)
+	}
+	if !containsPath(inputs, "policy/plugins.yaml") {
+		t.Fatalf("custom-policy inputs = %#v, missing custom policy path", inputs)
+	}
+	if containsPath(inputs, ".drydock/plugins.yaml") {
+		t.Fatalf("custom-policy inputs = %#v, should not include default policy path", inputs)
+	}
+}
+
+func TestListApplicationsRunsPluginPolicyBootstrapWhenMaxDiscoveryDepthZero(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("depth-zero", "workloads/depth-zero"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path: root,
+		DiscoveryOptions: DiscoveryOptions{
+			MaxDiscoveryDepth:    0,
+			MaxDiscoveryDepthSet: true,
+		},
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("exec runner calls = %d, want one bootstrap render", runner.calls)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "depth-zero" {
+		t.Fatalf("Applications = %#v, want bootstrap-rendered Application with max depth 0", names)
+	}
+}
+
+func TestListApplicationsDiscoveryModeStaticDisablesPluginPolicyBootstrap(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("disabled", "workloads/disabled"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path: root,
+		DiscoveryOptions: DiscoveryOptions{
+			DiscoveryMode: DiscoveryModeStatic,
+		},
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("exec runner calls = %d, want static discovery to skip bootstrap", runner.calls)
+	}
+	if len(result.Applications) != 0 {
+		t.Fatalf("Applications = %#v, want no bootstrap-discovered Applications in static mode", applicationNames(result.Applications))
+	}
+}
+
+func TestListApplicationsExpandsPluginPolicyBootstrapApplicationSetsWhenMaxDiscoveryDepthZero(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationSetYAML())},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path: root,
+		DiscoveryOptions: DiscoveryOptions{
+			MaxDiscoveryDepth:    0,
+			MaxDiscoveryDepthSet: true,
+		},
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("exec runner calls = %d, want one bootstrap render", runner.calls)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "generated" {
+		t.Fatalf("Applications = %#v, want Application generated from bootstrap-rendered ApplicationSet", names)
+	}
+	inputs, ok := applicationInputPaths(result.ApplicationInputs, "generated")
+	if !ok {
+		t.Fatalf("ApplicationInputs = %#v, missing generated", result.ApplicationInputs)
+	}
+	for _, want := range []string{".drydock/plugins.yaml", "bootstrap"} {
+		if !containsPath(inputs, want) {
+			t.Fatalf("generated inputs = %#v, missing %q", inputs, want)
+		}
+	}
+}
+
+func TestListApplicationsKeepsStaticApplicationAheadOfPluginPolicyBootstrapDuplicate(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: apps/static
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("demo", "apps/bootstrap"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("exec runner calls = %d, want one bootstrap render", runner.calls)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "demo" {
+		t.Fatalf("Applications = %#v, want one demo Application", names)
+	}
+	if got := result.Applications[0].Spec.GetSource().Path; got != "apps/static" {
+		t.Fatalf("demo source path = %q, want static committed Application to win", got)
+	}
+	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); !ok || !strings.Contains(diag.Message, "duplicate Application") {
+		t.Fatalf("Diagnostics = %#v, want duplicate discovery warning", result.Diagnostics)
+	}
+}
+
+func TestListApplicationsKeepsStaticNamespaceLessApplicationAheadOfPluginPolicyBootstrapDuplicate(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "PklProject"), "")
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: apps/static
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("demo", "apps/bootstrap"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("exec runner calls = %d, want one bootstrap render", runner.calls)
+	}
+	if names := applicationNames(result.Applications); strings.Join(names, ",") != "demo" {
+		t.Fatalf("Applications = %#v, want one demo Application", names)
+	}
+	if got := result.Applications[0].Spec.GetSource().Path; got != "apps/static" {
+		t.Fatalf("demo source path = %q, want namespace-less static Application to win over bootstrap", got)
+	}
+	if got := result.Applications[0].Namespace; got != "" {
+		t.Fatalf("demo namespace = %q, want namespace-less static Application", got)
+	}
+}
+
+func TestListApplicationsFailsWhenPluginPolicyBootstrapDiscoverRuleDoesNotMatch(t *testing.T) {
+	root := t.TempDir()
+	writeBootstrapExecPluginPolicy(t, root, "bootstrap", "PklProject")
+	writeTestFile(t, filepath.Join(root, "bootstrap", "other.txt"), "")
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{Stdout: []byte(bootstrapApplicationYAML("unmatched", "workloads/unmatched"))},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).ListApplications(context.Background(), BuildRequest{
+		Path:          root,
+		PluginOptions: trustedBootstrapPluginOptions(t, root),
+	})
+	if err == nil {
+		t.Fatalf("ListApplications() error = nil, want unmatched bootstrap discover rule error; result = %#v", result)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("exec runner calls = %d, want unmatched bootstrap source to fail before render", runner.calls)
+	}
+	message := err.Error()
+	for _, want := range []string{`bootstrap entrypoint "cluster-root"`, `plugin "pkl"`, "discover", "did not match"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("ListApplications() error = %q, want fragment %q", message, want)
+		}
+	}
+	if !strings.Contains(message, `sourcePath "bootstrap"`) && !strings.Contains(message, `source path "bootstrap"`) {
+		t.Fatalf("ListApplications() error = %q, want bootstrap source path context", message)
+	}
+}
+
+func writeBootstrapExecPluginPolicy(t *testing.T, root, sourcePath, discoverFileName string) {
+	t.Helper()
+	writeBootstrapExecPluginPolicyAt(t, root, defaultPluginPolicyPath, sourcePath, discoverFileName)
+}
+
+func writeBootstrapExecPluginPolicyAt(t *testing.T, root, policyPath, sourcePath, discoverFileName string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, filepath.FromSlash(policyPath)), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: cluster-root
+      plugin: pkl
+      sourcePath: `+sourcePath+`
+plugins:
+  pkl:
+    engine: exec
+    match:
+      discover:
+        fileName: `+discoverFileName+`
+    generate:
+      command: ["pkl", "eval", "index.pkl"]
+      timeout: `+testExecPolicyCommandTimeout+`
+`)
+}
+
+func trustedBootstrapPluginOptions(t *testing.T, root string) PluginOptions {
+	t.Helper()
+	return trustedBootstrapPluginOptionsAt(t, root, defaultPluginPolicyPath)
+}
+
+func trustedBootstrapPluginOptionsAt(t *testing.T, root, policyPath string) PluginOptions {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(policyPath)))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	policy, err := pluginpolicy.Parse(policyPath, data)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	fingerprint, err := pluginpolicy.Fingerprint(policy)
+	if err != nil {
+		t.Fatalf("Fingerprint() error = %v", err)
+	}
+	return PluginOptions{
+		EnablePlugins:            true,
+		PluginPolicyPath:         policyPath,
+		PluginPolicyPathExplicit: policyPath != defaultPluginPolicyPath,
+		pluginPolicyLoaded:       true,
+		pluginPolicy:             policy,
+		pluginPolicyFingerprint:  fingerprint,
+		pluginPolicyExecTrusted:  true,
+	}
+}
+
+func bootstrapApplicationYAML(name, sourcePath string) string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ` + name + `
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: ` + sourcePath + `
+  destination:
+    name: in-cluster
+    namespace: ` + name + `
+`
+}
+
+func bootstrapApplicationSetYAML() string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: generated
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: generated
+  template:
+    metadata:
+      name: "{{name}}"
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: main
+        path: workloads/{{name}}
+      destination:
+        name: in-cluster
+        namespace: "{{name}}"
+`
+}

--- a/internal/app/discovery_merge.go
+++ b/internal/app/discovery_merge.go
@@ -294,8 +294,10 @@ func discoveryTierPriority(tier discovery.SourceTier) int {
 		return 0
 	case discovery.SourceTierStatic:
 		return 1
-	case discovery.SourceTierRenderedFleet:
+	case discovery.SourceTierPolicyBootstrap:
 		return 2
+	case discovery.SourceTierRenderedFleet:
+		return 3
 	default:
 		return 1
 	}
@@ -306,6 +308,11 @@ func resolveNamespaceDefaultedDiscoveryConflict(kind, existingKey, incomingKey s
 	incomingNamespace, incomingOK := discoveryKeyNamespace(incomingKey)
 	if !existingOK || !incomingOK || existingNamespace == incomingNamespace || (existingNamespace != "" && incomingNamespace != "") {
 		return resolveDiscoveryConflict(kind, incomingKey, existingTier, existingPath, existingDocument, incomingTier, incomingPath, incomingDocument)
+	}
+	existingPriority := discoveryTierPriority(existingTier)
+	incomingPriority := discoveryTierPriority(incomingTier)
+	if incomingPriority != existingPriority {
+		return incomingPriority < existingPriority, nil
 	}
 	replace := incomingNamespace != ""
 	return replace, nil

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/plugincontainer"
+	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/render"
@@ -42,6 +44,8 @@ type localProvider struct {
 	pluginPolicy                 pluginpolicy.Policy
 	pluginPolicyFingerprint      string
 	pluginPolicyExecTrusted      bool
+	pluginExecRunner             pluginexec.Runner
+	pluginContainerRunner        plugincontainer.Runner
 	kustomizeBuildOptions        []string
 	configManagementPlugins      map[string]config.ConfigManagementPlugin
 	cacheEvents                  *cacheevent.Recorder

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/plugincontainer"
+	"github.com/sholdee/drydock/internal/pluginexec"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -18,6 +20,14 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 	gitAcquirer := orchestrator.GitAcquirer
 	if gitAcquirer == nil {
 		gitAcquirer = sourcepkg.DefaultGitAcquirer{}
+	}
+	pluginExecRunner := orchestrator.PluginExecRunner
+	if pluginExecRunner == nil {
+		pluginExecRunner = pluginexec.DefaultRunner{}
+	}
+	pluginContainerRunner := orchestrator.PluginContainerRunner
+	if pluginContainerRunner == nil {
+		pluginContainerRunner = plugincontainer.DefaultRunner{}
 	}
 	forbiddenRoots := requestForbiddenRoots(root, request.AcquisitionOptions)
 	provider := localProvider{
@@ -47,6 +57,8 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		pluginPolicy:                 request.pluginPolicy,
 		pluginPolicyFingerprint:      request.pluginPolicyFingerprint,
 		pluginPolicyExecTrusted:      request.pluginPolicyExecTrusted,
+		pluginExecRunner:             pluginExecRunner,
+		pluginContainerRunner:        pluginContainerRunner,
 		kustomizeBuildOptions:        settingsBuildOptions(settings),
 		configManagementPlugins:      settings.ConfigManagementPlugins,
 		cacheEvents:                  recorder,

--- a/internal/app/local_provider_plugin.go
+++ b/internal/app/local_provider_plugin.go
@@ -6,15 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
-
-	"strings"
 )
 
 func (p localProvider) renderPluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, error) {
@@ -81,13 +81,34 @@ func (p localProvider) renderPolicyPluginSource(ctx context.Context, source rend
 	}
 	name := strings.TrimSpace(opts.Plugin.Name)
 	if name == "" {
-		return nil, unsupportedPluginDiagnostic("config management plugin name is required"), true, unsupportedPolicyPluginError("config management plugin name is required")
+		matches, err := p.policyPluginStaticDiscoveryMatches(source)
+		if err != nil {
+			return nil, nil, true, err
+		}
+		switch len(matches) {
+		case 0:
+			message := unnamedPolicyPluginNoMatchMessage()
+			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+		case 1:
+			name = matches[0].name
+			policyPlugin := matches[0].plugin
+			plugin := *opts.Plugin
+			plugin.Name = name
+			opts.Plugin = &plugin
+			if message := validatePolicyPluginSource(name, source, opts, policyPlugin); message != "" {
+				return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+			}
+			return p.renderMatchedPolicyPluginSource(ctx, source, opts, name, policyPlugin)
+		default:
+			message := unnamedPolicyPluginAmbiguousMessage(matches)
+			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+		}
 	}
 	policyPlugin, ok := p.pluginPolicy.Plugin(name)
 	if !ok {
 		return nil, nil, false, nil
 	}
-	if message := validatePolicyPluginSource(name, source, opts); message != "" {
+	if message := validatePolicyPluginSource(name, source, opts, policyPlugin); message != "" {
 		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
 	}
 
@@ -102,6 +123,11 @@ func (p localProvider) renderMatchedPolicyPluginSource(ctx context.Context, sour
 		if source.Chart != "" {
 			message := fmt.Sprintf("config management plugin %s uses chart source, which is unsupported by native-kustomize policy", pluginDisplayName(name))
 			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+		}
+		if policyPlugin.ConfigManagementPlugin != nil && policyPlugin.ConfigManagementPlugin.Generate != nil {
+			plugin := configManagementPluginSeed(name, policyPlugin.ConfigManagementPlugin)
+			manifests, diags, err := p.renderNativeKustomizePluginSourceWithConfig(ctx, source, opts, name, plugin)
+			return manifests, diags, true, err
 		}
 		manifests, diags, handled, err := p.renderNativeKustomizePluginSource(ctx, source, opts)
 		if handled {
@@ -119,14 +145,27 @@ func (p localProvider) renderMatchedPolicyPluginSource(ctx context.Context, sour
 			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
 		}
 		return p.renderExecPolicyPluginSource(ctx, source, opts, name, policyPlugin)
+	case pluginpolicy.EngineContainer:
+		if !opts.EnablePlugins {
+			message := fmt.Sprintf("config management plugin %s uses container policy, which requires --enable-plugins", pluginDisplayName(name))
+			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+		}
+		if !p.pluginPolicyExecTrusted {
+			message := fmt.Sprintf("config management plugin %s uses container policy from an untrusted policy source; use a policy from the diff baseline or pass --plugin-policy-ref for a trusted Git ref", pluginDisplayName(name))
+			return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+		}
+		return p.renderContainerPolicyPluginSource(ctx, source, opts, name, policyPlugin)
 	default:
 		message := fmt.Sprintf("config management plugin %s has unsupported trusted policy engine %q", pluginDisplayName(name), policyPlugin.Engine)
 		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
 	}
 }
 
-func validatePolicyPluginSource(name string, source render.ResolvedSource, opts render.RenderOptions) string {
-	if len(opts.Plugin.Env) > 0 || len(opts.Plugin.Parameters) > 0 {
+func validatePolicyPluginSource(name string, source render.ResolvedSource, opts render.RenderOptions, policyPlugin pluginpolicy.Plugin) string {
+	if len(opts.Plugin.Env) > 0 {
+		return fmt.Sprintf("config management plugin %s uses env or parameters, which are unsupported by trusted native plugin policy", pluginDisplayName(name))
+	}
+	if len(opts.Plugin.Parameters) > 0 && policyPlugin.Engine != pluginpolicy.EngineExec && policyPlugin.Engine != pluginpolicy.EngineContainer {
 		return fmt.Sprintf("config management plugin %s uses env or parameters, which are unsupported by trusted native plugin policy", pluginDisplayName(name))
 	}
 	if source.Path == "" && source.Chart == "" {
@@ -190,23 +229,39 @@ func (p localProvider) renderExecPolicyPluginSource(ctx context.Context, source 
 		return nil, nil, true, err
 	}
 	sourceDir := filepath.Join(source.RepoRoot, sourcePath)
-	result, err := (pluginexec.DefaultRunner{}).Run(ctx, pluginexec.Request{
-		SourceDir:      sourceDir,
-		Config:         *policyPlugin.Exec,
-		ProtectedRoots: p.execProtectedRoots(source.RepoRoot),
+	params, message := validateExecPluginParameters(name, policyPlugin, opts.Plugin, source.RepoRoot, sourcePath)
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	execConfig, sensitive, message := expandExecPluginCommandTemplates(*policyPlugin.Exec, params)
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(fmt.Sprintf("config management plugin %s %s", pluginDisplayName(name), message)), true, unsupportedPolicyPluginError(message)
+	}
+	extraEnv := append([]string(nil), params.extraEnv...)
+	if p.offline {
+		extraEnv = append(extraEnv, "DRYDOCK_OFFLINE=true")
+	}
+	result, err := p.pluginExecRunner.Run(ctx, pluginexec.Request{
+		SourceDir:       sourceDir,
+		RepositoryDir:   source.RepoRoot,
+		SourceRelPath:   sourcePath,
+		Config:          execConfig,
+		ProtectedRoots:  p.execProtectedRoots(source.RepoRoot),
+		ExtraEnv:        extraEnv,
+		SensitiveValues: sensitive,
 	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, nil, true, ctxErr
 		}
-		message := fmt.Sprintf("config management plugin %s failed: %s", pluginDisplayName(name), err)
-		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s: %w", message, err)
+		message := fmt.Sprintf("config management plugin %s failed: %s", pluginDisplayName(name), redactSensitiveText(err.Error(), sensitive))
+		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s", message)
 	}
 	phase, decodePath := execPolicyDecodeTarget(name, source, len(policyPlugin.Exec.PostRenderers) > 0)
 	docs, err := manifest.DecodeDocuments(decodePath, bytes.NewReader(result.Stdout))
 	if err != nil {
-		message := fmt.Sprintf("config management plugin %s produced invalid %s for %s at %s: %s", pluginDisplayName(name), phase, execPolicySourceLabel(source), decodePath, err)
-		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s: %w", message, err)
+		message := fmt.Sprintf("config management plugin %s produced invalid %s for %s at %s: %s", pluginDisplayName(name), phase, execPolicySourceLabel(source), decodePath, redactSensitiveText(err.Error(), sensitive))
+		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s", message)
 	}
 	manifests := make([]render.Manifest, 0, len(docs))
 	for _, doc := range docs {
@@ -215,7 +270,83 @@ func (p localProvider) renderExecPolicyPluginSource(ctx context.Context, source 
 			Object: doc.Object,
 		})
 	}
-	p.recordPluginExecutions(opts, source, name, result.Executions)
+	p.recordPluginExecutions(opts, source, name, pluginExecutionDetails{
+		engine:     string(pluginpolicy.EngineExec),
+		executions: result.Executions,
+	})
+	return manifests, nil, true, nil
+}
+
+func (p localProvider) renderContainerPolicyPluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions, name string, policyPlugin pluginpolicy.Plugin) ([]render.Manifest, []diagnostic.Diagnostic, bool, error) {
+	if source.Chart != "" {
+		message := fmt.Sprintf("config management plugin %s uses chart source, which is unsupported by container policy", pluginDisplayName(name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	if source.Path == "" {
+		message := fmt.Sprintf("config management plugin %s must define path for container policy", pluginDisplayName(name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	if policyPlugin.Container == nil {
+		message := fmt.Sprintf("config management plugin %s has invalid container policy", pluginDisplayName(name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	sourcePath, err := cleanLocalSourcePath(source.Path)
+	if err != nil {
+		return nil, nil, true, err
+	}
+	if err := rejectLocalSymlinkComponents(source.RepoRoot, sourcePath); err != nil {
+		return nil, nil, true, err
+	}
+	sourceDir := filepath.Join(source.RepoRoot, sourcePath)
+	params, message := validateContainerPluginParameters(name, policyPlugin, opts.Plugin, source.RepoRoot, sourcePath)
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	lifecycle, sensitive, message := expandExecPluginCommandTemplates(policyPlugin.Container.Lifecycle, params)
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(fmt.Sprintf("config management plugin %s %s", pluginDisplayName(name), message)), true, unsupportedPolicyPluginError(message)
+	}
+	containerConfig := *policyPlugin.Container
+	containerConfig.Lifecycle = lifecycle
+	extraEnv := append([]string(nil), params.extraEnv...)
+	if p.offline {
+		extraEnv = append(extraEnv, "DRYDOCK_OFFLINE=true")
+	}
+	result, err := p.pluginContainerRunner.Run(ctx, plugincontainer.Request{
+		SourceDir:       sourceDir,
+		RepositoryDir:   source.RepoRoot,
+		SourceRelPath:   sourcePath,
+		Config:          containerConfig,
+		Offline:         p.offline,
+		ExtraEnv:        extraEnv,
+		SensitiveValues: sensitive,
+	})
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, true, ctxErr
+		}
+		message := fmt.Sprintf("config management plugin %s failed: %s", pluginDisplayName(name), redactSensitiveText(err.Error(), sensitive))
+		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s", message)
+	}
+	phase, decodePath := execPolicyDecodeTarget(name, source, len(policyPlugin.Container.Lifecycle.PostRenderers) > 0)
+	docs, err := manifest.DecodeDocuments(decodePath, bytes.NewReader(result.Stdout))
+	if err != nil {
+		message := fmt.Sprintf("config management plugin %s produced invalid %s for %s at %s: %s", pluginDisplayName(name), phase, execPolicySourceLabel(source), decodePath, redactSensitiveText(err.Error(), sensitive))
+		return nil, []diagnostic.Diagnostic{pluginFailedDiagnostic(message)}, true, fmt.Errorf("%s", message)
+	}
+	manifests := make([]render.Manifest, 0, len(docs))
+	for _, doc := range docs {
+		manifests = append(manifests, render.Manifest{
+			Path:   doc.Path,
+			Object: doc.Object,
+		})
+	}
+	p.recordPluginExecutions(opts, source, name, pluginExecutionDetails{
+		engine:     string(pluginpolicy.EngineContainer),
+		runtime:    string(policyPlugin.Container.Runtime),
+		image:      policyPlugin.Container.Image,
+		executions: result.Executions,
+	})
 	return manifests, nil, true, nil
 }
 
@@ -258,6 +389,17 @@ func execPolicyDecodeTarget(name string, source render.ResolvedSource, hasPostRe
 	return "generated manifests", "plugin/" + displayName + "/" + execPolicySourcePath(source) + "/generate-output"
 }
 
+func redactSensitiveText(value string, sensitive []string) string {
+	sortSensitiveValues(sensitive)
+	for _, item := range sensitive {
+		if item == "" {
+			continue
+		}
+		value = strings.ReplaceAll(value, item, "<redacted>")
+	}
+	return value
+}
+
 func execPolicySourcePath(source render.ResolvedSource) string {
 	if source.Path != "" {
 		return "path/" + strings.Trim(source.Path, `/\`)
@@ -278,11 +420,18 @@ func execPolicySourceLabel(source render.ResolvedSource) string {
 	return "source"
 }
 
-func (p localProvider) recordPluginExecutions(opts render.RenderOptions, source render.ResolvedSource, name string, executions []pluginexec.Execution) {
-	if p.pluginExecutions == nil || len(executions) == 0 {
+type pluginExecutionDetails struct {
+	engine     string
+	runtime    string
+	image      string
+	executions []pluginexec.Execution
+}
+
+func (p localProvider) recordPluginExecutions(opts render.RenderOptions, source render.ResolvedSource, name string, details pluginExecutionDetails) {
+	if p.pluginExecutions == nil || len(details.executions) == 0 {
 		return
 	}
-	for _, execution := range executions {
+	for _, execution := range details.executions {
 		*p.pluginExecutions = append(*p.pluginExecutions, PluginExecution{
 			AppNamespace: opts.AppNamespace,
 			AppName:      opts.AppName,
@@ -290,7 +439,9 @@ func (p localProvider) recordPluginExecutions(opts render.RenderOptions, source 
 			SourceName:   opts.SourceName,
 			SourcePath:   source.Path,
 			PluginName:   pluginDisplayName(name),
-			Engine:       string(pluginpolicy.EngineExec),
+			Engine:       details.engine,
+			Runtime:      details.runtime,
+			Image:        details.image,
 			Phase:        execution.Phase,
 			Command:      execution.Command,
 			Duration:     formatPluginExecutionDuration(execution.Duration),

--- a/internal/app/native_kustomize_cmp.go
+++ b/internal/app/native_kustomize_cmp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
 )
 
@@ -19,27 +20,50 @@ func (p localProvider) renderNativeKustomizePluginSource(ctx context.Context, so
 	if !ok {
 		return nil, nil, false, nil
 	}
+	manifests, diags, err := p.renderNativeKustomizePluginSourceWithConfig(ctx, source, opts, opts.Plugin.Name, plugin)
+	return manifests, diags, true, err
+}
+
+func (p localProvider) renderNativeKustomizePluginSourceWithConfig(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions, name string, plugin config.ConfigManagementPlugin) ([]render.Manifest, []diagnostic.Diagnostic, error) {
 	if source.Chart != "" {
 		reason := "chart sources are unsupported by the native Kustomize adapter"
-		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name, reason), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name, reason)
+		return nil, unsupportedNativeKustomizePluginDiagnostic(name, reason), unsupportedNativeKustomizePluginError(name, reason)
 	}
 	if source.Path == "" {
 		reason := "path source is required for the native Kustomize adapter"
-		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name, reason), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name, reason)
+		return nil, unsupportedNativeKustomizePluginDiagnostic(name, reason), unsupportedNativeKustomizePluginError(name, reason)
 	}
 	if len(opts.Plugin.Env) != 0 || len(opts.Plugin.Parameters) != 0 {
 		reason := "Application plugin env or parameters are unsupported by the native Kustomize adapter"
-		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name, reason), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name, reason)
+		return nil, unsupportedNativeKustomizePluginDiagnostic(name, reason), unsupportedNativeKustomizePluginError(name, reason)
 	}
 	buildOptions, err := nativeKustomizePluginBuildOptions(plugin)
 	if err != nil {
-		return nil, unsupportedNativeKustomizePluginDiagnostic(opts.Plugin.Name, err.Error()), true, unsupportedNativeKustomizePluginError(opts.Plugin.Name, err.Error())
+		return nil, unsupportedNativeKustomizePluginDiagnostic(name, err.Error()), unsupportedNativeKustomizePluginError(name, err.Error())
 	}
 	nativeOptions := opts
 	nativeOptions.Plugin = nil
 	nativeOptions.BuildOptions = append([]string(nil), buildOptions...)
 	manifests, diags, err := (render.KustomizeRenderer{}).Render(ctx, source, nativeOptions)
-	return manifests, diags, true, err
+	return manifests, diags, err
+}
+
+func configManagementPluginSeed(name string, seed *pluginpolicy.ConfigManagementPluginSeed) config.ConfigManagementPlugin {
+	if seed == nil {
+		return config.ConfigManagementPlugin{Name: name}
+	}
+	plugin := config.ConfigManagementPlugin{Name: name}
+	if seed.Generate != nil {
+		plugin.GenerateCommand = append([]string(nil), seed.Generate.Command...)
+		plugin.GenerateArgs = append([]string(nil), seed.Generate.Args...)
+	}
+	if seed.Discover != nil {
+		plugin.Discover = config.ConfigManagementPluginDiscovery{
+			FileName: seed.Discover.FileName,
+			FindGlob: seed.Discover.FindGlob,
+		}
+	}
+	return plugin
 }
 
 func nativeKustomizePluginBuildOptions(plugin config.ConfigManagementPlugin) ([]string, error) {

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sholdee/drydock/internal/discovery"
 	"github.com/sholdee/drydock/internal/luahealth"
 	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/plugincontainer"
+	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
@@ -91,6 +93,8 @@ type PluginExecution struct {
 	SourcePath   string `json:"sourcePath,omitempty" yaml:"sourcePath,omitempty"`
 	PluginName   string `json:"pluginName" yaml:"pluginName"`
 	Engine       string `json:"engine" yaml:"engine"`
+	Runtime      string `json:"runtime,omitempty" yaml:"runtime,omitempty"`
+	Image        string `json:"image,omitempty" yaml:"image,omitempty"`
 	Phase        string `json:"phase" yaml:"phase"`
 	Command      string `json:"command" yaml:"command"`
 	Duration     string `json:"duration" yaml:"duration"`
@@ -126,6 +130,8 @@ type Orchestrator struct {
 	GitAcquirer            sourcepkg.GitAcquirer
 	RemoteResourceAcquirer remote.Acquirer
 	PluginRenderer         render.PluginRenderer
+	PluginExecRunner       pluginexec.Runner
+	PluginContainerRunner  plugincontainer.Runner
 }
 
 func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult, error) {

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/plugincontainer"
+	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
 )
@@ -395,19 +397,768 @@ func TestOrchestratorBuildRendersTrustedExecPolicyPlugin(t *testing.T) {
 	}
 }
 
+func TestOrchestratorBuildUsesInjectedExecPolicyRunner(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "exec-renderer")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	policy, fingerprint := testExecPluginPolicy(t, "exec-renderer", []string{"renderer"})
+	runner := &recordingExecRunner{
+		result: pluginexec.Result{
+			Stdout: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injected-runner
+data:
+  value: from-fake
+`),
+			Executions: []pluginexec.Execution{{
+				Phase:    "generate",
+				Command:  "renderer",
+				Duration: 12 * time.Millisecond,
+			}},
+		},
+	}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner calls = %d, want 1", runner.calls)
+	}
+	if len(result.Manifests) != 1 || result.Manifests[0].Object.GetName() != "injected-runner" {
+		t.Fatalf("Manifests = %#v, want injected runner manifest", result.Manifests)
+	}
+	assertExecPolicyPluginExecution(t, result.PluginExecutions)
+}
+
+func TestOrchestratorBuildRendersTrustedContainerPolicyPlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "container-renderer")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	policy, fingerprint := testContainerPluginPolicy(t, "container-renderer")
+	runner := &recordingContainerRunner{
+		result: pluginexec.Result{
+			Stdout: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: container-runner
+data:
+  value: from-fake
+`),
+			Executions: []pluginexec.Execution{{
+				Phase:    "generate",
+				Command:  "pkl",
+				Duration: 12 * time.Millisecond,
+			}},
+		},
+	}
+
+	result, err := (Orchestrator{PluginContainerRunner: runner}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner calls = %d, want 1", runner.calls)
+	}
+	if len(result.Manifests) != 1 || result.Manifests[0].Object.GetName() != "container-runner" {
+		t.Fatalf("Manifests = %#v, want container runner manifest", result.Manifests)
+	}
+	if len(result.PluginExecutions) != 1 {
+		t.Fatalf("PluginExecutions = %#v, want one container execution", result.PluginExecutions)
+	}
+	execution := result.PluginExecutions[0]
+	if execution.Engine != "container" || execution.Runtime != "docker" || execution.Image != "registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("PluginExecution = %#v, want container runtime/image metadata", execution)
+	}
+}
+
+func TestOrchestratorBuildRejectsContainerPolicyWithoutEnablePlugins(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "container-renderer")
+	policy, fingerprint := testContainerPluginPolicy(t, "container-renderer")
+
+	result, err := (Orchestrator{PluginContainerRunner: &recordingContainerRunner{}}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want enable-plugins failure")
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "requires --enable-plugins") {
+		t.Fatalf("Diagnostics = %#v, want enable-plugins guidance", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRendersTrustedExecPolicyUnnamedPluginMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		matchYAML string
+		files     map[string]string
+	}{
+		{
+			name: "fileName",
+			matchYAML: `    match:
+      discover:
+        fileName: match.txt
+`,
+			files: map[string]string{"match.txt": "match"},
+		},
+		{
+			name: "find glob",
+			matchYAML: `    match:
+      discover:
+        find:
+          glob: "**/match.txt"
+`,
+			files: map[string]string{"nested/match.txt": "match"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeUnnamedPluginBuildApplication(t, root, "plugin")
+			writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+			for path, content := range tt.files {
+				writeTestFile(t, filepath.Join(root, "manifests", "plugin", filepath.FromSlash(path)), content)
+			}
+			t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+			t.Setenv("DRYDOCK_APP_EXEC_VALUE", "allowed-value")
+			policy, fingerprint := testExecPluginPolicyWithMatch(t, "exec-renderer", appExecCommand(t, "manifest"), tt.matchYAML)
+
+			result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+				Path: root,
+				PluginOptions: PluginOptions{
+					EnablePlugins:           true,
+					pluginPolicyLoaded:      true,
+					pluginPolicy:            policy,
+					pluginPolicyFingerprint: fingerprint,
+					pluginPolicyExecTrusted: true,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+			}
+			assertExecPolicyManifestData(t, result.Manifests)
+			assertExecPolicyPluginExecution(t, result.PluginExecutions)
+		})
+	}
+}
+
+func TestOrchestratorBuildRejectsUnnamedPluginWithoutPolicyOwnedMatch(t *testing.T) {
+	root := t.TempDir()
+	writeUnnamedPluginBuildApplication(t, root, "plugin")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "match")
+	writeCMPConfigMapSpec(t, root, "exec-renderer", `discover:
+  fileName: marker.txt
+`)
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicy(t, "exec-renderer", appExecCommand(t, "manifest"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want unnamed plugin match failure")
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "no trusted plugin policy match.discover") {
+		t.Fatalf("Diagnostics = %#v, want policy-owned match failure", result.Diagnostics)
+	}
+	if len(result.PluginExecutions) != 0 {
+		t.Fatalf("PluginExecutions = %#v, want no execution", result.PluginExecutions)
+	}
+}
+
+func TestOrchestratorBuildRejectsAmbiguousUnnamedPluginPolicyMatch(t *testing.T) {
+	root := t.TempDir()
+	writeUnnamedPluginBuildApplication(t, root, "plugin")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "match.txt"), "match")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policyRoot := t.TempDir()
+	command := strings.Join(yamlSingleQuotedList(appExecCommand(t, "manifest")), ", ")
+	writeTestFile(t, filepath.Join(policyRoot, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  alpha:
+    engine: exec
+    match:
+      discover:
+        fileName: match.txt
+    generate:
+      command: [`+command+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+  beta:
+    engine: exec
+    match:
+      discover:
+        fileName: match.txt
+    generate:
+      command: [`+command+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+`)
+	policy, fingerprint := readTestPluginPolicy(t, policyRoot)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want ambiguous unnamed plugin match")
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "ambiguous") || !hasDiagnosticMessage(result.Diagnostics, "alpha via match.discover, beta via match.discover") {
+		t.Fatalf("Diagnostics = %#v, want ambiguous alpha, beta match", result.Diagnostics)
+	}
+	if len(result.PluginExecutions) != 0 {
+		t.Fatalf("PluginExecutions = %#v, want no execution", result.PluginExecutions)
+	}
+}
+
+func TestOrchestratorBuildDoesNotSelectUnnamedPluginPolicyMatchThroughSymlink(t *testing.T) {
+	root := t.TempDir()
+	writeUnnamedPluginBuildApplication(t, root, "plugin")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "target.txt"), "match")
+	if err := os.Symlink("target.txt", filepath.Join(root, "manifests", "plugin", "match.txt")); err != nil {
+		t.Skipf("Symlink() unavailable: %v", err)
+	}
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithMatch(t, "exec-renderer", appExecCommand(t, "manifest"), `    match:
+      discover:
+        fileName: match.txt
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want symlink match to fail closed")
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "no trusted plugin policy match.discover") {
+		t.Fatalf("Diagnostics = %#v, want no match through symlink", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRendersTrustedExecPolicyPluginParameters(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: path
+          string: components/app.pkl
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithParameters(t, "exec-renderer", append(appExecCommand(t, "params"), "{{param:path}}"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	manifest, ok := manifestByName(result.Manifests, "exec-params")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want exec-params", result.Manifests)
+	}
+	data := configMapData(t, manifest)
+	if data["arg"] != "components/app.pkl" || data["param"] != "components/app.pkl" {
+		t.Fatalf("data = %#v, want expanded argv and PARAM_PATH env", data)
+	}
+	if !strings.Contains(fmt.Sprint(data["json"]), `"name":"path"`) || !strings.Contains(fmt.Sprint(data["json"]), `"components/app.pkl"`) {
+		t.Fatalf("data.json = %#v, want ARGOCD_APP_PARAMETERS JSON", data["json"])
+	}
+}
+
+func TestOrchestratorBuildRendersTrustedExecPolicyPluginRepositoryParameter(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: path
+          string: shared/config.txt
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	writeTestFile(t, filepath.Join(root, "shared", "config.txt"), "repo-level")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithRepositoryParameter(t, "exec-renderer", append(appExecCommand(t, "repo-param"), "{{param:path}}"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	manifest, ok := manifestByName(result.Manifests, "exec-repo-param")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want exec repo parameter manifest", result.Manifests)
+	}
+	data := configMapData(t, manifest)
+	if data["value"] != "repo-level" {
+		t.Fatalf("data.value = %#v, want repo-level", data["value"])
+	}
+}
+
+func TestOrchestratorBuildRedactsExecPolicyPluginParameterValues(t *testing.T) {
+	root := t.TempDir()
+	const secret = "top-secret-parameter"
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: token
+          string: `+secret+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithStringParameter(t, "exec-renderer", append(appExecCommand(t, "manifest"), "../{{param:token}}"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want invalid argument failure")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked parameter value: %v", err)
+	}
+	for _, diag := range result.Diagnostics {
+		if strings.Contains(diag.Message, secret) {
+			t.Fatalf("diagnostic leaked parameter value: %#v", diag)
+		}
+	}
+}
+
+func TestOrchestratorBuildRedactsExecPolicyPluginRepositoryParameterFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		command     []string
+		include     string
+		allow       string
+		want        string
+		writeSecret bool
+	}{
+		{
+			name:    "escaped repo path",
+			value:   "../sentinel-secret.yaml",
+			include: `["shared/**"]`,
+			allow:   `["**/*.yaml"]`,
+			want:    "escapes",
+		},
+		{
+			name:        "excluded repo path",
+			value:       "private/sentinel-secret.txt",
+			include:     `["shared/**"]`,
+			allow:       `["private/*.txt"]`,
+			want:        "copy.include",
+			writeSecret: true,
+		},
+		{
+			name:        "argv escape",
+			value:       "shared/sentinel-secret.txt",
+			command:     append(appExecCommand(t, "repo-param"), "../{{param:path}}"),
+			include:     `["shared/**"]`,
+			allow:       `["shared/*.txt"]`,
+			want:        "<redacted>",
+			writeSecret: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			command := tt.command
+			if len(command) == 0 {
+				command = append(appExecCommand(t, "repo-param"), "{{param:path}}")
+			}
+			writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: path
+          string: `+tt.value+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+			writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+			if tt.writeSecret {
+				writeTestFile(t, filepath.Join(root, filepath.FromSlash(tt.value)), "repo-level")
+			}
+			t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+			policyRoot := t.TempDir()
+			writeExecPluginPolicyWithParameters(t, policyRoot, "exec-renderer", command, `      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow: `+tt.allow+`
+`, `    copy:
+      scope: repository
+      include: `+tt.include+`
+`)
+			policy, fingerprint := readTestPluginPolicy(t, policyRoot)
+
+			result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+				Path: root,
+				PluginOptions: PluginOptions{
+					EnablePlugins:           true,
+					pluginPolicyLoaded:      true,
+					pluginPolicy:            policy,
+					pluginPolicyFingerprint: fingerprint,
+					pluginPolicyExecTrusted: true,
+				},
+			})
+			if err == nil {
+				t.Fatal("Build() error = nil, want repository parameter failure")
+			}
+			if strings.Contains(err.Error(), "sentinel-secret") || hasDiagnosticMessage(result.Diagnostics, "sentinel-secret") {
+				t.Fatalf("result leaked repository parameter: err=%v diagnostics=%#v", err, result.Diagnostics)
+			}
+			if !strings.Contains(err.Error(), tt.want) && !hasDiagnosticMessage(result.Diagnostics, tt.want) {
+				t.Fatalf("result = err=%v diagnostics=%#v, want %q", err, result.Diagnostics, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrchestratorBuildRedactsExecPolicyPluginRepositoryParameterStagingFailure(t *testing.T) {
+	root := t.TempDir()
+	const sentinel = "sentinel-secret"
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: path
+          string: shared/`+sentinel+`.txt
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	writeTestFile(t, filepath.Join(root, "shared", "target.txt"), "repo-level")
+	if err := os.Symlink("target.txt", filepath.Join(root, "shared", sentinel+".txt")); err != nil {
+		t.Skipf("Symlink() unavailable: %v", err)
+	}
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithRepositoryParameter(t, "exec-renderer", append(appExecCommand(t, "repo-param"), "{{param:path}}"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want symlink staging failure")
+	}
+	if strings.Contains(err.Error(), sentinel) || hasDiagnosticMessage(result.Diagnostics, sentinel) {
+		t.Fatalf("result leaked repository parameter: err=%v diagnostics=%#v", err, result.Diagnostics)
+	}
+	if !strings.Contains(err.Error(), "<redacted>") && !hasDiagnosticMessage(result.Diagnostics, "<redacted>") {
+		t.Fatalf("result = err=%v diagnostics=%#v, want redacted marker", err, result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRejectsExecPolicyPluginParameterTemplateInExecutable(t *testing.T) {
+	root := t.TempDir()
+	const secret = "top-secret-tool"
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: tool
+          string: `+secret+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	policy, fingerprint := testExecPluginPolicyWithStringParameterName(t, "exec-renderer", []string{"{{param:tool}}"}, "tool")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want executable template rejection")
+	}
+	if strings.Contains(err.Error(), secret) || hasDiagnosticMessage(result.Diagnostics, secret) {
+		t.Fatalf("result leaked parameter value: err=%v diagnostics=%#v", err, result.Diagnostics)
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "command executable") {
+		t.Fatalf("Diagnostics = %#v, want command executable rejection", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRedactsExecPolicyPluginParameterInvalidOutput(t *testing.T) {
+	root := t.TempDir()
+	const secret = "top-secret-output-token"
+	const secretPrefix = "top-secret-output"
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: token
+          string: `+secret+`
+        - name: prefix
+          string: `+secretPrefix+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policyRoot := t.TempDir()
+	writeExecPluginPolicyWithParameters(t, policyRoot, "exec-renderer", append(appExecCommand(t, "invalid-param"), "{{param:token}}"), `      allow:
+        - name: token
+          type: string
+        - name: prefix
+          type: string
+`)
+	policy, fingerprint := readTestPluginPolicy(t, policyRoot)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want invalid output failure")
+	}
+	if strings.Contains(err.Error(), secret) || hasDiagnosticMessage(result.Diagnostics, secret) ||
+		strings.Contains(err.Error(), secretPrefix) || hasDiagnosticMessage(result.Diagnostics, secretPrefix) ||
+		strings.Contains(err.Error(), "<redacted>-token") || hasDiagnosticMessage(result.Diagnostics, "<redacted>-token") {
+		t.Fatalf("result leaked parameter value: err=%v diagnostics=%#v", err, result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRejectsExecPolicyPluginParameterNameWhitespace(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: exec-renderer
+      parameters:
+        - name: " path "
+          string: components/app.pkl
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicyWithParameters(t, "exec-renderer", append(appExecCommand(t, "params"), "{{param:path}}"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want invalid parameter name")
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "invalid Application plugin parameter name") {
+		t.Fatalf("Diagnostics = %#v, want invalid parameter name", result.Diagnostics)
+	}
+}
+
 func assertExecPolicyManifestData(t *testing.T, manifests []render.Manifest) {
 	t.Helper()
 	manifest, ok := manifestByName(manifests, "exec-rendered")
 	if !ok {
 		t.Fatalf("Manifests = %#v, want exec-rendered", manifests)
 	}
+	data := configMapData(t, manifest)
+	if data["marker"] != "from-source" || data["env"] != "allowed-value" {
+		t.Fatalf("data = %#v, want source marker and allowed env", data)
+	}
+}
+
+func configMapData(t *testing.T, manifest render.Manifest) map[string]any {
+	t.Helper()
 	data, ok := manifest.Object.Object["data"].(map[string]any)
 	if !ok {
 		t.Fatalf("data = %#v, want map", manifest.Object.Object["data"])
 	}
-	if data["marker"] != "from-source" || data["env"] != "allowed-value" {
-		t.Fatalf("data = %#v, want source marker and allowed env", data)
-	}
+	return data
 }
 
 func assertExecPolicyPluginExecution(t *testing.T, executions []PluginExecution) {
@@ -425,6 +1176,28 @@ func assertExecPolicyPluginExecution(t *testing.T, executions []PluginExecution)
 	if execution.SourceIndex != 0 || execution.SourcePath != "manifests/plugin" {
 		t.Fatalf("PluginExecution source = %#v, want source index 0 path manifests/plugin", execution)
 	}
+}
+
+type recordingExecRunner struct {
+	calls  int
+	result pluginexec.Result
+	err    error
+}
+
+func (r *recordingExecRunner) Run(context.Context, pluginexec.Request) (pluginexec.Result, error) {
+	r.calls++
+	return r.result, r.err
+}
+
+type recordingContainerRunner struct {
+	calls  int
+	result pluginexec.Result
+	err    error
+}
+
+func (r *recordingContainerRunner) Run(context.Context, plugincontainer.Request) (pluginexec.Result, error) {
+	r.calls++
+	return r.result, r.err
 }
 
 func TestOrchestratorDiagReturnsExecPolicyPluginMetadata(t *testing.T) {
@@ -585,6 +1358,24 @@ func TestApplicationRenderCacheDisablesMatchedExecPolicy(t *testing.T) {
 	}
 	if key != "" {
 		t.Fatalf("applicationRenderCacheKey() = %q, want empty key for matched exec policy", key)
+	}
+}
+
+func TestApplicationRenderCacheDisablesUnnamedStaticExecPolicyMatch(t *testing.T) {
+	policy, _ := testExecPluginPolicyWithMatch(t, "cue", appExecCommand(t, "manifest"), `    match:
+      discover:
+        fileName: match.txt
+`)
+	application := pluginApplication("plugin")
+	application.Spec.Source.Plugin.Name = ""
+	key, err := applicationRenderCacheKey(renderContext{
+		request: BuildRequest{PluginOptions: PluginOptions{pluginPolicy: policy}},
+	}, application)
+	if err != nil {
+		t.Fatalf("applicationRenderCacheKey() error = %v", err)
+	}
+	if key != "" {
+		t.Fatalf("applicationRenderCacheKey() = %q, want empty key for unnamed static exec policy match", key)
 	}
 }
 
@@ -790,6 +1581,70 @@ generate:
 	if hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginAutoDiscovery) {
 		t.Fatalf("Diagnostics = %#v, did not want auto-discovery warning for explicit native CMP plugin", result.Diagnostics)
 	}
+}
+
+func TestOrchestratorBuildRendersNativeKustomizePolicySeed(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-seed")
+	writeNativeKustomizePluginPolicySeed(t, root, "kustomize-seed", "kustomize, build", "--enable-helm")
+	writeNativeKustomizeSource(t, root, "plugin", "seeded")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if _, ok := manifestByName(result.Manifests, "seeded"); !ok {
+		t.Fatalf("Manifests = %#v, want native Kustomize seed render", result.Manifests)
+	}
+}
+
+func TestOrchestratorBuildPrefersNativeKustomizePolicySeedOverCurrentTreeCMP(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "kustomize-seed")
+	writeNativeKustomizePluginPolicySeed(t, root, "kustomize-seed", "kustomize, build", "--enable-helm")
+	writeNativeKustomizeCMPHelmValues(t, root, "kustomize-seed", "", "sh, -c", "kustomize build | sed s/a/b/")
+	writeNativeKustomizeSource(t, root, "plugin", "seeded")
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if _, ok := manifestByName(result.Manifests, "seeded"); !ok {
+		t.Fatalf("Manifests = %#v, want trusted seed to take precedence over current-tree CMP", result.Manifests)
+	}
+}
+
+func TestOrchestratorBuildExecPolicyUsesSeedDiscoveryButNotSeedGenerate(t *testing.T) {
+	root := t.TempDir()
+	writeUnnamedPluginBuildApplication(t, root, "plugin")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "match.txt"), "match")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	t.Setenv("DRYDOCK_APP_EXEC_VALUE", "allowed-value")
+	policyRoot := t.TempDir()
+	writeExecPluginPolicyWithSeed(t, policyRoot, "exec-renderer", appExecCommand(t, "manifest"), `    configManagementPlugin:
+      discover:
+        fileName: match.txt
+      generate:
+        command: ["drydock-seed-should-not-run"]
+`)
+	policy, fingerprint := readTestPluginPolicy(t, policyRoot)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path: root,
+		PluginOptions: PluginOptions{
+			EnablePlugins:           true,
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	assertExecPolicyManifestData(t, result.Manifests)
+	assertExecPolicyPluginExecution(t, result.PluginExecutions)
 }
 
 func TestOrchestratorBuildDoesNotWarnForAVPCompatPolicyWhenDiscoveryMatches(t *testing.T) {
@@ -1313,6 +2168,27 @@ func indentYAMLBlock(input string, spaces int) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+func writeUnnamedPluginBuildApplication(t *testing.T, root, appName string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", appName+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+appName+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+appName+`
+    targetRevision: main
+    plugin: {}
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", appName, ".keep"), "")
+}
+
 func writePluginPolicy(t *testing.T, root, name, engine string) {
 	t.Helper()
 	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
@@ -1323,20 +2199,63 @@ plugins:
 `)
 }
 
+func writeNativeKustomizePluginPolicySeed(t *testing.T, root, name, command, args string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: native-kustomize
+    configManagementPlugin:
+      generate:
+        command: [`+command+`]
+        args: [`+args+`]
+`)
+}
+
 const testExecPolicyCommandTimeout = "15s"
 
 func writeExecPluginPolicy(t *testing.T, root, name string, command []string) {
 	t.Helper()
-	quoted := make([]string, 0, len(command))
-	for _, arg := range command {
-		quoted = append(quoted, yamlSingleQuoted(arg))
-	}
+	quoted := yamlSingleQuotedList(command)
 	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
 kind: PluginPolicy
 plugins:
   `+name+`:
     engine: exec
     generate:
+      command: [`+strings.Join(quoted, ", ")+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+`)
+}
+
+func writeExecPluginPolicyWithMatch(t *testing.T, root, name string, command []string, matchYAML string) {
+	t.Helper()
+	quoted := yamlSingleQuotedList(command)
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: exec
+`+matchYAML+`    generate:
+      command: [`+strings.Join(quoted, ", ")+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+`)
+}
+
+func writeExecPluginPolicyWithSeed(t *testing.T, root, name string, command []string, seedYAML string) {
+	t.Helper()
+	quoted := yamlSingleQuotedList(command)
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: exec
+`+seedYAML+`    generate:
       command: [`+strings.Join(quoted, ", ")+`]
       timeout: `+testExecPolicyCommandTimeout+`
     env:
@@ -1351,10 +2270,80 @@ func testExecPluginPolicy(t *testing.T, name string, command []string) (pluginpo
 	return readTestPluginPolicy(t, root)
 }
 
+func testContainerPluginPolicy(t *testing.T, name string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: container
+    image: registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    configManagementPlugin:
+      discover:
+        fileName: marker.txt
+    generate:
+      command: ["pkl", "eval", "index.pkl"]
+`)
+	return readTestPluginPolicy(t, root)
+}
+
+func testExecPluginPolicyWithMatch(t *testing.T, name string, command []string, matchYAML string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeExecPluginPolicyWithMatch(t, root, name, command, matchYAML)
+	return readTestPluginPolicy(t, root)
+}
+
 func testExecPluginPolicyWithPostRenderer(t *testing.T, name string, command, postRenderer []string) (pluginpolicy.Policy, string) {
 	t.Helper()
 	root := t.TempDir()
 	writeExecPluginPolicyWithPostRenderer(t, root, name, command, postRenderer)
+	return readTestPluginPolicy(t, root)
+}
+
+func testExecPluginPolicyWithParameters(t *testing.T, name string, command []string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeExecPluginPolicyWithParameters(t, root, name, command, `      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            allow: ["components/*.pkl"]
+`)
+	return readTestPluginPolicy(t, root)
+}
+
+func testExecPluginPolicyWithRepositoryParameter(t *testing.T, name string, command []string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeExecPluginPolicyWithParameters(t, root, name, command, `      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow: ["shared/*.txt"]
+`, `    copy:
+      scope: repository
+      include: ["shared/**"]
+`)
+	return readTestPluginPolicy(t, root)
+}
+
+func testExecPluginPolicyWithStringParameter(t *testing.T, name string, command []string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	return testExecPluginPolicyWithStringParameterName(t, name, command, "token")
+}
+
+func testExecPluginPolicyWithStringParameterName(t *testing.T, name string, command []string, parameterName string) (pluginpolicy.Policy, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeExecPluginPolicyWithParameters(t, root, name, command, `      allow:
+        - name: `+parameterName+`
+          type: string
+`)
 	return readTestPluginPolicy(t, root)
 }
 
@@ -1375,16 +2364,29 @@ func readTestPluginPolicy(t *testing.T, root string) (pluginpolicy.Policy, strin
 	return policy, fingerprint
 }
 
+func writeExecPluginPolicyWithParameters(t *testing.T, root, name string, command []string, parameters string, extraExecFields ...string) {
+	t.Helper()
+	quoted := yamlSingleQuotedList(command)
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: exec
+    generate:
+      command: [`+strings.Join(quoted, ", ")+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+`+strings.Join(extraExecFields, "")+`
+    parameters:
+`+parameters+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+`)
+}
+
 func writeExecPluginPolicyWithPostRenderer(t *testing.T, root, name string, command, postRenderer []string) {
 	t.Helper()
-	quotedCommand := make([]string, 0, len(command))
-	for _, arg := range command {
-		quotedCommand = append(quotedCommand, yamlSingleQuoted(arg))
-	}
-	quotedPostRenderer := make([]string, 0, len(postRenderer))
-	for _, arg := range postRenderer {
-		quotedPostRenderer = append(quotedPostRenderer, yamlSingleQuoted(arg))
-	}
+	quotedCommand := yamlSingleQuotedList(command)
+	quotedPostRenderer := yamlSingleQuotedList(postRenderer)
 	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
 kind: PluginPolicy
 plugins:
@@ -1399,6 +2401,14 @@ plugins:
     env:
       allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
 `)
+}
+
+func yamlSingleQuotedList(values []string) []string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, yamlSingleQuoted(value))
+	}
+	return quoted
 }
 
 func appExecCommand(t *testing.T, mode string) []string {
@@ -1418,40 +2428,114 @@ func TestAppExecPluginHelperProcess(t *testing.T) {
 	if os.Getenv("DRYDOCK_APP_EXEC_HELPER") != "1" {
 		return
 	}
-	args := os.Args
-	for len(args) > 0 && args[0] != "--" {
-		args = args[1:]
-	}
+	args := appExecPluginHelperArgs(os.Args)
 	if len(args) < 2 {
 		os.Exit(2)
 	}
 	switch args[1] {
 	case "manifest":
-		marker, _ := os.ReadFile("marker.txt")
-		value := strings.TrimSpace(string(marker))
-		if value == "" {
-			value = "rendered"
+		appExecPluginHelperManifest()
+		os.Exit(0)
+	case "params":
+		appExecPluginHelperParams(args)
+		os.Exit(0)
+	case "repo-param":
+		if err := appExecPluginHelperRepoParam(args); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
 		}
-		_ = os.WriteFile("generated.txt", []byte("temp"), 0o644)
-		fmt.Println("apiVersion: v1")
-		fmt.Println("kind: ConfigMap")
-		fmt.Println("metadata:")
-		fmt.Println("  name: exec-rendered")
-		fmt.Println("data:")
-		fmt.Printf("  marker: %q\n", value)
-		fmt.Printf("  env: %q\n", os.Getenv("DRYDOCK_APP_EXEC_VALUE"))
 		os.Exit(0)
 	case "invalid":
-		fmt.Println("metadata: [")
+		appExecPluginHelperInvalid()
+		os.Exit(0)
+	case "invalid-param":
+		appExecPluginHelperInvalidParam(args)
 		os.Exit(0)
 	case "post-render":
-		input, _ := io.ReadAll(os.Stdin)
-		fmt.Print(string(input))
-		fmt.Println("  post: rendered")
+		appExecPluginHelperPostRender()
 		os.Exit(0)
 	default:
 		os.Exit(2)
 	}
+}
+
+func appExecPluginHelperArgs(args []string) []string {
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	return args
+}
+
+func appExecPluginHelperManifest() {
+	marker, _ := os.ReadFile("marker.txt")
+	value := strings.TrimSpace(string(marker))
+	if value == "" {
+		value = "rendered"
+	}
+	_ = os.WriteFile("generated.txt", []byte("temp"), 0o644)
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: exec-rendered")
+	fmt.Println("data:")
+	fmt.Printf("  marker: %q\n", value)
+	fmt.Printf("  env: %q\n", os.Getenv("DRYDOCK_APP_EXEC_VALUE"))
+}
+
+func appExecPluginHelperParams(args []string) {
+	paramArg := ""
+	if len(args) > 2 {
+		paramArg = args[2]
+	}
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: exec-params")
+	fmt.Println("data:")
+	fmt.Printf("  arg: %q\n", paramArg)
+	fmt.Printf("  param: %q\n", os.Getenv("PARAM_PATH"))
+	fmt.Printf("  json: %q\n", os.Getenv("ARGOCD_APP_PARAMETERS"))
+}
+
+func appExecPluginHelperRepoParam(args []string) error {
+	paramArg := ""
+	if len(args) > 2 {
+		paramArg = args[2]
+	}
+	value, err := os.ReadFile(paramArg)
+	if err != nil {
+		return fmt.Errorf("read repo param: %w", err)
+	}
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: exec-repo-param")
+	fmt.Println("data:")
+	fmt.Printf("  value: %q\n", strings.TrimSpace(string(value)))
+	return nil
+}
+
+func appExecPluginHelperInvalid() {
+	fmt.Println("metadata: [")
+}
+
+func appExecPluginHelperInvalidParam(args []string) {
+	key := "token"
+	if len(args) > 2 {
+		key = args[2]
+	}
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: invalid")
+	fmt.Println("data:")
+	fmt.Printf("  %s: [\n", key)
+}
+
+func appExecPluginHelperPostRender() {
+	input, _ := io.ReadAll(os.Stdin)
+	fmt.Print(string(input))
+	fmt.Println("  post: rendered")
 }
 
 func writeNativeKustomizeCMPRawHelmValues(t *testing.T, root, name, version, command, args string) {

--- a/internal/app/plugin_parameters.go
+++ b/internal/app/plugin_parameters.go
@@ -1,0 +1,403 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/sholdee/drydock/internal/pathsafety"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+const maxPluginParameterValueBytes = 16 * 1024
+
+var pluginParameterTemplatePattern = regexp.MustCompile(`\{\{param:([A-Za-z0-9_.-]+)\}\}`)
+var pluginParameterNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+type validatedPluginParameters struct {
+	byName         map[string]argoappv1.ApplicationSourcePluginParameter
+	templateByName map[string]string
+	extraEnv       []string
+	sensitive      []string
+	envNames       map[string]string
+	policyByName   map[string]pluginpolicy.ExecParameter
+}
+
+func validateExecPluginParameters(name string, policy pluginpolicy.Plugin, application *render.PluginConfig, repoRoot, sourcePath string) (validatedPluginParameters, string) {
+	out := newValidatedPluginParameters()
+	if policy.Exec == nil {
+		return out, fmt.Sprintf("config management plugin %s has invalid exec policy", pluginDisplayName(name))
+	}
+	return validatePolicyPluginParameters(name, policy.Exec.Parameters, policy.Exec.Copy, application, repoRoot, sourcePath, out)
+}
+
+func validateContainerPluginParameters(name string, policy pluginpolicy.Plugin, application *render.PluginConfig, repoRoot, sourcePath string) (validatedPluginParameters, string) {
+	out := newValidatedPluginParameters()
+	if policy.Container == nil {
+		return out, fmt.Sprintf("config management plugin %s has invalid container policy", pluginDisplayName(name))
+	}
+	return validatePolicyPluginParameters(name, policy.Container.Lifecycle.Parameters, policy.Container.Lifecycle.Copy, application, repoRoot, sourcePath, out)
+}
+
+func validatePolicyPluginParameters(name string, parameters pluginpolicy.ExecParameters, copyPolicy pluginpolicy.ExecCopy, application *render.PluginConfig, repoRoot, sourcePath string, out validatedPluginParameters) (validatedPluginParameters, string) {
+	for _, allowed := range parameters.Allow {
+		out.policyByName[allowed.Name] = allowed
+	}
+	if application == nil {
+		application = &render.PluginConfig{}
+	}
+	if message := recordApplicationPluginParameters(name, application.Parameters, copyPolicy, repoRoot, sourcePath, &out); message != "" {
+		return out, message
+	}
+	if message := requireApplicationPluginParameters(name, parameters.Allow, out.byName); message != "" {
+		return out, message
+	}
+	if message := recordApplicationPluginParameterEnv(name, application.Parameters, &out); message != "" {
+		return out, message
+	}
+	recordSensitivePluginParameterValues(application.Parameters, &out)
+	return out, ""
+}
+
+func newValidatedPluginParameters() validatedPluginParameters {
+	return validatedPluginParameters{
+		byName:         map[string]argoappv1.ApplicationSourcePluginParameter{},
+		templateByName: map[string]string{},
+		envNames:       map[string]string{},
+		policyByName:   map[string]pluginpolicy.ExecParameter{},
+	}
+}
+
+func recordApplicationPluginParameters(name string, params argoappv1.ApplicationSourcePluginParameters, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string, out *validatedPluginParameters) string {
+	for _, param := range params {
+		if message := recordApplicationPluginParameter(name, param, copyPolicy, repoRoot, sourcePath, out); message != "" {
+			return message
+		}
+	}
+	return ""
+}
+
+func recordApplicationPluginParameter(name string, param argoappv1.ApplicationSourcePluginParameter, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string, out *validatedPluginParameters) string {
+	paramName := param.Name
+	if paramName == "" {
+		return fmt.Sprintf("config management plugin %s has an unnamed Application plugin parameter", pluginDisplayName(name))
+	}
+	if strings.TrimSpace(paramName) != paramName || !pluginParameterNamePattern.MatchString(paramName) {
+		return fmt.Sprintf("config management plugin %s has invalid Application plugin parameter name %q", pluginDisplayName(name), paramName)
+	}
+	if _, ok := out.byName[paramName]; ok {
+		return fmt.Sprintf("config management plugin %s has duplicate Application plugin parameter %q", pluginDisplayName(name), paramName)
+	}
+	allowed, ok := out.policyByName[paramName]
+	if !ok {
+		return fmt.Sprintf("config management plugin %s uses Application plugin parameter %q, which is not allowed by trusted plugin policy", pluginDisplayName(name), paramName)
+	}
+	templateValue, message := validateApplicationPluginParameterValue(name, allowed, param, copyPolicy, repoRoot, sourcePath)
+	if message != "" {
+		return message
+	}
+	out.byName[paramName] = param
+	if allowed.Type == pluginpolicy.ExecParameterTypeString {
+		out.templateByName[paramName] = templateValue
+	}
+	return ""
+}
+
+func requireApplicationPluginParameters(name string, allowed []pluginpolicy.ExecParameter, byName map[string]argoappv1.ApplicationSourcePluginParameter) string {
+	for _, param := range allowed {
+		if param.Required {
+			if _, ok := byName[param.Name]; !ok {
+				return fmt.Sprintf("config management plugin %s is missing required Application plugin parameter %q", pluginDisplayName(name), param.Name)
+			}
+		}
+	}
+	return ""
+}
+
+func recordApplicationPluginParameterEnv(name string, params argoappv1.ApplicationSourcePluginParameters, out *validatedPluginParameters) string {
+	if len(params) == 0 {
+		return ""
+	}
+	extraEnv, err := params.Environ()
+	if err != nil {
+		return fmt.Sprintf("config management plugin %s has invalid Application plugin parameters", pluginDisplayName(name))
+	}
+	for _, entry := range extraEnv {
+		envName, _, _ := strings.Cut(entry, "=")
+		if message := recordApplicationPluginParameterEnvEntry(name, envName, entry, out); message != "" {
+			return message
+		}
+	}
+	out.extraEnv = extraEnv
+	return ""
+}
+
+func recordApplicationPluginParameterEnvEntry(name, envName, entry string, out *validatedPluginParameters) string {
+	if envName != "ARGOCD_APP_PARAMETERS" {
+		if _, ok := out.envNames[envName]; ok {
+			return fmt.Sprintf("config management plugin %s has Application plugin parameters that collide in environment variable %q", pluginDisplayName(name), envName)
+		}
+	}
+	if existing, ok := out.envNames[envName]; ok && existing != entry {
+		return fmt.Sprintf("config management plugin %s has Application plugin parameters that collide in environment variable %q", pluginDisplayName(name), envName)
+	}
+	out.envNames[envName] = entry
+	return ""
+}
+
+func recordSensitivePluginParameterValues(params argoappv1.ApplicationSourcePluginParameters, out *validatedPluginParameters) {
+	for _, param := range params {
+		out.sensitive = append(out.sensitive, pluginParameterValues(param)...)
+	}
+	for _, value := range out.templateByName {
+		if value != "" {
+			out.sensitive = append(out.sensitive, value)
+		}
+	}
+}
+
+func validateApplicationPluginParameterValue(name string, allowed pluginpolicy.ExecParameter, param argoappv1.ApplicationSourcePluginParameter, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string) (string, string) {
+	if applicationPluginParameterValueKinds(param) != 1 {
+		return "", fmt.Sprintf("config management plugin %s parameter %q must set exactly one value type", pluginDisplayName(name), param.Name)
+	}
+	switch allowed.Type {
+	case pluginpolicy.ExecParameterTypeString:
+		return validateApplicationPluginStringParameter(name, allowed, param, copyPolicy, repoRoot, sourcePath)
+	case pluginpolicy.ExecParameterTypeArray:
+		return validateApplicationPluginArrayParameter(name, param)
+	case pluginpolicy.ExecParameterTypeMap:
+		return validateApplicationPluginMapParameter(name, param)
+	default:
+		return "", ""
+	}
+}
+
+func applicationPluginParameterValueKinds(param argoappv1.ApplicationSourcePluginParameter) int {
+	valueKinds := 0
+	if param.String_ != nil {
+		valueKinds++
+	}
+	if param.OptionalArray != nil {
+		valueKinds++
+	}
+	if param.OptionalMap != nil {
+		valueKinds++
+	}
+	return valueKinds
+}
+
+func validateApplicationPluginStringParameter(name string, allowed pluginpolicy.ExecParameter, param argoappv1.ApplicationSourcePluginParameter, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string) (string, string) {
+	if param.String_ == nil {
+		return "", fmt.Sprintf("config management plugin %s parameter %q must be a string", pluginDisplayName(name), param.Name)
+	}
+	if len(*param.String_) > maxPluginParameterValueBytes {
+		return "", fmt.Sprintf("config management plugin %s parameter %q value is too large", pluginDisplayName(name), param.Name)
+	}
+	if allowed.Path != nil {
+		templateValue, err := validatePluginPathParameter(*param.String_, allowed.Path, copyPolicy, repoRoot, sourcePath)
+		if err != nil {
+			return "", fmt.Sprintf("config management plugin %s parameter %q path is not allowed: %s", pluginDisplayName(name), param.Name, err)
+		}
+		return templateValue, ""
+	}
+	return *param.String_, ""
+}
+
+func validateApplicationPluginArrayParameter(name string, param argoappv1.ApplicationSourcePluginParameter) (string, string) {
+	if param.OptionalArray == nil {
+		return "", fmt.Sprintf("config management plugin %s parameter %q must be an array", pluginDisplayName(name), param.Name)
+	}
+	for _, value := range param.Array {
+		if len(value) > maxPluginParameterValueBytes {
+			return "", fmt.Sprintf("config management plugin %s parameter %q value is too large", pluginDisplayName(name), param.Name)
+		}
+	}
+	return "", ""
+}
+
+func validateApplicationPluginMapParameter(name string, param argoappv1.ApplicationSourcePluginParameter) (string, string) {
+	if param.OptionalMap == nil {
+		return "", fmt.Sprintf("config management plugin %s parameter %q must be a map", pluginDisplayName(name), param.Name)
+	}
+	envNames := map[string]string{}
+	for key, value := range param.Map {
+		if len(value) > maxPluginParameterValueBytes {
+			return "", fmt.Sprintf("config management plugin %s parameter %q value is too large", pluginDisplayName(name), param.Name)
+		}
+		envName := argoPluginParameterEnvName(param.Name) + "_" + argoPluginParameterEnvName(key)
+		if existing, ok := envNames[envName]; ok && existing != key {
+			return "", fmt.Sprintf("config management plugin %s parameter %q map keys collide in environment variable %q", pluginDisplayName(name), param.Name, envName)
+		}
+		envNames[envName] = key
+	}
+	return "", ""
+}
+
+func validatePluginPathParameter(value string, pathPolicy *pluginpolicy.ExecParameterPath, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	value = filepath.ToSlash(value)
+	if filepath.IsAbs(value) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	clean, ok := pathsafety.CleanRelative(value)
+	if !ok || clean == "." {
+		return "", fmt.Errorf("path escapes the plugin workdir")
+	}
+	if len(pathPolicy.Allow) == 0 {
+		return execPluginPathTemplateValue(clean, pathPolicy, copyPolicy, repoRoot, sourcePath)
+	}
+	for _, pattern := range pathPolicy.Allow {
+		matched, err := doublestar.Match(pattern, filepath.ToSlash(clean))
+		if err == nil && matched {
+			return execPluginPathTemplateValue(clean, pathPolicy, copyPolicy, repoRoot, sourcePath)
+		}
+	}
+	return "", fmt.Errorf("path does not match allowlist")
+}
+
+func execPluginPathTemplateValue(clean string, pathPolicy *pluginpolicy.ExecParameterPath, copyPolicy pluginpolicy.ExecCopy, repoRoot, sourcePath string) (string, error) {
+	if pathPolicy.Base != pluginpolicy.ExecParameterPathBaseRepository {
+		return filepath.ToSlash(clean), nil
+	}
+	if copyPolicy.Scope != pluginpolicy.ExecCopyScopeRepository {
+		return "", fmt.Errorf("repository paths require copy.scope repository")
+	}
+	if !execPluginPathIsCopied(clean, sourcePath, copyPolicy.Include) {
+		return "", fmt.Errorf("path is not included by copy.include")
+	}
+	if exists, err := localPathExists(filepath.Join(repoRoot, clean)); err != nil {
+		return "", err
+	} else if !exists {
+		return "", fmt.Errorf("path does not exist")
+	}
+	sourceBase := filepath.Clean(sourcePath)
+	if sourceBase == "." {
+		return filepath.ToSlash(clean), nil
+	}
+	rel, err := filepath.Rel(sourceBase, clean)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func execPluginPathIsCopied(clean, sourcePath string, include []string) bool {
+	sourceBase := filepath.ToSlash(filepath.Clean(sourcePath))
+	clean = filepath.ToSlash(clean)
+	if sourceBase == "." || clean == sourceBase || strings.HasPrefix(clean, sourceBase+"/") {
+		return true
+	}
+	for _, pattern := range include {
+		matched, err := doublestar.Match(pattern, clean)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func expandExecPluginCommandTemplates(config pluginpolicy.ExecConfig, params validatedPluginParameters) (pluginpolicy.ExecConfig, []string, string) {
+	out := config
+	if commandHasExecutableTemplate(config.Generate) {
+		return out, nil, "uses parameter template in command executable, which is not allowed"
+	}
+	missing := ""
+	out.Generate = expandExecCommand(config.Generate, params, &missing)
+	if missing != "" {
+		return out, nil, fmt.Sprintf("references missing string parameter %q", missing)
+	}
+	var sensitive []string
+	if out.Generate.Command == nil {
+		return out, nil, "generate command is empty after parameter expansion"
+	}
+	for _, value := range params.sensitive {
+		if value != "" {
+			sensitive = append(sensitive, value)
+		}
+	}
+	if config.Init != nil {
+		if commandHasExecutableTemplate(*config.Init) {
+			return out, nil, "uses parameter template in command executable, which is not allowed"
+		}
+		init := expandExecCommand(*config.Init, params, &missing)
+		if missing != "" {
+			return out, nil, fmt.Sprintf("references missing string parameter %q", missing)
+		}
+		out.Init = &init
+	}
+	if len(config.PostRenderers) > 0 {
+		out.PostRenderers = make([]pluginpolicy.ExecCommand, 0, len(config.PostRenderers))
+		for _, command := range config.PostRenderers {
+			if commandHasExecutableTemplate(command) {
+				return out, nil, "uses parameter template in command executable, which is not allowed"
+			}
+			out.PostRenderers = append(out.PostRenderers, expandExecCommand(command, params, &missing))
+			if missing != "" {
+				return out, nil, fmt.Sprintf("references missing string parameter %q", missing)
+			}
+		}
+	}
+	sortSensitiveValues(sensitive)
+	return out, sensitive, ""
+}
+
+func sortSensitiveValues(values []string) {
+	sort.SliceStable(values, func(i, j int) bool {
+		if len(values[i]) == len(values[j]) {
+			return values[i] < values[j]
+		}
+		return len(values[i]) > len(values[j])
+	})
+}
+
+func commandHasExecutableTemplate(command pluginpolicy.ExecCommand) bool {
+	return len(command.Command) > 0 && pluginParameterTemplatePattern.MatchString(command.Command[0])
+}
+
+func expandExecCommand(command pluginpolicy.ExecCommand, params validatedPluginParameters, missing *string) pluginpolicy.ExecCommand {
+	out := command
+	out.Command = make([]string, 0, len(command.Command))
+	for _, token := range command.Command {
+		expanded := pluginParameterTemplatePattern.ReplaceAllStringFunc(token, func(match string) string {
+			name := pluginParameterTemplatePattern.FindStringSubmatch(match)[1]
+			value, ok := params.templateByName[name]
+			if !ok {
+				if missing != nil && *missing == "" {
+					*missing = name
+				}
+				return ""
+			}
+			return value
+		})
+		out.Command = append(out.Command, expanded)
+	}
+	return out
+}
+
+func pluginParameterValues(param argoappv1.ApplicationSourcePluginParameter) []string {
+	var out []string
+	if param.String_ != nil {
+		out = append(out, *param.String_)
+	}
+	if param.OptionalArray != nil {
+		out = append(out, param.Array...)
+	}
+	if param.OptionalMap != nil {
+		for _, value := range param.Map {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func argoPluginParameterEnvName(name string) string {
+	name = strings.ToUpper(name)
+	return regexp.MustCompile(`[^A-Z0-9_]`).ReplaceAllString(name, "_")
+}

--- a/internal/app/plugin_policy_match.go
+++ b/internal/app/plugin_policy_match.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+type policyPluginStaticMatch struct {
+	name       string
+	plugin     pluginpolicy.Plugin
+	discoverBy string
+}
+
+func (p localProvider) policyPluginStaticDiscoveryMatches(source render.ResolvedSource) ([]policyPluginStaticMatch, error) {
+	if source.Path == "" {
+		return nil, nil
+	}
+	sourcePath, err := cleanLocalSourcePath(source.Path)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectLocalSymlinkComponents(source.RepoRoot, sourcePath); err != nil {
+		return nil, err
+	}
+	sourceDir := filepath.Join(source.RepoRoot, sourcePath)
+	names := make([]string, 0, len(p.pluginPolicy.Plugins))
+	for name := range p.pluginPolicy.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	matches := make([]policyPluginStaticMatch, 0, len(names))
+	for _, name := range names {
+		plugin := p.pluginPolicy.Plugins[name]
+		discover, discoverBy, ok := policyPluginStaticDiscoverRule(plugin)
+		if !ok {
+			continue
+		}
+		matched, err := policyPluginDiscoverMatch(sourceDir, discover)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matches = append(matches, policyPluginStaticMatch{name: name, plugin: plugin, discoverBy: discoverBy})
+		}
+	}
+	return matches, nil
+}
+
+func policyPluginStaticDiscoverRule(plugin pluginpolicy.Plugin) (pluginpolicy.PluginDiscoverMatch, string, bool) {
+	if plugin.Match != nil {
+		return plugin.Match.Discover, "match.discover", true
+	}
+	if plugin.ConfigManagementPlugin != nil && plugin.ConfigManagementPlugin.Discover != nil {
+		return *plugin.ConfigManagementPlugin.Discover, "configManagementPlugin.discover", true
+	}
+	return pluginpolicy.PluginDiscoverMatch{}, "", false
+}
+
+func policyPluginDiscoverMatch(sourceDir string, rule pluginpolicy.PluginDiscoverMatch) (bool, error) {
+	switch {
+	case rule.FileName != "":
+		return policyPluginFileNameMatch(sourceDir, rule.FileName)
+	case rule.FindGlob != "":
+		return policyPluginFindGlobMatch(sourceDir, rule.FindGlob)
+	default:
+		return false, nil
+	}
+}
+
+func policyPluginFileNameMatch(sourceDir, pattern string) (bool, error) {
+	matches, err := filepath.Glob(filepath.Join(sourceDir, filepath.FromSlash(pattern)))
+	if err != nil {
+		return false, err
+	}
+	for _, match := range matches {
+		if policyPluginMatchedPathAllowed(sourceDir, match) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func policyPluginFindGlobMatch(sourceDir, pattern string) (bool, error) {
+	matched := false
+	err := filepath.WalkDir(sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == sourceDir {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		if policyPluginMatchHasDotGit(filepath.ToSlash(rel)) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		ok, err := doublestar.Match(pattern, filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		if ok {
+			matched = true
+		}
+		return nil
+	})
+	return matched, err
+}
+
+func policyPluginMatchedPathAllowed(sourceDir, match string) bool {
+	if !cmpDiscoveryMatchInside(sourceDir, match) {
+		return false
+	}
+	rel, err := filepath.Rel(sourceDir, match)
+	if err != nil {
+		return false
+	}
+	if policyPluginMatchHasDotGit(filepath.ToSlash(rel)) {
+		return false
+	}
+	return rejectLocalSymlinkComponents(sourceDir, rel) == nil
+}
+
+func policyPluginMatchHasDotGit(rel string) bool {
+	return slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), ".git")
+}
+
+func policyPluginMatchNames(matches []policyPluginStaticMatch) string {
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if match.discoverBy != "" {
+			names = append(names, match.name+" via "+match.discoverBy)
+			continue
+		}
+		names = append(names, match.name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func unnamedPolicyPluginNoMatchMessage() string {
+	return "config management plugin name is required and no trusted plugin policy match.discover or configManagementPlugin.discover rule matched this source"
+}
+
+func unnamedPolicyPluginAmbiguousMessage(matches []policyPluginStaticMatch) string {
+	return fmt.Sprintf("config management plugin name is ambiguous; trusted plugin policy discovery rules matched: %s", policyPluginMatchNames(matches))
+}

--- a/internal/app/render_cache.go
+++ b/internal/app/render_cache.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -155,7 +156,7 @@ type renderContext struct {
 }
 
 func applicationRenderCacheKey(ctx renderContext, application argoappv1.Application) (string, error) {
-	if applicationUsesMatchedExecPolicy(application, ctx.request.pluginPolicy) {
+	if applicationUsesMatchedExternalPolicy(application, ctx.request.pluginPolicy) {
 		return "", nil
 	}
 	input := struct {
@@ -203,7 +204,7 @@ func applicationRenderCacheKey(ctx renderContext, application argoappv1.Applicat
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func applicationUsesMatchedExecPolicy(application argoappv1.Application, policy pluginpolicy.Policy) bool {
+func applicationUsesMatchedExternalPolicy(application argoappv1.Application, policy pluginpolicy.Policy) bool {
 	sources := application.Spec.Sources
 	if len(sources) == 0 && application.Spec.Source != nil {
 		sources = argoappv1.ApplicationSources{*application.Spec.Source}
@@ -212,12 +213,34 @@ func applicationUsesMatchedExecPolicy(application argoappv1.Application, policy 
 		if source.Plugin == nil {
 			continue
 		}
+		if strings.TrimSpace(source.Plugin.Name) == "" {
+			if policyHasStaticExternalMatch(policy) {
+				return true
+			}
+			continue
+		}
 		plugin, ok := policy.Plugin(source.Plugin.Name)
-		if ok && plugin.Engine == pluginpolicy.EngineExec {
+		if ok && pluginEngineBypassesApplicationRenderCache(plugin.Engine) {
 			return true
 		}
 	}
 	return false
+}
+
+func policyHasStaticExternalMatch(policy pluginpolicy.Policy) bool {
+	for _, plugin := range policy.Plugins {
+		if !pluginEngineBypassesApplicationRenderCache(plugin.Engine) {
+			continue
+		}
+		if _, _, ok := policyPluginStaticDiscoverRule(plugin); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func pluginEngineBypassesApplicationRenderCache(engine pluginpolicy.Engine) bool {
+	return engine == pluginpolicy.EngineExec || engine == pluginpolicy.EngineContainer
 }
 
 type applicationRenderCacheInput struct {

--- a/internal/chart/repository_http.go
+++ b/internal/chart/repository_http.go
@@ -120,29 +120,39 @@ func repositoryIndexURL(repository string) (string, error) {
 }
 func findChartURL(repository string, request Request, index repositoryIndex) (string, error) {
 	versions := index.Entries[request.Name]
-	for _, version := range versions {
-		if version.Version != request.Version {
-			continue
-		}
-		if len(version.URLs) == 0 {
-			return "", fmt.Errorf("chart %s version %s has no archive URLs", request.Name, request.Version)
-		}
-		archiveURL, err := url.Parse(version.URLs[0])
-		if err != nil {
-			return "", fmt.Errorf("parse chart archive URL %q: %w", version.URLs[0], err)
-		}
-		if archiveURL.IsAbs() {
-			if archiveURL.Scheme != "http" && archiveURL.Scheme != "https" {
-				return "", fmt.Errorf("absolute chart URL %s must use http or https", redactedFetchURL(archiveURL.String(), true))
+	for _, candidate := range chartVersionCandidates(request.Version) {
+		for _, version := range versions {
+			if version.Version != candidate {
+				continue
 			}
-			return archiveURL.String(), nil
+			if len(version.URLs) == 0 {
+				return "", fmt.Errorf("chart %s version %s has no archive URLs", request.Name, candidate)
+			}
+			archiveURL, err := url.Parse(version.URLs[0])
+			if err != nil {
+				return "", fmt.Errorf("parse chart archive URL %q: %w", version.URLs[0], err)
+			}
+			if archiveURL.IsAbs() {
+				if archiveURL.Scheme != "http" && archiveURL.Scheme != "https" {
+					return "", fmt.Errorf("absolute chart URL %s must use http or https", redactedFetchURL(archiveURL.String(), true))
+				}
+				return archiveURL.String(), nil
+			}
+			base, err := url.Parse(repository)
+			if err != nil {
+				return "", err
+			}
+			base.Path = strings.TrimRight(base.Path, "/") + "/"
+			return base.ResolveReference(archiveURL).String(), nil
 		}
-		base, err := url.Parse(repository)
-		if err != nil {
-			return "", err
-		}
-		base.Path = strings.TrimRight(base.Path, "/") + "/"
-		return base.ResolveReference(archiveURL).String(), nil
 	}
 	return "", fmt.Errorf("chart %s version %s not found in repository index", request.Name, request.Version)
+}
+
+func chartVersionCandidates(version string) []string {
+	version = strings.TrimSpace(version)
+	if len(version) > 1 && (version[0] == 'v' || version[0] == 'V') && version[1] >= '0' && version[1] <= '9' {
+		return []string{version, version[1:]}
+	}
+	return []string{version}
 }

--- a/internal/chart/repository_test.go
+++ b/internal/chart/repository_test.go
@@ -349,6 +349,45 @@ entries:
 	}
 }
 
+func TestDefaultAcquirerAcceptsLeadingVSemverChartVersion(t *testing.T) {
+	archive := chartArchive(t, "demo", map[string]string{
+		"Chart.yaml": "apiVersion: v2\nname: demo\nversion: 1.2.3\n",
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			fmt.Fprint(w, `apiVersion: v1
+entries:
+  demo:
+    - version: 1.2.3
+      urls:
+        - demo-1.2.3.tgz
+`)
+		case "/demo-1.2.3.tgz":
+			if _, err := w.Write(archive); err != nil {
+				t.Fatalf("write archive response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := (DefaultAcquirer{Client: server.Client()}).Acquire(context.Background(), Request{
+		Repository: server.URL,
+		Name:       "demo",
+		Version:    "v1.2.3",
+		Kind:       RepositoryHTTP,
+	}, Options{CacheDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	if result.Version != "v1.2.3" {
+		t.Fatalf("Result.Version = %q, want requested version", result.Version)
+	}
+}
+
 func TestDefaultAcquirerMissingVersionDiagnostic(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/index.yaml" {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -138,7 +138,7 @@ func bindRemoteAcquisitionCacheFlags(cmd *cobra.Command, flags *commonFlags) {
 
 func bindPluginFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.enableAVPCompat, "enable-avp-compat", flags.enableAVPCompat, "replace argocd-vault-plugin placeholders with deterministic redacted values")
-	cmd.Flags().BoolVar(&flags.enablePlugins, "enable-plugins", flags.enablePlugins, "enable trusted exec plugin policy entries")
+	cmd.Flags().BoolVar(&flags.enablePlugins, "enable-plugins", flags.enablePlugins, "enable trusted exec/container plugin policy entries")
 	cmd.Flags().StringVar(&flags.pluginPolicyPath, "plugin-policy-path", flags.pluginPolicyPath, "trusted plugin policy path relative to the selected policy root")
 	cmd.Flags().StringVar(&flags.pluginPolicyRef, "plugin-policy-ref", flags.pluginPolicyRef, "Git ref to use as the trusted plugin policy source")
 	cmd.Flags().StringVar(&flags.pluginPolicyRepo, "plugin-policy-repo", flags.pluginPolicyRepo, "local Git repository path used to resolve --plugin-policy-ref")

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -73,13 +73,13 @@ func TestRepresentativeCommandsExposeFocusedFlagGroups(t *testing.T) {
 	}
 }
 
-func TestEnablePluginsHelpDescribesTrustedExecPolicy(t *testing.T) {
+func TestEnablePluginsHelpDescribesTrustedCommandPolicy(t *testing.T) {
 	cmd := findCLICommand(t, "build", "apps")
 	flag := cmd.Flags().Lookup("enable-plugins")
 	if flag == nil {
 		t.Fatal("build apps missing --enable-plugins")
 	}
-	for _, want := range []string{"trusted", "exec", "plugin policy"} {
+	for _, want := range []string{"trusted", "exec", "container", "plugin policy"} {
 		if !strings.Contains(flag.Usage, want) {
 			t.Fatalf("--enable-plugins usage = %q, want %q", flag.Usage, want)
 		}

--- a/internal/cli/diag_test.go
+++ b/internal/cli/diag_test.go
@@ -547,6 +547,8 @@ func TestDiagJSONOutputIncludesPluginExecutions(t *testing.T) {
 				SourcePath:   "manifests/plugin",
 				PluginName:   "exec-renderer",
 				Engine:       "exec",
+				Runtime:      "docker",
+				Image:        "registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Phase:        "generate",
 				Command:      "argocd-vault-plugin",
 				Duration:     "12ms",
@@ -567,6 +569,9 @@ func TestDiagJSONOutputIncludesPluginExecutions(t *testing.T) {
 		PluginExecutions []struct {
 			AppName    string `json:"appName"`
 			PluginName string `json:"pluginName"`
+			Engine     string `json:"engine"`
+			Runtime    string `json:"runtime"`
+			Image      string `json:"image"`
 			Phase      string `json:"phase"`
 			Command    string `json:"command"`
 			Duration   string `json:"duration"`
@@ -581,6 +586,9 @@ func TestDiagJSONOutputIncludesPluginExecutions(t *testing.T) {
 	execution := report.PluginExecutions[0]
 	if execution.AppName != "plugin-app" || execution.PluginName != "exec-renderer" || execution.Phase != "generate" || execution.Command != "argocd-vault-plugin" || execution.Duration != "12ms" {
 		t.Fatalf("pluginExecutions[0] = %#v, want exec metadata", execution)
+	}
+	if execution.Engine != "exec" || execution.Runtime != "docker" || execution.Image != "registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("pluginExecutions[0] = %#v, want engine/runtime/image metadata", execution)
 	}
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -21,6 +21,7 @@ type SourceTier int
 const (
 	SourceTierStatic SourceTier = iota
 	SourceTierExplicitRendered
+	SourceTierPolicyBootstrap
 	SourceTierRenderedFleet
 )
 

--- a/internal/plugincontainer/plugincontainer.go
+++ b/internal/plugincontainer/plugincontainer.go
@@ -1,0 +1,541 @@
+package plugincontainer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+)
+
+const (
+	workMount = "/work"
+)
+
+type Runner interface {
+	Run(ctx context.Context, request Request) (pluginexec.Result, error)
+}
+
+type ProcessRunner interface {
+	Run(ctx context.Context, request ProcessRequest) error
+}
+
+type DefaultRunner struct {
+	ProcessRunner ProcessRunner
+	DockerPath    string
+}
+
+type Request struct {
+	SourceDir       string
+	RepositoryDir   string
+	SourceRelPath   string
+	Config          pluginpolicy.ContainerConfig
+	Offline         bool
+	EnvLookup       func(string) (string, bool)
+	ExtraEnv        []string
+	SensitiveValues []string
+}
+
+type ProcessRequest struct {
+	Path    string
+	Args    []string
+	Dir     string
+	Env     []string
+	Timeout time.Duration
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+func (r DefaultRunner) Run(ctx context.Context, request Request) (pluginexec.Result, error) {
+	return runWithProcess(ctx, request, r.ProcessRunner, r.DockerPath)
+}
+
+func runWithProcess(ctx context.Context, request Request, processRunner ProcessRunner, dockerPath string) (pluginexec.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return pluginexec.Result{}, err
+	}
+	if processRunner == nil {
+		processRunner = defaultProcessRunner{}
+	}
+	if strings.TrimSpace(request.SourceDir) == "" {
+		return pluginexec.Result{}, &pluginexec.Error{Reason: "source directory is required"}
+	}
+	if request.Offline && request.Config.Network == pluginpolicy.ContainerNetworkDefault {
+		return pluginexec.Result{}, &pluginexec.Error{Reason: "container network default is not allowed when offline"}
+	}
+	dockerClientConfigDir, cleanupDockerClientConfig, err := prepareDockerClientConfig(request)
+	if err != nil {
+		return pluginexec.Result{}, err
+	}
+	defer cleanupDockerClientConfig()
+	workspace, err := pluginexec.PrepareWorkspace(pluginexec.Request{
+		SourceDir:     request.SourceDir,
+		RepositoryDir: request.RepositoryDir,
+		SourceRelPath: request.SourceRelPath,
+		Config:        request.Config.Lifecycle,
+	})
+	if err != nil {
+		return pluginexec.Result{}, err
+	}
+	defer workspace.Cleanup()
+	if err := makeWorkspaceWritable(workspace); err != nil {
+		return pluginexec.Result{}, err
+	}
+	containerEnv, dockerEnv, err := containerProcessEnv(request, dockerClientConfigDir)
+	if err != nil {
+		return pluginexec.Result{}, err
+	}
+	return runContainerLifecycle(ctx, request, processRunner, dockerPath, workspace, dockerEnv, containerEnv)
+}
+
+func prepareDockerClientConfig(request Request) (string, func(), error) {
+	if !request.Offline {
+		return "", func() {}, nil
+	}
+	if err := rejectOfflineDockerClientRemoteConfig(request.EnvLookup); err != nil {
+		return "", nil, &pluginexec.Error{Reason: "offline container plugin requires a local Docker client", Err: err}
+	}
+	dir, cleanup, err := createOfflineDockerClientConfig()
+	if err != nil {
+		return "", nil, &pluginexec.Error{Reason: "offline container plugin requires isolated Docker client config", Err: err}
+	}
+	return dir, cleanup, nil
+}
+
+func containerProcessEnv(request Request, dockerClientConfigDir string) ([]string, []string, error) {
+	containerEnv, err := pluginexec.BuildEnv(request.Config.Lifecycle.Env, request.EnvLookup, request.ExtraEnv)
+	if err != nil {
+		return nil, nil, err
+	}
+	dockerEnv := dockerClientEnv(request.EnvLookup, dockerClientConfigDir)
+	return containerEnv, dockerEnv, nil
+}
+
+func runContainerLifecycle(ctx context.Context, request Request, processRunner ProcessRunner, dockerPath string, workspace pluginexec.Workspace, dockerEnv, containerEnv []string) (pluginexec.Result, error) {
+	var executions []pluginexec.Execution
+	if request.Config.Lifecycle.Init != nil {
+		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "init", *request.Config.Lifecycle.Init, nil, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+		if err != nil {
+			return pluginexec.Result{}, err
+		}
+		executions = append(executions, result.Execution)
+	}
+	result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "generate", request.Config.Lifecycle.Generate, nil, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+	if err != nil {
+		return pluginexec.Result{}, err
+	}
+	stdout := result.Stdout
+	executions = append(executions, result.Execution)
+	for index, command := range request.Config.Lifecycle.PostRenderers {
+		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, fmt.Sprintf("post-renderer %d", index), command, stdout, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+		if err != nil {
+			return pluginexec.Result{}, err
+		}
+		stdout = result.Stdout
+		executions = append(executions, result.Execution)
+	}
+	return pluginexec.Result{Stdout: stdout, Executions: executions}, nil
+}
+
+type commandResult struct {
+	Stdout    []byte
+	Execution pluginexec.Execution
+}
+
+func runConfiguredContainerCommand(
+	ctx context.Context,
+	processRunner ProcessRunner,
+	dockerPath string,
+	phase string,
+	command pluginpolicy.ExecCommand,
+	stdin []byte,
+	workspace pluginexec.Workspace,
+	config pluginpolicy.ContainerConfig,
+	offline bool,
+	dockerEnv []string,
+	containerEnv []string,
+) (commandResult, error) {
+	if err := validateContainerCommand(command.Command); err != nil {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: safeCommandName(command.Command), Reason: "invalid command", Err: err}
+	}
+	envFile, cleanupEnvFile, err := writeContainerEnvFile(containerEnv)
+	if err != nil {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: safeCommandName(command.Command), Reason: "invalid container env", Err: err}
+	}
+	defer cleanupEnvFile()
+	cidFile, cleanupCIDFile, err := createCIDFile()
+	if err != nil {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: safeCommandName(command.Command), Reason: "invalid cidfile", Err: err}
+	}
+	defer cleanupCIDFile()
+	docker, err := resolveDockerPath(dockerPath)
+	if err != nil {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: "docker", Reason: "invalid runtime", Err: err}
+	}
+	stdout := &limitBuffer{limit: config.Lifecycle.Output.MaxStdoutBytes}
+	stderr := &limitBuffer{limit: config.Lifecycle.Output.MaxStderrBytes}
+	args := dockerRunArgs(config, workspace, offline, envFile, cidFile, command.Command)
+	started := time.Now()
+	err = processRunner.Run(ctx, ProcessRequest{
+		Path:    docker,
+		Args:    append([]string{docker}, args...),
+		Dir:     workspace.Workdir,
+		Env:     dockerEnv,
+		Timeout: command.Timeout,
+		Stdin:   bytes.NewReader(stdin),
+		Stdout:  stdout,
+		Stderr:  stderr,
+	})
+	execution := pluginexec.Execution{
+		Phase:    phase,
+		Command:  safeCommandName(command.Command),
+		Duration: time.Since(started),
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			_ = cleanupContainer(ctx, processRunner, docker, dockerEnv, cidFile)
+			return commandResult{}, err
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			_ = cleanupContainer(ctx, processRunner, docker, dockerEnv, cidFile)
+			return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "command timed out"}
+		}
+		var exitErr exitError
+		if errors.As(err, &exitErr) {
+			code := exitErr.Code
+			return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "container command failed; stderr omitted to avoid leaking secrets", ExitCode: &code}
+		}
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "container command failed; stderr omitted to avoid leaking secrets", Err: err}
+	}
+	if stdout.overflow {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "stdout limit exceeded"}
+	}
+	if stderr.overflow {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "stderr limit exceeded; stderr omitted to avoid leaking secrets"}
+	}
+	return commandResult{Stdout: stdout.Bytes(), Execution: execution}, nil
+}
+
+func dockerRunArgs(config pluginpolicy.ContainerConfig, workspace pluginexec.Workspace, offline bool, envFile string, cidFile string, command []string) []string {
+	network := string(config.Network)
+	if network == "" {
+		network = string(pluginpolicy.DefaultContainerNetwork)
+	}
+	args := []string{
+		"run",
+		"--rm",
+		"--interactive",
+		"--cidfile", cidFile,
+		"--network", network,
+		"--mount", "type=bind,src=" + workspace.ArgumentRoot + ",dst=" + workMount,
+		"--workdir", containerWorkdir(workspace),
+	}
+	if offline {
+		args = append(args, "--pull", "never")
+	}
+	if envFile != "" {
+		args = append(args, "--env-file", envFile)
+	}
+	args = append(args, "--entrypoint", command[0], config.Image)
+	args = append(args, command[1:]...)
+	return args
+}
+
+func writeContainerEnvFile(env []string) (string, func(), error) {
+	var lines []string
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || name == "" || name == "PATH" {
+			continue
+		}
+		if strings.ContainsAny(value, "\r\n") {
+			return "", func() {}, fmt.Errorf("env value %s contains a newline", name)
+		}
+		lines = append(lines, name+"="+value)
+	}
+	if len(lines) == 0 {
+		return "", func() {}, nil
+	}
+	file, err := os.CreateTemp("", "drydock-container-env-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	_, writeErr := file.WriteString(strings.Join(lines, "\n") + "\n")
+	closeErr := file.Close()
+	if writeErr != nil {
+		cleanup()
+		return "", func() {}, writeErr
+	}
+	if closeErr != nil {
+		cleanup()
+		return "", func() {}, closeErr
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return path, cleanup, nil
+}
+
+func createCIDFile() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "drydock-container-cid-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	path := filepath.Join(dir, "container.cid")
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	return path, cleanup, nil
+}
+
+func cleanupContainer(ctx context.Context, processRunner ProcessRunner, docker string, dockerEnv []string, cidFile string) error {
+	data, err := os.ReadFile(cidFile)
+	if err != nil || len(bytes.TrimSpace(data)) == 0 {
+		return err
+	}
+	containerID := string(bytes.TrimSpace(data))
+	cleanupCtx := context.WithoutCancel(ctx)
+	return processRunner.Run(cleanupCtx, ProcessRequest{
+		Path:    docker,
+		Args:    []string{docker, "rm", "-f", containerID},
+		Env:     dockerEnv,
+		Timeout: 5 * time.Second,
+		Stdin:   bytes.NewReader(nil),
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+	})
+}
+
+func containerWorkdir(workspace pluginexec.Workspace) string {
+	if workspace.ArgumentRoot == workspace.Workdir {
+		return workMount
+	}
+	rel, err := filepath.Rel(workspace.ArgumentRoot, workspace.Workdir)
+	if err != nil || rel == "." {
+		return workMount
+	}
+	return filepath.ToSlash(filepath.Join(workMount, rel))
+}
+
+func validateContainerCommand(command []string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("command must not be empty")
+	}
+	for index, token := range command {
+		if strings.TrimSpace(token) == "" {
+			return fmt.Errorf("command[%d] must not be empty", index)
+		}
+		if hasCredentialBearingURL(token) {
+			return fmt.Errorf("argument contains credential-bearing URL")
+		}
+		if name, value, ok := strings.Cut(token, "="); ok && strings.HasPrefix(name, "--") && hasCredentialBearingURL(value) {
+			return fmt.Errorf("argument contains credential-bearing URL")
+		}
+	}
+	return nil
+}
+
+func createOfflineDockerClientConfig() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "drydock-docker-client-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func dockerClientEnv(lookup func(string) (string, bool), isolatedConfigDir string) []string {
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	env := []string{"PATH=" + pluginexec.ControlledPath}
+	if isolatedConfigDir != "" {
+		env = append(env, "HOME="+isolatedConfigDir, "DOCKER_CONFIG="+isolatedConfigDir)
+	}
+	for _, name := range []string{"DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"} {
+		if isolatedConfigDir != "" && name == "DOCKER_CONFIG" {
+			continue
+		}
+		if value, ok := lookup(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
+}
+
+func rejectOfflineDockerClientRemoteConfig(lookup func(string) (string, bool)) error {
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	for _, name := range []string{"DOCKER_CONTEXT", "DOCKER_CONFIG", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"} {
+		if value, ok := lookup(name); ok && strings.TrimSpace(value) != "" {
+			return fmt.Errorf("%s is not allowed in offline mode", name)
+		}
+	}
+	if value, ok := lookup("DOCKER_HOST"); ok && strings.TrimSpace(value) != "" {
+		host := strings.TrimSpace(value)
+		if strings.HasPrefix(host, "unix://") || strings.HasPrefix(host, "npipe://") {
+			return nil
+		}
+		return fmt.Errorf("DOCKER_HOST must be local unix:// or npipe:// in offline mode")
+	}
+	return nil
+}
+
+func resolveDocker() (string, error) {
+	for _, dir := range filepath.SplitList(pluginexec.ControlledPath) {
+		candidate := filepath.Join(dir, "docker")
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("docker not found on controlled PATH %q", pluginexec.ControlledPath)
+}
+
+func resolveDockerPath(path string) (string, error) {
+	if strings.TrimSpace(path) != "" {
+		return path, nil
+	}
+	return resolveDocker()
+}
+
+func makeWorkspaceWritable(workspace pluginexec.Workspace) error {
+	for _, root := range []string{workspace.ArgumentRoot, workspace.Workdir} {
+		if root == "" {
+			continue
+		}
+		if err := chmodTree(root); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func chmodTree(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, info.Mode().Perm()|0o777)
+		}
+		if info.Mode().IsRegular() {
+			return os.Chmod(path, info.Mode().Perm()|0o666)
+		}
+		return nil
+	})
+}
+
+type defaultProcessRunner struct{}
+
+func (defaultProcessRunner) Run(ctx context.Context, request ProcessRequest) error {
+	return runProcess(ctx, request)
+}
+
+type exitError struct {
+	Code int
+}
+
+func (e exitError) Error() string {
+	return fmt.Sprintf("exit code %d", e.Code)
+}
+
+type execExitError interface {
+	ExitCode() int
+}
+
+func runProcess(ctx context.Context, request ProcessRequest) error {
+	runCtx := ctx
+	cancel := func() {}
+	if request.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, request.Timeout)
+	}
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, request.Path, request.Args[1:]...)
+	cmd.Dir = request.Dir
+	cmd.Env = request.Env
+	cmd.Stdin = request.Stdin
+	cmd.Stdout = request.Stdout
+	cmd.Stderr = request.Stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			return context.DeadlineExceeded
+		}
+		var exitErr execExitError
+		if errors.As(err, &exitErr) {
+			return exitError{Code: exitErr.ExitCode()}
+		}
+		return err
+	}
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return ctx.Err()
+}
+
+func safeCommandName(command []string) string {
+	if len(command) == 0 {
+		return ""
+	}
+	return filepath.Base(command[0])
+}
+
+type limitBuffer struct {
+	buffer   bytes.Buffer
+	limit    int64
+	overflow bool
+}
+
+func (b *limitBuffer) Write(data []byte) (int, error) {
+	if b.limit <= 0 {
+		b.overflow = true
+		return len(data), nil
+	}
+	remaining := b.limit - int64(b.buffer.Len())
+	if remaining <= 0 {
+		b.overflow = true
+		return len(data), nil
+	}
+	if int64(len(data)) > remaining {
+		b.overflow = true
+		_, _ = b.buffer.Write(data[:int(remaining)])
+		return len(data), nil
+	}
+	_, _ = b.buffer.Write(data)
+	return len(data), nil
+}
+
+func (b *limitBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
+}
+
+func hasCredentialBearingURL(value string) bool {
+	for _, scheme := range []string{"http://", "https://", "ssh://", "git://"} {
+		_, rest, ok := strings.Cut(value, scheme)
+		if !ok {
+			continue
+		}
+		beforeAt, _, ok := strings.Cut(rest, "@")
+		if ok && strings.Contains(beforeAt, ":") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugincontainer/plugincontainer_test.go
+++ b/internal/plugincontainer/plugincontainer_test.go
@@ -1,0 +1,420 @@
+package plugincontainer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+)
+
+func TestDefaultRunnerRunsDockerWithTempWorkspaceAndEnvFile(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "index.pkl"), []byte("input"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, ".git", "config"), []byte("private"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	process := &recordingProcessRunner{
+		stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: rendered\n"),
+	}
+	t.Setenv("PARAM_PATH", "index.pkl")
+
+	result, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config: pluginpolicy.ContainerConfig{
+			Runtime: pluginpolicy.ContainerRuntimeDocker,
+			Image:   "registry.example.test/plugins/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Network: pluginpolicy.ContainerNetworkNone,
+			Lifecycle: pluginpolicy.ExecConfig{
+				Generate: pluginpolicy.ExecCommand{
+					Command: []string{"pkl", "eval", "index.pkl"},
+					Timeout: time.Second,
+				},
+				Env: pluginpolicy.ExecEnv{Allow: []string{"PARAM_PATH"}},
+				Output: pluginpolicy.ExecOutput{
+					MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+					MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if string(result.Stdout) != "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: rendered\n" {
+		t.Fatalf("Stdout = %q, want rendered manifest", result.Stdout)
+	}
+	if len(process.requests) != 1 {
+		t.Fatalf("process requests = %d, want 1", len(process.requests))
+	}
+	request := process.requests[0]
+	assertArgSequence(t, request.Args, "--network", "none")
+	assertArgSequence(t, request.Args, "--entrypoint", "pkl")
+	if strings.Join(request.Args, "\x00") == "" || !strings.Contains(strings.Join(request.Args, "\x00"), "registry.example.test/plugins/pkl@sha256:") {
+		t.Fatalf("docker args = %#v, want image reference", request.Args)
+	}
+	if strings.Contains(strings.Join(request.Args, "\x00"), "PARAM_PATH=index.pkl") {
+		t.Fatalf("docker args leaked env value: %#v", request.Args)
+	}
+	if string(process.envFileData) != "PARAM_PATH=index.pkl\n" {
+		t.Fatalf("env file = %q, want allowed env", process.envFileData)
+	}
+	if _, err := os.Stat(filepath.Join(mountSrc(t, request.Args), ".git", "config")); !os.IsNotExist(err) {
+		t.Fatalf("container .git/config stat = %v, want skipped metadata", err)
+	}
+	if strings.Join(request.Env, "\x00") != "PATH=/usr/local/bin:/usr/bin:/bin" {
+		t.Fatalf("docker client env = %#v, want controlled PATH only", request.Env)
+	}
+}
+
+func TestDefaultRunnerOfflineAddsPullNeverAndRejectsDefaultNetwork(t *testing.T) {
+	source := t.TempDir()
+	process := &recordingProcessRunner{}
+	config := pluginpolicy.ContainerConfig{
+		Runtime: pluginpolicy.ContainerRuntimeDocker,
+		Image:   "registry.example.test/plugins/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Network: pluginpolicy.ContainerNetworkNone,
+		Lifecycle: pluginpolicy.ExecConfig{
+			Generate: pluginpolicy.ExecCommand{Command: []string{"pkl"}, Timeout: time.Second},
+			Output: pluginpolicy.ExecOutput{
+				MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+				MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+			},
+		},
+	}
+	if _, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{SourceDir: source, Config: config, Offline: true}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	assertArgSequence(t, process.requests[0].Args, "--pull", "never")
+
+	config.Network = pluginpolicy.ContainerNetworkDefault
+	_, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{SourceDir: source, Config: config, Offline: true})
+	if err == nil {
+		t.Fatal("Run() error = nil, want offline default network rejection")
+	}
+	if !strings.Contains(err.Error(), "network default") {
+		t.Fatalf("Run() error = %v, want network default rejection", err)
+	}
+}
+
+func TestDefaultRunnerOfflineRejectsRemoteDockerClientEnv(t *testing.T) {
+	source := t.TempDir()
+	config := basicContainerConfig()
+	for _, tt := range []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "tcp host", env: map[string]string{"DOCKER_HOST": "tcp://docker.example.test:2376"}, want: "DOCKER_HOST"},
+		{name: "context", env: map[string]string{"DOCKER_CONTEXT": "remote"}, want: "DOCKER_CONTEXT"},
+		{name: "config", env: map[string]string{"DOCKER_CONFIG": "/tmp/docker"}, want: "DOCKER_CONFIG"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+				SourceDir: source,
+				Config:    config,
+				Offline:   true,
+				EnvLookup: mapLookup(tt.env),
+			})
+			if err == nil {
+				t.Fatal("Run() error = nil, want remote Docker client env rejection")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Run() error = %v, want %s", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRunnerOfflineIsolatesAmbientDockerClientConfig(t *testing.T) {
+	source := t.TempDir()
+	ambientHome := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ambientHome, ".docker"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ambientHome, ".docker", "config.json"), []byte(`{"currentContext":"remote"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", ambientHome)
+	process := &recordingProcessRunner{}
+
+	_, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    basicContainerConfig(),
+		Offline:   true,
+		EnvLookup: mapLookup(nil),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(process.requests) != 1 {
+		t.Fatalf("process requests = %d, want 1", len(process.requests))
+	}
+	env := envMap(process.requests[0].Env)
+	home := env["HOME"]
+	dockerConfig := env["DOCKER_CONFIG"]
+	if home == "" || dockerConfig == "" {
+		t.Fatalf("docker client env = %#v, want isolated HOME and DOCKER_CONFIG", process.requests[0].Env)
+	}
+	if home == ambientHome || dockerConfig == filepath.Join(ambientHome, ".docker") {
+		t.Fatalf("docker client env = %#v, used ambient Docker config", process.requests[0].Env)
+	}
+	if home != dockerConfig {
+		t.Fatalf("HOME = %q, DOCKER_CONFIG = %q, want same isolated config dir", home, dockerConfig)
+	}
+	if process.dockerConfigHadConfig {
+		t.Fatalf("docker client env = %#v, isolated Docker config unexpectedly had config.json", process.requests[0].Env)
+	}
+	if _, err := os.Stat(filepath.Join(home, "config.json")); !os.IsNotExist(err) {
+		t.Fatalf("isolated Docker config stat = %v, want empty config dir", err)
+	}
+}
+
+func TestDefaultRunnerCleansUpContainerOnTimeout(t *testing.T) {
+	source := t.TempDir()
+	process := &recordingProcessRunner{err: context.DeadlineExceeded, cid: "container-123", assertCIDFileAbsent: true}
+	_, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    basicContainerConfig(),
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("Run() error = %v, want timeout", err)
+	}
+	if len(process.requests) != 2 {
+		t.Fatalf("process requests = %d, want docker run plus cleanup", len(process.requests))
+	}
+	if process.cidFileAlreadyExist {
+		t.Fatal("cidfile existed before docker run wrote container id")
+	}
+	cleanup := process.requests[1]
+	want := []string{"/usr/bin/docker", "rm", "-f", "container-123"}
+	if strings.Join(cleanup.Args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("cleanup args = %#v, want %#v", cleanup.Args, want)
+	}
+}
+
+func TestDefaultRunnerEnforcesOutputLimits(t *testing.T) {
+	source := t.TempDir()
+	config := basicContainerConfig()
+	config.Lifecycle.Output.MaxStdoutBytes = 4
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{stdout: []byte("12345")}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    config,
+	})
+	if err == nil || !strings.Contains(err.Error(), "stdout limit exceeded") {
+		t.Fatalf("Run() error = %v, want stdout limit exceeded", err)
+	}
+
+	config = basicContainerConfig()
+	config.Lifecycle.Output.MaxStderrBytes = 4
+	_, err = (DefaultRunner{ProcessRunner: &recordingProcessRunner{stderr: []byte("12345")}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    config,
+	})
+	if err == nil || !strings.Contains(err.Error(), "stderr limit exceeded") {
+		t.Fatalf("Run() error = %v, want stderr limit exceeded", err)
+	}
+}
+
+func TestDefaultRunnerRejectsCredentialBearingArguments(t *testing.T) {
+	source := t.TempDir()
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config: pluginpolicy.ContainerConfig{
+			Runtime: pluginpolicy.ContainerRuntimeDocker,
+			Image:   "registry.example.test/plugins/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Network: pluginpolicy.ContainerNetworkNone,
+			Lifecycle: pluginpolicy.ExecConfig{
+				Generate: pluginpolicy.ExecCommand{
+					Command: []string{"pkl", "eval", "https://user:pass@example.test/repo"},
+					Timeout: time.Second,
+				},
+				Output: pluginpolicy.ExecOutput{
+					MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+					MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want credential-bearing URL rejection")
+	}
+	if !strings.Contains(err.Error(), "credential-bearing URL") {
+		t.Fatalf("Run() error = %v, want credential-bearing URL rejection", err)
+	}
+}
+
+type recordingProcessRunner struct {
+	requests              []ProcessRequest
+	stdout                []byte
+	stderr                []byte
+	err                   error
+	cid                   string
+	assertCIDFileAbsent   bool
+	cidFileAlreadyExist   bool
+	dockerConfigHadConfig bool
+	envFileData           []byte
+}
+
+func (r *recordingProcessRunner) Run(_ context.Context, request ProcessRequest) error {
+	r.requests = append(r.requests, cloneProcessRequest(request))
+	if dockerConfig := envMap(request.Env)["DOCKER_CONFIG"]; dockerConfig != "" {
+		if _, err := os.Stat(filepath.Join(dockerConfig, "config.json")); err == nil {
+			r.dockerConfigHadConfig = true
+		}
+	}
+	if cidFile := optionalArgAfter(request.Args, "--cidfile"); cidFile != "" && r.cid != "" {
+		if r.assertCIDFileAbsent {
+			if _, err := os.Stat(cidFile); err == nil || !os.IsNotExist(err) {
+				r.cidFileAlreadyExist = true
+			}
+		}
+		_ = os.WriteFile(cidFile, []byte(r.cid), 0o600)
+	}
+	if envFile := optionalArgAfter(request.Args, "--env-file"); envFile != "" {
+		r.envFileData, _ = os.ReadFile(envFile)
+	}
+	if len(r.stdout) > 0 {
+		_, _ = request.Stdout.Write(r.stdout)
+	}
+	if len(r.stderr) > 0 {
+		_, _ = request.Stderr.Write(r.stderr)
+	}
+	return r.err
+}
+
+func cloneProcessRequest(request ProcessRequest) ProcessRequest {
+	var stdin bytes.Buffer
+	if request.Stdin != nil {
+		_, _ = io.Copy(&stdin, request.Stdin)
+	}
+	return ProcessRequest{
+		Path:    request.Path,
+		Args:    append([]string(nil), request.Args...),
+		Dir:     request.Dir,
+		Env:     append([]string(nil), request.Env...),
+		Timeout: request.Timeout,
+		Stdin:   bytes.NewReader(stdin.Bytes()),
+		Stdout:  request.Stdout,
+		Stderr:  request.Stderr,
+	}
+}
+
+func assertArgSequence(t *testing.T, args []string, left, right string) {
+	t.Helper()
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == left && args[index+1] == right {
+			return
+		}
+	}
+	t.Fatalf("args = %#v, missing %s %s", args, left, right)
+}
+
+func argAfter(t *testing.T, args []string, flag string) string {
+	t.Helper()
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag {
+			return args[index+1]
+		}
+	}
+	t.Fatalf("args = %#v, missing %s", args, flag)
+	return ""
+}
+
+func optionalArgAfter(args []string, flag string) string {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func mountSrc(t *testing.T, args []string) string {
+	t.Helper()
+	value := argAfter(t, args, "--mount")
+	for part := range strings.SplitSeq(value, ",") {
+		if src, ok := strings.CutPrefix(part, "src="); ok {
+			return src
+		}
+	}
+	t.Fatalf("mount = %q, missing src", value)
+	return ""
+}
+
+func TestDefaultRunnerReportsProcessExit(t *testing.T) {
+	source := t.TempDir()
+	_, err := (DefaultRunner{
+		ProcessRunner: &recordingProcessRunner{err: exitError{Code: 7}},
+		DockerPath:    "/usr/bin/docker",
+	}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config: pluginpolicy.ContainerConfig{
+			Runtime: pluginpolicy.ContainerRuntimeDocker,
+			Image:   "registry.example.test/plugins/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Network: pluginpolicy.ContainerNetworkNone,
+			Lifecycle: pluginpolicy.ExecConfig{
+				Generate: pluginpolicy.ExecCommand{Command: []string{"pkl"}, Timeout: time.Second},
+				Output: pluginpolicy.ExecOutput{
+					MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+					MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want process exit")
+	}
+	var pluginErr *pluginexec.Error
+	if !errors.As(err, &pluginErr) || pluginErr.ExitCode == nil || *pluginErr.ExitCode != 7 {
+		t.Fatalf("Run() error = %v, want plugin exec exit code 7", err)
+	}
+}
+
+func basicContainerConfig() pluginpolicy.ContainerConfig {
+	return pluginpolicy.ContainerConfig{
+		Runtime: pluginpolicy.ContainerRuntimeDocker,
+		Image:   "registry.example.test/plugins/pkl@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Network: pluginpolicy.ContainerNetworkNone,
+		Lifecycle: pluginpolicy.ExecConfig{
+			Generate: pluginpolicy.ExecCommand{Command: []string{"pkl"}, Timeout: time.Second},
+			Output: pluginpolicy.ExecOutput{
+				MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+				MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+			},
+		},
+	}
+}
+
+func mapLookup(values map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		value, ok := values[name]
+		return value, ok
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			out[name] = value
+		}
+	}
+	return out
+}

--- a/internal/pluginexec/pluginexec.go
+++ b/internal/pluginexec/pluginexec.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/sholdee/drydock/internal/filecopy"
 	"github.com/sholdee/drydock/internal/pathsafety"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
@@ -29,15 +32,26 @@ type Runner interface {
 type DefaultRunner struct{}
 
 type Request struct {
-	SourceDir      string
-	Config         pluginpolicy.ExecConfig
-	ProtectedRoots []string
-	EnvLookup      func(string) (string, bool)
+	SourceDir       string
+	RepositoryDir   string
+	SourceRelPath   string
+	Config          pluginpolicy.ExecConfig
+	ProtectedRoots  []string
+	EnvLookup       func(string) (string, bool)
+	ExtraEnv        []string
+	SensitiveValues []string
 }
 
 type Result struct {
 	Stdout     []byte
 	Executions []Execution
+}
+
+type Workspace struct {
+	Workdir        string
+	ArgumentRoot   string
+	ProtectedRoots []string
+	Cleanup        func()
 }
 
 type Execution struct {
@@ -88,34 +102,39 @@ func (DefaultRunner) Run(ctx context.Context, request Request) (Result, error) {
 	if strings.TrimSpace(request.SourceDir) == "" {
 		return Result{}, &Error{Reason: "source directory is required"}
 	}
-	workdir, cleanup, err := copySourceDir(request.SourceDir)
+	workspace, err := PrepareWorkspace(request)
 	if err != nil {
 		return Result{}, err
 	}
-	defer cleanup()
+	defer workspace.Cleanup()
 
 	protectedRoots := append([]string(nil), request.ProtectedRoots...)
-	protectedRoots = append(protectedRoots, request.SourceDir, workdir)
-	env, err := buildEnv(request.Config.Env, request.EnvLookup)
+	protectedRoots = append(protectedRoots, request.SourceDir)
+	protectedRoots = append(protectedRoots, workspace.ProtectedRoots...)
+	if request.RepositoryDir != "" {
+		protectedRoots = append(protectedRoots, request.RepositoryDir)
+	}
+	env, err := BuildEnv(request.Config.Env, request.EnvLookup, request.ExtraEnv)
 	if err != nil {
 		return Result{}, err
 	}
+	redactor := newRedactor(request.SensitiveValues)
 	var executions []Execution
 	if request.Config.Init != nil {
-		result, err := runConfiguredCommand(ctx, "init", *request.Config.Init, nil, workdir, protectedRoots, env, request.Config.Output)
+		result, err := runConfiguredCommand(ctx, "init", *request.Config.Init, nil, workspace.Workdir, workspace.ArgumentRoot, protectedRoots, env, request.Config.Output, redactor)
 		if err != nil {
 			return Result{}, err
 		}
 		executions = append(executions, result.Execution)
 	}
-	result, err := runConfiguredCommand(ctx, "generate", request.Config.Generate, nil, workdir, protectedRoots, env, request.Config.Output)
+	result, err := runConfiguredCommand(ctx, "generate", request.Config.Generate, nil, workspace.Workdir, workspace.ArgumentRoot, protectedRoots, env, request.Config.Output, redactor)
 	if err != nil {
 		return Result{}, err
 	}
 	stdout := result.Stdout
 	executions = append(executions, result.Execution)
 	for index, command := range request.Config.PostRenderers {
-		result, err := runConfiguredCommand(ctx, fmt.Sprintf("post-renderer %d", index), command, stdout, workdir, protectedRoots, env, request.Config.Output)
+		result, err := runConfiguredCommand(ctx, fmt.Sprintf("post-renderer %d", index), command, stdout, workspace.Workdir, workspace.ArgumentRoot, protectedRoots, env, request.Config.Output, redactor)
 		if err != nil {
 			return Result{}, err
 		}
@@ -130,12 +149,12 @@ type commandResult struct {
 	Execution Execution
 }
 
-func runConfiguredCommand(ctx context.Context, phase string, command pluginpolicy.ExecCommand, stdin []byte, workdir string, protectedRoots []string, env []string, output pluginpolicy.ExecOutput) (commandResult, error) {
+func runConfiguredCommand(ctx context.Context, phase string, command pluginpolicy.ExecCommand, stdin []byte, workdir string, argumentRoot string, protectedRoots []string, env []string, output pluginpolicy.ExecOutput, redactor redactor) (commandResult, error) {
 	resolved, err := resolveCommand(command.Command[0], protectedRoots)
 	if err != nil {
 		return commandResult{}, &Error{Phase: phase, Command: safeCommandName(command.Command[0]), Reason: "invalid command", Err: err}
 	}
-	if err := validateArguments(command.Command[1:], workdir, protectedRoots); err != nil {
+	if err := validateArguments(command.Command[1:], workdir, argumentRoot, protectedRoots, redactor); err != nil {
 		return commandResult{}, &Error{Phase: phase, Command: safeCommandName(resolved), Reason: "invalid arguments", Err: err}
 	}
 	stdout := &limitBuffer{limit: output.MaxStdoutBytes}
@@ -179,14 +198,104 @@ func runConfiguredCommand(ctx context.Context, phase string, command pluginpolic
 	return commandResult{Stdout: stdout.Bytes(), Execution: execution}, nil
 }
 
-func copySourceDir(sourceDir string) (string, func(), error) {
+type workspace struct {
+	workdir        string
+	argumentRoot   string
+	protectedRoots []string
+}
+
+func PrepareWorkspace(request Request) (Workspace, error) {
 	tempRoot, err := os.MkdirTemp("", "drydock-plugin-*")
 	if err != nil {
-		return "", func() {}, err
+		return Workspace{}, err
 	}
 	cleanup := func() { _ = os.RemoveAll(tempRoot) }
-	workdir := filepath.Join(tempRoot, "source")
-	if err := filepath.WalkDir(sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
+	staged, err := copyWorkspaceInto(tempRoot, request)
+	if err != nil {
+		cleanup()
+		return Workspace{}, err
+	}
+	return Workspace{
+		Workdir:        staged.workdir,
+		ArgumentRoot:   staged.argumentRoot,
+		ProtectedRoots: append([]string(nil), staged.protectedRoots...),
+		Cleanup:        cleanup,
+	}, nil
+}
+
+func copyWorkspaceInto(tempRoot string, request Request) (workspace, error) {
+	scope := request.Config.Copy.Scope
+	if scope == "" {
+		scope = pluginpolicy.ExecCopyScopeSource
+	}
+	switch scope {
+	case pluginpolicy.ExecCopyScopeSource:
+		if len(request.Config.Copy.Include) > 0 {
+			return workspace{}, fmt.Errorf("plugin copy.include requires copy.scope %q", pluginpolicy.ExecCopyScopeRepository)
+		}
+		workdir := filepath.Join(tempRoot, "source")
+		if err := copyTree(request.SourceDir, workdir); err != nil {
+			return workspace{}, err
+		}
+		return workspace{
+			workdir:        workdir,
+			argumentRoot:   workdir,
+			protectedRoots: []string{workdir},
+		}, nil
+	case pluginpolicy.ExecCopyScopeRepository:
+		if strings.TrimSpace(request.RepositoryDir) == "" {
+			return workspace{}, fmt.Errorf("repository directory is required for plugin copy.scope %q", scope)
+		}
+		sourceRel, err := requestSourceRelPath(request)
+		if err != nil {
+			return workspace{}, err
+		}
+		tempRepo := filepath.Join(tempRoot, "repository")
+		workdir := filepath.Join(tempRepo, filepath.FromSlash(sourceRel))
+		if err := copyTree(request.SourceDir, workdir); err != nil {
+			return workspace{}, err
+		}
+		if err := copyRepositoryIncludes(request.RepositoryDir, tempRepo, request.Config.Copy.Include); err != nil {
+			return workspace{}, err
+		}
+		return workspace{
+			workdir:        workdir,
+			argumentRoot:   tempRepo,
+			protectedRoots: []string{tempRepo, workdir},
+		}, nil
+	default:
+		return workspace{}, fmt.Errorf("plugin copy.scope %q is unsupported", request.Config.Copy.Scope)
+	}
+}
+
+func requestSourceRelPath(request Request) (string, error) {
+	if strings.TrimSpace(request.SourceRelPath) != "" {
+		return cleanSlashRelPath(request.SourceRelPath, "source path", true)
+	}
+	rel, err := filepath.Rel(request.RepositoryDir, request.SourceDir)
+	if err != nil {
+		return "", err
+	}
+	return cleanSlashRelPath(filepath.ToSlash(rel), "source path", true)
+}
+
+func cleanSlashRelPath(raw string, label string, allowDot bool) (string, error) {
+	normalized := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
+	clean := path.Clean(strings.Trim(normalized, "/"))
+	if clean == "." {
+		if allowDot {
+			return ".", nil
+		}
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	if strings.HasPrefix(normalized, "/") || hasParentComponent(normalized) || pathsafety.SlashRelEscapes(clean) || hasDotGitComponent(clean) {
+		return "", fmt.Errorf("%s %q must be repository-relative and non-escaping", label, raw)
+	}
+	return clean, nil
+}
+
+func copyTree(sourceDir string, targetRoot string) error {
+	return filepath.WalkDir(sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -194,8 +303,14 @@ func copySourceDir(sourceDir string) (string, func(), error) {
 		if err != nil {
 			return err
 		}
-		target := filepath.Join(workdir, rel)
-		info, err := entry.Info()
+		if hasDotGitComponent(filepath.ToSlash(rel)) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		target := filepath.Join(targetRoot, rel)
+		info, err := os.Lstat(path)
 		if err != nil {
 			return err
 		}
@@ -210,14 +325,166 @@ func copySourceDir(sourceDir string) (string, func(), error) {
 			return filecopy.CopyRegularFile(path, target, mode.Perm())
 		}
 		return fmt.Errorf("plugin source path %q is not a regular file or directory", path)
-	}); err != nil {
-		cleanup()
-		return "", func() {}, err
-	}
-	return workdir, cleanup, nil
+	})
 }
 
-func buildEnv(policy pluginpolicy.ExecEnv, lookup func(string) (string, bool)) ([]string, error) {
+func copyRepositoryIncludes(repositoryDir string, tempRepo string, include []string) error {
+	patterns, err := normalizeIncludePatterns(include)
+	if err != nil {
+		return err
+	}
+	if len(patterns) == 0 {
+		return nil
+	}
+	copiedDirs := map[string]struct{}{}
+	return filepath.WalkDir(repositoryDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(repositoryDir, path)
+		if err != nil {
+			return err
+		}
+		slashRel := filepath.ToSlash(rel)
+		if slashRel == "." {
+			return nil
+		}
+		return copyRepositoryIncludePath(path, rel, slashRel, entry, tempRepo, patterns, copiedDirs)
+	})
+}
+
+func copyRepositoryIncludePath(
+	path string,
+	rel string,
+	slashRel string,
+	entry os.DirEntry,
+	tempRepo string,
+	patterns []string,
+	copiedDirs map[string]struct{},
+) error {
+	if handled, err := handleRepositoryMetadataInclude(path, slashRel, entry, patterns); handled {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return handleRepositoryIncludeSymlink(path, slashRel, patterns)
+	}
+	if entry.IsDir() {
+		return copyRepositoryIncludeDir(path, rel, slashRel, tempRepo, patterns, copiedDirs)
+	}
+	if !info.Mode().IsRegular() || !includePatternsMatch(patterns, slashRel) {
+		return nil
+	}
+	if wasCopiedFromParentInclude(copiedDirs, slashRel) {
+		return nil
+	}
+	return filecopy.CopyRegularFile(path, filepath.Join(tempRepo, rel), info.Mode().Perm())
+}
+
+func handleRepositoryMetadataInclude(path string, slashRel string, entry os.DirEntry, patterns []string) (bool, error) {
+	if !hasDotGitComponent(slashRel) {
+		return false, nil
+	}
+	if includePatternsTouchPath(patterns, slashRel) {
+		return true, fmt.Errorf("plugin repository include path %q includes .git metadata", path)
+	}
+	if entry.IsDir() {
+		return true, filepath.SkipDir
+	}
+	return true, nil
+}
+
+func handleRepositoryIncludeSymlink(path string, slashRel string, patterns []string) error {
+	if includePatternsTouchPath(patterns, slashRel) {
+		return fmt.Errorf("plugin repository include path %q is a symlink", path)
+	}
+	return nil
+}
+
+func copyRepositoryIncludeDir(
+	path string,
+	rel string,
+	slashRel string,
+	tempRepo string,
+	patterns []string,
+	copiedDirs map[string]struct{},
+) error {
+	if !includePatternsMatch(patterns, slashRel) {
+		return nil
+	}
+	if err := copyTree(path, filepath.Join(tempRepo, rel)); err != nil {
+		return err
+	}
+	copiedDirs[slashRel] = struct{}{}
+	return filepath.SkipDir
+}
+
+func wasCopiedFromParentInclude(copiedDirs map[string]struct{}, slashRel string) bool {
+	for copied := range copiedDirs {
+		if slashRel == copied || strings.HasPrefix(slashRel, copied+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeIncludePatterns(include []string) ([]string, error) {
+	out := make([]string, 0, len(include))
+	seen := map[string]struct{}{}
+	for _, raw := range include {
+		if strings.Contains(raw, `\`) {
+			return nil, fmt.Errorf("plugin copy.include glob %q must use slash-normalized paths", raw)
+		}
+		clean, err := cleanSlashRelPath(raw, "plugin copy.include glob", false)
+		if err != nil {
+			return nil, err
+		}
+		if !doublestar.ValidatePattern(clean) {
+			return nil, fmt.Errorf("plugin copy.include glob %q is invalid", raw)
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	return out, nil
+}
+
+func includePatternsMatch(patterns []string, rel string) bool {
+	for _, pattern := range patterns {
+		if doublestar.MatchUnvalidated(pattern, rel) {
+			return true
+		}
+	}
+	return false
+}
+
+func includePatternsTouchPath(patterns []string, rel string) bool {
+	if includePatternsMatch(patterns, rel) {
+		return true
+	}
+	probe := rel + "/__drydock_probe__"
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, rel+"/") || doublestar.MatchUnvalidated(pattern, probe) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDotGitComponent(rel string) bool {
+	return slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), ".git")
+}
+
+func hasParentComponent(rel string) bool {
+	return slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), "..")
+}
+
+func BuildEnv(policy pluginpolicy.ExecEnv, lookup func(string) (string, bool), extraEnv []string) ([]string, error) {
 	if lookup == nil {
 		lookup = os.LookupEnv
 	}
@@ -231,6 +498,16 @@ func buildEnv(policy pluginpolicy.ExecEnv, lookup func(string) (string, bool)) (
 			return nil, fmt.Errorf("env value %s exceeds %d bytes", name, MaxEnvValueBytes)
 		}
 		env = append(env, name+"="+value)
+	}
+	for _, entry := range extraEnv {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("extra env entry is invalid")
+		}
+		if len(value) > MaxEnvValueBytes {
+			return nil, fmt.Errorf("env value %s exceeds %d bytes", name, MaxEnvValueBytes)
+		}
+		env = append(env, entry)
 	}
 	return env, nil
 }
@@ -272,13 +549,13 @@ func validateResolvedCommand(command string, protectedRoots []string) (string, e
 	return resolved, nil
 }
 
-func validateArguments(args []string, workdir string, protectedRoots []string) error {
+func validateArguments(args []string, workdir string, argumentRoot string, protectedRoots []string, redactor redactor) error {
 	for _, arg := range args {
-		if err := validateArgumentValue(arg, workdir, protectedRoots); err != nil {
+		if err := validateArgumentValue(arg, workdir, argumentRoot, protectedRoots, redactor); err != nil {
 			return err
 		}
 		if name, value, ok := strings.Cut(arg, "="); ok && strings.HasPrefix(name, "--") {
-			if err := validateArgumentValue(value, workdir, protectedRoots); err != nil {
+			if err := validateArgumentValue(value, workdir, argumentRoot, protectedRoots, redactor); err != nil {
 				return err
 			}
 		}
@@ -286,7 +563,7 @@ func validateArguments(args []string, workdir string, protectedRoots []string) e
 	return nil
 }
 
-func validateArgumentValue(value string, workdir string, protectedRoots []string) error {
+func validateArgumentValue(value string, workdir string, argumentRoot string, protectedRoots []string, redactor redactor) error {
 	if value == "" {
 		return nil
 	}
@@ -294,27 +571,85 @@ func validateArgumentValue(value string, workdir string, protectedRoots []string
 		return fmt.Errorf("argument contains credential-bearing URL")
 	}
 	if filepath.IsAbs(value) {
-		if inside, root, err := pathsafety.IsInsideAny(value, protectedRoots); err != nil {
-			return err
-		} else if inside {
-			return fmt.Errorf("argument path %q is inside protected root %q", value, root)
-		}
-		return nil
+		return validateAbsoluteArgumentPath(value, workdir, argumentRoot, protectedRoots, redactor)
 	}
 	if !isPathLikeArgument(value) {
 		return nil
 	}
-	clean := filepath.Clean(value)
-	if pathsafety.RelEscapes(clean) {
-		return fmt.Errorf("argument path %q escapes plugin workdir", value)
+	return validateRelativeArgumentPath(value, workdir, argumentRoot, protectedRoots, redactor)
+}
+
+func validateAbsoluteArgumentPath(value string, workdir string, argumentRoot string, protectedRoots []string, redactor redactor) error {
+	if inside, _, err := pathsafety.IsInsideAny(value, []string{argumentRoot}); err != nil {
+		return err
+	} else if inside {
+		return nil
 	}
+	if inside, root, err := pathsafety.IsInsideAny(value, protectedRoots); err != nil {
+		return err
+	} else if inside {
+		return fmt.Errorf("argument path %q is inside protected root %q", redactor.argument(value), root)
+	}
+	return escapedArgumentPathError(value, workdir, argumentRoot, redactor)
+}
+
+func validateRelativeArgumentPath(value string, workdir string, argumentRoot string, protectedRoots []string, redactor redactor) error {
+	clean := filepath.Clean(value)
 	target := filepath.Join(workdir, clean)
+	if inside, _, err := pathsafety.IsInsideAny(target, []string{argumentRoot}); err != nil {
+		return err
+	} else if !inside {
+		return escapedArgumentPathError(value, workdir, argumentRoot, redactor)
+	}
 	if inside, root, err := pathsafety.IsInsideAny(target, protectedRoots); err != nil {
 		return err
-	} else if inside && root != workdir {
-		return fmt.Errorf("argument path %q is inside protected root %q", value, root)
+	} else if inside && !samePath(root, argumentRoot) && !samePath(root, workdir) {
+		return fmt.Errorf("argument path %q is inside protected root %q", redactor.argument(value), root)
 	}
 	return nil
+}
+
+func escapedArgumentPathError(value string, workdir string, argumentRoot string, redactor redactor) error {
+	if samePath(argumentRoot, workdir) {
+		return fmt.Errorf("argument path %q escapes plugin workdir", redactor.argument(value))
+	}
+	return fmt.Errorf("argument path %q escapes plugin repository", redactor.argument(value))
+}
+
+func samePath(left string, right string) bool {
+	leftAbs, err := filepath.Abs(left)
+	if err != nil {
+		return filepath.Clean(left) == filepath.Clean(right)
+	}
+	rightAbs, err := filepath.Abs(right)
+	if err != nil {
+		return filepath.Clean(left) == filepath.Clean(right)
+	}
+	return filepath.Clean(leftAbs) == filepath.Clean(rightAbs)
+}
+
+type redactor struct {
+	values []string
+}
+
+func newRedactor(values []string) redactor {
+	out := redactor{}
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		out.values = append(out.values, value)
+	}
+	return out
+}
+
+func (r redactor) argument(value string) string {
+	for _, sensitive := range r.values {
+		if strings.Contains(value, sensitive) {
+			return "<redacted>"
+		}
+	}
+	return value
 }
 
 func isPathLikeArgument(value string) bool {

--- a/internal/pluginexec/pluginexec_test.go
+++ b/internal/pluginexec/pluginexec_test.go
@@ -60,14 +60,50 @@ func TestDefaultRunnerRunsGenerateFromTempSource(t *testing.T) {
 	}
 }
 
+func TestDefaultRunnerSourceCopyScopeSkipsGitMetadata(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "marker.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, ".git", "config"), []byte("private\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    sourceCopyTestConfig(t, ".git/config"),
+		ProtectedRoots: []string{
+			source,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want skipped .git/config read failure")
+	}
+	if strings.Contains(err.Error(), ".git metadata") {
+		t.Fatalf("Run() error = %v, want .git metadata skipped rather than rejected during copy", err)
+	}
+	var pluginErr *Error
+	if !errors.As(err, &pluginErr) || pluginErr.ExitCode == nil || *pluginErr.ExitCode != 3 {
+		t.Fatalf("Run() error = %v, want helper exit code 3 for missing staged .git/config", err)
+	}
+}
+
 func TestDefaultRunnerRejectsProtectedArgumentsAndCredentialURLs(t *testing.T) {
 	source := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.yaml")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	for _, tt := range []struct {
 		name string
 		arg  string
 		want string
 	}{
 		{name: "protected absolute", arg: filepath.Join(source, "secret.yaml"), want: "protected root"},
+		{name: "unprotected absolute", arg: outside, want: "escapes plugin workdir"},
 		{name: "relative escape", arg: "../escape.yaml", want: "escapes plugin workdir"},
 		{name: "flag protected", arg: "--config=" + filepath.Join(source, "secret.yaml"), want: "protected root"},
 		{name: "credential url", arg: "https://user:pass@example.test/repo", want: "credential-bearing URL"},
@@ -97,6 +133,262 @@ func TestDefaultRunnerRejectsProtectedArgumentsAndCredentialURLs(t *testing.T) {
 				t.Fatalf("Run() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultRunnerAddsExtraEnv(t *testing.T) {
+	source := t.TempDir()
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	result, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config: pluginpolicy.ExecConfig{
+			Workdir: pluginpolicy.ExecWorkdirSource,
+			Generate: pluginpolicy.ExecCommand{
+				Command: []string{helperPath(t), "-test.run=TestHelperProcess", "--", "env"},
+				Timeout: pluginExecCommandTimeout,
+			},
+			Env: pluginpolicy.ExecEnv{Allow: []string{"DRYDOCK_PLUGINEXEC_HELPER"}},
+			Output: pluginpolicy.ExecOutput{
+				MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+				MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+			},
+		},
+		ProtectedRoots: []string{source},
+		ExtraEnv:       []string{"PARAM_PATH=components/app.pkl"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(string(result.Stdout), "components/app.pkl") {
+		t.Fatalf("Stdout = %q, want extra env value", result.Stdout)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeAllowsIncludedRepositoryFileArgument(t *testing.T) {
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, "shared.txt"), []byte("shared\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	result, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, []string{"shared.txt"}, "../shared.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := string(result.Stdout); got != "shared\n" {
+		t.Fatalf("Stdout = %q, want included repository file", got)
+	}
+}
+
+func TestDefaultRunnerSourceCopyScopeRejectsRepositoryRelativeArgument(t *testing.T) {
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, "shared.txt"), []byte("shared\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config:    sourceCopyTestConfig(t, "../shared.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want source-scope argument rejection")
+	}
+	if !strings.Contains(err.Error(), "escapes plugin workdir") {
+		t.Fatalf("Run() error = %v, want workdir escape rejection", err)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeRejectsArgumentEscapingRepository(t *testing.T) {
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, nil, "../../escape.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want repository-scope argument rejection")
+	}
+	if !strings.Contains(err.Error(), "escapes plugin repository") {
+		t.Fatalf("Run() error = %v, want repository escape rejection", err)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeRejectsIncludedFileSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on Windows test hosts")
+	}
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, "target.txt"), []byte("target\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(repository, "shared.txt")); err != nil {
+		t.Skipf("Symlink() unavailable: %v", err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, []string{"shared.txt"}, "../shared.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want included symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Run() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeRejectsIncludedDirectorySymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on Windows test hosts")
+	}
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repository, "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(repository, "linked")); err != nil {
+		t.Skipf("Symlink() unavailable: %v", err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, []string{"linked/**"}, "../linked/file.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want included directory symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Run() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeRejectsIncludedGitMetadata(t *testing.T) {
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repository, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, ".git", "config"), []byte("private\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, []string{"**"}, "../shared.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want .git metadata rejection")
+	}
+	if !strings.Contains(err.Error(), ".git metadata") {
+		t.Fatalf("Run() error = %v, want .git metadata rejection", err)
+	}
+}
+
+func TestDefaultRunnerRepositoryCopyScopeRejectsBackslashInclude(t *testing.T) {
+	repository := t.TempDir()
+	source := filepath.Join(repository, "app")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir:     source,
+		RepositoryDir: repository,
+		SourceRelPath: "app",
+		Config:        repositoryCopyTestConfig(t, []string{`shared\**`}, "../shared/file.txt"),
+		ProtectedRoots: []string{
+			repository,
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want backslash include rejection")
+	}
+	if !strings.Contains(err.Error(), "slash-normalized") {
+		t.Fatalf("Run() error = %v, want slash-normalized rejection", err)
+	}
+}
+
+func TestDefaultRunnerRedactsSensitiveArguments(t *testing.T) {
+	source := t.TempDir()
+	t.Setenv("DRYDOCK_PLUGINEXEC_HELPER", "1")
+	const secret = "top-secret-argument"
+	_, err := (DefaultRunner{}).Run(context.Background(), Request{
+		SourceDir: source,
+		Config: pluginpolicy.ExecConfig{
+			Workdir: pluginpolicy.ExecWorkdirSource,
+			Generate: pluginpolicy.ExecCommand{
+				Command: []string{helperPath(t), "-test.run=TestHelperProcess", "--", "manifest", "../" + secret},
+				Timeout: pluginExecCommandTimeout,
+			},
+			Env: pluginpolicy.ExecEnv{Allow: []string{"DRYDOCK_PLUGINEXEC_HELPER"}},
+			Output: pluginpolicy.ExecOutput{
+				MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+				MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+			},
+		},
+		ProtectedRoots:  []string{source},
+		SensitiveValues: []string{secret},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want argument rejection")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("Run() error leaked sensitive argument: %v", err)
+	}
+	if !strings.Contains(err.Error(), "<redacted>") {
+		t.Fatalf("Run() error = %v, want redacted marker", err)
 	}
 }
 
@@ -366,42 +658,91 @@ func TestHelperProcess(t *testing.T) {
 	if os.Getenv("DRYDOCK_PLUGINEXEC_HELPER") != "1" {
 		return
 	}
-	args := os.Args
-	for len(args) > 0 && args[0] != "--" {
-		args = args[1:]
-	}
+	args := helperProcessArgs(os.Args)
 	if len(args) < 2 {
 		os.Exit(2)
 	}
+	os.Exit(runHelperProcess(args))
+}
+
+func helperProcessArgs(args []string) []string {
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	return args
+}
+
+func runHelperProcess(args []string) int {
 	switch args[1] {
 	case "manifest":
-		if _, err := os.Stat("marker.txt"); err == nil {
-			_ = os.WriteFile("generated.txt", []byte("temp"), 0o644)
-		}
-		fmt.Println("apiVersion: v1")
-		fmt.Println("kind: ConfigMap")
-		fmt.Println("metadata:")
-		fmt.Println("  name: rendered")
-		os.Exit(0)
+		return runHelperManifest()
 	case "raw":
-		fmt.Println("base")
-		os.Exit(0)
+		return runHelperRaw()
 	case "append":
-		input, _ := io.ReadAll(os.Stdin)
-		fmt.Print(string(input))
-		if len(args) > 2 {
-			fmt.Println(args[2])
-		}
-		os.Exit(0)
+		return runHelperAppend(args)
+	case "env":
+		return runHelperEnv()
+	case "read":
+		return runHelperRead(args)
 	case "sleep":
-		time.Sleep(5 * time.Second)
-		os.Exit(0)
+		return runHelperSleep()
 	case "fail":
-		fmt.Fprintln(os.Stderr, "stderr secret:", os.Getenv("DRYDOCK_PLUGINEXEC_SECRET"))
-		os.Exit(7)
+		return runHelperFail()
 	default:
-		os.Exit(2)
+		return 2
 	}
+}
+
+func runHelperManifest() int {
+	if _, err := os.Stat("marker.txt"); err == nil {
+		_ = os.WriteFile("generated.txt", []byte("temp"), 0o644)
+	}
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: rendered")
+	return 0
+}
+
+func runHelperRaw() int {
+	fmt.Println("base")
+	return 0
+}
+
+func runHelperAppend(args []string) int {
+	input, _ := io.ReadAll(os.Stdin)
+	fmt.Print(string(input))
+	if len(args) > 2 {
+		fmt.Println(args[2])
+	}
+	return 0
+}
+
+func runHelperEnv() int {
+	fmt.Println(os.Getenv("PARAM_PATH"))
+	return 0
+}
+
+func runHelperRead(args []string) int {
+	for _, name := range args[2:] {
+		data, err := os.ReadFile(name)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 3
+		}
+		fmt.Print(string(data))
+	}
+	return 0
+}
+
+func runHelperSleep() int {
+	time.Sleep(5 * time.Second)
+	return 0
+}
+
+func runHelperFail() int {
+	fmt.Fprintln(os.Stderr, "stderr secret:", os.Getenv("DRYDOCK_PLUGINEXEC_SECRET"))
+	return 7
 }
 
 func helperPath(t *testing.T) string {
@@ -411,4 +752,30 @@ func helperPath(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func sourceCopyTestConfig(t *testing.T, readPath string) pluginpolicy.ExecConfig {
+	t.Helper()
+	return pluginpolicy.ExecConfig{
+		Workdir: pluginpolicy.ExecWorkdirSource,
+		Generate: pluginpolicy.ExecCommand{
+			Command: []string{helperPath(t), "-test.run=TestHelperProcess", "--", "read", readPath},
+			Timeout: pluginExecCommandTimeout,
+		},
+		Env: pluginpolicy.ExecEnv{Allow: []string{"DRYDOCK_PLUGINEXEC_HELPER"}},
+		Output: pluginpolicy.ExecOutput{
+			MaxStdoutBytes: pluginpolicy.DefaultMaxStdoutBytes,
+			MaxStderrBytes: pluginpolicy.DefaultMaxStderrBytes,
+		},
+	}
+}
+
+func repositoryCopyTestConfig(t *testing.T, include []string, readPath string) pluginpolicy.ExecConfig {
+	t.Helper()
+	config := sourceCopyTestConfig(t, readPath)
+	config.Copy = pluginpolicy.ExecCopy{
+		Scope:   pluginpolicy.ExecCopyScopeRepository,
+		Include: include,
+	}
+	return config
 }

--- a/internal/pluginpolicy/container_parse.go
+++ b/internal/pluginpolicy/container_parse.go
@@ -1,0 +1,141 @@
+package pluginpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/distribution/reference"
+	"go.yaml.in/yaml/v4"
+)
+
+func parseContainerPlugin(fields map[string]*yaml.Node, path, pointer string) (Plugin, error) {
+	if err := rejectUnknownFields(fields, containerPluginAllowedFields(), pointer); err != nil {
+		return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	optional, err := parsePluginOptionalFields(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	runtime, err := parseContainerRuntime(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	allowMutableImageTag, err := parseContainerAllowMutableImageTag(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	image, err := parseContainerImage(fields, allowMutableImageTag, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	network, err := parseContainerNetwork(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	lifecycle, err := parseExecLifecycleConfig(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	return Plugin{
+		Engine:                 EngineContainer,
+		Match:                  optional.matchPtr(),
+		ConfigManagementPlugin: optional.seedPtr(),
+		Container: &ContainerConfig{
+			Runtime:              runtime,
+			Image:                image,
+			AllowMutableImageTag: allowMutableImageTag,
+			Network:              network,
+			Lifecycle:            lifecycle,
+		},
+	}, nil
+}
+
+func containerPluginAllowedFields() map[string]bool {
+	fields := execLifecycleAllowedFields()
+	fields["engine"] = true
+	fields["match"] = true
+	fields["configManagementPlugin"] = true
+	fields["runtime"] = true
+	fields["image"] = true
+	fields["allowMutableImageTag"] = true
+	fields["network"] = true
+	return fields
+}
+
+func parseContainerRuntime(fields map[string]*yaml.Node, path, pointer string) (ContainerRuntime, error) {
+	runtime := DefaultContainerRuntime
+	if node := fields["runtime"]; node != nil {
+		value, err := stringValue(node, pointer+".runtime")
+		if err != nil {
+			return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		runtime = ContainerRuntime(strings.TrimSpace(value))
+	}
+	switch runtime {
+	case ContainerRuntimeDocker:
+		return runtime, nil
+	default:
+		return "", fmt.Errorf("parse plugin policy %s: %s.runtime has unsupported container runtime %q", path, pointer, runtime)
+	}
+}
+
+func parseContainerAllowMutableImageTag(fields map[string]*yaml.Node, path, pointer string) (bool, error) {
+	if fields["allowMutableImageTag"] == nil {
+		return false, nil
+	}
+	allow, err := boolValue(fields["allowMutableImageTag"], pointer+".allowMutableImageTag")
+	if err != nil {
+		return false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	return allow, nil
+}
+
+func parseContainerImage(fields map[string]*yaml.Node, allowMutableImageTag bool, path, pointer string) (string, error) {
+	value, err := requiredString(fields, "image", pointer+".image")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	image := strings.TrimSpace(value)
+	if image == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image must not be empty", path, pointer)
+	}
+	ref, err := reference.Parse(image)
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image %q is invalid: %w", path, pointer, image, err)
+	}
+	named, ok := ref.(reference.Named)
+	if !ok {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image %q must be a named image reference", path, pointer, image)
+	}
+	if reference.Domain(named) == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image %q must be fully qualified with a registry host", path, pointer, image)
+	}
+	_, hasDigest := ref.(reference.Digested)
+	if hasDigest {
+		return image, nil
+	}
+	if _, hasTag := ref.(reference.Tagged); !hasTag {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image %q must include a digest or tag", path, pointer, image)
+	}
+	if !allowMutableImageTag {
+		return "", fmt.Errorf("parse plugin policy %s: %s.image digest is required unless allowMutableImageTag is true", path, pointer)
+	}
+	return image, nil
+}
+
+func parseContainerNetwork(fields map[string]*yaml.Node, path, pointer string) (ContainerNetwork, error) {
+	network := DefaultContainerNetwork
+	if node := fields["network"]; node != nil {
+		value, err := stringValue(node, pointer+".network")
+		if err != nil {
+			return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		network = ContainerNetwork(strings.TrimSpace(value))
+	}
+	switch network {
+	case ContainerNetworkNone, ContainerNetworkDefault:
+		return network, nil
+	default:
+		return "", fmt.Errorf("parse plugin policy %s: %s.network has unsupported container network %q", path, pointer, network)
+	}
+}

--- a/internal/pluginpolicy/exec_parse.go
+++ b/internal/pluginpolicy/exec_parse.go
@@ -12,42 +12,31 @@ import (
 )
 
 func parseExecConfig(fields map[string]*yaml.Node, path, pointer string) (ExecConfig, error) {
-	allowed := map[string]bool{
-		"engine":        true,
-		"workdir":       true,
-		"init":          true,
-		"generate":      true,
-		"postRenderers": true,
-		"env":           true,
-		"output":        true,
-	}
-	if err := rejectUnknownFields(fields, allowed, pointer); err != nil {
+	if err := rejectUnknownFields(fields, execPluginAllowedFields(), pointer); err != nil {
 		return ExecConfig{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
 	}
-	workdir := ExecWorkdirSource
-	if node := fields["workdir"]; node != nil {
-		got, err := stringValue(node, pointer+".workdir")
-		if err != nil {
-			return ExecConfig{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
-		}
-		workdir = got
+	return parseExecLifecycleConfig(fields, path, pointer)
+}
+
+func parseExecLifecycleConfig(fields map[string]*yaml.Node, path, pointer string) (ExecConfig, error) {
+	workdir, err := parseExecWorkdir(fields, path, pointer)
+	if err != nil {
+		return ExecConfig{}, err
 	}
-	if workdir != ExecWorkdirSource {
-		return ExecConfig{}, fmt.Errorf("parse plugin policy %s: %s.workdir must be %q", path, pointer, ExecWorkdirSource)
+	copyConfig, err := parseExecCopy(fields["copy"], path, pointer+".copy")
+	if err != nil {
+		return ExecConfig{}, err
 	}
 
+	initCommand, hasInit, err := parseExecInit(fields, path, pointer)
+	if err != nil {
+		return ExecConfig{}, err
+	}
 	var init *ExecCommand
-	if node := fields["init"]; node != nil && !isNullNode(node) {
-		command, err := parseExecCommand(node, path, pointer+".init", DefaultInitTimeout)
-		if err != nil {
-			return ExecConfig{}, err
-		}
-		init = &command
+	if hasInit {
+		init = &initCommand
 	}
-	if fields["generate"] == nil || isNullNode(fields["generate"]) {
-		return ExecConfig{}, fmt.Errorf("parse plugin policy %s: missing required field %s.generate", path, pointer)
-	}
-	generate, err := parseExecCommand(fields["generate"], path, pointer+".generate", DefaultGenerateTimeout)
+	generate, err := parseExecGenerate(fields, path, pointer)
 	if err != nil {
 		return ExecConfig{}, err
 	}
@@ -59,18 +48,138 @@ func parseExecConfig(fields map[string]*yaml.Node, path, pointer string) (ExecCo
 	if err != nil {
 		return ExecConfig{}, err
 	}
+	parameters, err := parseExecParameters(fields["parameters"], copyConfig.Scope, path, pointer+".parameters")
+	if err != nil {
+		return ExecConfig{}, err
+	}
 	output, err := parseExecOutput(fields["output"], path, pointer+".output")
 	if err != nil {
 		return ExecConfig{}, err
 	}
 	return ExecConfig{
 		Workdir:       workdir,
+		Copy:          copyConfig,
 		Init:          init,
 		Generate:      generate,
 		PostRenderers: postRenderers,
 		Env:           env,
+		Parameters:    parameters,
 		Output:        output,
 	}, nil
+}
+
+func parseExecWorkdir(fields map[string]*yaml.Node, path, pointer string) (string, error) {
+	workdir := ExecWorkdirSource
+	if node := fields["workdir"]; node != nil {
+		got, err := stringValue(node, pointer+".workdir")
+		if err != nil {
+			return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		workdir = got
+	}
+	if workdir != ExecWorkdirSource {
+		return "", fmt.Errorf("parse plugin policy %s: %s.workdir must be %q", path, pointer, ExecWorkdirSource)
+	}
+	return workdir, nil
+}
+
+func parseExecInit(fields map[string]*yaml.Node, path, pointer string) (ExecCommand, bool, error) {
+	node := fields["init"]
+	if node == nil || isNullNode(node) {
+		return ExecCommand{}, false, nil
+	}
+	command, err := parseExecCommand(node, path, pointer+".init", DefaultInitTimeout)
+	if err != nil {
+		return ExecCommand{}, false, err
+	}
+	return command, true, nil
+}
+
+func parseExecGenerate(fields map[string]*yaml.Node, path, pointer string) (ExecCommand, error) {
+	if fields["generate"] == nil || isNullNode(fields["generate"]) {
+		return ExecCommand{}, fmt.Errorf("parse plugin policy %s: missing required field %s.generate", path, pointer)
+	}
+	return parseExecCommand(fields["generate"], path, pointer+".generate", DefaultGenerateTimeout)
+}
+
+func parseExecCopy(node *yaml.Node, path, pointer string) (ExecCopy, error) {
+	out := ExecCopy{Scope: ExecCopyScopeSource}
+	if node == nil || isNullNode(node) {
+		return out, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fields[name] = node.Content[i+1]
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"scope": true, "include": true}, pointer); err != nil {
+		return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["scope"] != nil {
+		scope, err := stringValue(fields["scope"], pointer+".scope")
+		if err != nil {
+			return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		out.Scope = strings.TrimSpace(scope)
+	}
+	switch out.Scope {
+	case ExecCopyScopeSource, ExecCopyScopeRepository:
+	default:
+		return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %s.scope has unsupported copy scope %q", path, pointer, out.Scope)
+	}
+	include, err := parseExecCopyInclude(fields["include"], path, pointer+".include")
+	if err != nil {
+		return ExecCopy{}, err
+	}
+	out.Include = include
+	if out.Scope == ExecCopyScopeRepository && len(out.Include) == 0 {
+		return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %s.include is required when scope is %q", path, pointer, ExecCopyScopeRepository)
+	}
+	if out.Scope == ExecCopyScopeSource && len(out.Include) > 0 {
+		return ExecCopy{}, fmt.Errorf("parse plugin policy %s: %s.include is only supported when scope is %q", path, pointer, ExecCopyScopeRepository)
+	}
+	return out, nil
+}
+
+func parseExecCopyInclude(node *yaml.Node, path, pointer string) ([]string, error) {
+	if node == nil || isNullNode(node) {
+		return nil, nil
+	}
+	include, err := stringSequence(node, pointer)
+	if err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if len(include) > maxExecCopyIncludeCount {
+		return nil, fmt.Errorf("parse plugin policy %s: %s has %d entries, maximum is %d", path, pointer, len(include), maxExecCopyIncludeCount)
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(include))
+	for index, raw := range include {
+		raw = strings.TrimSpace(raw)
+		if strings.Contains(raw, `\`) {
+			return nil, fmt.Errorf("parse plugin policy %s: %s[%d] is invalid: backslashes are not allowed", path, pointer, index)
+		}
+		pattern := filepath.ToSlash(raw)
+		if pattern == "" {
+			return nil, fmt.Errorf("parse plugin policy %s: %s[%d] must not be empty", path, pointer, index)
+		}
+		if err := validateRepositoryRelativePattern(pattern); err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %s[%d] is invalid: %w", path, pointer, index, err)
+		}
+		if _, ok := seen[pattern]; ok {
+			return nil, fmt.Errorf("parse plugin policy %s: %s contains duplicate include pattern %q", path, pointer, pattern)
+		}
+		seen[pattern] = struct{}{}
+		out = append(out, pattern)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 func parsePostRenderers(node *yaml.Node, path, pointer string) ([]ExecCommand, error) {
@@ -180,6 +289,251 @@ func parseExecEnv(node *yaml.Node, path, pointer string) (ExecEnv, error) {
 	return ExecEnv{Allow: normalized}, nil
 }
 
+func parseExecParameters(node *yaml.Node, copyScope string, path, pointer string) (ExecParameters, error) {
+	if node == nil || isNullNode(node) {
+		return ExecParameters{}, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return ExecParameters{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return ExecParameters{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"allow": true}, pointer); err != nil {
+		return ExecParameters{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	allowNode := fields["allow"]
+	if allowNode == nil || isNullNode(allowNode) {
+		return ExecParameters{}, nil
+	}
+	if allowNode.Kind != yaml.SequenceNode {
+		return ExecParameters{}, fmt.Errorf("parse plugin policy %s: %s.allow must be a sequence", path, pointer)
+	}
+	if len(allowNode.Content) > maxExecParameterAllowCount {
+		return ExecParameters{}, fmt.Errorf("parse plugin policy %s: %s.allow has %d entries, maximum is %d", path, pointer, len(allowNode.Content), maxExecParameterAllowCount)
+	}
+	allow, err := parseExecParameterAllow(allowNode, copyScope, path, pointer)
+	if err != nil {
+		return ExecParameters{}, err
+	}
+	return ExecParameters{Allow: allow}, nil
+}
+
+type execParameterSeen struct {
+	names    map[string]struct{}
+	envNames map[string]string
+}
+
+func newExecParameterSeen() execParameterSeen {
+	return execParameterSeen{
+		names:    map[string]struct{}{},
+		envNames: map[string]string{},
+	}
+}
+
+func parseExecParameterAllow(node *yaml.Node, copyScope string, path, pointer string) ([]ExecParameter, error) {
+	seen := newExecParameterSeen()
+	allow := make([]ExecParameter, 0, len(node.Content))
+	for index, child := range node.Content {
+		item, err := parseExecParameter(child, path, fmt.Sprintf("%s.allow[%d]", pointer, index))
+		if err != nil {
+			return nil, err
+		}
+		if err := validateExecParameterCopyScope(item, copyScope, path, pointer, index); err != nil {
+			return nil, err
+		}
+		if err := seen.add(item, path, pointer); err != nil {
+			return nil, err
+		}
+		allow = append(allow, item)
+	}
+	sort.Slice(allow, func(i, j int) bool { return allow[i].Name < allow[j].Name })
+	return allow, nil
+}
+
+func validateExecParameterCopyScope(item ExecParameter, copyScope string, path, pointer string, index int) error {
+	if item.Path == nil || item.Path.Base != ExecParameterPathBaseRepository || copyScope == ExecCopyScopeRepository {
+		return nil
+	}
+	return fmt.Errorf("parse plugin policy %s: %s.allow[%d].path.base %q requires copy.scope %q", path, pointer, index, ExecParameterPathBaseRepository, ExecCopyScopeRepository)
+}
+
+func (seen execParameterSeen) add(item ExecParameter, path, pointer string) error {
+	if _, ok := seen.names[item.Name]; ok {
+		return fmt.Errorf("parse plugin policy %s: %s.allow contains duplicate parameter name %q", path, pointer, item.Name)
+	}
+	seen.names[item.Name] = struct{}{}
+	envName := parameterEnvName(item.Name)
+	if existing, ok := seen.envNames[envName]; ok {
+		return fmt.Errorf("parse plugin policy %s: %s.allow parameter names %q and %q collide in environment variable %q", path, pointer, existing, item.Name, envName)
+	}
+	seen.envNames[envName] = item.Name
+	return nil
+}
+
+func parseExecParameter(node *yaml.Node, path, pointer string) (ExecParameter, error) {
+	if node.Kind != yaml.MappingNode {
+		return ExecParameter{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return ExecParameter{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"name": true, "type": true, "required": true, "path": true}, pointer); err != nil {
+		return ExecParameter{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	name, err := parseExecParameterName(fields, path, pointer)
+	if err != nil {
+		return ExecParameter{}, err
+	}
+	typ, err := parseExecParameterType(fields, path, pointer)
+	if err != nil {
+		return ExecParameter{}, err
+	}
+	required, err := parseExecParameterRequired(fields, path, pointer)
+	if err != nil {
+		return ExecParameter{}, err
+	}
+	pathConstraintValue, hasPathConstraint, err := parseExecParameterPathConstraint(fields["path"], typ, path, pointer)
+	if err != nil {
+		return ExecParameter{}, err
+	}
+	var pathConstraint *ExecParameterPath
+	if hasPathConstraint {
+		pathConstraint = &pathConstraintValue
+	}
+	return ExecParameter{Name: name, Type: typ, Required: required, Path: pathConstraint}, nil
+}
+
+func parseExecParameterName(fields map[string]*yaml.Node, path, pointer string) (string, error) {
+	name, err := requiredString(fields, "name", pointer+".name")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty", path, pointer)
+	}
+	if !parameterNamePattern.MatchString(name) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name %q is invalid", path, pointer, name)
+	}
+	return name, nil
+}
+
+func parseExecParameterType(fields map[string]*yaml.Node, path, pointer string) (ExecParameterType, error) {
+	typValue, err := requiredString(fields, "type", pointer+".type")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	typ := ExecParameterType(strings.TrimSpace(typValue))
+	switch typ {
+	case ExecParameterTypeString, ExecParameterTypeArray, ExecParameterTypeMap:
+		return typ, nil
+	default:
+		return "", fmt.Errorf("parse plugin policy %s: %s.type has unsupported parameter type %q", path, pointer, typValue)
+	}
+}
+
+func parseExecParameterRequired(fields map[string]*yaml.Node, path, pointer string) (bool, error) {
+	if fields["required"] == nil {
+		return false, nil
+	}
+	required, err := boolValue(fields["required"], pointer+".required")
+	if err != nil {
+		return false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	return required, nil
+}
+
+func parseExecParameterPathConstraint(node *yaml.Node, typ ExecParameterType, path, pointer string) (ExecParameterPath, bool, error) {
+	if node == nil || isNullNode(node) {
+		return ExecParameterPath{}, false, nil
+	}
+	if typ != ExecParameterTypeString {
+		return ExecParameterPath{}, false, fmt.Errorf("parse plugin policy %s: %s.path is only supported for string parameters", path, pointer)
+	}
+	pathConstraint, err := parseExecParameterPath(node, path, pointer+".path")
+	if err != nil {
+		return ExecParameterPath{}, false, err
+	}
+	return *pathConstraint, true, nil
+}
+
+func parseExecParameterPath(node *yaml.Node, path, pointer string) (*ExecParameterPath, error) {
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fields[name] = node.Content[i+1]
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"base": true, "allow": true}, pointer); err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	base := ExecParameterPathBaseSource
+	if fields["base"] != nil {
+		value, err := stringValue(fields["base"], pointer+".base")
+		if err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		base = strings.TrimSpace(value)
+	}
+	switch base {
+	case ExecParameterPathBaseSource, ExecParameterPathBaseRepository:
+	default:
+		return nil, fmt.Errorf("parse plugin policy %s: %s.base has unsupported path base %q", path, pointer, base)
+	}
+	allow, err := stringSequence(fields["allow"], pointer+".allow")
+	if fields["allow"] != nil && err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	normalized := make([]string, 0, len(allow))
+	seen := map[string]struct{}{}
+	for index, raw := range allow {
+		raw = strings.TrimSpace(raw)
+		if strings.Contains(raw, `\`) {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must use slash-normalized paths", path, pointer, index)
+		}
+		value := filepath.ToSlash(raw)
+		if value == "" {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must not be empty", path, pointer, index)
+		}
+		if err := validateRepositoryRelativePattern(value); err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must be a relative non-escaping glob: %w", path, pointer, index, err)
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return &ExecParameterPath{Base: base, Allow: normalized}, nil
+}
+
+func validateRepositoryRelativePattern(pattern string) error {
+	if filepath.IsAbs(pattern) {
+		return fmt.Errorf("absolute paths are not allowed")
+	}
+	if pattern == "" {
+		return fmt.Errorf("empty paths are not allowed")
+	}
+	for part := range strings.SplitSeq(pattern, "/") {
+		switch part {
+		case "..":
+			return fmt.Errorf("parent directory segments are not allowed")
+		case ".git":
+			return fmt.Errorf(".git paths are not allowed")
+		}
+	}
+	return nil
+}
+
 func parseExecOutput(node *yaml.Node, path, pointer string) (ExecOutput, error) {
 	output := ExecOutput{
 		MaxStdoutBytes: DefaultMaxStdoutBytes,
@@ -254,9 +608,12 @@ func isDeniedInterpreter(command string) bool {
 }
 
 var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var parameterNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+var bootstrapEntrypointNamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 var reservedExecEnvNames = map[string]struct{}{
 	"PATH":                        {},
+	"ARGOCD_APP_PARAMETERS":       {},
 	"BASH_ENV":                    {},
 	"ENV":                         {},
 	"PYTHONPATH":                  {},
@@ -272,7 +629,7 @@ var reservedExecEnvNames = map[string]struct{}{
 	"POWERSHELL_TELEMETRY_OPTOUT": {},
 }
 
-var reservedExecEnvPrefixes = []string{"LD_", "DYLD_"}
+var reservedExecEnvPrefixes = []string{"LD_", "DYLD_", "PARAM_"}
 
 func validateEnvName(name string) error {
 	if !envNamePattern.MatchString(name) {
@@ -288,4 +645,9 @@ func validateEnvName(name string) error {
 		}
 	}
 	return nil
+}
+
+func parameterEnvName(name string) string {
+	name = strings.ToUpper(name)
+	return regexp.MustCompile(`[^A-Z0-9_]`).ReplaceAllString(name, "_")
 }

--- a/internal/pluginpolicy/fingerprint.go
+++ b/internal/pluginpolicy/fingerprint.go
@@ -1,24 +1,84 @@
 package pluginpolicy
 
-import "fmt"
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+)
 
 type fingerprintPolicy struct {
 	APIVersion string                       `json:"apiVersion"`
 	Kind       string                       `json:"kind"`
+	Bootstrap  *fingerprintBootstrap        `json:"bootstrap,omitempty"`
 	Plugins    map[string]fingerprintPlugin `json:"plugins"`
 }
 
-type fingerprintPlugin struct {
-	Engine Engine                 `json:"engine"`
-	Exec   *fingerprintExecConfig `json:"exec,omitempty"`
+type fingerprintBootstrap struct {
+	Entrypoints []fingerprintBootstrapEntrypoint `json:"entrypoints"`
 }
 
-type fingerprintExecConfig struct {
+type fingerprintBootstrapEntrypoint struct {
+	Name       string                 `json:"name"`
+	Plugin     string                 `json:"plugin"`
+	SourcePath string                 `json:"sourcePath"`
+	Parameters []fingerprintParameter `json:"parameters,omitempty"`
+}
+
+type fingerprintParameter struct {
+	Name   string                         `json:"name"`
+	String *string                        `json:"string,omitempty"`
+	Array  *fingerprintParameterArray     `json:"array,omitempty"`
+	Map    *fingerprintParameterStringMap `json:"map,omitempty"`
+}
+
+type fingerprintParameterArray struct {
+	Values []string `json:"values"`
+}
+
+type fingerprintParameterStringMap struct {
+	Values map[string]string `json:"values"`
+}
+
+type fingerprintPlugin struct {
+	Engine                 Engine                             `json:"engine"`
+	Match                  *fingerprintPluginMatch            `json:"match,omitempty"`
+	ConfigManagementPlugin *fingerprintConfigManagementPlugin `json:"configManagementPlugin,omitempty"`
+	Exec                   *fingerprintLifecycleConfig        `json:"exec,omitempty"`
+	Container              *fingerprintContainerConfig        `json:"container,omitempty"`
+}
+
+type fingerprintPluginMatch struct {
+	Discover fingerprintPluginDiscoverMatch `json:"discover"`
+}
+
+type fingerprintPluginDiscoverMatch struct {
+	FileName string               `json:"fileName,omitempty"`
+	Find     *fingerprintFindGlob `json:"find,omitempty"`
+}
+
+type fingerprintFindGlob struct {
+	Glob string `json:"glob"`
+}
+
+type fingerprintConfigManagementPlugin struct {
+	Discover *fingerprintPluginDiscoverMatch       `json:"discover,omitempty"`
+	Generate *fingerprintConfigManagementPluginGen `json:"generate,omitempty"`
+}
+
+type fingerprintConfigManagementPluginGen struct {
+	Command []string `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+}
+
+type fingerprintLifecycleConfig struct {
 	Workdir       string               `json:"workdir"`
+	Copy          ExecCopy             `json:"copy"`
 	Init          *fingerprintCommand  `json:"init,omitempty"`
 	Generate      fingerprintCommand   `json:"generate"`
 	PostRenderers []fingerprintCommand `json:"postRenderers,omitempty"`
 	Env           ExecEnv              `json:"env"`
+	Parameters    ExecParameters       `json:"parameters"`
 	Output        ExecOutput           `json:"output"`
 }
 
@@ -27,39 +87,229 @@ type fingerprintCommand struct {
 	Timeout string   `json:"timeout"`
 }
 
+type fingerprintContainerConfig struct {
+	Runtime              ContainerRuntime           `json:"runtime"`
+	Image                string                     `json:"image"`
+	AllowMutableImageTag bool                       `json:"allowMutableImageTag"`
+	Network              ContainerNetwork           `json:"network"`
+	Lifecycle            fingerprintLifecycleConfig `json:"lifecycle"`
+}
+
 func newFingerprintPlugin(plugin Plugin) (fingerprintPlugin, error) {
-	out := fingerprintPlugin{Engine: plugin.Engine}
-	if plugin.Engine != EngineExec {
+	out := fingerprintPlugin{
+		Engine:                 plugin.Engine,
+		Match:                  clonePluginMatch(plugin.Match),
+		ConfigManagementPlugin: cloneConfigManagementPluginSeed(plugin.ConfigManagementPlugin),
+	}
+	switch plugin.Engine {
+	case EngineAVPCompat, EngineNativeKustomize:
 		return out, nil
+	case EngineExec:
+		if plugin.Exec == nil {
+			if plugin.ConfigManagementPlugin != nil {
+				return out, nil
+			}
+			return fingerprintPlugin{}, fmt.Errorf("exec config is required")
+		}
+		out.Exec = newFingerprintLifecycleConfig(plugin.Exec)
+	case EngineContainer:
+		if plugin.Container == nil {
+			return fingerprintPlugin{}, fmt.Errorf("container config is required")
+		}
+		out.Container = &fingerprintContainerConfig{
+			Runtime:              plugin.Container.Runtime,
+			Image:                plugin.Container.Image,
+			AllowMutableImageTag: plugin.Container.AllowMutableImageTag,
+			Network:              plugin.Container.Network,
+			Lifecycle:            *newFingerprintLifecycleConfig(&plugin.Container.Lifecycle),
+		}
+	default:
+		return fingerprintPlugin{}, fmt.Errorf("unsupported engine %q", plugin.Engine)
 	}
-	if plugin.Exec == nil {
-		return fingerprintPlugin{}, fmt.Errorf("exec config is required")
-	}
-	out.Exec = &fingerprintExecConfig{
-		Workdir: plugin.Exec.Workdir,
+	return out, nil
+}
+
+func newFingerprintLifecycleConfig(config *ExecConfig) *fingerprintLifecycleConfig {
+	out := &fingerprintLifecycleConfig{
+		Workdir: config.Workdir,
+		Copy: ExecCopy{
+			Scope:   config.Copy.Scope,
+			Include: append([]string(nil), config.Copy.Include...),
+		},
 		Generate: fingerprintCommand{
-			Command: append([]string(nil), plugin.Exec.Generate.Command...),
-			Timeout: plugin.Exec.Generate.Timeout.String(),
+			Command: append([]string(nil), config.Generate.Command...),
+			Timeout: config.Generate.Timeout.String(),
 		},
 		Env: ExecEnv{
-			Allow: append([]string(nil), plugin.Exec.Env.Allow...),
+			Allow: append([]string(nil), config.Env.Allow...),
 		},
-		Output: plugin.Exec.Output,
+		Parameters: cloneExecParameters(config.Parameters),
+		Output:     config.Output,
 	}
-	if plugin.Exec.Init != nil {
-		out.Exec.Init = &fingerprintCommand{
-			Command: append([]string(nil), plugin.Exec.Init.Command...),
-			Timeout: plugin.Exec.Init.Timeout.String(),
+	if config.Init != nil {
+		out.Init = &fingerprintCommand{
+			Command: append([]string(nil), config.Init.Command...),
+			Timeout: config.Init.Timeout.String(),
 		}
 	}
-	if len(plugin.Exec.PostRenderers) > 0 {
-		out.Exec.PostRenderers = make([]fingerprintCommand, 0, len(plugin.Exec.PostRenderers))
-		for _, command := range plugin.Exec.PostRenderers {
-			out.Exec.PostRenderers = append(out.Exec.PostRenderers, fingerprintCommand{
+	if len(config.PostRenderers) > 0 {
+		out.PostRenderers = make([]fingerprintCommand, 0, len(config.PostRenderers))
+		for _, command := range config.PostRenderers {
+			out.PostRenderers = append(out.PostRenderers, fingerprintCommand{
 				Command: append([]string(nil), command.Command...),
 				Timeout: command.Timeout.String(),
 			})
 		}
 	}
+	return out
+}
+
+func newFingerprintBootstrap(bootstrap Bootstrap, plugins map[string]Plugin) (fingerprintBootstrap, bool, error) {
+	if len(bootstrap.Entrypoints) == 0 {
+		return fingerprintBootstrap{}, false, nil
+	}
+	seen := map[string]struct{}{}
+	entrypoints := make([]fingerprintBootstrapEntrypoint, 0, len(bootstrap.Entrypoints))
+	for _, entrypoint := range bootstrap.Entrypoints {
+		name := strings.TrimSpace(entrypoint.Name)
+		if name == "" {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint name is empty")
+		}
+		if len(name) > 63 || !bootstrapEntrypointNamePattern.MatchString(name) {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint %q is invalid", name)
+		}
+		if _, ok := seen[name]; ok {
+			return fingerprintBootstrap{}, false, fmt.Errorf("duplicate bootstrap entrypoint name %q", name)
+		}
+		seen[name] = struct{}{}
+		pluginName := strings.TrimSpace(entrypoint.Plugin)
+		plugin, ok := plugins[pluginName]
+		if !ok {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint %q references unknown plugin %q", name, pluginName)
+		}
+		if _, _, ok := bootstrapPluginDiscoverRule(plugin); !ok {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint %q plugin %q must define match.discover or configManagementPlugin.discover", name, pluginName)
+		}
+		sourcePath, err := cleanBootstrapSourcePath(entrypoint.SourcePath)
+		if err != nil {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint %q sourcePath: %w", name, err)
+		}
+		parameters, err := cloneBootstrapParameters(entrypoint.Parameters)
+		if err != nil {
+			return fingerprintBootstrap{}, false, fmt.Errorf("bootstrap entrypoint %q: %w", name, err)
+		}
+		entrypoints = append(entrypoints, fingerprintBootstrapEntrypoint{
+			Name:       name,
+			Plugin:     pluginName,
+			SourcePath: sourcePath,
+			Parameters: parameters,
+		})
+	}
+	sort.Slice(entrypoints, func(i, j int) bool {
+		return entrypoints[i].Name < entrypoints[j].Name
+	})
+	return fingerprintBootstrap{Entrypoints: entrypoints}, true, nil
+}
+
+func cloneBootstrapParameters(input []BootstrapParameter) ([]fingerprintParameter, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]fingerprintParameter, 0, len(input))
+	for _, parameter := range input {
+		name := strings.TrimSpace(parameter.Name)
+		if name == "" {
+			return nil, fmt.Errorf("bootstrap parameter name is empty")
+		}
+		if !parameterNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("bootstrap parameter name %q is invalid", name)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate bootstrap parameter name %q", name)
+		}
+		seen[name] = struct{}{}
+		count := 0
+		cloned := fingerprintParameter{Name: name}
+		if parameter.String != nil {
+			value := *parameter.String
+			cloned.String = &value
+			count++
+		}
+		if parameter.Array != nil {
+			cloned.Array = &fingerprintParameterArray{Values: append([]string(nil), parameter.Array.Values...)}
+			count++
+		}
+		if parameter.Map != nil {
+			values := map[string]string{}
+			maps.Copy(values, parameter.Map.Values)
+			cloned.Map = &fingerprintParameterStringMap{Values: values}
+			count++
+		}
+		if count != 1 {
+			return nil, fmt.Errorf("bootstrap parameter %q must contain exactly one of string, array, or map", name)
+		}
+		out = append(out, cloned)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
 	return out, nil
+}
+
+func cloneConfigManagementPluginSeed(input *ConfigManagementPluginSeed) *fingerprintConfigManagementPlugin {
+	if input == nil {
+		return nil
+	}
+	out := &fingerprintConfigManagementPlugin{}
+	if input.Discover != nil {
+		discover := clonePluginDiscoverMatch(*input.Discover)
+		out.Discover = &discover
+	}
+	if input.Generate != nil {
+		out.Generate = &fingerprintConfigManagementPluginGen{
+			Command: append([]string(nil), input.Generate.Command...),
+			Args:    append([]string(nil), input.Generate.Args...),
+		}
+	}
+	return out
+}
+
+func clonePluginMatch(input *PluginMatch) *fingerprintPluginMatch {
+	if input == nil {
+		return nil
+	}
+	out := &fingerprintPluginMatch{
+		Discover: clonePluginDiscoverMatch(input.Discover),
+	}
+	return out
+}
+
+func clonePluginDiscoverMatch(input PluginDiscoverMatch) fingerprintPluginDiscoverMatch {
+	out := fingerprintPluginDiscoverMatch{
+		FileName: input.FileName,
+	}
+	if input.FindGlob != "" {
+		out.Find = &fingerprintFindGlob{Glob: input.FindGlob}
+	}
+	return out
+}
+
+func cloneExecParameters(input ExecParameters) ExecParameters {
+	out := ExecParameters{Allow: make([]ExecParameter, 0, len(input.Allow))}
+	for _, parameter := range input.Allow {
+		cloned := ExecParameter{
+			Name:     parameter.Name,
+			Type:     parameter.Type,
+			Required: parameter.Required,
+		}
+		if parameter.Path != nil {
+			cloned.Path = &ExecParameterPath{
+				Base:  parameter.Path.Base,
+				Allow: append([]string(nil), parameter.Path.Allow...),
+			}
+		}
+		out.Allow = append(out.Allow, cloned)
+	}
+	return out
 }

--- a/internal/pluginpolicy/policy.go
+++ b/internal/pluginpolicy/policy.go
@@ -5,9 +5,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -18,13 +22,20 @@ const (
 	NoPolicyFingerprint = ""
 
 	ExecWorkdirSource          = "source"
+	ExecCopyScopeSource        = "source"
+	ExecCopyScopeRepository    = "repository"
 	DefaultInitTimeout         = 10 * time.Second
 	DefaultGenerateTimeout     = 60 * time.Second
 	DefaultPostRendererTimeout = 30 * time.Second
 	DefaultMaxStdoutBytes      = int64(10 * 1024 * 1024)
 	DefaultMaxStderrBytes      = int64(64 * 1024)
+	DefaultContainerRuntime    = ContainerRuntimeDocker
+	DefaultContainerNetwork    = ContainerNetworkNone
 
 	maxEnvAllowCount = 64
+
+	maxExecParameterAllowCount = 64
+	maxExecCopyIncludeCount    = 64
 )
 
 type Engine string
@@ -33,24 +44,81 @@ const (
 	EngineAVPCompat       Engine = "avp-compat"
 	EngineNativeKustomize Engine = "native-kustomize"
 	EngineExec            Engine = "exec"
+	EngineContainer       Engine = "container"
 )
 
 type Policy struct {
-	Plugins map[string]Plugin
+	Bootstrap Bootstrap
+	Plugins   map[string]Plugin
+}
+
+type Bootstrap struct {
+	Entrypoints []BootstrapEntrypoint
+}
+
+type BootstrapEntrypoint struct {
+	Name       string
+	Plugin     string
+	SourcePath string
+	Parameters []BootstrapParameter
+}
+
+type BootstrapParameter struct {
+	Name   string
+	String *string
+	Array  *BootstrapParameterArray
+	Map    *BootstrapParameterMap
+}
+
+type BootstrapParameterArray struct {
+	Values []string
+}
+
+type BootstrapParameterMap struct {
+	Values map[string]string
 }
 
 type Plugin struct {
-	Engine Engine
-	Exec   *ExecConfig
+	Engine                 Engine
+	Match                  *PluginMatch
+	ConfigManagementPlugin *ConfigManagementPluginSeed
+	Exec                   *ExecConfig
+	Container              *ContainerConfig
+}
+
+type PluginMatch struct {
+	Discover PluginDiscoverMatch
+}
+
+type PluginDiscoverMatch struct {
+	FileName string
+	FindGlob string
+}
+
+type ConfigManagementPluginSeed struct {
+	Discover *PluginDiscoverMatch
+	Generate *ConfigManagementPluginGenerate
+}
+
+type ConfigManagementPluginGenerate struct {
+	Command []string
+	Args    []string
 }
 
 type ExecConfig struct {
 	Workdir       string
+	Copy          ExecCopy
 	Init          *ExecCommand
 	Generate      ExecCommand
 	PostRenderers []ExecCommand
 	Env           ExecEnv
+	Parameters    ExecParameters
 	Output        ExecOutput
+}
+
+type ExecCopy struct {
+	Scope   string
+	Include []string
 }
 
 type ExecCommand struct {
@@ -62,9 +130,59 @@ type ExecEnv struct {
 	Allow []string
 }
 
+type ExecParameterType string
+
+const (
+	ExecParameterTypeString ExecParameterType = "string"
+	ExecParameterTypeArray  ExecParameterType = "array"
+	ExecParameterTypeMap    ExecParameterType = "map"
+)
+
+type ExecParameters struct {
+	Allow []ExecParameter
+}
+
+type ExecParameter struct {
+	Name     string
+	Type     ExecParameterType
+	Required bool
+	Path     *ExecParameterPath
+}
+
+type ExecParameterPath struct {
+	Base  string
+	Allow []string
+}
+
+const (
+	ExecParameterPathBaseSource     = "source"
+	ExecParameterPathBaseRepository = "repository"
+)
+
 type ExecOutput struct {
 	MaxStdoutBytes int64
 	MaxStderrBytes int64
+}
+
+type ContainerRuntime string
+
+const (
+	ContainerRuntimeDocker ContainerRuntime = "docker"
+)
+
+type ContainerNetwork string
+
+const (
+	ContainerNetworkNone    ContainerNetwork = "none"
+	ContainerNetworkDefault ContainerNetwork = "default"
+)
+
+type ContainerConfig struct {
+	Runtime              ContainerRuntime
+	Image                string
+	AllowMutableImageTag bool
+	Network              ContainerNetwork
+	Lifecycle            ExecConfig
 }
 
 func Parse(path string, data []byte) (Policy, error) {
@@ -109,16 +227,25 @@ func Fingerprint(policy Policy) (string, error) {
 			return "", fmt.Errorf("fingerprint plugin policy: plugin %q: %w", normalized, err)
 		}
 		switch plugin.Engine {
-		case EngineAVPCompat, EngineNativeKustomize, EngineExec:
+		case EngineAVPCompat, EngineNativeKustomize, EngineExec, EngineContainer:
 			plugins[normalized] = fingerprint
 		default:
 			return "", fmt.Errorf("fingerprint plugin policy: plugin %q has unsupported engine %q", normalized, plugin.Engine)
 		}
 	}
+	bootstrap, hasBootstrap, err := newFingerprintBootstrap(policy.Bootstrap, policy.Plugins)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint plugin policy: %w", err)
+	}
+	var bootstrapPtr *fingerprintBootstrap
+	if hasBootstrap {
+		bootstrapPtr = &bootstrap
+	}
 
 	input := fingerprintPolicy{
 		APIVersion: apiVersion,
 		Kind:       kind,
+		Bootstrap:  bootstrapPtr,
 		Plugins:    plugins,
 	}
 	data, err := json.Marshal(input)
@@ -143,7 +270,7 @@ func parsePolicy(root *yaml.Node, path string) (Policy, error) {
 			return Policy{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
 		}
 		switch name {
-		case "apiVersion", "kind", "plugins":
+		case "apiVersion", "kind", "bootstrap", "plugins":
 			fields[name] = value
 		default:
 			return Policy{}, fmt.Errorf("parse plugin policy %s: unknown top-level field %q", path, name)
@@ -163,18 +290,303 @@ func parsePolicy(root *yaml.Node, path string) (Policy, error) {
 
 	policy := Policy{Plugins: map[string]Plugin{}}
 	pluginsNode := fields["plugins"]
-	if pluginsNode == nil || isNullNode(pluginsNode) {
-		return policy, nil
+	if pluginsNode != nil && !isNullNode(pluginsNode) {
+		if pluginsNode.Kind != yaml.MappingNode {
+			return Policy{}, fmt.Errorf("parse plugin policy %s: $.plugins must be a mapping", path)
+		}
+		plugins, err := parsePlugins(pluginsNode, path)
+		if err != nil {
+			return Policy{}, err
+		}
+		policy.Plugins = plugins
 	}
-	if pluginsNode.Kind != yaml.MappingNode {
-		return Policy{}, fmt.Errorf("parse plugin policy %s: $.plugins must be a mapping", path)
-	}
-	plugins, err := parsePlugins(pluginsNode, path)
+	bootstrap, err := parseBootstrap(fields["bootstrap"], policy.Plugins, path)
 	if err != nil {
 		return Policy{}, err
 	}
-	policy.Plugins = plugins
+	policy.Bootstrap = bootstrap
 	return policy, nil
+}
+
+func parseBootstrap(node *yaml.Node, plugins map[string]Plugin, policyPath string) (Bootstrap, error) {
+	if node == nil {
+		return Bootstrap{}, nil
+	}
+	if isNullNode(node) {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: $.bootstrap must be a mapping", policyPath)
+	}
+	if node.Kind != yaml.MappingNode {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: $.bootstrap must be a mapping", policyPath)
+	}
+	fields, err := mappingFields(node, "$.bootstrap")
+	if err != nil {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"entrypoints": true}, "$.bootstrap"); err != nil {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	entrypointsNode := fields["entrypoints"]
+	if entrypointsNode == nil || isNullNode(entrypointsNode) {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: missing required field $.bootstrap.entrypoints", policyPath)
+	}
+	if entrypointsNode.Kind != yaml.SequenceNode {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: $.bootstrap.entrypoints must be a sequence", policyPath)
+	}
+	if len(entrypointsNode.Content) == 0 {
+		return Bootstrap{}, fmt.Errorf("parse plugin policy %s: $.bootstrap.entrypoints must not be empty", policyPath)
+	}
+	seen := map[string]struct{}{}
+	entrypoints := make([]BootstrapEntrypoint, 0, len(entrypointsNode.Content))
+	for index, child := range entrypointsNode.Content {
+		pointer := fmt.Sprintf("$.bootstrap.entrypoints[%d]", index)
+		entrypoint, err := parseBootstrapEntrypoint(child, plugins, policyPath, pointer)
+		if err != nil {
+			return Bootstrap{}, err
+		}
+		if _, ok := seen[entrypoint.Name]; ok {
+			return Bootstrap{}, fmt.Errorf("parse plugin policy %s: $.bootstrap.entrypoints contains duplicate name %q", policyPath, entrypoint.Name)
+		}
+		seen[entrypoint.Name] = struct{}{}
+		entrypoints = append(entrypoints, entrypoint)
+	}
+	sort.Slice(entrypoints, func(i, j int) bool {
+		return entrypoints[i].Name < entrypoints[j].Name
+	})
+	return Bootstrap{Entrypoints: entrypoints}, nil
+}
+
+func parseBootstrapEntrypoint(node *yaml.Node, plugins map[string]Plugin, policyPath, pointer string) (BootstrapEntrypoint, error) {
+	if node.Kind != yaml.MappingNode {
+		return BootstrapEntrypoint{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", policyPath, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return BootstrapEntrypoint{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"name": true, "plugin": true, "sourcePath": true, "parameters": true}, pointer); err != nil {
+		return BootstrapEntrypoint{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name, err := parseBootstrapEntrypointName(fields, policyPath, pointer)
+	if err != nil {
+		return BootstrapEntrypoint{}, err
+	}
+	pluginName, plugin, err := parseBootstrapEntrypointPlugin(fields, plugins, policyPath, pointer)
+	if err != nil {
+		return BootstrapEntrypoint{}, err
+	}
+	if _, _, ok := bootstrapPluginDiscoverRule(plugin); !ok {
+		return BootstrapEntrypoint{}, fmt.Errorf("parse plugin policy %s: %s.plugin %q must define match.discover or configManagementPlugin.discover", policyPath, pointer, pluginName)
+	}
+	sourcePath, err := parseBootstrapEntrypointSourcePath(fields, policyPath, pointer)
+	if err != nil {
+		return BootstrapEntrypoint{}, err
+	}
+	parameters, err := parseBootstrapParameters(fields["parameters"], policyPath, pointer+".parameters")
+	if err != nil {
+		return BootstrapEntrypoint{}, err
+	}
+	return BootstrapEntrypoint{
+		Name:       name,
+		Plugin:     pluginName,
+		SourcePath: sourcePath,
+		Parameters: parameters,
+	}, nil
+}
+
+func parseBootstrapEntrypointName(fields map[string]*yaml.Node, policyPath, pointer string) (string, error) {
+	value, err := requiredString(fields, "name", pointer+".name")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty", policyPath, pointer)
+	}
+	if len(name) > 63 || !bootstrapEntrypointNamePattern.MatchString(name) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name %q is invalid", policyPath, pointer, name)
+	}
+	return name, nil
+}
+
+func parseBootstrapEntrypointPlugin(fields map[string]*yaml.Node, plugins map[string]Plugin, policyPath, pointer string) (string, Plugin, error) {
+	value, err := requiredString(fields, "plugin", pointer+".plugin")
+	if err != nil {
+		return "", Plugin{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return "", Plugin{}, fmt.Errorf("parse plugin policy %s: %s.plugin must not be empty", policyPath, pointer)
+	}
+	plugin, ok := plugins[name]
+	if !ok {
+		return "", Plugin{}, fmt.Errorf("parse plugin policy %s: %s.plugin references unknown plugin %q", policyPath, pointer, name)
+	}
+	return name, plugin, nil
+}
+
+func parseBootstrapEntrypointSourcePath(fields map[string]*yaml.Node, policyPath, pointer string) (string, error) {
+	value, err := requiredString(fields, "sourcePath", pointer+".sourcePath")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	sourcePath, err := cleanBootstrapSourcePath(value)
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %s.sourcePath %q is invalid: %w", policyPath, pointer, value, err)
+	}
+	return sourcePath, nil
+}
+
+func cleanBootstrapSourcePath(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("empty paths are not allowed")
+	}
+	if strings.Contains(value, `\`) {
+		return "", fmt.Errorf("backslashes are not allowed")
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	for part := range strings.SplitSeq(value, "/") {
+		switch part {
+		case "":
+			return "", fmt.Errorf("empty path components are not allowed")
+		case ".":
+			if value != "." {
+				return "", fmt.Errorf("dot path components are not allowed")
+			}
+		case "..":
+			return "", fmt.Errorf("parent directory segments are not allowed")
+		case ".git":
+			return "", fmt.Errorf(".git paths are not allowed")
+		}
+	}
+	clean := path.Clean(strings.Trim(value, "/"))
+	if clean == "." {
+		return ".", nil
+	}
+	return clean, nil
+}
+
+func bootstrapPluginDiscoverRule(plugin Plugin) (PluginDiscoverMatch, string, bool) {
+	if plugin.Match != nil {
+		return plugin.Match.Discover, "match.discover", true
+	}
+	if plugin.ConfigManagementPlugin != nil && plugin.ConfigManagementPlugin.Discover != nil {
+		return *plugin.ConfigManagementPlugin.Discover, "configManagementPlugin.discover", true
+	}
+	return PluginDiscoverMatch{}, "", false
+}
+
+func parseBootstrapParameters(node *yaml.Node, policyPath, pointer string) ([]BootstrapParameter, error) {
+	if node == nil || isNullNode(node) {
+		return nil, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a sequence", policyPath, pointer)
+	}
+	seen := map[string]struct{}{}
+	parameters := make([]BootstrapParameter, 0, len(node.Content))
+	for index, child := range node.Content {
+		parameter, err := parseBootstrapParameter(child, policyPath, fmt.Sprintf("%s[%d]", pointer, index))
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[parameter.Name]; ok {
+			return nil, fmt.Errorf("parse plugin policy %s: %s contains duplicate parameter name %q", policyPath, pointer, parameter.Name)
+		}
+		seen[parameter.Name] = struct{}{}
+		parameters = append(parameters, parameter)
+	}
+	sort.Slice(parameters, func(i, j int) bool {
+		return parameters[i].Name < parameters[j].Name
+	})
+	return parameters, nil
+}
+
+func parseBootstrapParameter(node *yaml.Node, policyPath, pointer string) (BootstrapParameter, error) {
+	if node.Kind != yaml.MappingNode {
+		return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", policyPath, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"name": true, "string": true, "array": true, "map": true}, pointer); err != nil {
+		return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name, err := parseBootstrapParameterName(fields, policyPath, pointer)
+	if err != nil {
+		return BootstrapParameter{}, err
+	}
+	count := 0
+	var out BootstrapParameter
+	out.Name = name
+	if fields["string"] != nil {
+		value, err := stringValue(fields["string"], pointer+".string")
+		if err != nil {
+			return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+		}
+		out.String = &value
+		count++
+	}
+	if fields["array"] != nil {
+		values, err := stringSequence(fields["array"], pointer+".array")
+		if err != nil {
+			return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+		}
+		out.Array = &BootstrapParameterArray{Values: values}
+		count++
+	}
+	if fields["map"] != nil {
+		values, err := stringMapValue(fields["map"], pointer+".map")
+		if err != nil {
+			return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+		}
+		out.Map = &BootstrapParameterMap{Values: values}
+		count++
+	}
+	if count != 1 {
+		return BootstrapParameter{}, fmt.Errorf("parse plugin policy %s: %s must contain exactly one of string, array, or map", policyPath, pointer)
+	}
+	return out, nil
+}
+
+func parseBootstrapParameterName(fields map[string]*yaml.Node, policyPath, pointer string) (string, error) {
+	value, err := requiredString(fields, "name", pointer+".name")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty", policyPath, pointer)
+	}
+	if !parameterNamePattern.MatchString(name) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name %q is invalid", policyPath, pointer, name)
+	}
+	return name, nil
+}
+
+func stringMapValue(node *yaml.Node, pointer string) (map[string]string, error) {
+	if node == nil || isNullNode(node) {
+		return map[string]string{}, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("%s must be a mapping", pointer)
+	}
+	values := map[string]string{}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return nil, err
+		}
+		value, err := stringValue(node.Content[i+1], pointer+"."+key)
+		if err != nil {
+			return nil, err
+		}
+		values[key] = value
+	}
+	return values, nil
 }
 
 func parsePlugins(node *yaml.Node, path string) (map[string]Plugin, error) {
@@ -206,15 +618,9 @@ func parsePlugin(node *yaml.Node, path, pointer string) (Plugin, error) {
 	if node.Kind != yaml.MappingNode {
 		return Plugin{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
 	}
-	fields := map[string]*yaml.Node{}
-	for i := 0; i < len(node.Content); i += 2 {
-		key := node.Content[i]
-		value := node.Content[i+1]
-		name, err := stringKey(key, pointer)
-		if err != nil {
-			return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
-		}
-		fields[name] = value
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
 	}
 
 	engineValue, err := requiredString(fields, "engine", pointer+".engine")
@@ -224,19 +630,349 @@ func parsePlugin(node *yaml.Node, path, pointer string) (Plugin, error) {
 	engine := Engine(engineValue)
 	switch engine {
 	case EngineAVPCompat, EngineNativeKustomize:
-		if err := rejectUnknownFields(fields, map[string]bool{"engine": true}, pointer); err != nil {
-			return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
-		}
-		return Plugin{Engine: engine}, nil
+		return parseStaticPlugin(engine, fields, path, pointer)
 	case EngineExec:
-		execConfig, err := parseExecConfig(fields, path, pointer)
-		if err != nil {
-			return Plugin{}, err
-		}
-		return Plugin{Engine: engine, Exec: &execConfig}, nil
+		return parseExecPlugin(fields, path, pointer)
+	case EngineContainer:
+		return parseContainerPlugin(fields, path, pointer)
 	default:
 		return Plugin{}, fmt.Errorf("parse plugin policy %s: %s.engine has unsupported engine %q", path, pointer, engineValue)
 	}
+}
+
+type parsedPluginOptionalFields struct {
+	match    PluginMatch
+	hasMatch bool
+	seed     ConfigManagementPluginSeed
+	hasSeed  bool
+}
+
+func (fields *parsedPluginOptionalFields) matchPtr() *PluginMatch {
+	if !fields.hasMatch {
+		return nil
+	}
+	return &fields.match
+}
+
+func (fields *parsedPluginOptionalFields) seedPtr() *ConfigManagementPluginSeed {
+	if !fields.hasSeed {
+		return nil
+	}
+	return &fields.seed
+}
+
+func parseStaticPlugin(engine Engine, fields map[string]*yaml.Node, path, pointer string) (Plugin, error) {
+	if err := rejectUnknownFields(fields, map[string]bool{"engine": true, "match": true, "configManagementPlugin": true}, pointer); err != nil {
+		return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	optional, err := parsePluginOptionalFields(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	return Plugin{Engine: engine, Match: optional.matchPtr(), ConfigManagementPlugin: optional.seedPtr()}, nil
+}
+
+func parseExecPlugin(fields map[string]*yaml.Node, path, pointer string) (Plugin, error) {
+	if err := rejectUnknownFields(fields, execPluginAllowedFields(), pointer); err != nil {
+		return Plugin{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	optional, err := parsePluginOptionalFields(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	execConfig, err := parseExecConfig(fields, path, pointer)
+	if err != nil {
+		return Plugin{}, err
+	}
+	return Plugin{
+		Engine:                 EngineExec,
+		Match:                  optional.matchPtr(),
+		ConfigManagementPlugin: optional.seedPtr(),
+		Exec:                   &execConfig,
+	}, nil
+}
+
+func parsePluginOptionalFields(fields map[string]*yaml.Node, path, pointer string) (parsedPluginOptionalFields, error) {
+	var out parsedPluginOptionalFields
+	match, hasMatch, err := parsePluginMatch(fields["match"], path, pointer+".match")
+	if err != nil {
+		return parsedPluginOptionalFields{}, err
+	}
+	if hasMatch {
+		out.match = match
+		out.hasMatch = true
+	}
+	seed, hasSeed, err := parseConfigManagementPluginSeed(fields["configManagementPlugin"], path, pointer+".configManagementPlugin")
+	if err != nil {
+		return parsedPluginOptionalFields{}, err
+	}
+	if hasSeed {
+		out.seed = seed
+		out.hasSeed = true
+	}
+	if err := validateConfigManagementPluginSeedDiscover(out.matchPtr(), out.seedPtr(), path, pointer); err != nil {
+		return parsedPluginOptionalFields{}, err
+	}
+	return out, nil
+}
+
+func execPluginAllowedFields() map[string]bool {
+	fields := execLifecycleAllowedFields()
+	fields["engine"] = true
+	fields["match"] = true
+	fields["configManagementPlugin"] = true
+	return fields
+}
+
+func execLifecycleAllowedFields() map[string]bool {
+	return map[string]bool{
+		"workdir":       true,
+		"copy":          true,
+		"init":          true,
+		"generate":      true,
+		"postRenderers": true,
+		"env":           true,
+		"parameters":    true,
+		"output":        true,
+	}
+}
+
+func parseConfigManagementPluginSeed(node *yaml.Node, path, pointer string) (ConfigManagementPluginSeed, bool, error) {
+	if node == nil {
+		return ConfigManagementPluginSeed{}, false, nil
+	}
+	if isNullNode(node) {
+		return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	if node.Kind != yaml.MappingNode {
+		return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"discover": true, "generate": true}, pointer); err != nil {
+		return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["discover"] == nil && fields["generate"] == nil {
+		return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %s must contain discover or generate", path, pointer)
+	}
+	var out ConfigManagementPluginSeed
+	if fields["discover"] != nil {
+		if isNullNode(fields["discover"]) {
+			return ConfigManagementPluginSeed{}, false, fmt.Errorf("parse plugin policy %s: %s.discover must not be null", path, pointer)
+		}
+		discover, err := parsePluginDiscoverMatch(fields["discover"], path, pointer+".discover")
+		if err != nil {
+			return ConfigManagementPluginSeed{}, false, err
+		}
+		out.Discover = &discover
+	}
+	if fields["generate"] != nil {
+		generate, err := parseConfigManagementPluginGenerate(fields["generate"], path, pointer+".generate")
+		if err != nil {
+			return ConfigManagementPluginSeed{}, false, err
+		}
+		out.Generate = generate
+	}
+	return out, true, nil
+}
+
+func parseConfigManagementPluginGenerate(node *yaml.Node, path, pointer string) (*ConfigManagementPluginGenerate, error) {
+	if isNullNode(node) {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fields[name] = node.Content[i+1]
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"command": true, "args": true}, pointer); err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	command, err := seedArgvSequence(fields["command"], pointer+".command", true)
+	if err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	args, err := seedArgvSequence(fields["args"], pointer+".args", false)
+	if err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["command"] == nil && fields["args"] == nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must contain command or args", path, pointer)
+	}
+	return &ConfigManagementPluginGenerate{Command: command, Args: args}, nil
+}
+
+func seedArgvSequence(node *yaml.Node, pointer string, requireNonEmpty bool) ([]string, error) {
+	if node == nil || isNullNode(node) {
+		return nil, nil
+	}
+	values, err := stringSequence(node, pointer)
+	if err != nil {
+		return nil, err
+	}
+	if requireNonEmpty && len(values) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", pointer)
+	}
+	for index, token := range values {
+		if strings.TrimSpace(token) == "" {
+			return nil, fmt.Errorf("%s[%d] must not be empty", pointer, index)
+		}
+	}
+	return values, nil
+}
+
+func validateConfigManagementPluginSeedDiscover(match *PluginMatch, seed *ConfigManagementPluginSeed, path, pointer string) error {
+	if match == nil || seed == nil || seed.Discover == nil {
+		return nil
+	}
+	if match.Discover.FileName != "" {
+		if seed.Discover.FileName == match.Discover.FileName {
+			return nil
+		}
+		return fmt.Errorf("parse plugin policy %s: %s.configManagementPlugin.discover must match %s.match.discover", path, pointer, pointer)
+	}
+	if match.Discover.FindGlob != "" {
+		if seed.Discover.FindGlob == match.Discover.FindGlob {
+			return nil
+		}
+		return fmt.Errorf("parse plugin policy %s: %s.configManagementPlugin.discover must match %s.match.discover", path, pointer, pointer)
+	}
+	return nil
+}
+
+func parsePluginMatch(node *yaml.Node, path, pointer string) (PluginMatch, bool, error) {
+	if node == nil {
+		return PluginMatch{}, false, nil
+	}
+	if isNullNode(node) {
+		return PluginMatch{}, false, fmt.Errorf("parse plugin policy %s: %s must contain exactly one static discover rule", path, pointer)
+	}
+	if node.Kind != yaml.MappingNode {
+		return PluginMatch{}, false, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return PluginMatch{}, false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"discover": true}, pointer); err != nil {
+		return PluginMatch{}, false, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["discover"] == nil || isNullNode(fields["discover"]) {
+		return PluginMatch{}, false, fmt.Errorf("parse plugin policy %s: %s.discover must contain exactly one static rule", path, pointer)
+	}
+	discover, err := parsePluginDiscoverMatch(fields["discover"], path, pointer+".discover")
+	if err != nil {
+		return PluginMatch{}, false, err
+	}
+	return PluginMatch{Discover: discover}, true, nil
+}
+
+func parsePluginDiscoverMatch(node *yaml.Node, path, pointer string) (PluginDiscoverMatch, error) {
+	if node.Kind != yaml.MappingNode {
+		return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fields[name] = node.Content[i+1]
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"fileName": true, "find": true}, pointer); err != nil {
+		return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+
+	var out PluginDiscoverMatch
+	ruleCount := 0
+	if fields["fileName"] != nil {
+		if isNullNode(fields["fileName"]) {
+			return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %s.fileName must not be null", path, pointer)
+		}
+		fileName, err := stringValue(fields["fileName"], pointer+".fileName")
+		if err != nil {
+			return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fileName, err = normalizeMatchPattern(fileName, path, pointer+".fileName")
+		if err != nil {
+			return PluginDiscoverMatch{}, err
+		}
+		if _, err := filepath.Match(fileName, ""); err != nil {
+			return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %s must be a valid filepath glob: %w", path, pointer+".fileName", err)
+		}
+		out.FileName = fileName
+		ruleCount++
+	}
+	if fields["find"] != nil {
+		if isNullNode(fields["find"]) {
+			return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %s.find must not be null", path, pointer)
+		}
+		findGlob, err := parsePluginDiscoverFindGlob(fields["find"], path, pointer+".find")
+		if err != nil {
+			return PluginDiscoverMatch{}, err
+		}
+		out.FindGlob = findGlob
+		ruleCount++
+	}
+	if ruleCount != 1 {
+		return PluginDiscoverMatch{}, fmt.Errorf("parse plugin policy %s: %s must contain exactly one static rule", path, pointer)
+	}
+	return out, nil
+}
+
+func parsePluginDiscoverFindGlob(node *yaml.Node, path, pointer string) (string, error) {
+	if node.Kind != yaml.MappingNode {
+		return "", fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+	}
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+		}
+		fields[name] = node.Content[i+1]
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"glob": true}, pointer); err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["glob"] == nil || isNullNode(fields["glob"]) {
+		return "", fmt.Errorf("parse plugin policy %s: missing required field %s.glob", path, pointer)
+	}
+	glob, err := stringValue(fields["glob"], pointer+".glob")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	glob, err = normalizeMatchPattern(glob, path, pointer+".glob")
+	if err != nil {
+		return "", err
+	}
+	if !doublestar.ValidatePattern(glob) {
+		return "", fmt.Errorf("parse plugin policy %s: %s must be a valid doublestar glob", path, pointer+".glob")
+	}
+	return glob, nil
+}
+
+func normalizeMatchPattern(raw, path, pointer string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.Contains(raw, `\`) {
+		return "", fmt.Errorf("parse plugin policy %s: %s is invalid: backslashes are not allowed", path, pointer)
+	}
+	pattern := filepath.ToSlash(raw)
+	if pattern == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s must not be empty", path, pointer)
+	}
+	if err := validateRepositoryRelativePattern(pattern); err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %s is invalid: %w", path, pointer, err)
+	}
+	return pattern, nil
 }
 
 func rejectUnknownFields(fields map[string]*yaml.Node, allowed map[string]bool, pointer string) error {
@@ -246,4 +982,16 @@ func rejectUnknownFields(fields map[string]*yaml.Node, allowed map[string]bool, 
 		}
 	}
 	return nil
+}
+
+func mappingFields(node *yaml.Node, pointer string) (map[string]*yaml.Node, error) {
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		name, err := stringKey(node.Content[i], pointer)
+		if err != nil {
+			return nil, err
+		}
+		fields[name] = node.Content[i+1]
+	}
+	return fields, nil
 }

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -51,26 +51,128 @@ func TestPluginPolicySchemaMatchesCurrentContract(t *testing.T) {
 	}
 
 	properties := schemaObject(t, schema, "properties")
+	defs := schemaObject(t, schema, "$defs")
+	assertPolicyRootSchema(t, properties)
+	assertBootstrapSchema(t, defs)
+	assertNativePluginSchemas(t, defs)
+	assertExecPluginSchema(t, defs)
+	assertContainerPluginSchema(t, defs)
+	assertCMPAndParameterSchemas(t, defs)
+	assertFractionalDurationPolicy(t)
+}
+
+func assertPolicyRootSchema(t *testing.T, properties map[string]any) {
+	t.Helper()
 	assertSchemaConst(t, schemaObject(t, properties, "apiVersion"), apiVersion)
 	assertSchemaConst(t, schemaObject(t, properties, "kind"), kind)
+	assertSchemaRef(t, schemaObject(t, properties, "bootstrap"), "#/$defs/bootstrap")
+}
 
-	defs := schemaObject(t, schema, "$defs")
+func assertBootstrapSchema(t *testing.T, defs map[string]any) {
+	t.Helper()
+	pluginDef := schemaObject(t, defs, "plugin")
+	assertSchemaOneOfRefs(t, pluginDef, []string{
+		"#/$defs/avpCompatPlugin",
+		"#/$defs/nativeKustomizePlugin",
+		"#/$defs/execPlugin",
+		"#/$defs/containerPlugin",
+	})
+	bootstrap := schemaObject(t, defs, "bootstrap")
+	entrypoints := schemaObject(t, schemaObject(t, bootstrap, "properties"), "entrypoints")
+	if minItems, ok := entrypoints["minItems"].(float64); !ok || minItems != 1 {
+		t.Fatalf("bootstrap.entrypoints minItems = %#v, want 1", entrypoints["minItems"])
+	}
+	bootstrapEntrypoint := schemaObject(t, defs, "bootstrapEntrypoint")
+	bootstrapEntrypointProps := schemaObject(t, bootstrapEntrypoint, "properties")
+	assertSchemaRef(t, schemaObject(t, bootstrapEntrypointProps, "sourcePath"), "#/$defs/repoRelativePath")
+	bootstrapParameter := schemaObject(t, defs, "bootstrapEntrypointParameter")
+	if _, ok := bootstrapParameter["oneOf"].([]any); !ok {
+		t.Fatalf("bootstrap parameter schema oneOf = %#v, want exactly-one value constraint", bootstrapParameter["oneOf"])
+	}
+}
+
+func assertNativePluginSchemas(t *testing.T, defs map[string]any) {
+	t.Helper()
 	for name, engine := range map[string]Engine{
 		"avpCompatPlugin":       EngineAVPCompat,
 		"nativeKustomizePlugin": EngineNativeKustomize,
 	} {
 		def := schemaObject(t, defs, name)
-		engineProp := schemaObject(t, schemaObject(t, def, "properties"), "engine")
+		props := schemaObject(t, def, "properties")
+		engineProp := schemaObject(t, props, "engine")
 		assertSchemaConst(t, engineProp, string(engine))
+		assertSchemaRef(t, schemaObject(t, props, "match"), "#/$defs/match")
+		assertSchemaRef(t, schemaObject(t, props, "configManagementPlugin"), "#/$defs/configManagementPluginSeed")
 	}
+}
+
+func assertExecPluginSchema(t *testing.T, defs map[string]any) {
+	t.Helper()
 	execDef := schemaObject(t, defs, "execPlugin")
-	engineProp := schemaObject(t, schemaObject(t, execDef, "properties"), "engine")
+	execProps := schemaObject(t, execDef, "properties")
+	engineProp := schemaObject(t, execProps, "engine")
 	assertSchemaConst(t, engineProp, string(EngineExec))
+	assertSchemaRef(t, schemaObject(t, execProps, "match"), "#/$defs/match")
+	assertSchemaRef(t, schemaObject(t, execProps, "configManagementPlugin"), "#/$defs/configManagementPluginSeed")
+	parametersProp := schemaObject(t, execProps, "parameters")
+	if ref, ok := parametersProp["$ref"].(string); !ok || ref != "#/$defs/parameters" {
+		t.Fatalf("exec parameters schema ref = %#v, want #/$defs/parameters", parametersProp["$ref"])
+	}
+}
+
+func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
+	t.Helper()
+	containerDef := schemaObject(t, defs, "containerPlugin")
+	containerProps := schemaObject(t, containerDef, "properties")
+	assertSchemaRequired(t, containerDef, "engine", "image", "generate")
+	assertSchemaConst(t, schemaObject(t, containerProps, "engine"), string(EngineContainer))
+	assertSchemaRef(t, schemaObject(t, containerProps, "match"), "#/$defs/match")
+	assertSchemaRef(t, schemaObject(t, containerProps, "configManagementPlugin"), "#/$defs/configManagementPluginSeed")
+	assertSchemaEnum(t, schemaObject(t, containerProps, "runtime"), "docker")
+	assertSchemaDefault(t, schemaObject(t, containerProps, "runtime"), "docker")
+	if got, ok := schemaObject(t, containerProps, "image")["type"].(string); !ok || got != "string" {
+		t.Fatalf("container image schema type = %#v, want string", schemaObject(t, containerProps, "image")["type"])
+	}
+	if got, ok := schemaObject(t, containerProps, "allowMutableImageTag")["type"].(string); !ok || got != "boolean" {
+		t.Fatalf("container allowMutableImageTag schema type = %#v, want boolean", schemaObject(t, containerProps, "allowMutableImageTag")["type"])
+	}
+	assertSchemaDefault(t, schemaObject(t, containerProps, "allowMutableImageTag"), false)
+	assertSchemaEnum(t, schemaObject(t, containerProps, "network"), "none", "default")
+	assertSchemaDefault(t, schemaObject(t, containerProps, "network"), "none")
+	assertSchemaRef(t, schemaObject(t, containerProps, "generate"), "#/$defs/command")
+	assertSchemaRef(t, schemaObject(t, containerProps, "parameters"), "#/$defs/parameters")
+}
+
+func assertCMPAndParameterSchemas(t *testing.T, defs map[string]any) {
+	t.Helper()
+	cmpSeed := schemaObject(t, defs, "configManagementPluginSeed")
+	cmpSeedProps := schemaObject(t, cmpSeed, "properties")
+	assertSchemaRef(t, schemaObject(t, cmpSeedProps, "discover"), "#/$defs/discoverMatch")
+	assertSchemaRef(t, schemaObject(t, cmpSeedProps, "generate"), "#/$defs/configManagementPluginGenerateSeed")
+	matchDiscover := schemaObject(t, schemaObject(t, schemaObject(t, defs, "match"), "properties"), "discover")
+	assertSchemaRef(t, matchDiscover, "#/$defs/discoverMatch")
+	discoverMatch := schemaObject(t, defs, "discoverMatch")
+	if _, ok := discoverMatch["oneOf"].([]any); !ok {
+		t.Fatalf("discoverMatch schema oneOf = %#v, want exactly-one rule constraint", discoverMatch["oneOf"])
+	}
+	findMatch := schemaObject(t, defs, "discoverFindMatch")
+	if got, ok := findMatch["additionalProperties"].(bool); !ok || got {
+		t.Fatalf("discoverFindMatch additionalProperties = %#v, want false", findMatch["additionalProperties"])
+	}
+	parameterType := schemaObject(t, schemaObject(t, schemaObject(t, defs, "parameter"), "properties"), "type")
+	enum, ok := parameterType["enum"].([]any)
+	if !ok || len(enum) != 3 {
+		t.Fatalf("parameter type enum = %#v, want string/array/map", parameterType["enum"])
+	}
 
 	timeout := schemaObject(t, schemaObject(t, schemaObject(t, defs, "command"), "properties"), "timeout")
 	if _, ok := timeout["pattern"]; ok {
 		t.Fatalf("schema timeout has pattern %#v, want parser-authoritative Go duration string", timeout["pattern"])
 	}
+}
+
+func assertFractionalDurationPolicy(t *testing.T) {
+	t.Helper()
 	if _, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
 kind: PluginPolicy
 plugins:
@@ -81,6 +183,709 @@ plugins:
       timeout: 1.5s
 `)); err != nil {
 		t.Fatalf("Parse() fractional duration error = %v", err)
+	}
+}
+
+func TestParseConfigManagementPluginSeed(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+    configManagementPlugin:
+      discover:
+        find:
+          glob: "apps/**/kustomization.yaml"
+      generate:
+        command: ["kustomize", "build"]
+        args: ["--enable-helm", "."]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("cmp")
+	if !ok || plugin.ConfigManagementPlugin == nil {
+		t.Fatalf("Plugin(cmp) = %#v, want configManagementPlugin seed", plugin)
+	}
+	seed := plugin.ConfigManagementPlugin
+	if seed.Discover == nil || seed.Discover.FindGlob != "apps/**/kustomization.yaml" {
+		t.Fatalf("seed discover = %#v, want find glob", seed.Discover)
+	}
+	if seed.Generate == nil {
+		t.Fatal("seed generate = nil, want parsed generate")
+	}
+	if got := strings.Join(seed.Generate.Command, " "); got != "kustomize build" {
+		t.Fatalf("seed generate command = %q, want kustomize build", got)
+	}
+	if got := strings.Join(seed.Generate.Args, " "); got != "--enable-helm ." {
+		t.Fatalf("seed generate args = %q, want --enable-helm .", got)
+	}
+}
+
+func TestParseBootstrapEntrypoints(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: cluster-root
+      plugin: pkl
+      sourcePath: .
+      parameters:
+        - name: path
+          string: index.pkl
+        - name: packages
+          array: ["packages/base.pkl", "packages/extra.pkl"]
+        - name: labels
+          map:
+            cluster: home
+            environment: prod
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    generate:
+      command: ["pkl", "eval", "{{param:path}}"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(policy.Bootstrap.Entrypoints) != 1 {
+		t.Fatalf("len(Bootstrap.Entrypoints) = %d, want 1", len(policy.Bootstrap.Entrypoints))
+	}
+	entrypoint := policy.Bootstrap.Entrypoints[0]
+	if entrypoint.Name != "cluster-root" || entrypoint.Plugin != "pkl" || entrypoint.SourcePath != "." {
+		t.Fatalf("Bootstrap.Entrypoints[0] = %#v, want cluster-root pkl .", entrypoint)
+	}
+	params := bootstrapParametersByName(entrypoint.Parameters)
+	if param := params["path"]; param.String == nil || *param.String != "index.pkl" {
+		t.Fatalf("path parameter = %#v, want string index.pkl", param)
+	}
+	if param := params["packages"]; param.Array == nil || strings.Join(param.Array.Values, ",") != "packages/base.pkl,packages/extra.pkl" {
+		t.Fatalf("packages parameter = %#v, want array values", param)
+	}
+	if param := params["labels"]; param.Map == nil || param.Map.Values["cluster"] != "home" || param.Map.Values["environment"] != "prod" {
+		t.Fatalf("labels parameter = %#v, want map values", param)
+	}
+}
+
+func TestParseBootstrapRejectsInvalidEntrypoints(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: cluster-root
+      plugin: pkl
+      sourcePath: personal-cluster
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    generate:
+      command: ["pkl", "eval", "index.pkl"]
+`
+	for _, tt := range []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "missing entrypoints",
+			data: strings.Replace(base, "bootstrap:\n  entrypoints:\n    - name: cluster-root\n      plugin: pkl\n      sourcePath: personal-cluster\n", "bootstrap: {}\n", 1),
+			want: "missing required field $.bootstrap.entrypoints",
+		},
+		{
+			name: "duplicate name",
+			data: strings.Replace(base, "plugins:", "    - name: cluster-root\n      plugin: pkl\n      sourcePath: personal-cluster\nplugins:", 1),
+			want: "duplicate name",
+		},
+		{
+			name: "invalid name",
+			data: strings.Replace(base, "name: cluster-root", "name: Cluster_Root", 1),
+			want: "invalid",
+		},
+		{
+			name: "unknown plugin",
+			data: strings.Replace(base, "plugin: pkl", "plugin: cue", 1),
+			want: "unknown plugin",
+		},
+		{
+			name: "plugin without discover",
+			data: strings.Replace(base, "    configManagementPlugin:\n      discover:\n        fileName: PklProject\n", "", 1),
+			want: "must define match.discover or configManagementPlugin.discover",
+		},
+		{
+			name: "absolute source path",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: /personal-cluster", 1),
+			want: "absolute paths",
+		},
+		{
+			name: "parent source path",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: ../personal-cluster", 1),
+			want: "parent directory segments",
+		},
+		{
+			name: "git source path",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: .git", 1),
+			want: ".git paths",
+		},
+		{
+			name: "dot component source path",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster/.", 1),
+			want: "dot path components",
+		},
+		{
+			name: "repeated slash source path",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster//apps", 1),
+			want: "empty path components",
+		},
+		{
+			name: "parameter duplicate",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster\n      parameters:\n        - name: path\n          string: one\n        - name: path\n          string: two", 1),
+			want: "duplicate parameter",
+		},
+		{
+			name: "parameter no value",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster\n      parameters:\n        - name: path", 1),
+			want: "exactly one",
+		},
+		{
+			name: "parameter two values",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster\n      parameters:\n        - name: path\n          string: index.pkl\n          array: [index.pkl]", 1),
+			want: "exactly one",
+		},
+		{
+			name: "parameter map non-string value",
+			data: strings.Replace(base, "sourcePath: personal-cluster", "sourcePath: personal-cluster\n      parameters:\n        - name: labels\n          map:\n            cluster: 1", 1),
+			want: "must be a string",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(tt.data))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigManagementPluginSeedAllowsOmittedSeedGenerateForExec(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: plugin.yaml
+    generate:
+      command: ["renderer"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("cmp")
+	if !ok || plugin.ConfigManagementPlugin == nil {
+		t.Fatalf("Plugin(cmp) = %#v, want configManagementPlugin seed", plugin)
+	}
+	if plugin.Exec == nil {
+		t.Fatalf("Exec = nil, want exec config")
+	}
+	if plugin.ConfigManagementPlugin.Generate != nil {
+		t.Fatalf("seed generate = %#v, want nil", plugin.ConfigManagementPlugin.Generate)
+	}
+}
+
+func TestParseConfigManagementPluginSeedRejectsUnsupportedFields(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		seed string
+		want string
+	}{
+		{
+			name: "metadata",
+			seed: `    configManagementPlugin:
+      metadata:
+        name: cmp
+`,
+			want: "unknown field",
+		},
+		{
+			name: "version",
+			seed: `    configManagementPlugin:
+      version: v1
+`,
+			want: "unknown field",
+		},
+		{
+			name: "find command",
+			seed: `    configManagementPlugin:
+      discover:
+        find:
+          command: ["find", "."]
+`,
+			want: "unknown field",
+		},
+		{
+			name: "env",
+			seed: `    configManagementPlugin:
+      generate:
+        command: ["renderer"]
+        env: []
+`,
+			want: "unknown field",
+		},
+		{
+			name: "lockRepo",
+			seed: `    configManagementPlugin:
+      lockRepo: true
+`,
+			want: "unknown field",
+		},
+		{
+			name: "preserveFileMode",
+			seed: `    configManagementPlugin:
+      preserveFileMode: true
+`,
+			want: "unknown field",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+`+tt.seed))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigManagementPluginSeedRejectsUnsafePatterns(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		seed string
+		want string
+	}{
+		{
+			name: "fileName absolute",
+			seed: `    configManagementPlugin:
+      discover:
+        fileName: /plugin.yaml
+`,
+			want: "absolute paths",
+		},
+		{
+			name: "fileName parent",
+			seed: `    configManagementPlugin:
+      discover:
+        fileName: ../plugin.yaml
+`,
+			want: "parent directory segments",
+		},
+		{
+			name: "fileName git",
+			seed: `    configManagementPlugin:
+      discover:
+        fileName: .git/config
+`,
+			want: ".git paths",
+		},
+		{
+			name: "find glob backslash",
+			seed: `    configManagementPlugin:
+      discover:
+        find:
+          glob: "apps\\**"
+`,
+			want: "backslashes",
+		},
+		{
+			name: "find glob bad syntax",
+			seed: `    configManagementPlugin:
+      discover:
+        find:
+          glob: "apps/["
+`,
+			want: "valid doublestar glob",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+`+tt.seed))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigManagementPluginSeedRejectsEmptyArgvToken(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "command token",
+			body: `        command: ["renderer", ""]
+`,
+		},
+		{
+			name: "args token",
+			body: `        args: ["--flag", " "]
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+    configManagementPlugin:
+      generate:
+`+tt.body))
+			if err == nil {
+				t.Fatal("Parse() succeeded, want empty argv token error")
+			}
+			if !strings.Contains(err.Error(), "must not be empty") {
+				t.Fatalf("Parse() error = %v, want empty token error", err)
+			}
+		})
+	}
+}
+
+func TestParseConfigManagementPluginSeedDiscoverMustMatchPolicyMatch(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "rule type mismatch",
+			body: `    match:
+      discover:
+        fileName: plugin.yaml
+    configManagementPlugin:
+      discover:
+        find:
+          glob: plugin.yaml
+`,
+		},
+		{
+			name: "pattern mismatch",
+			body: `    match:
+      discover:
+        fileName: plugin.yaml
+    configManagementPlugin:
+      discover:
+        fileName: other.yaml
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+`+tt.body))
+			if err == nil {
+				t.Fatal("Parse() succeeded, want match-vs-seed mismatch error")
+			}
+			if !strings.Contains(err.Error(), "configManagementPlugin.discover must match") {
+				t.Fatalf("Parse() error = %v, want discover mismatch error", err)
+			}
+		})
+	}
+}
+
+func TestParseConfigManagementPluginSeedAllowsIdenticalNormalizedPolicyMatch(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: avp-compat
+    match:
+      discover:
+        fileName: " plugin.yaml "
+    configManagementPlugin:
+      discover:
+        fileName: plugin.yaml
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin := policy.Plugins["cmp"]
+	if plugin.Match == nil || plugin.ConfigManagementPlugin == nil || plugin.ConfigManagementPlugin.Discover == nil {
+		t.Fatalf("Plugin(cmp) = %#v, want match and seed discover", plugin)
+	}
+	if plugin.Match.Discover.FileName != "plugin.yaml" || plugin.ConfigManagementPlugin.Discover.FileName != "plugin.yaml" {
+		t.Fatalf("normalized discover = match %#v seed %#v, want plugin.yaml", plugin.Match.Discover, plugin.ConfigManagementPlugin.Discover)
+	}
+}
+
+func TestParsePluginMatchDiscoverRules(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  avp:
+    engine: avp-compat
+    match:
+      discover:
+        fileName: "config/*.yaml"
+  native:
+    engine: native-kustomize
+    match:
+      discover:
+        find:
+          glob: "**/kustomization.yaml"
+  exec:
+    engine: exec
+    match:
+      discover:
+        fileName: "plugin.yaml"
+    generate:
+      command: ["renderer"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	avp, ok := policy.Plugin("avp")
+	if !ok || avp.Match == nil {
+		t.Fatalf("Plugin(avp) = %#v, want match", avp)
+	}
+	if avp.Match.Discover.FileName != "config/*.yaml" || avp.Match.Discover.FindGlob != "" {
+		t.Fatalf("avp match = %#v, want fileName rule", avp.Match)
+	}
+	native, ok := policy.Plugin("native")
+	if !ok || native.Match == nil {
+		t.Fatalf("Plugin(native) = %#v, want match", native)
+	}
+	if native.Match.Discover.FindGlob != "**/kustomization.yaml" || native.Match.Discover.FileName != "" {
+		t.Fatalf("native match = %#v, want find.glob rule", native.Match)
+	}
+	exec, ok := policy.Plugin("exec")
+	if !ok || exec.Match == nil || exec.Exec == nil {
+		t.Fatalf("Plugin(exec) = %#v, want exec plugin with match", exec)
+	}
+	if exec.Match.Discover.FileName != "plugin.yaml" {
+		t.Fatalf("exec fileName = %q, want plugin.yaml", exec.Match.Discover.FileName)
+	}
+}
+
+func TestParsePluginMatchRejectsUnsafeRules(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		match string
+		want  string
+	}{
+		{
+			name: "empty match",
+			match: `    match: {}
+`,
+			want: "must contain exactly one static",
+		},
+		{
+			name: "null match",
+			match: `    match: null
+`,
+			want: "must contain exactly one static",
+		},
+		{
+			name: "empty discover",
+			match: `    match:
+      discover: {}
+`,
+			want: "must contain exactly one static",
+		},
+		{
+			name: "both fileName and find glob",
+			match: `    match:
+      discover:
+        fileName: plugin.yaml
+        find:
+          glob: "**/plugin.yaml"
+`,
+			want: "exactly one static rule",
+		},
+		{
+			name: "null fileName",
+			match: `    match:
+      discover:
+        fileName: null
+`,
+			want: "fileName must not be null",
+		},
+		{
+			name: "null find",
+			match: `    match:
+      discover:
+        find: null
+`,
+			want: "find must not be null",
+		},
+		{
+			name: "unknown match field",
+			match: `    match:
+      name: plugin
+      discover:
+        fileName: plugin.yaml
+`,
+			want: "unknown field",
+		},
+		{
+			name: "unknown discover field",
+			match: `    match:
+      discover:
+        name: plugin
+`,
+			want: "unknown field",
+		},
+		{
+			name: "find command",
+			match: `    match:
+      discover:
+        find:
+          command: ["find", "."]
+`,
+			want: "unknown field",
+		},
+		{
+			name: "missing find glob",
+			match: `    match:
+      discover:
+        find: {}
+`,
+			want: "missing required field $.plugins.demo.match.discover.find.glob",
+		},
+		{
+			name: "empty fileName",
+			match: `    match:
+      discover:
+        fileName: " "
+`,
+			want: "must not be empty",
+		},
+		{
+			name: "fileName backslash",
+			match: `    match:
+      discover:
+        fileName: "config\\*.yaml"
+`,
+			want: "backslashes",
+		},
+		{
+			name: "fileName absolute",
+			match: `    match:
+      discover:
+        fileName: "/plugin.yaml"
+`,
+			want: "absolute paths",
+		},
+		{
+			name: "fileName parent segment",
+			match: `    match:
+      discover:
+        fileName: "../plugin.yaml"
+`,
+			want: "parent directory segments",
+		},
+		{
+			name: "fileName git path",
+			match: `    match:
+      discover:
+        fileName: ".git/config"
+`,
+			want: ".git paths",
+		},
+		{
+			name: "fileName bad glob",
+			match: `    match:
+      discover:
+        fileName: "apps/["
+`,
+			want: "valid filepath glob",
+		},
+		{
+			name: "find glob backslash",
+			match: `    match:
+      discover:
+        find:
+          glob: "apps\\**"
+`,
+			want: "backslashes",
+		},
+		{
+			name: "find glob absolute",
+			match: `    match:
+      discover:
+        find:
+          glob: "/apps/**"
+`,
+			want: "absolute paths",
+		},
+		{
+			name: "find glob parent segment",
+			match: `    match:
+      discover:
+        find:
+          glob: "apps/../plugin.yaml"
+`,
+			want: "parent directory segments",
+		},
+		{
+			name: "find glob git path",
+			match: `    match:
+      discover:
+        find:
+          glob: "apps/.git/**"
+`,
+			want: ".git paths",
+		},
+		{
+			name: "find glob bad syntax",
+			match: `    match:
+      discover:
+        find:
+          glob: "apps/["
+`,
+			want: "valid doublestar glob",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  demo:
+    engine: avp-compat
+`+tt.match))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want substring %q", err, tt.want)
+			}
+		})
 	}
 }
 
@@ -179,6 +984,9 @@ plugins:
   renderer:
     engine: exec
     workdir: source
+    copy:
+      scope: repository
+      include: ["shared/**", "packages/*.pkl"]
     init:
       command: ["argocd-vault-plugin", "version"]
       timeout: 2s
@@ -219,19 +1027,329 @@ plugins:
 	if got := strings.Join(plugin.Exec.Env.Allow, ","); got != "AVP_TYPE,OP_CONNECT_HOST" {
 		t.Fatalf("Env allow = %q, want AVP_TYPE,OP_CONNECT_HOST", got)
 	}
+	if plugin.Exec.Copy.Scope != ExecCopyScopeRepository {
+		t.Fatalf("Copy.Scope = %q, want repository", plugin.Exec.Copy.Scope)
+	}
+	if got := strings.Join(plugin.Exec.Copy.Include, ","); got != "packages/*.pkl,shared/**" {
+		t.Fatalf("Copy.Include = %q, want sorted include globs", got)
+	}
 	if plugin.Exec.Output.MaxStdoutBytes != 1024 || plugin.Exec.Output.MaxStderrBytes != 128 {
 		t.Fatalf("Output = %#v, want explicit limits", plugin.Exec.Output)
 	}
 }
 
-func TestParseFixturePolicies(t *testing.T) {
-	tests := []struct {
-		path           string
-		plugin         string
-		engine         Engine
-		postRenderers  int
-		allowedEnvVars []string
+func TestParseExecPolicyParameters(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl", "eval", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: source
+            allow: ["*.pkl", "components/*.pkl"]
+        - name: pkl_modules
+          type: array
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("pkl")
+	if !ok || plugin.Exec == nil {
+		t.Fatalf("Plugin(pkl) = %#v, want exec plugin", plugin)
+	}
+	if got := len(plugin.Exec.Parameters.Allow); got != 2 {
+		t.Fatalf("len(Parameters.Allow) = %d, want 2", got)
+	}
+	pathParam := plugin.Exec.Parameters.Allow[0]
+	if pathParam.Name != "path" || pathParam.Type != ExecParameterTypeString || !pathParam.Required || pathParam.Path == nil {
+		t.Fatalf("path parameter = %#v, want required string path parameter", pathParam)
+	}
+	if got := strings.Join(pathParam.Path.Allow, ","); got != "*.pkl,components/*.pkl" {
+		t.Fatalf("path allow = %q, want sorted allow globs", got)
+	}
+}
+
+func TestParseExecPolicyRepositoryCopyParameter(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    copy:
+      scope: repository
+      include: ["shared/**"]
+    generate:
+      command: ["pkl", "eval", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow: ["shared/*.pkl"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("pkl")
+	if !ok || plugin.Exec == nil {
+		t.Fatalf("Plugin(pkl) = %#v, want exec plugin", plugin)
+	}
+	if plugin.Exec.Copy.Scope != ExecCopyScopeRepository || strings.Join(plugin.Exec.Copy.Include, ",") != "shared/**" {
+		t.Fatalf("Copy = %#v, want repository scope with shared include", plugin.Exec.Copy)
+	}
+	pathParam := plugin.Exec.Parameters.Allow[0]
+	if pathParam.Path == nil || pathParam.Path.Base != ExecParameterPathBaseRepository {
+		t.Fatalf("path parameter = %#v, want repository path base", pathParam)
+	}
+}
+
+func TestParseContainerPolicyDigestImageAppliesDefaults(t *testing.T) {
+	image := "registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+    engine: container
+    image: `+image+`
+    generate:
+      command: ["renderer", "generate"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("renderer")
+	if !ok {
+		t.Fatal("Plugin(renderer) missing")
+	}
+	if plugin.Engine != EngineContainer {
+		t.Fatalf("Engine = %q, want %q", plugin.Engine, EngineContainer)
+	}
+	if plugin.Exec != nil {
+		t.Fatalf("Exec = %#v, want nil for container plugin", plugin.Exec)
+	}
+	if plugin.Container == nil {
+		t.Fatal("Container = nil, want parsed container config")
+	}
+	if got := plugin.Container.Runtime; got != DefaultContainerRuntime {
+		t.Fatalf("Runtime = %q, want %q", got, DefaultContainerRuntime)
+	}
+	if got := plugin.Container.Network; got != DefaultContainerNetwork {
+		t.Fatalf("Network = %q, want %q", got, DefaultContainerNetwork)
+	}
+	if plugin.Container.AllowMutableImageTag {
+		t.Fatal("AllowMutableImageTag = true, want default false")
+	}
+	if plugin.Container.Image != image {
+		t.Fatalf("Image = %q, want %q", plugin.Container.Image, image)
+	}
+	if got := plugin.Container.Lifecycle.Generate.Timeout; got != DefaultGenerateTimeout {
+		t.Fatalf("Generate.Timeout = %s, want %s", got, DefaultGenerateTimeout)
+	}
+	if got := plugin.Container.Lifecycle.Workdir; got != ExecWorkdirSource {
+		t.Fatalf("Lifecycle.Workdir = %q, want %q", got, ExecWorkdirSource)
+	}
+	if got := plugin.Container.Lifecycle.Output.MaxStdoutBytes; got != DefaultMaxStdoutBytes {
+		t.Fatalf("MaxStdoutBytes = %d, want %d", got, DefaultMaxStdoutBytes)
+	}
+}
+
+func TestParseContainerPolicyMutableTagOptIn(t *testing.T) {
+	image := "ghcr.io/sholdee/drydock-renderer:v1.2.3"
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+    engine: container
+    image: `+image+`
+    allowMutableImageTag: true
+    network: default
+    generate:
+      command: ["renderer", "generate"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("renderer")
+	if !ok || plugin.Container == nil {
+		t.Fatalf("Plugin(renderer) = %#v, want container plugin", plugin)
+	}
+	if !plugin.Container.AllowMutableImageTag {
+		t.Fatal("AllowMutableImageTag = false, want true")
+	}
+	if plugin.Container.Image != image {
+		t.Fatalf("Image = %q, want %q", plugin.Container.Image, image)
+	}
+	if plugin.Container.Network != ContainerNetworkDefault {
+		t.Fatalf("Network = %q, want %q", plugin.Container.Network, ContainerNetworkDefault)
+	}
+}
+
+func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
+	digestImage := "registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	for _, tt := range []struct {
+		name string
+		body string
+		want string
 	}{
+		{
+			name: "missing image",
+			body: `    engine: container
+    generate:
+      command: ["renderer"]
+`,
+			want: "missing required field $.plugins.renderer.image",
+		},
+		{
+			name: "image must be string",
+			body: `    engine: container
+    image: 1
+    generate:
+      command: ["renderer"]
+`,
+			want: "image must be a string",
+		},
+		{
+			name: "mutable tag without opt-in",
+			body: `    engine: container
+    image: registry.example.com/drydock/renderer:v1.2.3
+    generate:
+      command: ["renderer"]
+`,
+			want: "digest is required unless allowMutableImageTag is true",
+		},
+		{
+			name: "unqualified image",
+			body: `    engine: container
+    image: renderer:v1.2.3
+    allowMutableImageTag: true
+    generate:
+      command: ["renderer"]
+`,
+			want: "fully qualified with a registry host",
+		},
+		{
+			name: "invalid image reference",
+			body: `    engine: container
+    image: registry.example.com/drydock/renderer@sha256:not-a-digest
+    generate:
+      command: ["renderer"]
+`,
+			want: "image \"registry.example.com/drydock/renderer@sha256:not-a-digest\" is invalid",
+		},
+		{
+			name: "unsupported runtime",
+			body: `    engine: container
+    runtime: podman
+    image: ` + digestImage + `
+    generate:
+      command: ["renderer"]
+`,
+			want: "unsupported container runtime",
+		},
+		{
+			name: "runtime must be string",
+			body: `    engine: container
+    runtime: 7
+    image: ` + digestImage + `
+    generate:
+      command: ["renderer"]
+`,
+			want: "runtime must be a string",
+		},
+		{
+			name: "unsupported network",
+			body: `    engine: container
+    image: ` + digestImage + `
+    network: host
+    generate:
+      command: ["renderer"]
+`,
+			want: "unsupported container network",
+		},
+		{
+			name: "network must be string",
+			body: `    engine: container
+    image: ` + digestImage + `
+    network: true
+    generate:
+      command: ["renderer"]
+`,
+			want: "network must be a string",
+		},
+		{
+			name: "allow mutable must be boolean",
+			body: `    engine: container
+    image: ` + digestImage + `
+    allowMutableImageTag: "true"
+    generate:
+      command: ["renderer"]
+`,
+			want: "allowMutableImageTag must be a boolean",
+		},
+		{
+			name: "unknown field",
+			body: `    engine: container
+    image: ` + digestImage + `
+    random: true
+    generate:
+      command: ["renderer"]
+`,
+			want: "unknown field",
+		},
+		{
+			name: "missing generate",
+			body: `    engine: container
+    image: ` + digestImage + `
+`,
+			want: "missing required field $.plugins.renderer.generate",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+`+tt.body))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Parse() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+type fixturePolicyCase struct {
+	path                 string
+	plugin               string
+	engine               Engine
+	bootstrapEntrypoint  string
+	bootstrapSourcePath  string
+	bootstrapParameters  int
+	postRenderers        int
+	allowedEnvVars       []string
+	seedDiscoverFileName string
+	initCommand          []string
+	generateCommand      []string
+	copyScope            string
+	copyInclude          []string
+	parameterName        string
+	parameterPathBase    string
+	parameterPathAllow   []string
+}
+
+func TestParseFixturePolicies(t *testing.T) {
+	tests := []fixturePolicyCase{
 		{
 			path:   "avp-placeholder.yaml",
 			plugin: "avp-directory-include",
@@ -244,43 +1362,188 @@ func TestParseFixturePolicies(t *testing.T) {
 			postRenderers:  1,
 			allowedEnvVars: []string{"CLUSTER_NAME", "ENVIRONMENT"},
 		},
+		{
+			path:                 "pkl-exec.yaml",
+			plugin:               "pkl",
+			engine:               EngineExec,
+			seedDiscoverFileName: "PklProject",
+			initCommand:          []string{"pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"},
+			generateCommand:      []string{"pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"},
+			copyScope:            ExecCopyScopeRepository,
+			copyInclude:          []string{"packages/**", "pkl-packages/**"},
+			parameterName:        "path",
+			parameterPathBase:    ExecParameterPathBaseRepository,
+			parameterPathAllow:   []string{"personal-cluster/**/*.pkl"},
+		},
+		{
+			path:                 "bootstrap-exec-entrypoints.yaml",
+			plugin:               "pkl",
+			engine:               EngineExec,
+			bootstrapEntrypoint:  "pkl-root",
+			bootstrapSourcePath:  ".",
+			bootstrapParameters:  3,
+			seedDiscoverFileName: "PklProject",
+			initCommand:          []string{"pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"},
+			generateCommand:      []string{"pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"},
+			copyScope:            ExecCopyScopeRepository,
+			copyInclude:          []string{"packages/**", "pkl-packages/**"},
+			parameterName:        "path",
+			parameterPathBase:    ExecParameterPathBaseRepository,
+			parameterPathAllow:   []string{"personal-cluster/**/*.pkl"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			policyPath := filepath.Join("..", "..", "testdata", "plugin-policy", tt.path)
-			data, err := os.ReadFile(policyPath)
-			if err != nil {
-				t.Fatalf("ReadFile(%q) error = %v", policyPath, err)
-			}
-			policy, err := Parse(policyPath, data)
-			if err != nil {
-				t.Fatalf("Parse(%q) error = %v", policyPath, err)
-			}
-			plugin, ok := policy.Plugin(tt.plugin)
-			if !ok {
-				t.Fatalf("Plugin(%q) missing in fixture", tt.plugin)
-			}
-			if plugin.Engine != tt.engine {
-				t.Fatalf("Engine = %q, want %q", plugin.Engine, tt.engine)
-			}
-			if plugin.Engine == EngineExec {
-				if plugin.Exec == nil {
-					t.Fatal("Exec = nil, want parsed exec config")
-				}
-				if got := len(plugin.Exec.PostRenderers); got != tt.postRenderers {
-					t.Fatalf("len(PostRenderers) = %d, want %d", got, tt.postRenderers)
-				}
-				if got := strings.Join(plugin.Exec.Env.Allow, ","); got != strings.Join(tt.allowedEnvVars, ",") {
-					t.Fatalf("Env.Allow = %q, want %q", got, strings.Join(tt.allowedEnvVars, ","))
-				}
-			}
-			if fingerprint, err := Fingerprint(policy); err != nil {
-				t.Fatalf("Fingerprint(%q) error = %v", policyPath, err)
-			} else if fingerprint == NoPolicyFingerprint {
-				t.Fatalf("Fingerprint(%q) = NoPolicyFingerprint, want stable non-empty fingerprint", policyPath)
-			}
+			assertFixturePolicy(t, tt)
 		})
+	}
+}
+
+func assertFixturePolicy(t *testing.T, tt fixturePolicyCase) {
+	t.Helper()
+	policyPath := filepath.Join("..", "..", "testdata", "plugin-policy", tt.path)
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", policyPath, err)
+	}
+	policy, err := Parse(policyPath, data)
+	if err != nil {
+		t.Fatalf("Parse(%q) error = %v", policyPath, err)
+	}
+	plugin, ok := policy.Plugin(tt.plugin)
+	if !ok {
+		t.Fatalf("Plugin(%q) missing in fixture", tt.plugin)
+	}
+	if plugin.Engine != tt.engine {
+		t.Fatalf("Engine = %q, want %q", plugin.Engine, tt.engine)
+	}
+	assertFixtureBootstrap(t, policy, tt)
+	assertFixtureSeedDiscover(t, plugin, tt)
+	assertFixtureExec(t, plugin, tt)
+	assertFixtureFingerprint(t, policy, policyPath)
+}
+
+func assertFixtureBootstrap(t *testing.T, policy Policy, tt fixturePolicyCase) {
+	t.Helper()
+	if tt.bootstrapEntrypoint == "" {
+		if len(policy.Bootstrap.Entrypoints) != 0 {
+			t.Fatalf("Bootstrap.Entrypoints = %#v, want none", policy.Bootstrap.Entrypoints)
+		}
+		return
+	}
+	if len(policy.Bootstrap.Entrypoints) != 1 {
+		t.Fatalf("len(Bootstrap.Entrypoints) = %d, want 1", len(policy.Bootstrap.Entrypoints))
+	}
+	entrypoint := policy.Bootstrap.Entrypoints[0]
+	if entrypoint.Name != tt.bootstrapEntrypoint || entrypoint.Plugin != tt.plugin || entrypoint.SourcePath != tt.bootstrapSourcePath {
+		t.Fatalf("Bootstrap.Entrypoints[0] = %#v, want %s/%s/%s", entrypoint, tt.bootstrapEntrypoint, tt.plugin, tt.bootstrapSourcePath)
+	}
+	if len(entrypoint.Parameters) != tt.bootstrapParameters {
+		t.Fatalf("len(Bootstrap.Entrypoints[0].Parameters) = %d, want %d", len(entrypoint.Parameters), tt.bootstrapParameters)
+	}
+}
+
+func assertFixtureSeedDiscover(t *testing.T, plugin Plugin, tt fixturePolicyCase) {
+	t.Helper()
+	if tt.seedDiscoverFileName == "" {
+		return
+	}
+	if plugin.ConfigManagementPlugin == nil || plugin.ConfigManagementPlugin.Discover == nil {
+		t.Fatalf("ConfigManagementPlugin = %#v, want discover seed", plugin.ConfigManagementPlugin)
+	}
+	if got := plugin.ConfigManagementPlugin.Discover.FileName; got != tt.seedDiscoverFileName {
+		t.Fatalf("configManagementPlugin.discover.fileName = %q, want %q", got, tt.seedDiscoverFileName)
+	}
+}
+
+func assertFixtureExec(t *testing.T, plugin Plugin, tt fixturePolicyCase) {
+	t.Helper()
+	if plugin.Engine != EngineExec {
+		return
+	}
+	if plugin.Exec == nil {
+		t.Fatal("Exec = nil, want parsed exec config")
+	}
+	if got := len(plugin.Exec.PostRenderers); got != tt.postRenderers {
+		t.Fatalf("len(PostRenderers) = %d, want %d", got, tt.postRenderers)
+	}
+	if got := strings.Join(plugin.Exec.Env.Allow, ","); got != strings.Join(tt.allowedEnvVars, ",") {
+		t.Fatalf("Env.Allow = %q, want %q", got, strings.Join(tt.allowedEnvVars, ","))
+	}
+	assertFixtureExecInit(t, plugin.Exec, tt)
+	assertFixtureExecGenerate(t, plugin.Exec, tt)
+	assertFixtureCopy(t, plugin.Exec, tt)
+	assertFixtureParameter(t, plugin.Exec, tt)
+}
+
+func assertFixtureExecInit(t *testing.T, execConfig *ExecConfig, tt fixturePolicyCase) {
+	t.Helper()
+	if len(tt.initCommand) == 0 {
+		return
+	}
+	if execConfig.Init == nil {
+		t.Fatal("Init = nil, want parsed init command")
+	}
+	if got := strings.Join(execConfig.Init.Command, "\x00"); got != strings.Join(tt.initCommand, "\x00") {
+		t.Fatalf("Init.Command = %#v, want %#v", execConfig.Init.Command, tt.initCommand)
+	}
+}
+
+func assertFixtureExecGenerate(t *testing.T, execConfig *ExecConfig, tt fixturePolicyCase) {
+	t.Helper()
+	if len(tt.generateCommand) == 0 {
+		return
+	}
+	if got := strings.Join(execConfig.Generate.Command, "\x00"); got != strings.Join(tt.generateCommand, "\x00") {
+		t.Fatalf("Generate.Command = %#v, want %#v", execConfig.Generate.Command, tt.generateCommand)
+	}
+}
+
+func assertFixtureCopy(t *testing.T, execConfig *ExecConfig, tt fixturePolicyCase) {
+	t.Helper()
+	if tt.copyScope == "" {
+		return
+	}
+	if execConfig.Copy.Scope != tt.copyScope {
+		t.Fatalf("Copy.Scope = %q, want %q", execConfig.Copy.Scope, tt.copyScope)
+	}
+	if got := strings.Join(execConfig.Copy.Include, ","); got != strings.Join(tt.copyInclude, ",") {
+		t.Fatalf("Copy.Include = %q, want %q", got, strings.Join(tt.copyInclude, ","))
+	}
+}
+
+func assertFixtureParameter(t *testing.T, execConfig *ExecConfig, tt fixturePolicyCase) {
+	t.Helper()
+	if tt.parameterName == "" {
+		return
+	}
+	if len(execConfig.Parameters.Allow) != 1 {
+		t.Fatalf("len(Parameters.Allow) = %d, want 1", len(execConfig.Parameters.Allow))
+	}
+	parameter := execConfig.Parameters.Allow[0]
+	if parameter.Name != tt.parameterName || parameter.Type != ExecParameterTypeString || !parameter.Required {
+		t.Fatalf("Parameters.Allow[0] = %#v, want required string parameter %q", parameter, tt.parameterName)
+	}
+	if parameter.Path == nil {
+		t.Fatalf("Parameters.Allow[0].Path = nil, want path policy")
+	}
+	if parameter.Path.Base != tt.parameterPathBase {
+		t.Fatalf("Parameters.Allow[0].Path.Base = %q, want %q", parameter.Path.Base, tt.parameterPathBase)
+	}
+	if got := strings.Join(parameter.Path.Allow, ","); got != strings.Join(tt.parameterPathAllow, ",") {
+		t.Fatalf("Parameters.Allow[0].Path.Allow = %q, want %q", got, strings.Join(tt.parameterPathAllow, ","))
+	}
+}
+
+func assertFixtureFingerprint(t *testing.T, policy Policy, policyPath string) {
+	t.Helper()
+	fingerprint, err := Fingerprint(policy)
+	if err != nil {
+		t.Fatalf("Fingerprint(%q) error = %v", policyPath, err)
+	}
+	if fingerprint == NoPolicyFingerprint {
+		t.Fatalf("Fingerprint(%q) = NoPolicyFingerprint, want stable non-empty fingerprint", policyPath)
 	}
 }
 
@@ -523,6 +1786,173 @@ func TestParseExecPolicyRejectsUnsafeFields(t *testing.T) {
 `,
 			want: "greater than zero",
 		},
+		{
+			name: "duplicate parameter",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+        - name: path
+          type: string
+`,
+			want: "duplicate parameter",
+		},
+		{
+			name: "unknown parameter type",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: path
+          type: object
+`,
+			want: "unsupported parameter type",
+		},
+		{
+			name: "parameter env collision",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: foo-bar
+          type: string
+        - name: foo_bar
+          type: string
+`,
+			want: "collide in environment variable",
+		},
+		{
+			name: "invalid parameter name",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: "$path"
+          type: string
+`,
+			want: "is invalid",
+		},
+		{
+			name: "reserved parameter env",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    env:
+      allow: ["PARAM_PATH"]
+`,
+			want: "reserved",
+		},
+		{
+			name: "path on non string parameter",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: values
+          type: array
+          path: {}
+`,
+			want: "only supported for string",
+		},
+		{
+			name: "escaping path allow",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          path:
+            allow: ["../secret.yaml"]
+`,
+			want: "relative non-escaping glob",
+		},
+		{
+			name: "repository path base without repository copy scope",
+			body: `    engine: exec
+    generate:
+      command: ["renderer"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          path:
+            base: repository
+`,
+			want: `requires copy.scope "repository"`,
+		},
+		{
+			name: "unknown copy scope",
+			body: `    engine: exec
+    copy:
+      scope: workspace
+    generate:
+      command: ["renderer"]
+`,
+			want: "unsupported copy scope",
+		},
+		{
+			name: "repository copy without include",
+			body: `    engine: exec
+    copy:
+      scope: repository
+    generate:
+      command: ["renderer"]
+`,
+			want: "include is required",
+		},
+		{
+			name: "source copy with include",
+			body: `    engine: exec
+    copy:
+      scope: source
+      include: ["shared/**"]
+    generate:
+      command: ["renderer"]
+`,
+			want: "include is only supported",
+		},
+		{
+			name: "copy include escape",
+			body: `    engine: exec
+    copy:
+      scope: repository
+      include: ["../shared/**"]
+    generate:
+      command: ["renderer"]
+`,
+			want: "parent directory segments",
+		},
+		{
+			name: "copy include git",
+			body: `    engine: exec
+    copy:
+      scope: repository
+      include: [".git/**"]
+    generate:
+      command: ["renderer"]
+`,
+			want: ".git paths",
+		},
+		{
+			name: "copy include backslash",
+			body: `    engine: exec
+    copy:
+      scope: repository
+      include: ["shared\\**"]
+    generate:
+      command: ["renderer"]
+`,
+			want: "backslashes",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
@@ -548,6 +1978,9 @@ plugins:
     engine: avp-compat
   renderer:
     engine: exec
+    copy:
+      scope: repository
+      include: ["shared/**", "components/*.pkl"]
     generate:
       timeout: 3s
       command: ["argocd-vault-plugin", "generate", "."]
@@ -556,6 +1989,13 @@ plugins:
       command: ["argocd-vault-plugin", "version"]
     env:
       allow: [" OP_CONNECT_HOST ", "AVP_TYPE"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            allow: ["components/*.pkl", "*.pkl"]
 `))
 	if err != nil {
 		t.Fatalf("Parse(left) error = %v", err)
@@ -564,6 +2004,9 @@ plugins:
 apiVersion: drydock.sholdee.dev/v1alpha1
 plugins:
   renderer:
+    copy:
+      include: ["components/*.pkl", "shared/**"]
+      scope: repository
     env:
       allow: ["AVP_TYPE", "OP_CONNECT_HOST"]
     init:
@@ -573,6 +2016,13 @@ plugins:
       command: ["argocd-vault-plugin", "generate", "."]
       timeout: 3s
     engine: exec
+    parameters:
+      allow:
+        - required: true
+          path:
+            allow: ["*.pkl", "components/*.pkl"]
+          type: string
+          name: path
   zeta:
     engine: avp-compat
 `))
@@ -676,6 +2126,147 @@ plugins:
 	}
 }
 
+func TestFingerprintIncludesPluginMatch(t *testing.T) {
+	left, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  avp:
+    engine: avp-compat
+    match:
+      discover:
+        fileName: plugin.yaml
+`))
+	if err != nil {
+		t.Fatalf("Parse(left) error = %v", err)
+	}
+	right, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  avp:
+    engine: avp-compat
+    match:
+      discover:
+        find:
+          glob: "**/plugin.yaml"
+`))
+	if err != nil {
+		t.Fatalf("Parse(right) error = %v", err)
+	}
+	leftFingerprint, err := Fingerprint(left)
+	if err != nil {
+		t.Fatalf("Fingerprint(left) error = %v", err)
+	}
+	rightFingerprint, err := Fingerprint(right)
+	if err != nil {
+		t.Fatalf("Fingerprint(right) error = %v", err)
+	}
+	if leftFingerprint == rightFingerprint {
+		t.Fatalf("fingerprints match for different match rules: %s", leftFingerprint)
+	}
+	wantJSON := `{"apiVersion":"drydock.sholdee.dev/v1alpha1","kind":"PluginPolicy","plugins":{"avp":{"engine":"avp-compat","match":{"discover":{"fileName":"plugin.yaml"}}}}}`
+	if want := sha256Hex(wantJSON); leftFingerprint != want {
+		t.Fatalf("Fingerprint() = %s, want %s", leftFingerprint, want)
+	}
+}
+
+func TestFingerprintChangesWhenConfigManagementPluginSeedChanges(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  cmp:
+    engine: native-kustomize
+    configManagementPlugin:
+      discover:
+        fileName: plugin.yaml
+      generate:
+        command: ["renderer"]
+        args: ["--mode", "default"]
+`
+	baseFingerprint := mustPolicyFingerprint(t, base)
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "discover",
+			data: strings.Replace(base, `plugin.yaml`, `other.yaml`, 1),
+		},
+		{
+			name: "command",
+			data: strings.Replace(base, `"renderer"`, `"other-renderer"`, 1),
+		},
+		{
+			name: "args",
+			data: strings.Replace(base, `"default"`, `"changed"`, 1),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fingerprint := mustPolicyFingerprint(t, tt.data)
+			if fingerprint == baseFingerprint {
+				t.Fatalf("fingerprint did not change for %s: %s", tt.name, fingerprint)
+			}
+		})
+	}
+}
+
+func TestFingerprintChangesWhenBootstrapChanges(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: cluster-root
+      plugin: pkl
+      sourcePath: personal-cluster
+      parameters:
+        - name: path
+          string: index.pkl
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    generate:
+      command: ["pkl", "eval", "{{param:path}}"]
+  cue:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: cue.mod/module.cue
+    generate:
+      command: ["cue", "export"]
+`
+	baseFingerprint := mustPolicyFingerprint(t, base)
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "entrypoint name",
+			data: strings.Replace(base, "cluster-root", "cluster-bootstrap", 1),
+		},
+		{
+			name: "plugin",
+			data: strings.Replace(base, "plugin: pkl", "plugin: cue", 1),
+		},
+		{
+			name: "sourcePath",
+			data: strings.Replace(base, "personal-cluster", ".", 1),
+		},
+		{
+			name: "parameter value",
+			data: strings.Replace(base, "index.pkl", "bootstrap.pkl", 1),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fingerprint := mustPolicyFingerprint(t, tt.data)
+			if fingerprint == baseFingerprint {
+				t.Fatalf("fingerprint did not change for %s: %s", tt.name, fingerprint)
+			}
+		})
+	}
+}
+
 func TestFingerprintChangesForExecPostRenderers(t *testing.T) {
 	base := `apiVersion: drydock.sholdee.dev/v1alpha1
 kind: PluginPolicy
@@ -749,6 +2340,48 @@ plugins:
 		{
 			name: "output limits",
 			data: strings.Replace(base, `maxStdoutBytes: 1024`, `maxStdoutBytes: 2048`, 1),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fingerprint := mustPolicyFingerprint(t, tt.data)
+			if fingerprint == baseFingerprint {
+				t.Fatalf("fingerprint did not change for %s: %s", tt.name, fingerprint)
+			}
+		})
+	}
+}
+
+func TestFingerprintChangesForContainerFields(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+    engine: container
+    image: registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    generate:
+      command: ["renderer", "generate"]
+      timeout: 3s
+`
+	baseFingerprint := mustPolicyFingerprint(t, base)
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "image",
+			data: strings.Replace(base, strings.Repeat("a", 64), strings.Repeat("b", 64), 1),
+		},
+		{
+			name: "network",
+			data: strings.Replace(base, "    generate:\n", "    network: default\n    generate:\n", 1),
+		},
+		{
+			name: "allow mutable flag",
+			data: strings.Replace(base, "    generate:\n", "    allowMutableImageTag: true\n    generate:\n", 1),
+		},
+		{
+			name: "lifecycle",
+			data: strings.Replace(base, "timeout: 3s", "timeout: 4s", 1),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1084,6 +2717,88 @@ func assertSchemaConst(t *testing.T, object map[string]any, want string) {
 	if got != want {
 		t.Fatalf("schema const = %q, want %q", got, want)
 	}
+}
+
+func assertSchemaRef(t *testing.T, object map[string]any, want string) {
+	t.Helper()
+	got, ok := object["$ref"].(string)
+	if !ok {
+		t.Fatalf("schema object = %#v, want string $ref", object)
+	}
+	if got != want {
+		t.Fatalf("schema $ref = %q, want %q", got, want)
+	}
+}
+
+func assertSchemaOneOfRefs(t *testing.T, object map[string]any, want []string) {
+	t.Helper()
+	oneOf, ok := object["oneOf"].([]any)
+	if !ok {
+		t.Fatalf("schema oneOf = %#v, want refs", object["oneOf"])
+	}
+	if len(oneOf) != len(want) {
+		t.Fatalf("schema oneOf length = %d, want %d", len(oneOf), len(want))
+	}
+	for index, item := range oneOf {
+		child, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("schema oneOf[%d] = %#v, want object", index, item)
+		}
+		assertSchemaRef(t, child, want[index])
+	}
+}
+
+func assertSchemaRequired(t *testing.T, object map[string]any, want ...string) {
+	t.Helper()
+	required, ok := object["required"].([]any)
+	if !ok {
+		t.Fatalf("schema required = %#v, want list", object["required"])
+	}
+	if len(required) != len(want) {
+		t.Fatalf("schema required length = %d, want %d", len(required), len(want))
+	}
+	for index, value := range want {
+		got, ok := required[index].(string)
+		if !ok || got != value {
+			t.Fatalf("schema required[%d] = %#v, want %q", index, required[index], value)
+		}
+	}
+}
+
+func assertSchemaEnum(t *testing.T, object map[string]any, want ...string) {
+	t.Helper()
+	enum, ok := object["enum"].([]any)
+	if !ok {
+		t.Fatalf("schema enum = %#v, want list", object["enum"])
+	}
+	if len(enum) != len(want) {
+		t.Fatalf("schema enum length = %d, want %d", len(enum), len(want))
+	}
+	for index, value := range want {
+		got, ok := enum[index].(string)
+		if !ok || got != value {
+			t.Fatalf("schema enum[%d] = %#v, want %q", index, enum[index], value)
+		}
+	}
+}
+
+func assertSchemaDefault(t *testing.T, object map[string]any, want any) {
+	t.Helper()
+	got, ok := object["default"]
+	if !ok {
+		t.Fatalf("schema object = %#v, want default %#v", object, want)
+	}
+	if got != want {
+		t.Fatalf("schema default = %#v, want %#v", got, want)
+	}
+}
+
+func bootstrapParametersByName(params []BootstrapParameter) map[string]BootstrapParameter {
+	out := make(map[string]BootstrapParameter, len(params))
+	for _, param := range params {
+		out[param.Name] = param
+	}
+	return out
 }
 
 func mustPolicyFingerprint(t *testing.T, data string) string {

--- a/internal/pluginpolicy/yaml.go
+++ b/internal/pluginpolicy/yaml.go
@@ -78,6 +78,17 @@ func int64Value(node *yaml.Node, pointer string) (int64, error) {
 	return value, nil
 }
 
+func boolValue(node *yaml.Node, pointer string) (bool, error) {
+	if node.Kind != yaml.ScalarNode || node.Tag != "!!bool" {
+		return false, fmt.Errorf("%s must be a boolean", pointer)
+	}
+	value, err := strconv.ParseBool(node.Value)
+	if err != nil {
+		return false, fmt.Errorf("%s must be a boolean: %w", pointer, err)
+	}
+	return value, nil
+}
+
 func stringSequence(node *yaml.Node, pointer string) ([]string, error) {
 	if node == nil || isNullNode(node) {
 		return nil, nil

--- a/pkg/drydock/results.go
+++ b/pkg/drydock/results.go
@@ -61,7 +61,7 @@ type CacheEvent struct {
 	Error    string
 }
 
-// PluginExecution describes one trusted exec plugin command that ran.
+// PluginExecution describes one trusted plugin command that ran.
 type PluginExecution struct {
 	Application Application
 	SourceIndex int
@@ -69,6 +69,8 @@ type PluginExecution struct {
 	SourcePath  string
 	PluginName  string
 	Engine      string
+	Runtime     string
+	Image       string
 	Phase       string
 	Command     string
 	Duration    string
@@ -253,6 +255,8 @@ func pluginExecutionsFromInternal(executions []app.PluginExecution) []PluginExec
 			SourcePath:  execution.SourcePath,
 			PluginName:  execution.PluginName,
 			Engine:      execution.Engine,
+			Runtime:     execution.Runtime,
+			Image:       execution.Image,
 			Phase:       execution.Phase,
 			Command:     execution.Command,
 			Duration:    execution.Duration,

--- a/pkg/drydock/results_test.go
+++ b/pkg/drydock/results_test.go
@@ -56,6 +56,8 @@ func TestRenderResultFromBuildGoldenClonesManifestsAndStabilizesDiagnostics(t *t
 			SourcePath:   "apps/demo",
 			PluginName:   "exec-renderer",
 			Engine:       "exec",
+			Runtime:      "docker",
+			Image:        "registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Phase:        "generate",
 			Command:      "renderer",
 			Duration:     "12ms",
@@ -147,5 +149,8 @@ func assertGoldenResultPluginExecution(t *testing.T, executions []PluginExecutio
 	}
 	if execution.PluginName != "exec-renderer" || execution.Engine != "exec" || execution.Phase != "generate" || execution.Command != "renderer" || execution.Duration != "12ms" {
 		t.Fatalf("PluginExecution = %#v, want exec metadata", execution)
+	}
+	if execution.Runtime != "docker" || execution.Image != "registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("PluginExecution = %#v, want runtime/image metadata", execution)
 	}
 }

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -26,9 +26,112 @@
       "additionalProperties": {
         "$ref": "#/$defs/plugin"
       }
+    },
+    "bootstrap": {
+      "$ref": "#/$defs/bootstrap"
     }
   },
   "$defs": {
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoints"
+      ],
+      "properties": {
+        "entrypoints": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/bootstrapEntrypoint"
+          }
+        }
+      }
+    },
+    "bootstrapEntrypoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "plugin",
+        "sourcePath"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/bootstrapEntrypointName"
+        },
+        "plugin": {
+          "type": "string",
+          "pattern": "\\S"
+        },
+        "sourcePath": {
+          "$ref": "#/$defs/repoRelativePath"
+        },
+        "parameters": {
+          "$ref": "#/$defs/bootstrapEntrypointParameters"
+        }
+      }
+    },
+    "bootstrapEntrypointName": {
+      "type": "string",
+      "maxLength": 63,
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+    },
+    "bootstrapEntrypointParameters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/bootstrapEntrypointParameter"
+      }
+    },
+    "bootstrapEntrypointParameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+$"
+        },
+        "string": {
+          "type": "string"
+        },
+        "array": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "string"
+          ]
+        },
+        {
+          "required": [
+            "array"
+          ]
+        },
+        {
+          "required": [
+            "map"
+          ]
+        }
+      ]
+    },
+    "repoRelativePath": {
+      "type": "string",
+      "pattern": "^(?:\\.|(?!/)(?!.*\\\\)(?!.*//)(?!.*(^|/)\\.($|/))(?!.*(^|/)\\.git($|/))(?!.*(^|/)\\.\\.($|/))[^/]+(?:/[^/]+)*)$"
+    },
     "plugin": {
       "oneOf": [
         {
@@ -39,6 +142,9 @@
         },
         {
           "$ref": "#/$defs/execPlugin"
+        },
+        {
+          "$ref": "#/$defs/containerPlugin"
         }
       ]
     },
@@ -51,6 +157,12 @@
       "properties": {
         "engine": {
           "const": "avp-compat"
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "configManagementPlugin": {
+          "$ref": "#/$defs/configManagementPluginSeed"
         }
       }
     },
@@ -63,6 +175,12 @@
       "properties": {
         "engine": {
           "const": "native-kustomize"
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "configManagementPlugin": {
+          "$ref": "#/$defs/configManagementPluginSeed"
         }
       }
     },
@@ -77,9 +195,18 @@
         "engine": {
           "const": "exec"
         },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "configManagementPlugin": {
+          "$ref": "#/$defs/configManagementPluginSeed"
+        },
         "workdir": {
           "const": "source",
           "description": "Only source workdir is supported."
+        },
+        "copy": {
+          "$ref": "#/$defs/copy"
         },
         "init": {
           "$ref": "#/$defs/command"
@@ -97,10 +224,262 @@
         "env": {
           "$ref": "#/$defs/env"
         },
+        "parameters": {
+          "$ref": "#/$defs/parameters"
+        },
         "output": {
           "$ref": "#/$defs/output"
         }
       }
+    },
+    "containerPlugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "engine",
+        "image",
+        "generate"
+      ],
+      "properties": {
+        "engine": {
+          "const": "container"
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "configManagementPlugin": {
+          "$ref": "#/$defs/configManagementPluginSeed"
+        },
+        "runtime": {
+          "enum": [
+            "docker"
+          ],
+          "default": "docker"
+        },
+        "image": {
+          "type": "string",
+          "description": "Fully qualified container image reference. The drydock parser requires a registry host and a digest unless allowMutableImageTag is true."
+        },
+        "allowMutableImageTag": {
+          "type": "boolean",
+          "default": false
+        },
+        "network": {
+          "enum": [
+            "none",
+            "default"
+          ],
+          "default": "none"
+        },
+        "workdir": {
+          "const": "source",
+          "description": "Only source workdir is supported."
+        },
+        "copy": {
+          "$ref": "#/$defs/copy"
+        },
+        "init": {
+          "$ref": "#/$defs/command"
+        },
+        "generate": {
+          "$ref": "#/$defs/command"
+        },
+        "postRenderers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        },
+        "env": {
+          "$ref": "#/$defs/env"
+        },
+        "parameters": {
+          "$ref": "#/$defs/parameters"
+        },
+        "output": {
+          "$ref": "#/$defs/output"
+        }
+      }
+    },
+    "match": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "discover"
+      ],
+      "properties": {
+        "discover": {
+          "$ref": "#/$defs/discoverMatch"
+        }
+      }
+    },
+    "discoverMatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fileName": {
+          "$ref": "#/$defs/sourceRelativeGlob"
+        },
+        "find": {
+          "$ref": "#/$defs/discoverFindMatch"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "fileName"
+          ]
+        },
+        {
+          "required": [
+            "find"
+          ]
+        }
+      ]
+    },
+    "discoverFindMatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "glob"
+      ],
+      "properties": {
+        "glob": {
+          "$ref": "#/$defs/sourceRelativeGlob"
+        }
+      }
+    },
+    "sourceRelativeGlob": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(^|/)\\.git($|/))(?!.*(^|/)\\.\\.($|/)).+$"
+    },
+    "configManagementPluginSeed": {
+      "type": "object",
+      "description": "Optional safe subset of the Argo CD ConfigManagementPlugin spec. The enclosing plugins map key is the CMP name.",
+      "additionalProperties": false,
+      "properties": {
+        "discover": {
+          "$ref": "#/$defs/discoverMatch"
+        },
+        "generate": {
+          "$ref": "#/$defs/configManagementPluginGenerateSeed"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "discover"
+          ]
+        },
+        {
+          "required": [
+            "generate"
+          ]
+        }
+      ]
+    },
+    "configManagementPluginGenerateSeed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "array",
+          "description": "Argv sequence from a ConfigManagementPlugin seed. It is fingerprinted but not executed by seed code.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "\\S"
+          }
+        },
+        "args": {
+          "type": "array",
+          "description": "Argv arguments from a ConfigManagementPlugin seed. They are fingerprinted but not executed by seed code.",
+          "items": {
+            "type": "string",
+            "pattern": "\\S"
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "command"
+          ]
+        },
+        {
+          "required": [
+            "args"
+          ]
+        }
+      ]
+    },
+    "copy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "enum": [
+            "source",
+            "repository"
+          ],
+          "default": "source"
+        },
+        "include": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^(?!.*\\\\)(?!.*(^|/)\\.git($|/))(?!.*(^|/)\\.\\.($|/)).+$"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "repository"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          },
+          "then": {
+            "required": [
+              "include"
+            ],
+            "properties": {
+              "include": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "not": {
+              "properties": {
+                "scope": {
+                  "const": "repository"
+                }
+              },
+              "required": [
+                "scope"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "include": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
     },
     "command": {
       "type": "object",
@@ -135,6 +514,67 @@
           "items": {
             "type": "string",
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "$ref": "#/$defs/parameter"
+          }
+        }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+$"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "array",
+            "map"
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "path": {
+          "$ref": "#/$defs/parameterPath"
+        }
+      }
+    },
+    "parameterPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "enum": [
+            "source",
+            "repository"
+          ],
+          "default": "source"
+        },
+        "allow": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^(?!.*\\\\)(?!.*(^|/)\\.git($|/))(?!.*(^|/)\\.\\.($|/)).+$"
           }
         }
       }

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -27,7 +27,7 @@ behavior, edge cases, and regression expectations.
 | ApplicationSets | Native and supported with input | Git directories, Git files, list, matrix, merge, template overrides, `templatePatch`, and fixture-backed provider generators. | No live Kubernetes, SCM, pull-request, cloud, or plugin provider API calls. |
 | Sources | Native and supported with input | Local paths, Git cache/fetch, `--repo-map`, HTTP(S) Helm, OCI Helm, remote Kustomize, external Helm value files, and cache lifecycle commands. | `--offline` requires local files, repo maps, or cache hits. Ambient Git helpers and Helm registry config are not read. |
 | Rendering | Native | Directory, Kustomize, Helm, Jsonnet, Kustomize Helm charts, Argo CD tracking metadata, namespace normalization, and custom health Lua validation. | No `kubectl`, `argocd`, Helm CLI, Kustomize CLI, repo-server wrapper, or live API defaulting. |
-| Plugins | Supported with input | Native safe Kustomize CMP compatibility, argocd-vault-plugin placeholder compatibility, in-process public API renderers, and trusted exec policy with `--enable-plugins`. | No default sidecar plugin execution, ambient plugin loading, or plugin credential injection. |
+| Plugins | Supported with input | Native safe Kustomize CMP compatibility, argocd-vault-plugin placeholder compatibility, in-process public API renderers, trusted exec or container policy with `--enable-plugins`, and `bootstrap.entrypoints` for plugin-rendered app discovery. | No default sidecar plugin execution, ambient plugin loading, or plugin credential injection. |
 | Diffs and images | Native | Desired-vs-desired manifest diffs, Git ref diffs, ignored-field normalization, markdown diff previews, and image extraction from PodSpecs and exact `image` keys. | No live managed-fields prediction, server-side diff, or arbitrary string image scanning. |
 | Projects and settings | Native and supported with input | Local `AppProject` checks, rendered project discovery, repository Secret metadata, cluster Secret metadata, Argo CD settings metadata, and structured diagnostics. | No full RBAC/Casbin simulation, live cluster existence checks, or secret credential reads. |
 | API and release shape | Native | Public Go API, stable diagnostics, cache event hooks, cache commands, static binary, setup action, PR action, and container image. | Argo CD dependency updates are deliberate compatibility work. |
@@ -38,12 +38,12 @@ behavior, edge cases, and regression expectations.
 | --- | --- |
 | Direct committed `Application` manifests | Run `drydock test apps` from the repository root. |
 | ApplicationSet-generated Applications | Use native supported generators; provide fixtures for provider-backed generators. |
-| App-of-apps or bootstrap manifests | Let recursive rendered fleet discovery find rendered Applications, or use `--discover-kustomize PATH` for explicit bootstrap entrypoints. |
+| App-of-apps or bootstrap manifests | Let recursive rendered fleet discovery find rendered Applications, use `--discover-kustomize PATH` for explicit Kustomize entrypoints, or use trusted PluginPolicy `bootstrap.entrypoints` when bootstrap apps are plugin-rendered. |
 | Multi-source Applications | Use normal commands; add `--repo-map URL=PATH` when external Git sources are already checked out locally. |
 | Remote Helm or OCI charts | Let drydock fetch into its chart cache, or pre-populate the cache and use `--offline`. |
 | Private Git, Helm, or remote Kustomize sources | Pass explicit auth flags or local repo maps. drydock does not read ambient credential helpers. |
 | Kustomize with Helm charts | Use the native renderer. `kustomize.buildOptions: --enable-helm` is honored without shelling out to Kustomize. |
-| Config management plugins | Prefer native compatibility paths. Use trusted plugin policy plus `--enable-plugins` only when an exec simulation is truly needed. |
+| Config management plugins | Prefer native compatibility paths. Use trusted plugin policy plus `--enable-plugins` only when exec or container command simulation is truly needed. |
 | Pull request review | Use `diff apps`, `diff images`, or the GitHub PR action for markdown comments and artifacts. |
 
 ## Detail By Area
@@ -83,12 +83,15 @@ See [source acquisition](/docs/source-acquisition/),
 ### Plugins
 
 Native compatibility paths cover safe Kustomize CMP definitions and
-argocd-vault-plugin placeholder redaction. For other plugin-dependent repos,
-drydock can use trusted plugin policy entries when the operator explicitly
-enables plugin execution.
+argocd-vault-plugin placeholder redaction. Policy can also declare trusted
+exec or container entries, explicit native overrides, and
+`bootstrap.entrypoints` for plugin-rendered fleet discovery inputs.
 
 This is a validation compatibility layer, not Argo CD sidecar auto-discovery.
-Plugin command execution is never enabled by default.
+Plugin command execution is never enabled by default. Bootstrap entrypoints are
+disabled by static discovery mode, are not disabled by
+`--max-discovery-depth 0`, and require trusted static discovery for the
+referenced plugin.
 
 See [plugin policy](/plugin-policy/) and
 [plugin policy reference](/docs/plugin-policy/).

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -12,8 +12,9 @@ diagnostics, with two repository snapshots for diff commands.
 
 drydock scans repository YAML for Argo CD `Application`, supported
 `ApplicationSet`, `AppProject`, and settings objects. It can also render
-explicit Kustomize discovery entrypoints when bootstrap inputs are not committed
-as inflated Argo CD objects.
+explicit Kustomize discovery entrypoints and trusted PluginPolicy bootstrap
+entrypoints when bootstrap inputs are not committed as inflated Argo CD
+objects.
 
 Supported ApplicationSet generators expand offline from local files, lists,
 matrix and merge combinations, or explicit provider fixtures. Unsupported
@@ -30,9 +31,9 @@ into explicit caches. `--offline` makes those source lookups cache-only.
 
 drydock renders desired manifests with native Go renderers for directory,
 Jsonnet, Kustomize, Helm, Kustomize `helmCharts`, remote Kustomize resources,
-and supported chart-only Helm sources. Config management plugin execution is
-disabled by default; trusted plugin policy and explicit opt-in are required for
-exec plugins.
+supported chart-only Helm sources, and native plugin compatibility paths.
+Config management plugin execution is disabled by default; trusted policy
+provenance and explicit opt-in are required for exec or container plugins.
 
 Argo CD remains the semantic reference for generated desired manifests. drydock
 keeps this rendering path runtime-offline, then validates covered fixture

--- a/site/content/concepts/topologies.md
+++ b/site/content/concepts/topologies.md
@@ -64,8 +64,10 @@ drydock test apps --path .
 drydock test apps --path . --plugin-policy-ref main --enable-plugins
 ```
 
-Start without plugin execution. Add trusted policy flags only when the
-repository depends on non-native plugin rendering.
+Start with native compatibility paths. Add trusted policy flags only when the
+repository depends on exec or container plugin rendering. Use
+`bootstrap.entrypoints` when plugin-rendered output contains bootstrap
+`Application` or `ApplicationSet` objects for fleet discovery.
 
 For deeper guidance, see the canonical
 [repository topology guide](/docs/topologies/),

--- a/site/content/plugin-policy/_index.md
+++ b/site/content/plugin-policy/_index.md
@@ -3,8 +3,9 @@ title: Plugin Policy
 ---
 
 drydock plugin policy is the trusted, drydock-specific gate for config
-management plugin compatibility. It is not Argo CD sidecar auto-discovery, and
-it does not make arbitrary discovered commands safe to execute.
+management plugin compatibility beyond drydock's built-in native adapters. It
+is not Argo CD repo-server sidecar auto-discovery, and it does not make
+arbitrary discovered commands safe to execute.
 
 Operators usually do not need policy for Kustomize wrapper plugins. If drydock
 discovers a config management plugin command that safely normalizes to
@@ -15,17 +16,23 @@ discovers a config management plugin command that safely normalizes to
 - Deterministic argocd-vault-plugin placeholder redaction with
   `engine: avp-compat`.
 - Explicit native Kustomize overrides with `engine: native-kustomize`.
-- Trusted shellout compatibility with `engine: exec` and `--enable-plugins`.
+- Trusted host-process compatibility with `engine: exec` and
+  `--enable-plugins`.
+- Trusted container compatibility with `engine: container` and
+  `--enable-plugins`.
+- Plugin-rendered `Application` and `ApplicationSet` discovery with
+  `bootstrap.entrypoints`.
 
-## Exec Gate
+## Command Execution Gate
 
-The CLI and default Go client run plugin commands only when all of these are
-true:
+The CLI and default Go client run exec or container plugin commands only when
+all of these are true:
 
-- The Application source names a plugin that matches a drydock policy entry.
-- The matched entry uses `engine: exec`.
+- The Application source names a plugin that matches a drydock policy entry,
+  or an unnamed plugin source matches trusted static discovery from policy.
+- The matched entry uses `engine: exec` or `engine: container`.
 - The caller passes `--enable-plugins`.
-- The exec policy comes from trusted policy provenance.
+- The command-backed policy comes from trusted policy provenance.
 
 For a single-tree command, use an explicit trusted ref:
 
@@ -39,5 +46,13 @@ For pull request diffs, drydock loads policy from the trusted baseline side:
 drydock diff apps --path-orig ../baseline --path . --enable-plugins
 ```
 
-For schema, provenance rules, native engines, and exec security controls, see
-the canonical [plugin policy guide](/docs/plugin-policy/).
+## Bootstrap Entrypoints
+
+`bootstrap.entrypoints` are fleet discovery inputs for repositories whose
+plugin-rendered output contains Argo CD `Application` or `ApplicationSet`
+objects. Static discovery mode disables them; `--max-discovery-depth 0` does
+not. Each entrypoint must match trusted static discovery for its plugin.
+
+For schema, provenance rules, native engines, command execution controls, and
+bootstrap details, see the canonical
+[plugin policy guide](/docs/plugin-policy/).

--- a/site/content/reference/_index.md
+++ b/site/content/reference/_index.md
@@ -15,8 +15,8 @@ local run.
   permissions, comments, outputs, and caches.
 - [Source acquisition](/docs/source-acquisition/): Git, Helm, remote
   Kustomize, caches, offline behavior, and auth.
-- [Plugin policy](/docs/plugin-policy/): trusted policy provenance, engines,
-  schema, and exec security.
+- [Plugin policy](/docs/plugin-policy/): trusted policy provenance, native
+  engines, the exec/container command gate, bootstrap entrypoints, and schema.
 - [Compatibility](/docs/compatibility/): supported Argo CD behavior and
   runtime-boundary status.
 

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -54,13 +54,18 @@ drydock diff apps --repo . --ref HEAD --ref-orig main --strict-changed-only
 ## Symptom: Plugin Source Fails Closed
 
 The CLI and default Go client do not execute config management plugin commands
-by default. Safe Kustomize wrapper plugins may render natively. Other plugin
-sources need trusted drydock plugin policy, and exec policy also needs
+by default. Safe Kustomize wrapper plugins and argocd-vault-plugin
+compatibility may render natively. Exec or container plugin rendering needs
+trusted drydock plugin policy, trusted policy provenance, and
 `--enable-plugins`.
 
 ```bash
 drydock test apps --path . --plugin-policy-ref main --enable-plugins
 ```
+
+If plugin-rendered bootstrap apps are missing, check PluginPolicy
+`bootstrap.entrypoints`. Static discovery mode disables those entrypoints;
+`--max-discovery-depth 0` does not.
 
 See [Plugin policy](/plugin-policy/) for the operator gate.
 

--- a/testdata/plugin-policy/bootstrap-exec-entrypoints.yaml
+++ b/testdata/plugin-policy/bootstrap-exec-entrypoints.yaml
@@ -1,0 +1,42 @@
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+bootstrap:
+  entrypoints:
+    - name: pkl-root
+      plugin: pkl
+      sourcePath: .
+      parameters:
+        - name: path
+          string: personal-cluster/main.pkl
+        - name: packages
+          array:
+            - packages/base.pkl
+            - pkl-packages/vendor.pkl
+        - name: labels
+          map:
+            cluster: home
+            environment: prod
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    copy:
+      scope: repository
+      include:
+        - packages/**
+        - pkl-packages/**
+    init:
+      command: ["pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"]
+    generate:
+      command: ["pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow:
+              - personal-cluster/**/*.pkl

--- a/testdata/plugin-policy/pkl-exec.yaml
+++ b/testdata/plugin-policy/pkl-exec.yaml
@@ -1,0 +1,26 @@
+apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    configManagementPlugin:
+      discover:
+        fileName: PklProject
+    copy:
+      scope: repository
+      include:
+        - packages/**
+        - pkl-packages/**
+    init:
+      command: ["pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"]
+    generate:
+      command: ["pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"]
+    parameters:
+      allow:
+        - name: path
+          type: string
+          required: true
+          path:
+            base: repository
+            allow:
+              - personal-cluster/**/*.pkl


### PR DESCRIPTION
## Summary

- add trusted PluginPolicy support for container-backed CMP rendering and plugin-rendered bootstrap discovery
- document the validated local workflow for command-backed PluginPolicy validation, including trusted policy refs, repo maps, and Pkl container bootstrap
- accept leading-`v` HTTP Helm chart versions when the repository index stores the semver without `v`, matching Helm CLI behavior

## Validation

- review agent approval: no blocking findings
- `git diff --check`
- `go test ./internal/chart ./internal/app -count=1`
- `go test ./internal/pluginpolicy ./internal/pluginexec ./internal/plugincontainer ./internal/discovery ./internal/cli ./pkg/drydock -count=1`
- `mise run docs-check`
- `go run github.com/shinagawa-web/gomarklint/v3@v3.2.3 docs/plugin-policy.md`
- validated `/Users/ethan.shold/git/argocd-repos/cluster` with a digest-pinned Pkl container PluginPolicy and no repository changes beyond `.drydock/plugins.yaml`
