### PR TITLE
feat(pr-action): cache plugin mounts

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -64,7 +64,7 @@ jobs:
 ## Pull Request Action
 
 Use the PR action when you want the standard render test, manifest diff, image
-diff, source cache, artifacts, and sticky comments:
+diff, render cache, artifacts, and sticky comments:
 
 ```yaml
 name: drydock
@@ -98,7 +98,7 @@ By default the action:
   image artifact;
 - writes image diff comments with drydock markdown output, including removed
   image references when present;
-- uses drydock source caches under the runner temp directory;
+- uses drydock render caches under the runner temp directory;
 - uploads full raw diff and browser-openable Full Rendered Diff View artifacts
   when manifest differences are found;
 - writes sticky PR comments for trusted same-repository pull requests.
@@ -112,8 +112,9 @@ artifact link opens in the current tab or a new tab.
 Open a public sample:
 [Full Rendered Diff View](https://sholdee.github.io/drydock/examples/full-rendered-diff-view.html).
 
-Fork pull requests do not restore or save drydock source caches by default,
-because source caches can contain private repository or chart material. They
+Fork pull requests do not restore or save drydock render caches by default,
+because render caches can contain private repository, chart, remote source, or
+plugin cache material. They
 also skip PR comments by default. Set `cache-untrusted-restore: "true"` only if
 restoring cache contents into fork PR runs is acceptable for that repository.
 Cache save remains disabled for fork PRs.
@@ -154,10 +155,14 @@ The token is used for release downloads, checkout, baseline fetch, and PR
 comments. It is not exported to `drydock test`, `drydock diff`, cache contents,
 or uploaded artifacts.
 
-Binary caching is separate from drydock source caching. Binary cache entries
+Binary caching is separate from drydock render caching. Binary cache entries
 contain only the released `drydock` archive and are keyed by release checksum.
-Source cache entries contain fetched Git, Helm, and remote Kustomize sources for
-the repository under test.
+Render cache entries contain fetched Git, Helm, and remote Kustomize sources for
+the repository under test. When trusted container plugins are enabled, the PR
+action also places policy-managed plugin cache mounts under the action cache
+root as `${cache-path}/plugin` and restores or saves them with the same cache
+entry. `drydock cache` lifecycle commands still manage only Git, chart, and
+remote-resource cache entry roots for now.
 
 ## Common Inputs
 

--- a/docs/plugin-policy.md
+++ b/docs/plugin-policy.md
@@ -354,6 +354,14 @@ cache root and scopes it by policy fingerprint, plugin name, and cache name.
 Targets cannot overlap `/work`, contain traversal, commas, control characters,
 backslashes, duplicate paths, or ancestor/descendant overlaps.
 
+`--plugin-cache-dir PATH` overrides the host root for these policy-managed
+container plugin cache mounts at render time. It does not change the trusted
+policy target paths, and it does not make plugin caches part of `drydock cache`
+lifecycle commands; those commands still manage only Git, chart, and
+remote-resource cache entry roots for now. The GitHub PR action sets the plugin
+cache directory under the action cache root, so trusted plugin cache mounts can
+be restored and saved with the render cache when trusted plugins are enabled.
+
 For `engine: exec`, the command environment starts with only drydock's
 controlled `PATH`. `env.allow` names additional caller environment variables
 that may be copied in.

--- a/docs/source-acquisition.md
+++ b/docs/source-acquisition.md
@@ -112,6 +112,7 @@ shorthand, a `.git` repository path, or explicit Git syntax such as `git::`,
 | `--chart-cache-dir PATH` | Override the default chart cache root. |
 | `--refresh-remotes` | Refresh cached remote Kustomize resources before rendering. |
 | `--remote-cache-dir PATH` | Override the default remote-resource cache root. |
+| `--plugin-cache-dir PATH` | Runtime override for policy-managed container plugin cache mounts. |
 | `--registry-config PATH` | Supply the only Helm OCI registry credentials. |
 
 Offline render/build/diff commands require cache hits, repo maps, local files,
@@ -127,6 +128,11 @@ cache.
 Cache entries include hidden `.drydock-cache/metadata.json` sidecars with
 redacted target metadata. Older hash-only entries are listed as legacy entries
 when their filesystem layout is recognized.
+
+`--plugin-cache-dir` is a render-time override for trusted container plugin
+`cacheMounts`, not a source-acquisition cache. It selects the host root for
+policy-managed durable plugin mounts while policy still controls which plugins
+may use mounts and which container paths they target.
 
 ## Credentials
 
@@ -172,8 +178,10 @@ Cache lifecycle commands are local filesystem operations only. They do not:
 - read credential flags
 - retry failed network or authentication acquisitions
 
-`cache prune` and `cache delete` operate only on recognized drydock cache entry
-roots. They reject cache roots that resolve inside the current working
+`cache prune` and `cache delete` operate only on recognized drydock Git, chart,
+and remote-resource cache entry roots for now. They do not list, prune, or
+delete plugin cache mount roots selected with `--plugin-cache-dir`. Cache
+lifecycle commands reject cache roots that resolve inside the current working
 directory, selected repository roots, Git repository trees, or symlink-resolved
 equivalents. Non-dry-run deletion requires `--yes`; dry-runs never require
 confirmation.

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -41,6 +41,7 @@ type localProvider struct {
 	helmValueFileSchemes         []string
 	helmValueFileSchemesSet      bool
 	pluginTimeout                time.Duration
+	pluginCacheDir               string
 	pluginPolicy                 pluginpolicy.Policy
 	pluginPolicyFingerprint      string
 	pluginPolicyExecTrusted      bool

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -54,6 +54,7 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		helmValueFileSchemes:         settingsHelmValueFileSchemes(settings),
 		helmValueFileSchemesSet:      settings.HelmValuesFileSchemesSet,
 		pluginTimeout:                request.PluginTimeout,
+		pluginCacheDir:               request.PluginCacheDir,
 		pluginPolicy:                 request.pluginPolicy,
 		pluginPolicyFingerprint:      request.pluginPolicyFingerprint,
 		pluginPolicyExecTrusted:      request.pluginPolicyExecTrusted,

--- a/internal/app/local_provider_plugin.go
+++ b/internal/app/local_provider_plugin.go
@@ -321,6 +321,7 @@ func (p localProvider) renderContainerPolicyPluginSource(ctx context.Context, so
 		Config:            containerConfig,
 		Offline:           p.offline,
 		ForbiddenRoots:    p.execProtectedRoots(source.RepoRoot),
+		CacheRoot:         p.pluginCacheDir,
 		ExtraEnv:          extraEnv,
 		SensitiveValues:   sensitive,
 	})

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -443,6 +443,7 @@ data:
 
 func TestOrchestratorBuildRendersTrustedContainerPolicyPlugin(t *testing.T) {
 	root := t.TempDir()
+	pluginCacheDir := filepath.Join(t.TempDir(), "plugin-cache")
 	writePluginBuildApplication(t, root, "plugin", "container-renderer")
 	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
 	policy, fingerprint := testContainerPluginPolicy(t, "container-renderer")
@@ -467,6 +468,7 @@ data:
 		Path: root,
 		PluginOptions: PluginOptions{
 			EnablePlugins:           true,
+			PluginCacheDir:          pluginCacheDir,
 			pluginPolicyLoaded:      true,
 			pluginPolicy:            policy,
 			pluginPolicyFingerprint: fingerprint,
@@ -478,6 +480,9 @@ data:
 	}
 	if runner.calls != 1 {
 		t.Fatalf("runner calls = %d, want 1", runner.calls)
+	}
+	if runner.lastRequest.CacheRoot != pluginCacheDir {
+		t.Fatalf("container CacheRoot = %q, want %q", runner.lastRequest.CacheRoot, pluginCacheDir)
 	}
 	if len(result.Manifests) != 1 || result.Manifests[0].Object.GetName() != "container-runner" {
 		t.Fatalf("Manifests = %#v, want container runner manifest", result.Manifests)
@@ -1190,13 +1195,15 @@ func (r *recordingExecRunner) Run(context.Context, pluginexec.Request) (pluginex
 }
 
 type recordingContainerRunner struct {
-	calls  int
-	result pluginexec.Result
-	err    error
+	calls       int
+	lastRequest plugincontainer.Request
+	result      pluginexec.Result
+	err         error
 }
 
-func (r *recordingContainerRunner) Run(context.Context, plugincontainer.Request) (pluginexec.Result, error) {
+func (r *recordingContainerRunner) Run(_ context.Context, request plugincontainer.Request) (pluginexec.Result, error) {
 	r.calls++
+	r.lastRequest = request
 	return r.result, r.err
 }
 

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -49,6 +49,7 @@ type PluginOptions struct {
 	PluginTimeout            time.Duration
 	EnableAVPCompat          bool
 	EnablePlugins            bool
+	PluginCacheDir           string
 	PluginPolicyPath         string
 	PluginPolicyPathExplicit bool
 	PluginPolicyRef          string

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -45,6 +45,7 @@ type commonFlags struct {
 	remoteBearerToken        string
 	enableAVPCompat          bool
 	enablePlugins            bool
+	pluginCacheDir           string
 	pluginPolicyPath         string
 	pluginPolicyPathExplicit bool
 	pluginPolicyRef          string
@@ -139,6 +140,7 @@ func bindRemoteAcquisitionCacheFlags(cmd *cobra.Command, flags *commonFlags) {
 func bindPluginFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.enableAVPCompat, "enable-avp-compat", flags.enableAVPCompat, "replace argocd-vault-plugin placeholders with deterministic redacted values")
 	cmd.Flags().BoolVar(&flags.enablePlugins, "enable-plugins", flags.enablePlugins, "enable trusted exec/container plugin policy entries")
+	cmd.Flags().StringVar(&flags.pluginCacheDir, "plugin-cache-dir", flags.pluginCacheDir, "directory for policy-managed container plugin caches")
 	cmd.Flags().StringVar(&flags.pluginPolicyPath, "plugin-policy-path", flags.pluginPolicyPath, "trusted plugin policy path relative to the selected policy root")
 	cmd.Flags().StringVar(&flags.pluginPolicyRef, "plugin-policy-ref", flags.pluginPolicyRef, "Git ref to use as the trusted plugin policy source")
 	cmd.Flags().StringVar(&flags.pluginPolicyRepo, "plugin-policy-repo", flags.pluginPolicyRepo, "local Git repository path used to resolve --plugin-policy-ref")
@@ -282,6 +284,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		RemoteResourceGitCredentials:   flags.remoteGitCredentials(),
 		EnableAVPCompat:                flags.enableAVPCompat,
 		EnablePlugins:                  flags.enablePlugins,
+		PluginCacheDir:                 flags.pluginCacheDir,
 		PluginPolicyPath:               flags.pluginPolicyPath,
 		PluginPolicyPathExplicit:       flags.pluginPolicyPathExplicit,
 		PluginPolicyRef:                flags.pluginPolicyRef,

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -42,22 +42,22 @@ func TestRepresentativeCommandsExposeFocusedFlagGroups(t *testing.T) {
 		{
 			name:    "build apps common acquisition discovery fixtures filters",
 			command: []string{"build", "apps"},
-			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-plugins", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind"},
+			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-plugins", "plugin-cache-dir", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind"},
 		},
 		{
 			name:    "diff apps common specialized diff flags",
 			command: []string{"diff", "apps"},
-			flags:   []string{"offline", "repo-map", "appset-provider-fixture", "skip-kind", "ref-orig", "show-ignored-fields"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "ref-orig", "show-ignored-fields"},
 		},
 		{
 			name:    "test apps common specialized lua flag",
 			command: []string{"test", "apps"},
-			flags:   []string{"offline", "repo-map", "appset-provider-fixture", "skip-kind", "skip-lua-health"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "skip-lua-health"},
 		},
 		{
 			name:    "diag common flags",
 			command: []string{"diag"},
-			flags:   []string{"offline", "repo-map", "appset-provider-fixture", "skip-kind"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind"},
 		},
 	}
 

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	RemoteResourceGitCredentials   remote.GitCredentials
 	EnableAVPCompat                bool
 	EnablePlugins                  bool
+	PluginCacheDir                 string
 	PluginPolicyPath               string
 	PluginPolicyPathExplicit       bool
 	PluginPolicyRef                string
@@ -136,6 +137,7 @@ func (options Options) pluginOptions() app.PluginOptions {
 		PluginTimeout:            options.PluginTimeout,
 		EnableAVPCompat:          options.EnableAVPCompat,
 		EnablePlugins:            options.EnablePlugins,
+		PluginCacheDir:           options.PluginCacheDir,
 		PluginPolicyPath:         options.PluginPolicyPath,
 		PluginPolicyPathExplicit: options.PluginPolicyPathExplicit,
 		PluginPolicyRef:          options.PluginPolicyRef,

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -37,6 +37,7 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RemoteResourceGitCredentials", request.RemoteResourceGitCredentials, remote.GitCredentials{Username: "remote-git-user"})
 	assertDeepEqual(t, "EnableAVPCompat", request.EnableAVPCompat, true)
 	assertDeepEqual(t, "EnablePlugins", request.EnablePlugins, true)
+	assertDeepEqual(t, "PluginCacheDir", request.PluginCacheDir, "plugin-cache")
 	assertDeepEqual(t, "PluginPolicyPath", request.PluginPolicyPath, ".drydock/custom-plugins.yaml")
 	assertDeepEqual(t, "PluginPolicyPathExplicit", request.PluginPolicyPathExplicit, true)
 	assertDeepEqual(t, "PluginPolicyRef", request.PluginPolicyRef, "main")
@@ -96,6 +97,7 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RemoteResourceGitCredentials", request.RemoteResourceGitCredentials, remote.GitCredentials{Username: "remote-git-user"})
 	assertDeepEqual(t, "EnableAVPCompat", request.EnableAVPCompat, true)
 	assertDeepEqual(t, "EnablePlugins", request.EnablePlugins, true)
+	assertDeepEqual(t, "PluginCacheDir", request.PluginCacheDir, "plugin-cache")
 	assertDeepEqual(t, "PluginPolicyPath", request.PluginPolicyPath, ".drydock/custom-plugins.yaml")
 	assertDeepEqual(t, "PluginPolicyPathExplicit", request.PluginPolicyPathExplicit, true)
 	assertDeepEqual(t, "PluginPolicyRef", request.PluginPolicyRef, "main")
@@ -162,6 +164,7 @@ func fixtureOptions() Options {
 		RemoteResourceGitCredentials: remote.GitCredentials{Username: "remote-git-user"},
 		EnableAVPCompat:              true,
 		EnablePlugins:                true,
+		PluginCacheDir:               "plugin-cache",
 		PluginPolicyPath:             ".drydock/custom-plugins.yaml",
 		PluginPolicyPathExplicit:     true,
 		PluginPolicyRef:              "main",

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -122,7 +122,7 @@ inputs:
     required: false
     default: "false"
   enable-plugins:
-    description: Enable trusted exec plugin policy entries.
+    description: Enable trusted exec and container plugin policy entries.
     required: false
     default: "false"
   plugin-policy-path:
@@ -148,15 +148,15 @@ inputs:
     description: Newline-delimited additional trusted arguments for drydock diff images.
     required: false
   cache:
-    description: Restore and save drydock source caches for trusted runs.
+    description: Restore and save drydock render caches for trusted runs.
     required: false
     default: "true"
   save-cache:
-    description: Save drydock source caches after trusted runs.
+    description: Save drydock render caches after trusted runs.
     required: false
     default: "true"
   cache-untrusted-restore:
-    description: Restore drydock source caches for fork pull requests. Cache save remains disabled for forks.
+    description: Restore drydock render caches for fork pull requests. Cache save remains disabled for forks.
     required: false
     default: "false"
   cache-path:
@@ -382,7 +382,7 @@ runs:
         DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: '"${GITHUB_ACTION_PATH}/fetch-base.sh"'
 
-    - name: Restore drydock source cache
+    - name: Restore drydock render cache
       id: cache-restore
       if: ${{ steps.prepare.outputs.cache-restore == 'true' }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -438,7 +438,7 @@ runs:
         DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
       run: '"${GITHUB_ACTION_PATH}/run.sh"'
 
-    - name: Save drydock source cache
+    - name: Save drydock render cache
       if: ${{ always() && steps.prepare.outputs.cache-save == 'true' && steps.cache-restore.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -274,7 +274,7 @@ work_dir="${DRYDOCK_ACTION_WORK_DIR}"
 mkdir -p "${work_dir}"
 cache_path="${DRYDOCK_CACHE_PATH:-}"
 if [[ -n "${cache_path}" ]]; then
-  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes"
+  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes" "${cache_path}/plugin"
 fi
 diff_html_artifact_name="${DRYDOCK_DIFF_HTML_ARTIFACT_NAME:-}"
 if [[ -z "${diff_html_artifact_name}" ]]; then
@@ -309,6 +309,7 @@ if [[ -n "${cache_path}" ]]; then
     "--git-cache-dir" "${cache_path}/git"
     "--chart-cache-dir" "${cache_path}/charts"
     "--remote-cache-dir" "${cache_path}/remotes"
+    "--plugin-cache-dir" "${cache_path}/plugin"
   )
 fi
 append_bool_flag common_args "${DRYDOCK_INPUT_SKIP_SECRETS}" "--skip-secrets"

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -362,6 +362,68 @@ func TestRunPassesChangedOnlyPathFiltersOnlyToDiffCommands(t *testing.T) {
 	}
 }
 
+func TestRunPassesPluginCacheDirToEveryInvocationWhenCachePathSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode: "both",
+		diffOutput:  true,
+		imageOutput: true,
+		runTest:     true,
+		cachePath:   cachePath,
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	lines := strings.Split(strings.TrimSpace(args), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
+	}
+	want := "--plugin-cache-dir " + filepath.Join(cachePath, "plugin")
+	for _, line := range lines {
+		if !strings.Contains(line, want) {
+			t.Fatalf("drydock invocation missing plugin cache dir %q:\n%s", want, line)
+		}
+	}
+	for _, name := range []string{"git", "charts", "remotes", "plugin"} {
+		path := filepath.Join(cachePath, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", path)
+		}
+	}
+}
+
+func TestRunOmitsPluginCacheDirWhenCachePathEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode: "both",
+		diffOutput:  true,
+		imageOutput: true,
+		runTest:     true,
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	lines := strings.Split(strings.TrimSpace(args), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "--plugin-cache-dir") {
+			t.Fatalf("drydock invocation included plugin cache dir with empty DRYDOCK_CACHE_PATH:\n%s", line)
+		}
+	}
+}
+
 func TestRunImageCommentsUseMarkdownAfterExtraImageArgs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -521,6 +583,7 @@ type commentScenario struct {
 	changedOnlyInclude              string
 	changedOnlyIgnore               string
 	omitDiffHTMLArtifactNameFromEnv bool
+	cachePath                       string
 }
 
 func runCommentScenario(t *testing.T, scenario commentScenario) string {
@@ -559,6 +622,9 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 	}
 	if scenario.omitDiffHTMLArtifactNameFromEnv {
 		env = withoutEnv(env, "DRYDOCK_DIFF_HTML_ARTIFACT_NAME")
+	}
+	if scenario.cachePath != "" {
+		env = append(withoutEnv(env, "DRYDOCK_CACHE_PATH"), "DRYDOCK_CACHE_PATH="+scenario.cachePath)
 	}
 
 	cmd := exec.Command("bash", "run.sh")

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -42,6 +42,10 @@ drydock cache list -o json
 drydock cache prune --older-than 720h --dry-run
 ```
 
