### PR TITLE
feat: refine HTML diff report UX

### DIFF
--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -162,7 +162,7 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--color=always", "--exit-code=false")
 
 	assertStdoutContainsAll(t, result,
-		"## drydock desired state diff",
+		"## drydock diff",
 		"**Summary:** 1 app, 1 resource, +1/-1, 1 warning.",
 		"Diagnostics:",
 		"&lt;tag&gt;",
@@ -186,7 +186,7 @@ func TestDiffAppsMarkdownRawOutputFilePreservesUnifiedDiff(t *testing.T) {
 	}
 
 	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--raw-output-file", rawPath, "--exit-code=false")
-	assertStdoutContainsAll(t, result, "## drydock desired state diff")
+	assertStdoutContainsAll(t, result, "## drydock diff")
 	raw, err := os.ReadFile(rawPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%s) error = %v", rawPath, err)
@@ -215,7 +215,7 @@ func TestDiffAppsHTMLOutputFilePreservesSelectedStdout(t *testing.T) {
 
 	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--html-output-file", htmlPath, "--exit-code=false")
 
-	assertStdoutContainsAll(t, result, "## drydock desired state diff", "```diff\n", "-  value: old", "+  value: new")
+	assertStdoutContainsAll(t, result, "## drydock diff", "```diff\n", "-  value: old", "+  value: new")
 	assertStdoutExcludesAll(t, result, "<!doctype html>", `data-view="side-by-side"`)
 	assertHTMLFileContainsAll(t, htmlPath,
 		"<!doctype html>",

--- a/internal/report/diffhtml/assets.go
+++ b/internal/report/diffhtml/assets.go
@@ -409,6 +409,57 @@ body.is-resizing-sidebar .sidebar-resizer::before {
 	line-height: 1.25;
 	color: var(--navy-deep);
 }
+.resource-heading {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	flex-wrap: wrap;
+}
+.resource-primary {
+	display: inline-flex;
+	gap: 5px;
+	min-width: 0;
+	font-weight: 750;
+}
+.resource-name {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.resource-meta {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	color: var(--quiet);
+	font-size: 13px;
+	font-weight: 650;
+}
+.resource-namespace {
+	min-width: 0;
+	max-width: min(32vw, 260px);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.resource-meta-separator {
+	color: var(--line-strong);
+}
+.resource-api-group {
+	display: inline-flex;
+	align-items: center;
+	min-height: 18px;
+	padding: 0 7px;
+	border: 1px solid rgba(129, 144, 163, 0.24);
+	border-radius: 999px;
+	background: rgba(129, 144, 163, 0.13);
+	color: var(--muted);
+	font-size: 12px;
+	font-weight: 750;
+	line-height: 1;
+}
 .diff-table {
 	width: 100%;
 	border-collapse: collapse;

--- a/internal/report/diffhtml/assets.go
+++ b/internal/report/diffhtml/assets.go
@@ -1342,6 +1342,74 @@ const reviewScript = `
 		}
 	};
 
+	let focusedTreeButton = null;
+	const treeButtonApp = (button) => button.closest('[data-tree-app]');
+	const treeButtonIsVisible = (button) => {
+		const app = treeButtonApp(button);
+		if (button.hidden || app?.hidden) {
+			return false;
+		}
+		return !(app instanceof HTMLDetailsElement) || app.open;
+	};
+	const visibleTreeButtons = () => treeButtons.filter(treeButtonIsVisible);
+	const setTreeButtonTabStop = (button) => {
+		treeButtons.forEach((candidate) => {
+			candidate.tabIndex = candidate === button ? 0 : -1;
+		});
+		focusedTreeButton = button || null;
+	};
+	const selectedTreeButton = () => treeButtons.find((button) => button.getAttribute('aria-current') === 'true') || null;
+	const currentTreeButton = () => {
+		const visible = visibleTreeButtons();
+		if (focusedTreeButton && visible.includes(focusedTreeButton)) {
+			return focusedTreeButton;
+		}
+		const selected = selectedTreeButton();
+		if (selected && visible.includes(selected)) {
+			return selected;
+		}
+		return visible[0] || null;
+	};
+	const focusTreeButton = (button) => {
+		if (!button) {
+			return;
+		}
+		setTreeButtonTabStop(button);
+		button.focus();
+		button.scrollIntoView({ block: 'nearest' });
+	};
+	const moveTreeFocus = (delta) => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			return;
+		}
+		const current = currentTreeButton();
+		const currentIndex = Math.max(0, visible.indexOf(current));
+		const nextIndex = clamp(currentIndex + delta, 0, visible.length - 1);
+		focusTreeButton(visible[nextIndex]);
+	};
+	const focusTreeEdge = (edge) => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			return;
+		}
+		focusTreeButton(edge === 'end' ? visible[visible.length - 1] : visible[0]);
+	};
+	const syncTreeFocusAfterFilter = () => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			setTreeButtonTabStop(null);
+			return;
+		}
+		const selected = selectedTreeButton();
+		const next = selected && visible.includes(selected) ? selected : visible[0];
+		const activeElement = document.activeElement;
+		setTreeButtonTabStop(next);
+		if (activeElement instanceof HTMLElement && activeElement.matches('[data-target-resource]') && !visible.includes(activeElement)) {
+			next.focus();
+		}
+	};
+
 	const selectResource = (id, options = {}) => {
 		if (!resourceIds.has(id)) {
 			return;
@@ -1363,6 +1431,7 @@ const reviewScript = `
 			}
 		});
 		if (activeButton) {
+			setTreeButtonTabStop(activeButton);
 			activeButton.scrollIntoView({ block: 'nearest' });
 		}
 		if (options.updateHash) {
@@ -1378,6 +1447,32 @@ const reviewScript = `
 			selectResource(button.dataset.targetResource, { updateHash: true });
 			if (mobileQuery.matches) {
 				setSidebar('closed');
+			}
+		});
+		button.addEventListener('keydown', (event) => {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				moveTreeFocus(1);
+				return;
+			}
+			if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				moveTreeFocus(-1);
+				return;
+			}
+			if (event.key === 'Home') {
+				event.preventDefault();
+				focusTreeEdge('start');
+				return;
+			}
+			if (event.key === 'End') {
+				event.preventDefault();
+				focusTreeEdge('end');
+				return;
+			}
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				button.click();
 			}
 		});
 	});
@@ -1487,7 +1582,12 @@ const reviewScript = `
 				app.open = true;
 			}
 		});
+		syncTreeFocusAfterFilter();
 	};
