### PR TITLE
feat(plugin-policy): add container cache mounts

### DIFF
--- a/docs/plugin-policy.md
+++ b/docs/plugin-policy.md
@@ -262,6 +262,7 @@ Plugin entry fields:
 | `image` | Yes | None | Fully qualified image reference. Digest required unless `allowMutableImageTag: true`. |
 | `allowMutableImageTag` | No | `false` | Allows tag-only image references for local/trusted workflows. |
 | `network` | No | `none` | `none` or `default`. `default` is rejected when `--offline` is set. |
+| `cacheMounts` | No | `[]` | Policy-managed durable cache mounts under reserved container paths below `/drydock-cache`. |
 
 Command fields:
 
@@ -344,6 +345,14 @@ remote Docker client configuration such as non-local `DOCKER_HOST`,
 `DOCKER_CONTEXT`, `DOCKER_CONFIG`, `DOCKER_TLS_VERIFY`, or
 `DOCKER_CERT_PATH`. Timed-out or canceled container commands are removed with
 `docker rm -f` when a container ID is available.
+
+Container `cacheMounts` let trusted plugins keep durable tool caches without
+granting policy authors a host path escape hatch. Each entry names a cache and
+chooses only a container target path under reserved `/drydock-cache`, not
+`/drydock-cache` itself. drydock selects the host cache directory under its user
+cache root and scopes it by policy fingerprint, plugin name, and cache name.
+Targets cannot overlap `/work`, contain traversal, commas, control characters,
+backslashes, duplicate paths, or ancestor/descendant overlaps.
 
 For `engine: exec`, the command environment starts with only drydock's
 controlled `PATH`. `env.allow` names additional caller environment variables