+`--plugin-cache-dir` is separate: it is a render-time override for
+policy-managed container plugin cache mounts. Cache lifecycle commands still
+manage only Git, chart, and remote-resource cache entry roots for now.
+
 ## Credentials
 
 Credentials are explicit and non-interactive. drydock does not read ambient Git

--- a/site/content/plugin-policy/_index.md
+++ b/site/content/plugin-policy/_index.md
@@ -46,6 +46,17 @@ For pull request diffs, drydock loads policy from the trusted baseline side:
 drydock diff apps --path-orig ../baseline --path . --enable-plugins
 ```
 
+## Container Cache Mounts
+
+Container `cacheMounts` are policy-managed durable tool caches mounted only
+under reserved `/drydock-cache` paths. `--plugin-cache-dir` is a render-time
+override for the host root backing those mounts; it does not change trusted
+policy target paths. Cache lifecycle commands still manage only Git, chart, and
+remote-resource cache entry roots for now.
+
+In the GitHub PR action, trusted plugin cache mounts live under the action cache
+root as `${cache-path}/plugin` when trusted plugins are enabled.
+
 ## Bootstrap Entrypoints
 
 `bootstrap.entrypoints` are fleet discovery inputs for repositories whose

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -9,7 +9,7 @@ drydock publishes two composite GitHub Actions:
   artifacts, and optionally maintain sticky PR comments.
 
 Use `setup-action` when you want to own the CLI commands. Use `pr-action` when
-you want the standard render test, markdown manifest diff, image diff, source
+you want the standard render test, markdown manifest diff, image diff, render
 cache, artifacts, and pull request comment workflow.
 
 ## Manual CLI Workflow
@@ -71,7 +71,12 @@ The PR action checks out the pull request, fetches the base ref, runs
 `drydock test apps`, renders the desired-state manifest diff, writes full diff
 artifacts when differences are found, and comments in trusted same-repository
 pull requests. Image diff comments are available as a companion signal. Fork
-pull requests skip comments and source-cache restore/save by default.
+pull requests skip comments and render-cache restore/save by default.
+
+When trusted container plugins are enabled, policy-managed plugin cache mounts
+live under the PR action cache root as `${cache-path}/plugin` and are restored
+or saved with that render cache. `drydock cache` lifecycle commands still manage
+only Git, chart, and remote-resource cache entry roots for now.
 
 ## Full Rendered Diff View
 


### PR DESCRIPTION
## Summary
- add --plugin-cache-dir runtime plumbing for policy-managed container plugin cache mounts
- cache PR action plugin mounts under the existing render cache root
- update action metadata and docs/site docs for render cache behavior

## Tests
- go test ./internal/requestopts ./internal/app ./internal/cli ./pr-action
- mise run lint