+
+	document.querySelectorAll('[data-tree-app]').forEach((app) => {
+		app.addEventListener('toggle', syncTreeFocusAfterFilter);
+	});
 
 	const clearSearch = () => {
 		if (!searchInput) {

--- a/internal/report/diffhtml/example_test.go
+++ b/internal/report/diffhtml/example_test.go
@@ -61,9 +61,10 @@ func TestFullRenderedDiffViewExampleMatchesRenderedDemo(t *testing.T) {
 		`<span class="tree-delta-added">+5</span><span class="tree-delta-removed">-5</span>`,
 		`data-change="removed"`,
 		`data-change="added"`,
-		`<h3>policy PodDisruptionBudget envoy-gateway-system/envoy-gateway</h3>`,
-		`<h3>monitoring.coreos.com ServiceMonitor renovate/renovate</h3>`,
-		`<h3>renovate-operator.mogenius.com RenovateJob renovate/renovate</h3>`,
+		`<h3 class="resource-heading" title="apps Deployment envoy-gateway-system/envoy-gateway" aria-label="apps Deployment envoy-gateway-system/envoy-gateway"><span class="resource-primary"><span class="resource-kind">Deployment</span> <span class="resource-name">envoy-gateway</span></span> <span class="resource-meta"><span class="resource-namespace">envoy-gateway-system</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">apps</span></span></h3>`,
+		`<h3 class="resource-heading" title="policy PodDisruptionBudget envoy-gateway-system/envoy-gateway" aria-label="policy PodDisruptionBudget envoy-gateway-system/envoy-gateway"><span class="resource-primary"><span class="resource-kind">PodDisruptionBudget</span> <span class="resource-name">envoy-gateway</span></span> <span class="resource-meta"><span class="resource-namespace">envoy-gateway-system</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">policy</span></span></h3>`,
+		`<h3 class="resource-heading" title="monitoring.coreos.com ServiceMonitor renovate/renovate" aria-label="monitoring.coreos.com ServiceMonitor renovate/renovate"><span class="resource-primary"><span class="resource-kind">ServiceMonitor</span> <span class="resource-name">renovate</span></span> <span class="resource-meta"><span class="resource-namespace">renovate</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">monitoring.coreos.com</span></span></h3>`,
+		`<h3 class="resource-heading" title="renovate-operator.mogenius.com RenovateJob renovate/renovate" aria-label="renovate-operator.mogenius.com RenovateJob renovate/renovate"><span class="resource-primary"><span class="resource-kind">RenovateJob</span> <span class="resource-name">renovate</span></span> <span class="resource-meta"><span class="resource-namespace">renovate</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">renovate-operator.mogenius.com</span></span></h3>`,
 		`<td class="line-code">  <span class="yaml-key">replicas</span><span class="yaml-punctuation">:</span> <span class="inline-change removed"><span class="yaml-number">3</span></span></td>`,
 		`<td class="line-code">  <span class="yaml-key">replicas</span><span class="yaml-punctuation">:</span> <span class="inline-change added"><span class="yaml-number">2</span></span></td>`,
 		`<td class="line-code">            <span class="yaml-punctuation">-</span> --gateway-class-name=<span class="inline-change removed">envoy</span>-gateway</td>`,
@@ -268,7 +269,7 @@ func renderFullRenderedDiffViewDemo(t *testing.T) []byte {
 
 func resourceIDByHeading(t *testing.T, text, heading string) string {
 	t.Helper()
-	article := resourceArticleByHeading(t, text, heading)
+	article := resourceArticleByCanonicalTitle(t, text, heading)
 	prefix := `<article class="resource" data-resource-id="`
 	start := strings.Index(article, prefix)
 	if start == -1 {
@@ -282,9 +283,9 @@ func resourceIDByHeading(t *testing.T, text, heading string) string {
 	return remaining[:end]
 }
 
-func resourceArticleByHeading(t *testing.T, text, heading string) string {
+func resourceArticleByCanonicalTitle(t *testing.T, text, heading string) string {
 	t.Helper()
-	headingHTML := "<h3>" + heading + "</h3>"
+	headingHTML := `<h3 class="resource-heading" title="` + heading + `"`
 	headingIndex := strings.Index(text, headingHTML)
 	if headingIndex == -1 {
 		t.Fatalf("HTML missing resource heading %q:\n%s", heading, text)

--- a/internal/report/diffhtml/render.go
+++ b/internal/report/diffhtml/render.go
@@ -835,7 +835,7 @@ func renderResource(builder *bytes.Buffer, entry groupEntry) error {
 	)
 	builder.WriteString("<header class=\"resource-header\">\n")
 	builder.WriteString("<div class=\"resource-title\">\n")
-	fmt.Fprintf(builder, "<h3>%s</h3>\n", escape(resourceLabel(result.Resource)))
+	renderResourceHeading(builder, result.Resource)
 	builder.WriteString("</div>\n")
 	renderViewToggle(builder)
 	builder.WriteString("</header>\n")
@@ -1200,6 +1200,52 @@ func clampOffset(offset, textLength int) int {
 		return textLength
 	}
 	return offset
+}
+
+func renderResourceHeading(builder *bytes.Buffer, resource diff.Resource) {
+	label := resourceLabel(resource)
+	fmt.Fprintf(builder, "<h3 class=\"resource-heading\" title=\"%s\" aria-label=\"%s\">",
+		escape(label),
+		escape(label),
+	)
+	renderResourcePrimary(builder, resource, label)
+	renderResourceMeta(builder, resource)
+	builder.WriteString("</h3>\n")
+}
+
+func renderResourcePrimary(builder *bytes.Buffer, resource diff.Resource, fallback string) {
+	builder.WriteString("<span class=\"resource-primary\">")
+	switch {
+	case resource.Kind != "" && resource.Name != "":
+		fmt.Fprintf(builder, "<span class=\"resource-kind\">%s</span> <span class=\"resource-name\">%s</span>",
+			escape(resource.Kind),
+			escape(resource.Name),
+		)
+	case resource.Kind != "":
+		fmt.Fprintf(builder, "<span class=\"resource-kind\">%s</span>", escape(resource.Kind))
+	case resource.Name != "":
+		fmt.Fprintf(builder, "<span class=\"resource-name\">%s</span>", escape(resource.Name))
+	default:
+		fmt.Fprintf(builder, "<span class=\"resource-name\">%s</span>", escape(fallback))
+	}
+	builder.WriteString("</span>")
+}
+
+func renderResourceMeta(builder *bytes.Buffer, resource diff.Resource) {
+	if resource.Namespace == "" && resource.Group == "" {
+		return
+	}
+	builder.WriteString(" <span class=\"resource-meta\">")
+	if resource.Namespace != "" {
+		fmt.Fprintf(builder, "<span class=\"resource-namespace\">%s</span>", escape(resource.Namespace))
+	}
+	if resource.Namespace != "" && resource.Group != "" {
+		builder.WriteString(" <span class=\"resource-meta-separator\" aria-hidden=\"true\">·</span> ")
+	}
+	if resource.Group != "" {
+		fmt.Fprintf(builder, "<span class=\"resource-api-group\">%s</span>", escape(resource.Group))
+	}
+	builder.WriteString("</span>")
 }
 
 func resourceLabel(resource diff.Resource) string {

--- a/internal/report/diffhtml/render_test.go
+++ b/internal/report/diffhtml/render_test.go
@@ -1198,6 +1198,45 @@ func TestRenderSearchKeyboardContract(t *testing.T) {
 	}
 }
 
+func TestRenderTreeKeyboardNavigationContract(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{
+			diffResult("argocd", "demo", "cm-one", "@@ -1,1 +1,1 @@\n-old\n+new\n"),
+			diffResult("argocd", "demo", "cm-two", "@@ -1,1 +1,1 @@\n-old\n+new\n"),
+			diffResult("argocd", "other", "cm-three", "@@ -1,1 +1,1 @@\n-old\n+new\n"),
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`let focusedTreeButton = null;`,
+		`const treeButtonIsVisible = (button) => {`,
+		`return !(app instanceof HTMLDetailsElement) || app.open;`,
+		`const visibleTreeButtons = () => treeButtons.filter(treeButtonIsVisible);`,
+		`const setTreeButtonTabStop = (button) => {`,
+		`candidate.tabIndex = candidate === button ? 0 : -1;`,
+		`const moveTreeFocus = (delta) => {`,
+		`const focusTreeEdge = (edge) => {`,
+		`const syncTreeFocusAfterFilter = () => {`,
+		`setTreeButtonTabStop(activeButton);`,
+		`button.addEventListener('keydown', (event) => {`,
+		`event.key === 'ArrowDown'`,
+		`event.key === 'ArrowUp'`,
+		`event.key === 'Home'`,
+		`event.key === 'End'`,
+		`event.key === 'Enter' || event.key === ' '`,
+		`button.click();`,
+		`syncTreeFocusAfterFilter();`,
+		`app.addEventListener('toggle', syncTreeFocusAfterFilter);`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing tree keyboard contract %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestRenderDefaultResourceScriptContract(t *testing.T) {
 	out, err := Render(app.DiffResult{
 		Results: []diff.Result{diffResult("argocd", "demo", "cm-one", "@@ -1,1 +1,1 @@\n-old\n+new\n")},

--- a/internal/report/diffhtml/render_test.go
+++ b/internal/report/diffhtml/render_test.go
@@ -256,6 +256,28 @@ func TestRenderPlacesGlobalControlsInHeaderAndResourceHeaderBeforeDiff(t *testin
 	}
 }
 
+func TestRenderResourceHeaderUsesReadableIdentityWithAPIGroupBadge(t *testing.T) {
+	out, err := Render(app.DiffResult{
+		Results: []diff.Result{
+			resourceChange("demo", "apps", "Deployment", "envoy-gateway-system", "envoy-gateway", diff.ChangeModified, diffWithChangedLines("-old", "+new")),
+			resourceChange("demo", "", "ConfigMap", "default", "app-config", diff.ChangeModified, diffWithChangedLines("-old", "+new")),
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		`<h3 class="resource-heading" title="apps Deployment envoy-gateway-system/envoy-gateway" aria-label="apps Deployment envoy-gateway-system/envoy-gateway"><span class="resource-primary"><span class="resource-kind">Deployment</span> <span class="resource-name">envoy-gateway</span></span> <span class="resource-meta"><span class="resource-namespace">envoy-gateway-system</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">apps</span></span></h3>`,
+		`<h3 class="resource-heading" title="ConfigMap default/app-config" aria-label="ConfigMap default/app-config"><span class="resource-primary"><span class="resource-kind">ConfigMap</span> <span class="resource-name">app-config</span></span> <span class="resource-meta"><span class="resource-namespace">default</span></span></h3>`,
+		`title="apps Deployment envoy-gateway-system/envoy-gateway"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("HTML missing resource header marker %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestRenderIncludesTypographyAndLogoContract(t *testing.T) {
 	out, err := Render(app.DiffResult{
 		Results: []diff.Result{{
@@ -403,6 +425,22 @@ func TestRenderIncludesTypographyAndLogoContract(t *testing.T) {
 		`background: #0a1421;`,
 	)
 	assertStyleRuleContains(t, text, ".resource h3", `margin: 0;`, `font-size: 16px;`, `line-height: 1.25;`)
+	assertStyleRuleContains(t, text, ".resource-heading",
+		`display: flex;`,
+		`align-items: center;`,
+		`gap: 8px;`,
+		`flex-wrap: wrap;`,
+	)
+	assertStyleRuleContains(t, text, ".resource-meta",
+		`display: inline-flex;`,
+		`font-size: 13px;`,
+		`color: var(--quiet);`,
+	)
+	assertStyleRuleContains(t, text, ".resource-api-group",
+		`border-radius: 999px;`,
+		`background: rgba(129, 144, 163, 0.13);`,
+		`color: var(--muted);`,
+	)
 	assertStyleRuleContains(t, text, ".diff-table", `margin-top: 0;`, `font-size: 13.5px;`, `line-height: 20px;`)
 	blankGutterSelector := strings.Join([]string{
 		".line-number-blank,",
@@ -575,7 +613,7 @@ func TestRenderCRDRemainsRenderedAndSelectableWhenHeuristicDefaultSkipsIt(t *tes
 	for _, want := range []string{
 		`data-target-resource="resource-0"`,
 		`<article class="resource" data-resource-id="resource-0"`,
-		`<h3>apiextensions.k8s.io CustomResourceDefinition widgets.example.io</h3>`,
+		`<h3 class="resource-heading" title="apiextensions.k8s.io CustomResourceDefinition widgets.example.io" aria-label="apiextensions.k8s.io CustomResourceDefinition widgets.example.io"><span class="resource-primary"><span class="resource-kind">CustomResourceDefinition</span> <span class="resource-name">widgets.example.io</span></span> <span class="resource-meta"><span class="resource-api-group">apiextensions.k8s.io</span></span></h3>`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("HTML missing rendered/selectable CRD marker %q:\n%s", want, text)
@@ -883,7 +921,7 @@ func TestRenderLargeRenderableResourceEmitsLazyPlaceholderAndPayload(t *testing.
 		t.Fatalf("Render() error = %v", err)
 	}
 	text := string(out)
-	article := resourceArticleByHeading(t, text, "ConfigMap cm-large")
+	article := resourceArticleByCanonicalTitle(t, text, "ConfigMap cm-large")
 	for _, want := range []string{
 		`data-lazy-diff="true"`,
 		`data-lazy-state="pending"`,
@@ -998,7 +1036,7 @@ func TestRenderTooLargeResourceEmitsBlockedPlaceholder(t *testing.T) {
 		t.Fatalf("Render() error = %v", err)
 	}
 	text := string(out)
-	article := resourceArticleByHeading(t, text, "ConfigMap cm-too-large")
+	article := resourceArticleByCanonicalTitle(t, text, "ConfigMap cm-too-large")
 	for _, want := range []string{
 		`data-lazy-diff="blocked"`,
 		`data-lazy-state="blocked"`,

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -76,7 +76,7 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 		options.DiagnosticLimit = defaultDiagLimit
 	}
 	if strings.TrimSpace(options.Title) == "" {
-		options.Title = "drydock desired state diff"
+		options.Title = "drydock diff"
 	}
 
 	groups := groupedDiffs(result.Results)

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -24,7 +24,7 @@ func TestDiffMarkdownGroupsByApplicationIdentity(t *testing.T) {
 		t.Fatalf("DiffMarkdown() error = %v", err)
 	}
 	text := string(out)
-	for _, want := range []string{"## drydock desired state diff", "**Summary:** 2 apps, 2 resources, +3/-3.", "<summary>other/demo", "<summary>argocd/demo"} {
+	for _, want := range []string{"## drydock diff", "**Summary:** 2 apps, 2 resources, +3/-3.", "<summary>other/demo", "<summary>argocd/demo"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("markdown missing %q:\n%s", want, text)
 		}

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -456,7 +456,7 @@ fi
 if [[ "${diff_comment}" == "true" ]]; then
   if [[ ! -s "${diff_comment_path}" ]]; then
     {
-      echo "## drydock desired state diff"
+      echo "## drydock diff"
       echo
       echo "**Summary:** 0 apps, 0 resources, +0/-0."
       echo

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -288,7 +288,7 @@ func TestRunDiffUsesMarkdownOutputAfterExtraDiffArgs(t *testing.T) {
 		t.Fatalf("raw diff artifact = %q, want raw diff", rawDiff)
 	}
 	diffComment := readFile(t, filepath.Join(workDir, "diff-comment.md"))
-	if !strings.Contains(diffComment, "## drydock desired state diff") {
+	if !strings.Contains(diffComment, "## drydock diff") {
 		t.Fatalf("diff comment = %q, want markdown report", diffComment)
 	}
 	if strings.Contains(diffComment, "Full diff output") || strings.Contains(diffComment, "actions/runs/12345") {
@@ -706,9 +706,9 @@ if [[ "$*" == *"diff apps"* ]]; then
   fi
   if [[ "${output}" == "markdown" ]]; then
     if [[ -n "${diff_body:-}" ]]; then
-      printf '## drydock desired state diff\n\n~~~diff\n%s~~~\n' "${diff_body}"
+      printf '## drydock diff\n\n~~~diff\n%s~~~\n' "${diff_body}"
     else
-      printf '## drydock desired state diff\n\n**Summary:** 0 apps, 0 resources, +0/-0.\n\nNo rendered manifest differences detected.\n'
+      printf '## drydock diff\n\n**Summary:** 0 apps, 0 resources, +0/-0.\n\nNo rendered manifest differences detected.\n'
     fi
   else
     printf '%s' "${diff_body:-}"

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -60,7 +60,7 @@ Manifest markdown is the primary review surface. It keeps the operator summary
 near the top and puts rendered resource patches behind per-Application details:
 
 ````markdown
-## drydock desired state diff
+## drydock diff
 
 **Summary:** 2 apps, 3 resources, +12/-5.
 

--- a/site/layouts/shortcodes/pr-comment-example.html
+++ b/site/layouts/shortcodes/pr-comment-example.html
@@ -13,7 +13,7 @@
         <span>commented now</span>
       </div>
       <div class="github-markdown-body">
-        <h2>drydock desired state diff</h2>
+        <h2>drydock diff</h2>
         <p><strong>Summary:</strong> 2 apps, 3 resources, +9/-9.</p>
         <details>
           <summary>renovate (+5/-5, 1 resources)</summary>

--- a/site/layouts/shortcodes/pr-comment-example.html
+++ b/site/layouts/shortcodes/pr-comment-example.html
@@ -14,14 +14,92 @@
       </div>
       <div class="github-markdown-body">
         <h2>drydock diff</h2>
-        <p><strong>Summary:</strong> 2 apps, 3 resources, +9/-9.</p>
+        <p><strong>Summary:</strong> 2 apps, 4 resources, +30/-26.</p>
         <details>
-          <summary>renovate (+5/-5, 1 resources)</summary>
+          <summary>envoy-gateway-system (+9/-21, 2 resources)</summary>
           <div class="github-comment-highlight">
             <div class="github-comment-code" aria-label="Diff excerpt">
-              <div class="github-comment-code-row pl-md">--- Application: renovate Source: 0 apps/renovate/kustomization.yaml renovate-operator.mogenius.com/RenovateJob: renovate/renovate</div>
-              <div class="github-comment-code-row pl-mi1">+++ Application: renovate Source: 0 apps/renovate/kustomization.yaml renovate-operator.mogenius.com/RenovateJob: renovate/renovate</div>
-              <div class="github-comment-code-row pl-mdr">@@ -34,18 +34,18 @@</div>
+              <div class="github-comment-code-row pl-md">--- Application: argocd/envoy-gateway-system Source: 0 platform/envoy-gateway/kustomization.yaml apps/Deployment: envoy-gateway-system/envoy-gateway</div>
+              <div class="github-comment-code-row pl-mi1">+++ Application: argocd/envoy-gateway-system Source: 0 platform/envoy-gateway/kustomization.yaml apps/Deployment: envoy-gateway-system/envoy-gateway</div>
+              <div class="github-comment-code-row pl-mdr">@@ -8,7 +8,7 @@</div>
+              <div class="github-comment-code-row diff-context">  name: envoy-gateway</div>
+              <div class="github-comment-code-row diff-context">  namespace: envoy-gateway-system</div>
+              <div class="github-comment-code-row diff-context">spec:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  replicas: 3</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  replicas: 2</div>
+              <div class="github-comment-code-row diff-context">  selector:</div>
+              <div class="github-comment-code-row diff-context">    matchLabels:</div>
+              <div class="github-comment-code-row diff-context">      app.kubernetes.io/instance: envoy-gateway</div>
+              <div class="github-comment-code-row pl-mdr">@@ -19,17 +19,17 @@</div>
+              <div class="github-comment-code-row diff-context">    spec:</div>
+              <div class="github-comment-code-row diff-context">      containers:</div>
+              <div class="github-comment-code-row diff-context">        - args:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>            - --gateway-class-name=envoy-gateway</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>            - --metrics-bind-address=0.0.0.0:19001</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>            - --enable-wasm-extension=false</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>          image: docker.io/envoyproxy/gateway:v1.3.2</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>            - --gateway-class-name=platform-gateway</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>            - --metrics-bind-address=0.0.0.0:19002</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>            - --enable-wasm-extension=true</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>          image: docker.io/envoyproxy/gateway:v1.4.0</div>
+              <div class="github-comment-code-row diff-context">          name: envoy-gateway</div>
+              <div class="github-comment-code-row diff-context">          resources:</div>
+              <div class="github-comment-code-row diff-context">            limits:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              cpu: 100m</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              memory: 150Mi</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              cpu: 150m</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              memory: 192Mi</div>
+              <div class="github-comment-code-row diff-context">            requests:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              cpu: 10m</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              memory: 150Mi</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              cpu: 25m</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              memory: 192Mi</div>
+              <div class="github-comment-code-row diff-context">          securityContext:</div>
+              <div class="github-comment-code-row diff-context">            allowPrivilegeEscalation: false</div>
+              <div class="github-comment-code-row pl-md">--- Application: argocd/envoy-gateway-system Source: 0 platform/envoy-gateway/kustomization.yaml policy/PodDisruptionBudget: envoy-gateway-system/envoy-gateway</div>
+              <div class="github-comment-code-row pl-mi1">+++ Application: argocd/envoy-gateway-system Source: 0 platform/envoy-gateway/kustomization.yaml policy/PodDisruptionBudget: envoy-gateway-system/envoy-gateway</div>
+              <div class="github-comment-code-row pl-mdr">@@ -1,12 +0,0 @@</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>apiVersion: policy/v1</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>kind: PodDisruptionBudget</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>metadata:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  annotations:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>    argocd.argoproj.io/tracking-id: envoy-gateway-system:policy/PodDisruptionBudget:envoy-gateway-system/envoy-gateway</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  name: envoy-gateway</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  namespace: envoy-gateway-system</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>spec:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  minAvailable: 1</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  selector:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>    matchLabels:</div>
+              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>      app.kubernetes.io/instance: envoy-gateway</div>
+            </div>
+          </div>
+        </details>
+        <details>
+          <summary>renovate (+21/-5, 2 resources)</summary>
+          <div class="github-comment-highlight">
+            <div class="github-comment-code" aria-label="Diff excerpt">
+              <div class="github-comment-code-row pl-md">--- Application: argocd/renovate Source: 0 apps/renovate/templates/servicemonitor.yaml monitoring.coreos.com/ServiceMonitor: renovate/renovate</div>
+              <div class="github-comment-code-row pl-mi1">+++ Application: argocd/renovate Source: 0 apps/renovate/templates/servicemonitor.yaml monitoring.coreos.com/ServiceMonitor: renovate/renovate</div>
+              <div class="github-comment-code-row pl-mdr">@@ -0,0 +1,16 @@</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>apiVersion: monitoring.coreos.com/v1</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>kind: ServiceMonitor</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>metadata:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  annotations:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>    argocd.argoproj.io/tracking-id: renovate:monitoring.coreos.com/ServiceMonitor:renovate/renovate</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  name: renovate</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  namespace: renovate</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>spec:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  endpoints:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>    - interval: 30s</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>      path: /metrics</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>      port: metrics</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>      scrapeTimeout: 10s</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  selector:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>    matchLabels:</div>
+              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>      app.kubernetes.io/name: renovate</div>
+              <div class="github-comment-code-row pl-md">--- Application: argocd/renovate Source: 0 apps/renovate/templates/renovatejob.yaml renovate-operator.mogenius.com/RenovateJob: renovate/renovate</div>
+              <div class="github-comment-code-row pl-mi1">+++ Application: argocd/renovate Source: 0 apps/renovate/templates/renovatejob.yaml renovate-operator.mogenius.com/RenovateJob: renovate/renovate</div>
+              <div class="github-comment-code-row pl-mdr">@@ -11,18 +11,18 @@</div>
               <div class="github-comment-code-row diff-context">      value: http://10.2.0.110:3900</div>
               <div class="github-comment-code-row diff-context">    - name: S3_FORCE_PATH_STYLE</div>
               <div class="github-comment-code-row diff-context">      value: "true"</div>
@@ -45,48 +123,6 @@
               <div class="github-comment-code-row diff-context">  secretRef: renovate-secret</div>
               <div class="github-comment-code-row diff-context">  webhook:</div>
               <div class="github-comment-code-row diff-context">    authentication:</div>
-            </div>
-          </div>
-        </details>
-        <details>
-          <summary>envoy-gateway-system (+4/-4, 2 resources)</summary>
-          <div class="github-comment-highlight">
-            <div class="github-comment-code" aria-label="Diff excerpt">
-              <div class="github-comment-code-row pl-md">--- Application: envoy-gateway-system Source: 0 apps/envoy-gateway-system/kustomization.yaml apps/Deployment: envoy-gateway-system/envoy-gateway</div>
-              <div class="github-comment-code-row pl-mi1">+++ Application: envoy-gateway-system Source: 0 apps/envoy-gateway-system/kustomization.yaml apps/Deployment: envoy-gateway-system/envoy-gateway</div>
-              <div class="github-comment-code-row pl-mdr">@@ -11,7 +11,7 @@</div>
-              <div class="github-comment-code-row diff-context">  name: envoy-gateway</div>
-              <div class="github-comment-code-row diff-context">  namespace: envoy-gateway-system</div>
-              <div class="github-comment-code-row diff-context">spec:</div>
-              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  replicas: 3</div>
-              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  replicas: 2</div>
-              <div class="github-comment-code-row diff-context">  selector:</div>
-              <div class="github-comment-code-row diff-context">    matchLabels:</div>
-              <div class="github-comment-code-row diff-context">      app.kubernetes.io/instance: envoy-gateway</div>
-              <div class="github-comment-code-row pl-mdr">@@ -67,10 +67,10 @@</div>
-              <div class="github-comment-code-row diff-context">            periodSeconds: 10</div>
-              <div class="github-comment-code-row diff-context">          resources:</div>
-              <div class="github-comment-code-row diff-context">            limits:</div>
-              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              cpu: 100m</div>
-              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              cpu: 150m</div>
-              <div class="github-comment-code-row diff-context">              memory: 150Mi</div>
-              <div class="github-comment-code-row diff-context">            requests:</div>
-              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>              cpu: 10m</div>
-              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>              cpu: 25m</div>
-              <div class="github-comment-code-row diff-context">              memory: 150Mi</div>
-              <div class="github-comment-code-row diff-context">          securityContext:</div>
-              <div class="github-comment-code-row diff-context">            allowPrivilegeEscalation: false</div>
-              <div class="github-comment-code-row pl-md">--- Application: envoy-gateway-system Source: 0 apps/envoy-gateway-system/kustomization.yaml policy/PodDisruptionBudget: envoy-gateway-system/envoy-gateway</div>
-              <div class="github-comment-code-row pl-mi1">+++ Application: envoy-gateway-system Source: 0 apps/envoy-gateway-system/kustomization.yaml policy/PodDisruptionBudget: envoy-gateway-system/envoy-gateway</div>
-              <div class="github-comment-code-row pl-mdr">@@ -6,7 +6,7 @@</div>
-              <div class="github-comment-code-row diff-context">  name: envoy-gateway</div>
-              <div class="github-comment-code-row diff-context">  namespace: envoy-gateway-system</div>
-              <div class="github-comment-code-row diff-context">spec:</div>
-              <div class="github-comment-code-row pl-md"><span class="diff-marker pl-md">-</span>  minAvailable: 1</div>
-              <div class="github-comment-code-row pl-mi1"><span class="diff-marker pl-mi1">+</span>  minAvailable: 2</div>
-              <div class="github-comment-code-row diff-context">  selector:</div>
-              <div class="github-comment-code-row diff-context">    matchLabels:</div>
-              <div class="github-comment-code-row diff-context">      app.kubernetes.io/instance: envoy-gateway</div>
             </div>
           </div>
         </details>

--- a/site/static/examples/full-rendered-diff-view.html
+++ b/site/static/examples/full-rendered-diff-view.html
@@ -414,6 +414,57 @@ body.is-resizing-sidebar .sidebar-resizer::before {
 	line-height: 1.25;
 	color: var(--navy-deep);
 }
+.resource-heading {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	flex-wrap: wrap;
+}
+.resource-primary {
+	display: inline-flex;
+	gap: 5px;
+	min-width: 0;
+	font-weight: 750;
+}
+.resource-name {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.resource-meta {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	color: var(--quiet);
+	font-size: 13px;
+	font-weight: 650;
+}
+.resource-namespace {
+	min-width: 0;
+	max-width: min(32vw, 260px);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.resource-meta-separator {
+	color: var(--line-strong);
+}
+.resource-api-group {
+	display: inline-flex;
+	align-items: center;
+	min-height: 18px;
+	padding: 0 7px;
+	border: 1px solid rgba(129, 144, 163, 0.24);
+	border-radius: 999px;
+	background: rgba(129, 144, 163, 0.13);
+	color: var(--muted);
+	font-size: 12px;
+	font-weight: 750;
+	line-height: 1;
+}
 .diff-table {
 	width: 100%;
 	border-collapse: collapse;
@@ -760,7 +811,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 <article class="resource" data-resource-id="resource-0" data-result-index="0" data-change="modified">
 <header class="resource-header">
 <div class="resource-title">
-<h3>apps Deployment envoy-gateway-system/envoy-gateway</h3>
+<h3 class="resource-heading" title="apps Deployment envoy-gateway-system/envoy-gateway" aria-label="apps Deployment envoy-gateway-system/envoy-gateway"><span class="resource-primary"><span class="resource-kind">Deployment</span> <span class="resource-name">envoy-gateway</span></span> <span class="resource-meta"><span class="resource-namespace">envoy-gateway-system</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">apps</span></span></h3>
 </div>
 <button class="view-toggle" type="button" data-view-toggle aria-label="Toggle diff layout">Unified</button>
 </header>
@@ -846,7 +897,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 <article class="resource" data-resource-id="resource-1" data-result-index="1" data-change="removed">
 <header class="resource-header">
 <div class="resource-title">
-<h3>policy PodDisruptionBudget envoy-gateway-system/envoy-gateway</h3>
+<h3 class="resource-heading" title="policy PodDisruptionBudget envoy-gateway-system/envoy-gateway" aria-label="policy PodDisruptionBudget envoy-gateway-system/envoy-gateway"><span class="resource-primary"><span class="resource-kind">PodDisruptionBudget</span> <span class="resource-name">envoy-gateway</span></span> <span class="resource-meta"><span class="resource-namespace">envoy-gateway-system</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">policy</span></span></h3>
 </div>
 <button class="view-toggle" type="button" data-view-toggle aria-label="Toggle diff layout">Unified</button>
 </header>
@@ -888,7 +939,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 <article class="resource" data-resource-id="resource-2" data-result-index="2" data-change="added">
 <header class="resource-header">
 <div class="resource-title">
-<h3>monitoring.coreos.com ServiceMonitor renovate/renovate</h3>
+<h3 class="resource-heading" title="monitoring.coreos.com ServiceMonitor renovate/renovate" aria-label="monitoring.coreos.com ServiceMonitor renovate/renovate"><span class="resource-primary"><span class="resource-kind">ServiceMonitor</span> <span class="resource-name">renovate</span></span> <span class="resource-meta"><span class="resource-namespace">renovate</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">monitoring.coreos.com</span></span></h3>
 </div>
 <button class="view-toggle" type="button" data-view-toggle aria-label="Toggle diff layout">Unified</button>
 </header>
@@ -938,7 +989,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 <article class="resource" data-resource-id="resource-3" data-result-index="3" data-change="modified">
 <header class="resource-header">
 <div class="resource-title">
-<h3>renovate-operator.mogenius.com RenovateJob renovate/renovate</h3>
+<h3 class="resource-heading" title="renovate-operator.mogenius.com RenovateJob renovate/renovate" aria-label="renovate-operator.mogenius.com RenovateJob renovate/renovate"><span class="resource-primary"><span class="resource-kind">RenovateJob</span> <span class="resource-name">renovate</span></span> <span class="resource-meta"><span class="resource-namespace">renovate</span> <span class="resource-meta-separator" aria-hidden="true">·</span> <span class="resource-api-group">renovate-operator.mogenius.com</span></span></h3>
 </div>
 <button class="view-toggle" type="button" data-view-toggle aria-label="Toggle diff layout">Unified</button>
 </header>

--- a/site/static/examples/full-rendered-diff-view.html
+++ b/site/static/examples/full-rendered-diff-view.html
@@ -1616,6 +1616,74 @@ body[data-view="unified"] .diff-table.side-by-side {
 		}
 	};
 
+	let focusedTreeButton = null;
+	const treeButtonApp = (button) => button.closest('[data-tree-app]');
+	const treeButtonIsVisible = (button) => {
+		const app = treeButtonApp(button);
+		if (button.hidden || app?.hidden) {
+			return false;
+		}
+		return !(app instanceof HTMLDetailsElement) || app.open;
+	};
+	const visibleTreeButtons = () => treeButtons.filter(treeButtonIsVisible);
+	const setTreeButtonTabStop = (button) => {
+		treeButtons.forEach((candidate) => {
+			candidate.tabIndex = candidate === button ? 0 : -1;
+		});
+		focusedTreeButton = button || null;
+	};
+	const selectedTreeButton = () => treeButtons.find((button) => button.getAttribute('aria-current') === 'true') || null;
+	const currentTreeButton = () => {
+		const visible = visibleTreeButtons();
+		if (focusedTreeButton && visible.includes(focusedTreeButton)) {
+			return focusedTreeButton;
+		}
+		const selected = selectedTreeButton();
+		if (selected && visible.includes(selected)) {
+			return selected;
+		}
+		return visible[0] || null;
+	};
+	const focusTreeButton = (button) => {
+		if (!button) {
+			return;
+		}
+		setTreeButtonTabStop(button);
+		button.focus();
+		button.scrollIntoView({ block: 'nearest' });
+	};
+	const moveTreeFocus = (delta) => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			return;
+		}
+		const current = currentTreeButton();
+		const currentIndex = Math.max(0, visible.indexOf(current));
+		const nextIndex = clamp(currentIndex + delta, 0, visible.length - 1);
+		focusTreeButton(visible[nextIndex]);
+	};
+	const focusTreeEdge = (edge) => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			return;
+		}
+		focusTreeButton(edge === 'end' ? visible[visible.length - 1] : visible[0]);
+	};
+	const syncTreeFocusAfterFilter = () => {
+		const visible = visibleTreeButtons();
+		if (visible.length === 0) {
+			setTreeButtonTabStop(null);
+			return;
+		}
+		const selected = selectedTreeButton();
+		const next = selected && visible.includes(selected) ? selected : visible[0];
+		const activeElement = document.activeElement;
+		setTreeButtonTabStop(next);
+		if (activeElement instanceof HTMLElement && activeElement.matches('[data-target-resource]') && !visible.includes(activeElement)) {
+			next.focus();
+		}
+	};
+
 	const selectResource = (id, options = {}) => {
 		if (!resourceIds.has(id)) {
 			return;
@@ -1637,6 +1705,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 			}
 		});
 		if (activeButton) {
+			setTreeButtonTabStop(activeButton);
 			activeButton.scrollIntoView({ block: 'nearest' });
 		}
 		if (options.updateHash) {
@@ -1652,6 +1721,32 @@ body[data-view="unified"] .diff-table.side-by-side {
 			selectResource(button.dataset.targetResource, { updateHash: true });
 			if (mobileQuery.matches) {
 				setSidebar('closed');
+			}
+		});
+		button.addEventListener('keydown', (event) => {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				moveTreeFocus(1);
+				return;
+			}
+			if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				moveTreeFocus(-1);
+				return;
+			}
+			if (event.key === 'Home') {
+				event.preventDefault();
+				focusTreeEdge('start');
+				return;
+			}
+			if (event.key === 'End') {
+				event.preventDefault();
+				focusTreeEdge('end');
+				return;
+			}
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				button.click();
 			}
 		});
 	});
@@ -1761,7 +1856,12 @@ body[data-view="unified"] .diff-table.side-by-side {
 				app.open = true;
 			}
 		});
+		syncTreeFocusAfterFilter();
 	};
+
+	document.querySelectorAll('[data-tree-app]').forEach((app) => {
+		app.addEventListener('toggle', syncTreeFocusAfterFilter);
+	});
 
 	const clearSearch = () => {
 		if (!searchInput) {


### PR DESCRIPTION
## Summary

- shorten PR diff comment heading to `drydock diff`
- refine HTML diff resource headings and sidebar navigation
- refresh PR comment docs/example artifact with the current dataset
- add keyboard navigation for sidebar resources

## Validation

- `go test -count=1 ./internal/report/diffhtml ./internal/cli`
- `mise run lint`
- `git diff --check`

Review agent approved the final keyboard-navigation slice with no findings.