@@ -518,10 +527,13 @@ plugins:
       include:
         - packages/**
         - personal-cluster/**
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache
     init:
-      command: ["pkl", "project", "resolve", "--cache-dir", ".drydock-pkl-cache"]
+      command: ["pkl", "project", "resolve", "--cache-dir", "/drydock-cache/pkl-cache"]
     generate:
-      command: ["pkl", "eval", "--cache-dir", ".drydock-pkl-cache", "{{param:path}}"]
+      command: ["pkl", "eval", "--cache-dir", "/drydock-cache/pkl-cache", "{{param:path}}"]
     parameters:
       allow:
         - name: path

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/apimachinery v0.36.1
@@ -159,7 +160,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect

--- a/internal/app/local_provider_plugin.go
+++ b/internal/app/local_provider_plugin.go
@@ -313,13 +313,16 @@ func (p localProvider) renderContainerPolicyPluginSource(ctx context.Context, so
 		extraEnv = append(extraEnv, "DRYDOCK_OFFLINE=true")
 	}
 	result, err := p.pluginContainerRunner.Run(ctx, plugincontainer.Request{
-		SourceDir:       sourceDir,
-		RepositoryDir:   source.RepoRoot,
-		SourceRelPath:   sourcePath,
-		Config:          containerConfig,
-		Offline:         p.offline,
-		ExtraEnv:        extraEnv,
-		SensitiveValues: sensitive,
+		SourceDir:         sourceDir,
+		RepositoryDir:     source.RepoRoot,
+		SourceRelPath:     sourcePath,
+		PluginName:        name,
+		PolicyFingerprint: p.pluginPolicyFingerprint,
+		Config:            containerConfig,
+		Offline:           p.offline,
+		ForbiddenRoots:    p.execProtectedRoots(source.RepoRoot),
+		ExtraEnv:          extraEnv,
+		SensitiveValues:   sensitive,
 	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {

--- a/internal/plugincontainer/container_cache.go
+++ b/internal/plugincontainer/container_cache.go
@@ -1,0 +1,346 @@
+package plugincontainer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/sholdee/drydock/internal/pathsafety"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+)
+
+const (
+	containerCacheMetadataFile = ".drydock-cache.json"
+	containerCacheLockSuffix   = ".lock"
+	containerCacheMetadataV1   = 1
+)
+
+type containerCacheMetadata struct {
+	Version           int    `json:"version"`
+	PolicyFingerprint string `json:"policyFingerprint"`
+	PluginNameSHA256  string `json:"pluginNameSHA256"`
+	CacheName         string `json:"cacheName"`
+	Target            string `json:"target"`
+}
+
+func prepareContainerCacheMounts(ctx context.Context, request Request) ([]containerCacheMount, func(), error) {
+	if len(request.Config.CacheMounts) == 0 {
+		return nil, func() {}, nil
+	}
+	plan, err := containerCachePlan(request)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	mounts := make([]containerCacheMount, 0, len(plan.entries))
+	var locks []*containerCacheLock
+	cleanup := func() {
+		for index := len(locks) - 1; index >= 0; index-- {
+			locks[index].Close()
+		}
+	}
+	for _, entry := range plan.entries {
+		source, existed, err := prepareContainerCacheDirectory(entry.source, request.ForbiddenRoots)
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		lock, err := lockContainerCacheDirectory(ctx, source)
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		locks = append(locks, lock)
+		if err := ensureContainerCacheMetadata(source, entry.metadata, existed); err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		mounts = append(mounts, containerCacheMount{Source: source, Target: entry.metadata.Target})
+	}
+	return mounts, cleanup, nil
+}
+
+type containerCachePlanEntry struct {
+	source   string
+	metadata containerCacheMetadata
+}
+
+type containerCachePlanResult struct {
+	entries []containerCachePlanEntry
+}
+
+func containerCachePlan(request Request) (containerCachePlanResult, error) {
+	pluginName := strings.TrimSpace(request.PluginName)
+	if pluginName == "" {
+		return containerCachePlanResult{}, fmt.Errorf("plugin name is required when cacheMounts are configured")
+	}
+	fingerprint := strings.TrimSpace(request.PolicyFingerprint)
+	if !isPolicyFingerprint(fingerprint) {
+		return containerCachePlanResult{}, fmt.Errorf("policy fingerprint is required when cacheMounts are configured")
+	}
+	root, err := containerCacheRoot(request.CacheRoot)
+	if err != nil {
+		return containerCachePlanResult{}, err
+	}
+	root, err = cleanContainerCachePath(root)
+	if err != nil {
+		return containerCachePlanResult{}, err
+	}
+	pluginNameHash := sha256Hex(pluginName)
+	pluginDir := filepath.Join(root, fingerprint, pluginNameHash)
+	entries := make([]containerCachePlanEntry, 0, len(request.Config.CacheMounts))
+	seenNames := map[string]struct{}{}
+	seenTargets := map[string]struct{}{}
+	for _, cacheMount := range request.Config.CacheMounts {
+		if err := validateContainerCacheName(cacheMount.Name); err != nil {
+			return containerCachePlanResult{}, err
+		}
+		if _, ok := seenNames[cacheMount.Name]; ok {
+			return containerCachePlanResult{}, fmt.Errorf("cache mount name %q is duplicated", cacheMount.Name)
+		}
+		seenNames[cacheMount.Name] = struct{}{}
+		if err := validateDockerMountValue(cacheMount.Target); err != nil {
+			return containerCachePlanResult{}, fmt.Errorf("cache mount %q target: %w", cacheMount.Name, err)
+		}
+		if _, ok := seenTargets[cacheMount.Target]; ok {
+			return containerCachePlanResult{}, fmt.Errorf("cache mount target %q is duplicated", cacheMount.Target)
+		}
+		seenTargets[cacheMount.Target] = struct{}{}
+		entries = append(entries, containerCachePlanEntry{
+			source: filepath.Join(pluginDir, cacheMount.Name),
+			metadata: containerCacheMetadata{
+				Version:           containerCacheMetadataV1,
+				PolicyFingerprint: fingerprint,
+				PluginNameSHA256:  pluginNameHash,
+				CacheName:         cacheMount.Name,
+				Target:            cacheMount.Target,
+			},
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].source < entries[j].source
+	})
+	return containerCachePlanResult{entries: entries}, nil
+}
+
+func containerCacheRoot(configured string) (string, error) {
+	if root := strings.TrimSpace(configured); root != "" {
+		return root, nil
+	}
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache dir: %w", err)
+	}
+	return filepath.Join(userCacheDir, "drydock", "plugin-cache"), nil
+}
+
+func prepareContainerCacheDirectory(dir string, forbiddenRoots []string) (string, bool, error) {
+	absDir, err := cleanContainerCachePath(dir)
+	if err != nil {
+		return "", false, err
+	}
+	if err := rejectForbiddenContainerCacheDir(absDir, forbiddenRoots); err != nil {
+		return "", false, err
+	}
+	existed, err := containerCacheDirectoryExists(absDir)
+	if err != nil {
+		return "", false, err
+	}
+	if err := os.MkdirAll(absDir, 0o700); err != nil {
+		return "", false, err
+	}
+	if err := validateContainerCacheDirectory(absDir); err != nil {
+		return "", false, err
+	}
+	if err := os.Chmod(absDir, 0o700); err != nil {
+		return "", false, err
+	}
+	if err := rejectForbiddenContainerCacheDir(absDir, forbiddenRoots); err != nil {
+		return "", false, err
+	}
+	return absDir, existed, nil
+}
+
+func cleanContainerCachePath(dir string) (string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	absDir = filepath.Clean(absDir)
+	if err := validateDockerMountValue(absDir); err != nil {
+		return "", err
+	}
+	return absDir, nil
+}
+
+func containerCacheDirectoryExists(absDir string) (bool, error) {
+	info, err := os.Lstat(absDir)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return false, fmt.Errorf("cache directory %q must not be a symlink", absDir)
+		}
+		if !info.IsDir() {
+			return false, fmt.Errorf("cache directory %q must be a directory", absDir)
+		}
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func validateContainerCacheDirectory(absDir string) error {
+	info, err := os.Lstat(absDir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("cache directory %q must not be a symlink", absDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("cache directory %q must be a directory", absDir)
+	}
+	return nil
+}
+
+func ensureContainerCacheMetadata(dir string, want containerCacheMetadata, existed bool) error {
+	path := filepath.Join(dir, containerCacheMetadataFile)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		var got containerCacheMetadata
+		if err := json.Unmarshal(data, &got); err != nil {
+			return fmt.Errorf("cache directory %q metadata is invalid: %w", dir, err)
+		}
+		if got != want {
+			return fmt.Errorf("cache directory %q metadata mismatch", dir)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("read cache directory %q metadata: %w", dir, err)
+	}
+	if existed {
+		return fmt.Errorf("cache directory %q is missing metadata", dir)
+	}
+	return writeContainerCacheMetadata(path, want)
+}
+
+func writeContainerCacheMetadata(path string, metadata containerCacheMetadata) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temp, err := os.CreateTemp(filepath.Dir(path), ".drydock-cache-metadata-*")
+	if err != nil {
+		return fmt.Errorf("create cache metadata temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	cleanup := func() { _ = os.Remove(tempPath) }
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		cleanup()
+		return fmt.Errorf("write cache metadata: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close cache metadata: %w", err)
+	}
+	if err := os.Chmod(tempPath, 0o600); err != nil {
+		cleanup()
+		return fmt.Errorf("chmod cache metadata: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("publish cache metadata: %w", err)
+	}
+	return nil
+}
+
+func containerCacheLockPath(dir string) string {
+	return filepath.Clean(dir) + containerCacheLockSuffix
+}
+
+func validateContainerCacheMountsForDocker(mounts []containerCacheMount, forbiddenRoots []string) error {
+	for _, mount := range mounts {
+		if err := validateDockerMountValue(mount.Source); err != nil {
+			return fmt.Errorf("cache mount source %q: %w", mount.Source, err)
+		}
+		if err := validateDockerMountValue(mount.Target); err != nil {
+			return fmt.Errorf("cache mount target %q: %w", mount.Target, err)
+		}
+		if err := validateContainerCacheDirectory(mount.Source); err != nil {
+			return err
+		}
+		if err := rejectForbiddenContainerCacheDir(mount.Source, forbiddenRoots); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectForbiddenContainerCacheDir(dir string, forbiddenRoots []string) error {
+	inside, matchedRoot, err := pathsafety.IsInsideAny(dir, forbiddenRoots)
+	if err != nil {
+		return err
+	}
+	if inside {
+		return fmt.Errorf("cache directory %q must not be inside protected root %q", dir, matchedRoot)
+	}
+	return nil
+}
+
+func validateContainerCacheName(name string) error {
+	if name == "" || len(name) > 63 {
+		return fmt.Errorf("cache mount name %q is invalid", name)
+	}
+	for index, char := range name {
+		valid := char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '-'
+		if !valid {
+			return fmt.Errorf("cache mount name %q is invalid", name)
+		}
+		if index == 0 && char == '-' {
+			return fmt.Errorf("cache mount name %q is invalid", name)
+		}
+	}
+	if strings.HasSuffix(name, "-") {
+		return fmt.Errorf("cache mount name %q is invalid", name)
+	}
+	return nil
+}
+
+func validateDockerMountValue(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("mount value must not be empty")
+	}
+	for _, char := range value {
+		if char == ',' || unicode.IsControl(char) {
+			return fmt.Errorf("mount value must not contain commas or control characters")
+		}
+	}
+	return nil
+}
+
+func isPolicyFingerprint(value string) bool {
+	if value == "" || value == pluginpolicy.NoPolicyFingerprint || len(value) != sha256.Size*2 {
+		return false
+	}
+	for _, char := range value {
+		if !(char >= '0' && char <= '9' || char >= 'a' && char <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/plugincontainer/container_cache.go
+++ b/internal/plugincontainer/container_cache.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -41,8 +42,8 @@ func prepareContainerCacheMounts(ctx context.Context, request Request) ([]contai
 	mounts := make([]containerCacheMount, 0, len(plan.entries))
 	var locks []*containerCacheLock
 	cleanup := func() {
-		for index := len(locks) - 1; index >= 0; index-- {
-			locks[index].Close()
+		for _, lock := range slices.Backward(locks) {
+			lock.Close()
 		}
 	}
 	for _, entry := range plan.entries {
@@ -333,7 +334,7 @@ func isPolicyFingerprint(value string) bool {
 		return false
 	}
 	for _, char := range value {
-		if !(char >= '0' && char <= '9' || char >= 'a' && char <= 'f') {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
 			return false
 		}
 	}

--- a/internal/plugincontainer/container_cache_lock_unix.go
+++ b/internal/plugincontainer/container_cache_lock_unix.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+package plugincontainer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type containerCacheLock struct {
+	file *os.File
+}
+
+func lockContainerCacheDirectory(ctx context.Context, dir string) (*containerCacheLock, error) {
+	file, err := os.OpenFile(containerCacheLockPath(dir), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open cache lock for %q: %w", dir, err)
+	}
+	if err := os.Chmod(file.Name(), 0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("chmod cache lock for %q: %w", dir, err)
+	}
+	for {
+		err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return &containerCacheLock{file: file}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock cache directory %q: %w", dir, err)
+		}
+		timer := time.NewTimer(25 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, fmt.Errorf("lock cache directory %q: %w", dir, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func (l *containerCacheLock) Close() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	_ = l.file.Close()
+}

--- a/internal/plugincontainer/container_cache_lock_windows.go
+++ b/internal/plugincontainer/container_cache_lock_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package plugincontainer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+type containerCacheLock struct {
+	file       *os.File
+	overlapped windows.Overlapped
+}
+
+func lockContainerCacheDirectory(ctx context.Context, dir string) (*containerCacheLock, error) {
+	file, err := os.OpenFile(containerCacheLockPath(dir), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open cache lock for %q: %w", dir, err)
+	}
+	if err := os.Chmod(file.Name(), 0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("chmod cache lock for %q: %w", dir, err)
+	}
+	lock := &containerCacheLock{file: file}
+	for {
+		err := windows.LockFileEx(
+			windows.Handle(file.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			&lock.overlapped,
+		)
+		if err == nil {
+			return lock, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock cache directory %q: %w", dir, err)
+		}
+		timer := time.NewTimer(25 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, fmt.Errorf("lock cache directory %q: %w", dir, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func (l *containerCacheLock) Close() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.overlapped)
+	_ = l.file.Close()
+}

--- a/internal/plugincontainer/plugincontainer.go
+++ b/internal/plugincontainer/plugincontainer.go
@@ -34,14 +34,18 @@ type DefaultRunner struct {
 }
 
 type Request struct {
-	SourceDir       string
-	RepositoryDir   string
-	SourceRelPath   string
-	Config          pluginpolicy.ContainerConfig
-	Offline         bool
-	EnvLookup       func(string) (string, bool)
-	ExtraEnv        []string
-	SensitiveValues []string
+	SourceDir         string
+	RepositoryDir     string
+	SourceRelPath     string
+	PluginName        string
+	PolicyFingerprint string
+	Config            pluginpolicy.ContainerConfig
+	Offline           bool
+	ForbiddenRoots    []string
+	CacheRoot         string
+	EnvLookup         func(string) (string, bool)
+	ExtraEnv          []string
+	SensitiveValues   []string
 }
 
 type ProcessRequest struct {
@@ -53,6 +57,11 @@ type ProcessRequest struct {
 	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
+}
+
+type containerCacheMount struct {
+	Source string
+	Target string
 }
 
 func (r DefaultRunner) Run(ctx context.Context, request Request) (pluginexec.Result, error) {
@@ -72,6 +81,11 @@ func runWithProcess(ctx context.Context, request Request, processRunner ProcessR
 	if request.Offline && request.Config.Network == pluginpolicy.ContainerNetworkDefault {
 		return pluginexec.Result{}, &pluginexec.Error{Reason: "container network default is not allowed when offline"}
 	}
+	cacheMounts, releaseCacheMounts, err := prepareContainerCacheMounts(ctx, request)
+	if err != nil {
+		return pluginexec.Result{}, &pluginexec.Error{Reason: "invalid container cache mounts", Err: err}
+	}
+	defer releaseCacheMounts()
 	dockerClientConfigDir, cleanupDockerClientConfig, err := prepareDockerClientConfig(request)
 	if err != nil {
 		return pluginexec.Result{}, err
@@ -94,7 +108,7 @@ func runWithProcess(ctx context.Context, request Request, processRunner ProcessR
 	if err != nil {
 		return pluginexec.Result{}, err
 	}
-	return runContainerLifecycle(ctx, request, processRunner, dockerPath, workspace, dockerEnv, containerEnv)
+	return runContainerLifecycle(ctx, request, processRunner, dockerPath, workspace, cacheMounts, dockerEnv, containerEnv)
 }
 
 func prepareDockerClientConfig(request Request) (string, func(), error) {
@@ -120,23 +134,23 @@ func containerProcessEnv(request Request, dockerClientConfigDir string) ([]strin
 	return containerEnv, dockerEnv, nil
 }
 
-func runContainerLifecycle(ctx context.Context, request Request, processRunner ProcessRunner, dockerPath string, workspace pluginexec.Workspace, dockerEnv, containerEnv []string) (pluginexec.Result, error) {
+func runContainerLifecycle(ctx context.Context, request Request, processRunner ProcessRunner, dockerPath string, workspace pluginexec.Workspace, cacheMounts []containerCacheMount, dockerEnv, containerEnv []string) (pluginexec.Result, error) {
 	var executions []pluginexec.Execution
 	if request.Config.Lifecycle.Init != nil {
-		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "init", *request.Config.Lifecycle.Init, nil, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "init", *request.Config.Lifecycle.Init, nil, workspace, request.Config, cacheMounts, request.ForbiddenRoots, request.Offline, dockerEnv, containerEnv)
 		if err != nil {
 			return pluginexec.Result{}, err
 		}
 		executions = append(executions, result.Execution)
 	}
-	result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "generate", request.Config.Lifecycle.Generate, nil, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+	result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, "generate", request.Config.Lifecycle.Generate, nil, workspace, request.Config, cacheMounts, request.ForbiddenRoots, request.Offline, dockerEnv, containerEnv)
 	if err != nil {
 		return pluginexec.Result{}, err
 	}
 	stdout := result.Stdout
 	executions = append(executions, result.Execution)
 	for index, command := range request.Config.Lifecycle.PostRenderers {
-		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, fmt.Sprintf("post-renderer %d", index), command, stdout, workspace, request.Config, request.Offline, dockerEnv, containerEnv)
+		result, err := runConfiguredContainerCommand(ctx, processRunner, dockerPath, fmt.Sprintf("post-renderer %d", index), command, stdout, workspace, request.Config, cacheMounts, request.ForbiddenRoots, request.Offline, dockerEnv, containerEnv)
 		if err != nil {
 			return pluginexec.Result{}, err
 		}
@@ -160,6 +174,8 @@ func runConfiguredContainerCommand(
 	stdin []byte,
 	workspace pluginexec.Workspace,
 	config pluginpolicy.ContainerConfig,
+	cacheMounts []containerCacheMount,
+	forbiddenRoots []string,
 	offline bool,
 	dockerEnv []string,
 	containerEnv []string,
@@ -183,7 +199,10 @@ func runConfiguredContainerCommand(
 	}
 	stdout := &limitBuffer{limit: config.Lifecycle.Output.MaxStdoutBytes}
 	stderr := &limitBuffer{limit: config.Lifecycle.Output.MaxStderrBytes}
-	args := dockerRunArgs(config, workspace, offline, envFile, cidFile, command.Command)
+	if err := validateContainerCacheMountsForDocker(cacheMounts, forbiddenRoots); err != nil {
+		return commandResult{}, &pluginexec.Error{Phase: phase, Command: safeCommandName(command.Command), Reason: "invalid container cache mounts", Err: err}
+	}
+	args := dockerRunArgs(config, workspace, cacheMounts, offline, envFile, cidFile, command.Command)
 	started := time.Now()
 	err = processRunner.Run(ctx, ProcessRequest{
 		Path:    docker,
@@ -225,7 +244,7 @@ func runConfiguredContainerCommand(
 	return commandResult{Stdout: stdout.Bytes(), Execution: execution}, nil
 }
 
-func dockerRunArgs(config pluginpolicy.ContainerConfig, workspace pluginexec.Workspace, offline bool, envFile string, cidFile string, command []string) []string {
+func dockerRunArgs(config pluginpolicy.ContainerConfig, workspace pluginexec.Workspace, cacheMounts []containerCacheMount, offline bool, envFile string, cidFile string, command []string) []string {
 	network := string(config.Network)
 	if network == "" {
 		network = string(pluginpolicy.DefaultContainerNetwork)
@@ -237,8 +256,11 @@ func dockerRunArgs(config pluginpolicy.ContainerConfig, workspace pluginexec.Wor
 		"--cidfile", cidFile,
 		"--network", network,
 		"--mount", "type=bind,src=" + workspace.ArgumentRoot + ",dst=" + workMount,
-		"--workdir", containerWorkdir(workspace),
 	}
+	for _, mount := range cacheMounts {
+		args = append(args, "--mount", "type=bind,src="+mount.Source+",target="+mount.Target)
+	}
+	args = append(args, "--workdir", containerWorkdir(workspace))
 	if offline {
 		args = append(args, "--pull", "never")
 	}

--- a/internal/plugincontainer/plugincontainer_test.go
+++ b/internal/plugincontainer/plugincontainer_test.go
@@ -3,6 +3,7 @@ package plugincontainer
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -259,6 +260,292 @@ func TestDefaultRunnerRejectsCredentialBearingArguments(t *testing.T) {
 	}
 }
 
+func TestDefaultRunnerAddsDeterministicCacheMountArgsAfterWorkMount(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	fingerprint := strings.Repeat("a", 64)
+	process := &recordingProcessRunner{}
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{
+		{Name: "z-cache", Target: "/drydock-cache/z"},
+		{Name: "a-cache", Target: "/drydock-cache/a"},
+	}
+
+	_, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "team/plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(process.requests) != 1 {
+		t.Fatalf("process requests = %d, want 1", len(process.requests))
+	}
+	args := process.requests[0].Args
+	mounts := mountArgs(args)
+	if len(mounts) != 3 {
+		t.Fatalf("mounts = %#v, want work plus two cache mounts", mounts)
+	}
+	if !strings.Contains(mounts[0], "dst=/work") {
+		t.Fatalf("first mount = %q, want /work", mounts[0])
+	}
+	pluginHash := sha256Hex("team/plugin")
+	wantA := filepath.Join(cacheRoot, fingerprint, pluginHash, "a-cache")
+	wantZ := filepath.Join(cacheRoot, fingerprint, pluginHash, "z-cache")
+	if mounts[1] != "type=bind,src="+wantA+",target=/drydock-cache/a" {
+		t.Fatalf("second mount = %q, want a-cache bind", mounts[1])
+	}
+	if mounts[2] != "type=bind,src="+wantZ+",target=/drydock-cache/z" {
+		t.Fatalf("third mount = %q, want z-cache bind", mounts[2])
+	}
+	if indexOfArg(args, "--workdir") < indexOfMount(args, mounts[2]) {
+		t.Fatalf("args = %#v, want cache mounts before --workdir", args)
+	}
+	if strings.Contains(strings.Join(mounts, "\x00"), "team/plugin") {
+		t.Fatalf("cache mount used raw plugin name: %#v", mounts)
+	}
+	metadata := readCacheMetadata(t, wantA)
+	if metadata.PolicyFingerprint != fingerprint || metadata.PluginNameSHA256 != pluginHash || metadata.CacheName != "a-cache" || metadata.Target != "/drydock-cache/a" {
+		t.Fatalf("metadata = %#v, want cache identity", metadata)
+	}
+	if mode := statMode(t, wantA); mode != 0o700 {
+		t.Fatalf("cache directory mode = %o, want 700", mode)
+	}
+	if _, err := os.Stat(filepath.Join(wantA, containerCacheLockSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("cache lock stat = %v, want lock outside mounted cache directory", err)
+	}
+	if _, err := os.Stat(containerCacheLockPath(wantA)); err != nil {
+		t.Fatalf("cache lock stat = %v, want sibling lock file", err)
+	}
+}
+
+func TestDefaultRunnerUsesDefaultUserCacheRootForCacheMounts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "xdg-cache"))
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := t.TempDir()
+	fingerprint := strings.Repeat("0", 64)
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err = (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := filepath.Join(userCacheDir, "drydock", "plugin-cache", fingerprint, sha256Hex("plugin"), "tool-cache")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("default cache dir stat = %v, want %s", err, want)
+	}
+}
+
+func TestDefaultRunnerRejectsOfflineDefaultNetworkBeforeCacheCreation(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	config := basicContainerConfig()
+	config.Network = pluginpolicy.ContainerNetworkDefault
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: strings.Repeat("b", 64),
+		Config:            config,
+		Offline:           true,
+		CacheRoot:         cacheRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "network default") {
+		t.Fatalf("Run() error = %v, want network default rejection", err)
+	}
+	if _, statErr := os.Stat(cacheRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("cache root stat = %v, want not created", statErr)
+	}
+}
+
+func TestDefaultRunnerRejectsCacheInsideProtectedRootBeforeCreation(t *testing.T) {
+	source := t.TempDir()
+	protected := t.TempDir()
+	cacheRoot := filepath.Join(protected, "plugin-cache")
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: strings.Repeat("c", 64),
+		Config:            config,
+		ForbiddenRoots:    []string{protected},
+		CacheRoot:         cacheRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "protected root") {
+		t.Fatalf("Run() error = %v, want protected root rejection", err)
+	}
+	if _, statErr := os.Stat(cacheRoot); !os.IsNotExist(statErr) {
+		t.Fatalf("cache root stat = %v, want not created", statErr)
+	}
+}
+
+func TestDefaultRunnerRejectsFinalCacheDirectorySymlink(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	fingerprint := strings.Repeat("d", 64)
+	finalDir := filepath.Join(cacheRoot, fingerprint, sha256Hex("plugin"), "tool-cache")
+	if err := os.MkdirAll(filepath.Dir(finalDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	if err := os.Symlink(target, finalDir); err != nil {
+		t.Fatal(err)
+	}
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Run() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestValidateContainerCacheMountsForDockerRechecksPreparedSource(t *testing.T) {
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	protected := t.TempDir()
+	fingerprint := strings.Repeat("1", 64)
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+	mounts, release, err := prepareContainerCacheMounts(context.Background(), Request{
+		SourceDir:         t.TempDir(),
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err != nil {
+		t.Fatalf("prepareContainerCacheMounts() error = %v", err)
+	}
+	defer release()
+	if len(mounts) != 1 {
+		t.Fatalf("mounts = %#v, want one mount", mounts)
+	}
+	if err := os.RemoveAll(mounts[0].Source); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(protected, mounts[0].Source); err != nil {
+		t.Fatal(err)
+	}
+
+	err = validateContainerCacheMountsForDocker(mounts, []string{protected})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("validateContainerCacheMountsForDocker() error = %v, want symlink recheck", err)
+	}
+}
+
+func TestDefaultRunnerRejectsCacheMetadataMismatch(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	fingerprint := strings.Repeat("e", 64)
+	finalDir := filepath.Join(cacheRoot, fingerprint, sha256Hex("plugin"), "tool-cache")
+	if err := os.MkdirAll(finalDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeContainerCacheMetadata(filepath.Join(finalDir, containerCacheMetadataFile), containerCacheMetadata{
+		Version:           containerCacheMetadataV1,
+		PolicyFingerprint: fingerprint,
+		PluginNameSHA256:  sha256Hex("other-plugin"),
+		CacheName:         "tool-cache",
+		Target:            "/drydock-cache/tool",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "metadata mismatch") {
+		t.Fatalf("Run() error = %v, want metadata mismatch", err)
+	}
+}
+
+func TestDefaultRunnerRejectsExistingCacheDirectoryMissingMetadata(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	fingerprint := strings.Repeat("e", 64)
+	finalDir := filepath.Join(cacheRoot, fingerprint, sha256Hex("plugin"), "tool-cache")
+	if err := os.MkdirAll(finalDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: &recordingProcessRunner{}, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing metadata") {
+		t.Fatalf("Run() error = %v, want missing metadata", err)
+	}
+}
+
+func TestDefaultRunnerHoldsCacheLockDuringContainerLifecycle(t *testing.T) {
+	source := t.TempDir()
+	cacheRoot := filepath.Join(t.TempDir(), "plugin-cache")
+	fingerprint := strings.Repeat("f", 64)
+	finalDir := filepath.Join(cacheRoot, fingerprint, sha256Hex("plugin"), "tool-cache")
+	process := &recordingProcessRunner{
+		onRun: func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+			defer cancel()
+			lock, err := lockContainerCacheDirectory(ctx, finalDir)
+			if err == nil {
+				lock.Close()
+				return errors.New("cache lock was available during container run")
+			}
+			if !strings.Contains(err.Error(), "context deadline exceeded") {
+				return err
+			}
+			return nil
+		},
+	}
+	config := basicContainerConfig()
+	config.CacheMounts = []pluginpolicy.ContainerCacheMount{{Name: "tool-cache", Target: "/drydock-cache/tool"}}
+
+	_, err := (DefaultRunner{ProcessRunner: process, DockerPath: "/usr/bin/docker"}).Run(context.Background(), Request{
+		SourceDir:         source,
+		PluginName:        "plugin",
+		PolicyFingerprint: fingerprint,
+		Config:            config,
+		CacheRoot:         cacheRoot,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
 type recordingProcessRunner struct {
 	requests              []ProcessRequest
 	stdout                []byte
@@ -269,10 +556,14 @@ type recordingProcessRunner struct {
 	cidFileAlreadyExist   bool
 	dockerConfigHadConfig bool
 	envFileData           []byte
+	onRun                 func() error
 }
 
 func (r *recordingProcessRunner) Run(_ context.Context, request ProcessRequest) error {
 	r.requests = append(r.requests, cloneProcessRequest(request))
+	if r.onRun != nil {
+		return r.onRun()
+	}
 	if dockerConfig := envMap(request.Env)["DOCKER_CONFIG"]; dockerConfig != "" {
 		if _, err := os.Stat(filepath.Join(dockerConfig, "config.json")); err == nil {
 			r.dockerConfigHadConfig = true
@@ -355,6 +646,56 @@ func mountSrc(t *testing.T, args []string) string {
 	}
 	t.Fatalf("mount = %q, missing src", value)
 	return ""
+}
+
+func mountArgs(args []string) []string {
+	var mounts []string
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "--mount" {
+			mounts = append(mounts, args[index+1])
+		}
+	}
+	return mounts
+}
+
+func indexOfArg(args []string, arg string) int {
+	for index, value := range args {
+		if value == arg {
+			return index
+		}
+	}
+	return -1
+}
+
+func indexOfMount(args []string, mount string) int {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "--mount" && args[index+1] == mount {
+			return index
+		}
+	}
+	return -1
+}
+
+func readCacheMetadata(t *testing.T, dir string) containerCacheMetadata {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, containerCacheMetadataFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata containerCacheMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	return metadata
+}
+
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Mode().Perm()
 }
 
 func TestDefaultRunnerReportsProcessExit(t *testing.T) {

--- a/internal/plugincontainer/plugincontainer_test.go
+++ b/internal/plugincontainer/plugincontainer_test.go
@@ -285,6 +285,14 @@ func TestDefaultRunnerAddsDeterministicCacheMountArgsAfterWorkMount(t *testing.T
 		t.Fatalf("process requests = %d, want 1", len(process.requests))
 	}
 	args := process.requests[0].Args
+	wantA := filepath.Join(cacheRoot, fingerprint, sha256Hex("team/plugin"), "a-cache")
+	wantZ := filepath.Join(cacheRoot, fingerprint, sha256Hex("team/plugin"), "z-cache")
+	assertDeterministicCacheMountArgs(t, args, wantA, wantZ)
+	assertCacheMountMetadataAndLock(t, wantA, fingerprint, sha256Hex("team/plugin"))
+}
+
+func assertDeterministicCacheMountArgs(t *testing.T, args []string, wantA, wantZ string) {
+	t.Helper()
 	mounts := mountArgs(args)
 	if len(mounts) != 3 {
 		t.Fatalf("mounts = %#v, want work plus two cache mounts", mounts)
@@ -292,9 +300,6 @@ func TestDefaultRunnerAddsDeterministicCacheMountArgsAfterWorkMount(t *testing.T
 	if !strings.Contains(mounts[0], "dst=/work") {
 		t.Fatalf("first mount = %q, want /work", mounts[0])
 	}
-	pluginHash := sha256Hex("team/plugin")
-	wantA := filepath.Join(cacheRoot, fingerprint, pluginHash, "a-cache")
-	wantZ := filepath.Join(cacheRoot, fingerprint, pluginHash, "z-cache")
 	if mounts[1] != "type=bind,src="+wantA+",target=/drydock-cache/a" {
 		t.Fatalf("second mount = %q, want a-cache bind", mounts[1])
 	}
@@ -307,6 +312,10 @@ func TestDefaultRunnerAddsDeterministicCacheMountArgsAfterWorkMount(t *testing.T
 	if strings.Contains(strings.Join(mounts, "\x00"), "team/plugin") {
 		t.Fatalf("cache mount used raw plugin name: %#v", mounts)
 	}
+}
+
+func assertCacheMountMetadataAndLock(t *testing.T, wantA, fingerprint, pluginHash string) {
+	t.Helper()
 	metadata := readCacheMetadata(t, wantA)
 	if metadata.PolicyFingerprint != fingerprint || metadata.PluginNameSHA256 != pluginHash || metadata.CacheName != "a-cache" || metadata.Target != "/drydock-cache/a" {
 		t.Fatalf("metadata = %#v, want cache identity", metadata)

--- a/internal/pluginpolicy/container_parse.go
+++ b/internal/pluginpolicy/container_parse.go
@@ -2,7 +2,10 @@ package pluginpolicy
 
 import (
 	"fmt"
+	pathpkg "path"
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/distribution/reference"
 	"go.yaml.in/yaml/v4"
@@ -32,6 +35,10 @@ func parseContainerPlugin(fields map[string]*yaml.Node, path, pointer string) (P
 	if err != nil {
 		return Plugin{}, err
 	}
+	cacheMounts, err := parseContainerCacheMounts(fields["cacheMounts"], path, pointer+".cacheMounts")
+	if err != nil {
+		return Plugin{}, err
+	}
 	lifecycle, err := parseExecLifecycleConfig(fields, path, pointer)
 	if err != nil {
 		return Plugin{}, err
@@ -45,6 +52,7 @@ func parseContainerPlugin(fields map[string]*yaml.Node, path, pointer string) (P
 			Image:                image,
 			AllowMutableImageTag: allowMutableImageTag,
 			Network:              network,
+			CacheMounts:          cacheMounts,
 			Lifecycle:            lifecycle,
 		},
 	}, nil
@@ -59,6 +67,7 @@ func containerPluginAllowedFields() map[string]bool {
 	fields["image"] = true
 	fields["allowMutableImageTag"] = true
 	fields["network"] = true
+	fields["cacheMounts"] = true
 	return fields
 }
 
@@ -138,4 +147,153 @@ func parseContainerNetwork(fields map[string]*yaml.Node, path, pointer string) (
 	default:
 		return "", fmt.Errorf("parse plugin policy %s: %s.network has unsupported container network %q", path, pointer, network)
 	}
+}
+
+func parseContainerCacheMounts(node *yaml.Node, policyPath, pointer string) ([]ContainerCacheMount, error) {
+	if node == nil || isNullNode(node) {
+		return nil, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a sequence", policyPath, pointer)
+	}
+	if len(node.Content) == 0 {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must not be empty", policyPath, pointer)
+	}
+	if len(node.Content) > maxContainerCacheMountCount {
+		return nil, fmt.Errorf("parse plugin policy %s: %s must contain at most %d entries", policyPath, pointer, maxContainerCacheMountCount)
+	}
+	mounts := make([]ContainerCacheMount, 0, len(node.Content))
+	seenNames := map[string]struct{}{}
+	seenTargets := map[string]struct{}{}
+	for index, child := range node.Content {
+		itemPointer := fmt.Sprintf("%s[%d]", pointer, index)
+		mount, err := parseContainerCacheMount(child, policyPath, itemPointer)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seenNames[mount.Name]; ok {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.name duplicate cache mount name %q", policyPath, itemPointer, mount.Name)
+		}
+		seenNames[mount.Name] = struct{}{}
+		if _, ok := seenTargets[mount.Target]; ok {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.target duplicate cache mount target %q", policyPath, itemPointer, mount.Target)
+		}
+		seenTargets[mount.Target] = struct{}{}
+		mounts = append(mounts, mount)
+	}
+	if err := rejectOverlappingContainerCacheTargets(mounts, policyPath, pointer); err != nil {
+		return nil, err
+	}
+	sort.Slice(mounts, func(i, j int) bool {
+		return mounts[i].Name < mounts[j].Name
+	})
+	return mounts, nil
+}
+
+func parseContainerCacheMount(node *yaml.Node, policyPath, pointer string) (ContainerCacheMount, error) {
+	if node.Kind != yaml.MappingNode {
+		return ContainerCacheMount{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", policyPath, pointer)
+	}
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return ContainerCacheMount{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	if err := rejectUnknownFields(fields, map[string]bool{"name": true, "target": true}, pointer); err != nil {
+		return ContainerCacheMount{}, fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name, err := parseContainerCacheMountName(fields, policyPath, pointer)
+	if err != nil {
+		return ContainerCacheMount{}, err
+	}
+	target, err := parseContainerCacheMountTarget(fields, policyPath, pointer)
+	if err != nil {
+		return ContainerCacheMount{}, err
+	}
+	return ContainerCacheMount{Name: name, Target: target}, nil
+}
+
+func parseContainerCacheMountName(fields map[string]*yaml.Node, policyPath, pointer string) (string, error) {
+	value, err := requiredString(fields, "name", pointer+".name")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	name := strings.TrimSpace(value)
+	if name != value {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not contain leading or trailing whitespace", policyPath, pointer)
+	}
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty, . or ..", policyPath, pointer)
+	}
+	if len(name) > 63 || !bootstrapEntrypointNamePattern.MatchString(name) || hasCommaOrControl(name) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.name %q must be a DNS-label-like cache name", policyPath, pointer, name)
+	}
+	return name, nil
+}
+
+func parseContainerCacheMountTarget(fields map[string]*yaml.Node, policyPath, pointer string) (string, error) {
+	value, err := requiredString(fields, "target", pointer+".target")
+	if err != nil {
+		return "", fmt.Errorf("parse plugin policy %s: %w", policyPath, err)
+	}
+	target := strings.TrimSpace(value)
+	if target != value {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must not contain leading or trailing whitespace", policyPath, pointer)
+	}
+	if target == "" {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must not be empty", policyPath, pointer)
+	}
+	if strings.Contains(target, "\\") {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must use Linux container paths", policyPath, pointer)
+	}
+	if hasCommaOrControl(target) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must not contain commas or control characters", policyPath, pointer)
+	}
+	if !pathpkg.IsAbs(target) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must be an absolute Linux container path", policyPath, pointer)
+	}
+	if hasDotDotPathComponent(target) {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must not contain .. path components", policyPath, pointer)
+	}
+	cleaned := pathpkg.Clean(target)
+	if cleaned == "/work" || strings.HasPrefix(cleaned, "/work/") {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must not overlap the /work source mount", policyPath, pointer)
+	}
+	if cleaned == ContainerCacheTargetRoot || !strings.HasPrefix(cleaned, ContainerCacheTargetRoot+"/") {
+		return "", fmt.Errorf("parse plugin policy %s: %s.target must be under %s without using the root itself", policyPath, pointer, ContainerCacheTargetRoot)
+	}
+	return cleaned, nil
+}
+
+func rejectOverlappingContainerCacheTargets(mounts []ContainerCacheMount, policyPath, pointer string) error {
+	targets := make([]string, 0, len(mounts))
+	for _, mount := range mounts {
+		targets = append(targets, mount.Target)
+	}
+	sort.Strings(targets)
+	for index := 1; index < len(targets); index++ {
+		previous := targets[index-1]
+		current := targets[index]
+		if current == previous || strings.HasPrefix(current, previous+"/") {
+			return fmt.Errorf("parse plugin policy %s: %s contains overlapping cache mount targets %q and %q", policyPath, pointer, previous, current)
+		}
+	}
+	return nil
+}
+
+func hasCommaOrControl(value string) bool {
+	for _, char := range value {
+		if char == ',' || unicode.IsControl(char) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDotDotPathComponent(value string) bool {
+	for _, component := range strings.Split(value, "/") {
+		if component == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pluginpolicy/container_parse.go
+++ b/internal/pluginpolicy/container_parse.go
@@ -3,6 +3,7 @@ package pluginpolicy
 import (
 	"fmt"
 	pathpkg "path"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -222,7 +223,7 @@ func parseContainerCacheMountName(fields map[string]*yaml.Node, policyPath, poin
 		return "", fmt.Errorf("parse plugin policy %s: %s.name must not contain leading or trailing whitespace", policyPath, pointer)
 	}
 	if name == "" || name == "." || name == ".." {
-		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty, . or ..", policyPath, pointer)
+		return "", fmt.Errorf("parse plugin policy %s: %s.name must not be empty or use a dot path segment", policyPath, pointer)
 	}
 	if len(name) > 63 || !bootstrapEntrypointNamePattern.MatchString(name) || hasCommaOrControl(name) {
 		return "", fmt.Errorf("parse plugin policy %s: %s.name %q must be a DNS-label-like cache name", policyPath, pointer, name)
@@ -290,10 +291,5 @@ func hasCommaOrControl(value string) bool {
 }
 
 func hasDotDotPathComponent(value string) bool {
-	for _, component := range strings.Split(value, "/") {
-		if component == ".." {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(value, "/"), "..")
 }

--- a/internal/pluginpolicy/fingerprint.go
+++ b/internal/pluginpolicy/fingerprint.go
@@ -92,7 +92,13 @@ type fingerprintContainerConfig struct {
 	Image                string                     `json:"image"`
 	AllowMutableImageTag bool                       `json:"allowMutableImageTag"`
 	Network              ContainerNetwork           `json:"network"`
+	CacheMounts          []fingerprintCacheMount    `json:"cacheMounts,omitempty"`
 	Lifecycle            fingerprintLifecycleConfig `json:"lifecycle"`
+}
+
+type fingerprintCacheMount struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
 }
 
 func newFingerprintPlugin(plugin Plugin) (fingerprintPlugin, error) {
@@ -121,12 +127,27 @@ func newFingerprintPlugin(plugin Plugin) (fingerprintPlugin, error) {
 			Image:                plugin.Container.Image,
 			AllowMutableImageTag: plugin.Container.AllowMutableImageTag,
 			Network:              plugin.Container.Network,
+			CacheMounts:          newFingerprintContainerCacheMounts(plugin.Container.CacheMounts),
 			Lifecycle:            *newFingerprintLifecycleConfig(&plugin.Container.Lifecycle),
 		}
 	default:
 		return fingerprintPlugin{}, fmt.Errorf("unsupported engine %q", plugin.Engine)
 	}
 	return out, nil
+}
+
+func newFingerprintContainerCacheMounts(input []ContainerCacheMount) []fingerprintCacheMount {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]fingerprintCacheMount, 0, len(input))
+	for _, mount := range input {
+		out = append(out, fingerprintCacheMount{Name: mount.Name, Target: mount.Target})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
 }
 
 func newFingerprintLifecycleConfig(config *ExecConfig) *fingerprintLifecycleConfig {

--- a/internal/pluginpolicy/fingerprint.go
+++ b/internal/pluginpolicy/fingerprint.go
@@ -142,7 +142,7 @@ func newFingerprintContainerCacheMounts(input []ContainerCacheMount) []fingerpri
 	}
 	out := make([]fingerprintCacheMount, 0, len(input))
 	for _, mount := range input {
-		out = append(out, fingerprintCacheMount{Name: mount.Name, Target: mount.Target})
+		out = append(out, fingerprintCacheMount(mount))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Name < out[j].Name

--- a/internal/pluginpolicy/policy.go
+++ b/internal/pluginpolicy/policy.go
@@ -31,11 +31,13 @@ const (
 	DefaultMaxStderrBytes      = int64(64 * 1024)
 	DefaultContainerRuntime    = ContainerRuntimeDocker
 	DefaultContainerNetwork    = ContainerNetworkNone
+	ContainerCacheTargetRoot   = "/drydock-cache"
 
 	maxEnvAllowCount = 64
 
-	maxExecParameterAllowCount = 64
-	maxExecCopyIncludeCount    = 64
+	maxExecParameterAllowCount  = 64
+	maxExecCopyIncludeCount     = 64
+	maxContainerCacheMountCount = 16
 )
 
 type Engine string
@@ -182,7 +184,13 @@ type ContainerConfig struct {
 	Image                string
 	AllowMutableImageTag bool
 	Network              ContainerNetwork
+	CacheMounts          []ContainerCacheMount
 	Lifecycle            ExecConfig
+}
+
+type ContainerCacheMount struct {
+	Name   string
+	Target string
 }
 
 func Parse(path string, data []byte) (Policy, error) {

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -143,13 +143,30 @@ func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
 	assertSchemaRef(t, schemaObject(t, containerProps, "generate"), "#/$defs/command")
 	assertSchemaRef(t, schemaObject(t, containerProps, "parameters"), "#/$defs/parameters")
 	cacheMounts := schemaObject(t, defs, "containerCacheMounts")
+	if got, ok := cacheMounts["minItems"].(float64); !ok || int(got) != 1 {
+		t.Fatalf("container cacheMounts minItems = %#v, want 1", cacheMounts["minItems"])
+	}
 	if got, ok := cacheMounts["maxItems"].(float64); !ok || int(got) != maxContainerCacheMountCount {
 		t.Fatalf("container cacheMounts maxItems = %#v, want %d", cacheMounts["maxItems"], maxContainerCacheMountCount)
+	}
+	cacheMountsDescription, _ := cacheMounts["description"].(string)
+	if !strings.Contains(cacheMountsDescription, "Host paths are selected by drydock") {
+		t.Fatalf("container cacheMounts description = %q, want host path ownership note", cacheMountsDescription)
 	}
 	cacheMount := schemaObject(t, defs, "containerCacheMount")
 	assertSchemaRequired(t, cacheMount, "name", "target")
 	cacheMountProps := schemaObject(t, cacheMount, "properties")
 	assertSchemaRef(t, schemaObject(t, cacheMountProps, "name"), "#/$defs/containerCacheMountName")
+	cacheMountTarget := schemaObject(t, cacheMountProps, "target")
+	targetDescription, _ := cacheMountTarget["description"].(string)
+	for _, want := range []string{"/drydock-cache", "Host paths are not accepted", "backslashes", "overlapping targets"} {
+		if !strings.Contains(targetDescription, want) {
+			t.Fatalf("container cache mount target description = %q, want substring %q", targetDescription, want)
+		}
+	}
+	if got, ok := cacheMountTarget["pattern"].(string); !ok || got != "^/drydock-cache/.+" {
+		t.Fatalf("container cache mount target pattern = %#v, want reserved cache root prefix", cacheMountTarget["pattern"])
+	}
 	cacheMountName := schemaObject(t, defs, "containerCacheMountName")
 	if got, ok := cacheMountName["maxLength"].(float64); !ok || int(got) != 63 {
 		t.Fatalf("container cache mount name maxLength = %#v, want 63", cacheMountName["maxLength"])
@@ -1414,6 +1431,18 @@ func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
 			want: "leading or trailing whitespace",
 		},
 		{
+			name: "cache mount name rejects nul",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: "pkl\u0000cache"
+        target: /drydock-cache/pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "DNS-label-like cache name",
+		},
+		{
 			name: "cache mount duplicate name",
 			body: `    engine: container
     image: ` + digestImage + `
@@ -1426,6 +1455,20 @@ func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
       command: ["renderer"]
 `,
 			want: "duplicate cache mount name",
+		},
+		{
+			name: "cache mount duplicate normalized target",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache
+      - name: pkl-cache-2
+        target: /drydock-cache/pkl-cache//
+    generate:
+      command: ["renderer"]
+`,
+			want: "duplicate cache mount target",
 		},
 		{
 			name: "cache mount target must be absolute",
@@ -1462,6 +1505,18 @@ func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
       command: ["renderer"]
 `,
 			want: "without using the root itself",
+		},
+		{
+			name: "cache mount target rejects work root",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /work
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not overlap the /work source mount",
 		},
 		{
 			name: "cache mount target rejects work mount",
@@ -1518,6 +1573,18 @@ func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
     cacheMounts:
       - name: pkl-cache
         target: "/drydock-cache/pkl\u0085cache"
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not contain commas or control characters",
+		},
+		{
+			name: "cache mount target rejects nul",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: "/drydock-cache/pkl\u0000cache"
     generate:
       command: ["renderer"]
 `,
@@ -2303,6 +2370,54 @@ plugins:
     generate:
       command: ["argocd-vault-plugin", "generate", "."]
     engine: exec
+`))
+	if err != nil {
+		t.Fatalf("Parse(right) error = %v", err)
+	}
+	leftFingerprint, err := Fingerprint(left)
+	if err != nil {
+		t.Fatalf("Fingerprint(left) error = %v", err)
+	}
+	rightFingerprint, err := Fingerprint(right)
+	if err != nil {
+		t.Fatalf("Fingerprint(right) error = %v", err)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatalf("fingerprints differ:\nleft:  %s\nright: %s", leftFingerprint, rightFingerprint)
+	}
+}
+
+func TestFingerprintContainerCacheMountsAreDeterministic(t *testing.T) {
+	left, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+    engine: container
+    image: registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    cacheMounts:
+      - name: z-cache
+        target: /drydock-cache/z-cache
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache//module
+    generate:
+      command: ["renderer", "generate"]
+`))
+	if err != nil {
+		t.Fatalf("Parse(left) error = %v", err)
+	}
+	right, err := Parse("policy.yaml", []byte(`kind: PluginPolicy
+apiVersion: drydock.sholdee.dev/v1alpha1
+plugins:
+  renderer:
+    cacheMounts:
+      - target: /drydock-cache/pkl-cache/module
+        name: pkl-cache
+      - target: /drydock-cache/z-cache/
+        name: z-cache
+    generate:
+      command: ["renderer", "generate"]
+    image: registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    engine: container
 `))
 	if err != nil {
 		t.Fatalf("Parse(right) error = %v", err)

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -139,8 +139,21 @@ func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
 	assertSchemaDefault(t, schemaObject(t, containerProps, "allowMutableImageTag"), false)
 	assertSchemaEnum(t, schemaObject(t, containerProps, "network"), "none", "default")
 	assertSchemaDefault(t, schemaObject(t, containerProps, "network"), "none")
+	assertSchemaRef(t, schemaObject(t, containerProps, "cacheMounts"), "#/$defs/containerCacheMounts")
 	assertSchemaRef(t, schemaObject(t, containerProps, "generate"), "#/$defs/command")
 	assertSchemaRef(t, schemaObject(t, containerProps, "parameters"), "#/$defs/parameters")
+	cacheMounts := schemaObject(t, defs, "containerCacheMounts")
+	if got, ok := cacheMounts["maxItems"].(float64); !ok || int(got) != maxContainerCacheMountCount {
+		t.Fatalf("container cacheMounts maxItems = %#v, want %d", cacheMounts["maxItems"], maxContainerCacheMountCount)
+	}
+	cacheMount := schemaObject(t, defs, "containerCacheMount")
+	assertSchemaRequired(t, cacheMount, "name", "target")
+	cacheMountProps := schemaObject(t, cacheMount, "properties")
+	assertSchemaRef(t, schemaObject(t, cacheMountProps, "name"), "#/$defs/containerCacheMountName")
+	cacheMountName := schemaObject(t, defs, "containerCacheMountName")
+	if got, ok := cacheMountName["maxLength"].(float64); !ok || int(got) != 63 {
+		t.Fatalf("container cache mount name maxLength = %#v, want 63", cacheMountName["maxLength"])
+	}
 }
 
 func assertCMPAndParameterSchemas(t *testing.T, defs map[string]any) {
@@ -1145,6 +1158,9 @@ plugins:
 	if got := plugin.Container.Network; got != DefaultContainerNetwork {
 		t.Fatalf("Network = %q, want %q", got, DefaultContainerNetwork)
 	}
+	if len(plugin.Container.CacheMounts) != 0 {
+		t.Fatalf("CacheMounts = %#v, want none by default", plugin.Container.CacheMounts)
+	}
 	if plugin.Container.AllowMutableImageTag {
 		t.Fatal("AllowMutableImageTag = true, want default false")
 	}
@@ -1190,6 +1206,43 @@ plugins:
 	}
 	if plugin.Container.Network != ContainerNetworkDefault {
 		t.Fatalf("Network = %q, want %q", plugin.Container.Network, ContainerNetworkDefault)
+	}
+}
+
+func TestParseContainerPolicyCacheMounts(t *testing.T) {
+	image := "registry.example.com/drydock/renderer@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  renderer:
+    engine: container
+    image: `+image+`
+    cacheMounts:
+      - name: z-cache
+        target: /drydock-cache/z-cache
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache//module
+    generate:
+      command: ["renderer", "generate"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	plugin, ok := policy.Plugin("renderer")
+	if !ok || plugin.Container == nil {
+		t.Fatalf("Plugin(renderer) = %#v, want container plugin", plugin)
+	}
+	want := []ContainerCacheMount{
+		{Name: "pkl-cache", Target: "/drydock-cache/pkl-cache/module"},
+		{Name: "z-cache", Target: "/drydock-cache/z-cache"},
+	}
+	if len(plugin.Container.CacheMounts) != len(want) {
+		t.Fatalf("CacheMounts = %#v, want %#v", plugin.Container.CacheMounts, want)
+	}
+	for index, mount := range want {
+		if plugin.Container.CacheMounts[index] != mount {
+			t.Fatalf("CacheMounts[%d] = %#v, want %#v", index, plugin.Container.CacheMounts[index], mount)
+		}
 	}
 }
 
@@ -1304,6 +1357,185 @@ func TestParseContainerPolicyRejectsUnsafeFields(t *testing.T) {
       command: ["renderer"]
 `,
 			want: "unknown field",
+		},
+		{
+			name: "cache mounts must be sequence",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts: {}
+    generate:
+      command: ["renderer"]
+`,
+			want: "cacheMounts must be a sequence",
+		},
+		{
+			name: "cache mounts must not be empty",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts: []
+    generate:
+      command: ["renderer"]
+`,
+			want: "cacheMounts must not be empty",
+		},
+		{
+			name: "cache mount item must be mapping",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "cacheMounts[0] must be a mapping",
+		},
+		{
+			name: "cache mount name must be path safe",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: Pkl_Cache
+        target: /drydock-cache/pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "DNS-label-like cache name",
+		},
+		{
+			name: "cache mount name rejects whitespace",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: " pkl-cache"
+        target: /drydock-cache/pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "leading or trailing whitespace",
+		},
+		{
+			name: "cache mount duplicate name",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache-2
+    generate:
+      command: ["renderer"]
+`,
+			want: "duplicate cache mount name",
+		},
+		{
+			name: "cache mount target must be absolute",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: drydock-cache/pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "absolute Linux container path",
+		},
+		{
+			name: "cache mount target must be under drydock cache root",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /cache/pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "target must be under /drydock-cache",
+		},
+		{
+			name: "cache mount target rejects drydock cache root",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "without using the root itself",
+		},
+		{
+			name: "cache mount target rejects work mount",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /work/.cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not overlap the /work source mount",
+		},
+		{
+			name: "cache mount target rejects traversal",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache/../other
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not contain .. path components",
+		},
+		{
+			name: "cache mount target rejects backslash",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache\pkl-cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "must use Linux container paths",
+		},
+		{
+			name: "cache mount target rejects comma",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl,cache
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not contain commas",
+		},
+		{
+			name: "cache mount target rejects unicode control",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: "/drydock-cache/pkl\u0085cache"
+    generate:
+      command: ["renderer"]
+`,
+			want: "must not contain commas or control characters",
+		},
+		{
+			name: "cache mount targets must not overlap",
+			body: `    engine: container
+    image: ` + digestImage + `
+    cacheMounts:
+      - name: pkl-cache
+        target: /drydock-cache/pkl-cache
+      - name: nested
+        target: /drydock-cache/pkl-cache/nested
+    generate:
+      command: ["renderer"]
+`,
+			want: "overlapping cache mount targets",
 		},
 		{
 			name: "missing generate",
@@ -2382,6 +2614,10 @@ plugins:
 		{
 			name: "lifecycle",
 			data: strings.Replace(base, "timeout: 3s", "timeout: 4s", 1),
+		},
+		{
+			name: "cache mounts",
+			data: strings.Replace(base, "    generate:\n", "    cacheMounts:\n      - name: pkl-cache\n        target: /drydock-cache/pkl-cache\n    generate:\n", 1),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -142,6 +142,11 @@ func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
 	assertSchemaRef(t, schemaObject(t, containerProps, "cacheMounts"), "#/$defs/containerCacheMounts")
 	assertSchemaRef(t, schemaObject(t, containerProps, "generate"), "#/$defs/command")
 	assertSchemaRef(t, schemaObject(t, containerProps, "parameters"), "#/$defs/parameters")
+	assertContainerCacheMountSchema(t, defs)
+}
+
+func assertContainerCacheMountSchema(t *testing.T, defs map[string]any) {
+	t.Helper()
 	cacheMounts := schemaObject(t, defs, "containerCacheMounts")
 	if got, ok := cacheMounts["minItems"].(float64); !ok || int(got) != 1 {
 		t.Fatalf("container cacheMounts minItems = %#v, want 1", cacheMounts["minItems"])

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -271,6 +271,9 @@
           ],
           "default": "none"
         },
+        "cacheMounts": {
+          "$ref": "#/$defs/containerCacheMounts"
+        },
         "workdir": {
           "const": "source",
           "description": "Only source workdir is supported."
@@ -301,6 +304,38 @@
           "$ref": "#/$defs/output"
         }
       }
+    },
+    "containerCacheMounts": {
+      "type": "array",
+      "description": "Policy-managed durable cache mounts for trusted container plugins. Host paths are selected by drydock.",
+      "minItems": 1,
+      "maxItems": 16,
+      "items": {
+        "$ref": "#/$defs/containerCacheMount"
+      }
+    },
+    "containerCacheMount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "target"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/containerCacheMountName"
+        },
+        "target": {
+          "type": "string",
+          "description": "Absolute Linux container path under /drydock-cache. The drydock Go parser rejects /drydock-cache itself, /work, traversal, commas, control characters, and overlapping targets.",
+          "pattern": "^/drydock-cache/.+"
+        }
+      }
+    },
+    "containerCacheMountName": {
+      "type": "string",
+      "maxLength": 63,
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
     },
     "match": {
       "type": "object",

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -307,7 +307,7 @@
     },
     "containerCacheMounts": {
       "type": "array",
-      "description": "Policy-managed durable cache mounts for trusted container plugins. Host paths are selected by drydock.",
+      "description": "Policy-managed durable cache mounts for trusted container plugins. Host paths are selected by drydock under its user cache root; policy supplies only cache names and container target paths.",
       "minItems": 1,
       "maxItems": 16,
       "items": {
@@ -327,7 +327,7 @@
         },
         "target": {
           "type": "string",
-          "description": "Absolute Linux container path under /drydock-cache. The drydock Go parser rejects /drydock-cache itself, /work, traversal, commas, control characters, and overlapping targets.",
+          "description": "Absolute Linux container path under reserved /drydock-cache. Host paths are not accepted in policy. The drydock Go parser rejects /drydock-cache itself, /work, traversal, commas, control characters, backslashes, duplicate targets, and overlapping targets.",
           "pattern": "^/drydock-cache/.+"
         }
       }


### PR DESCRIPTION
## Summary
- add PluginPolicy container cacheMounts under reserved /drydock-cache targets
- create policy-scoped host cache directories with metadata, protected-root checks, and inter-process locks
- document cacheMounts and update the trusted Pkl container example

## Validation
- go test ./... -count=1
- mise run lint
- mise run docs-check
- GOOS=windows go test -c -o /private/tmp/drydock-plugincontainer-windows.test.exe ./internal/plugincontainer
- drydock test apps --enable-plugins --plugin-policy-ref main in /Users/ethan.shold/git/argocd-repos/cluster