### PR TITLE
fix: size diff view to mobile viewport

### DIFF
--- a/internal/report/diffhtml/assets.go
+++ b/internal/report/diffhtml/assets.go
@@ -41,6 +41,7 @@ html {
 body {
 	margin: 0;
 	min-height: 100vh;
+	min-height: 100dvh;
 	overflow: hidden;
 	background: linear-gradient(180deg, #07111d 0%, #0a1421 46%, #101827 100%);
 	color: var(--ink);
@@ -170,6 +171,7 @@ body.is-resizing-sidebar * {
 	display: grid;
 	grid-template-columns: var(--sidebar-width) 0 minmax(0, 1fr);
 	height: calc(100vh - var(--topbar-height));
+	height: calc(100dvh - var(--topbar-height));
 	min-height: 0;
 }
 @media (min-width: 801px) {
@@ -694,6 +696,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 	.review-layout {
 		display: block;
 		height: calc(100vh - var(--topbar-height));
+		height: calc(100dvh - var(--topbar-height));
 		min-height: 0;
 		overflow: hidden;
 	}

--- a/internal/report/diffhtml/render_test.go
+++ b/internal/report/diffhtml/render_test.go
@@ -312,7 +312,7 @@ func TestRenderIncludesTypographyAndLogoContract(t *testing.T) {
 		`--header-title-gap: 18px;`,
 	)
 	assertStyleRuleContains(t, text, "html", `-webkit-text-size-adjust: 100%;`, `text-size-adjust: 100%;`)
-	assertStyleRuleContains(t, text, "body", `overflow: hidden;`, `font-size: 14px;`, `line-height: 1.45;`)
+	assertStyleRuleContains(t, text, "body", `min-height: 100vh;`, `min-height: 100dvh;`, `overflow: hidden;`, `font-size: 14px;`, `line-height: 1.45;`)
 	assertStyleRuleContains(t, text, "body.is-resizing-sidebar", `cursor: col-resize;`)
 	assertStyleRuleContains(t, text, "body.is-resizing-sidebar *", `user-select: none;`)
 	assertStyleRuleContains(t, text, ".report-header",
@@ -359,6 +359,7 @@ func TestRenderIncludesTypographyAndLogoContract(t *testing.T) {
 	assertStyleRuleContains(t, text, ".review-layout",
 		`grid-template-columns: var(--sidebar-width) 0 minmax(0, 1fr);`,
 		`height: calc(100vh - var(--topbar-height));`,
+		`height: calc(100dvh - var(--topbar-height));`,
 		`min-height: 0;`,
 	)
 	assertStyleRuleContains(t, text, ".tree", `grid-column: 1;`, `min-height: 0;`, `overflow: auto;`)

--- a/site/static/examples/full-rendered-diff-view.html
+++ b/site/static/examples/full-rendered-diff-view.html
@@ -46,6 +46,7 @@ html {
 body {
 	margin: 0;
 	min-height: 100vh;
+	min-height: 100dvh;
 	overflow: hidden;
 	background: linear-gradient(180deg, #07111d 0%, #0a1421 46%, #101827 100%);
 	color: var(--ink);
@@ -175,6 +176,7 @@ body.is-resizing-sidebar * {
 	display: grid;
 	grid-template-columns: var(--sidebar-width) 0 minmax(0, 1fr);
 	height: calc(100vh - var(--topbar-height));
+	height: calc(100dvh - var(--topbar-height));
 	min-height: 0;
 }
 @media (min-width: 801px) {
@@ -699,6 +701,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 	.review-layout {
 		display: block;
 		height: calc(100vh - var(--topbar-height));
+		height: calc(100dvh - var(--topbar-height));
 		min-height: 0;
 		overflow: hidden;
 	}


### PR DESCRIPTION
## Summary
- keep the existing 100vh fallback and add 100dvh sizing for the static diff view shell
- apply the same dynamic viewport sizing inside the mobile layout rule
- regenerate the checked-in Full Rendered Diff View example and pin the CSS contract in tests

## Diagnosis
The HTML diff artifact locks body scrolling and scrolls inside the review pane. On mobile browsers, 100vh can include browser toolbar space, so the pane can reach its own bottom while the final rows remain below the visible viewport. 100dvh makes the pane track the visible dynamic viewport on modern mobile browsers.

## Validation
- UPDATE_DIFFHTML_EXAMPLE=1 go test ./internal/report/diffhtml -run TestFullRenderedDiffViewExampleIsCurrent
- go test ./internal/report/diffhtml ./internal/cli
- go test ./...
- mise run lint
- headless mobile layout harness confirmed line 35 is reachable with a shortened visible viewport
- review agent approved