### PR TITLE
docs: showcase rendered diff view

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -11,6 +11,21 @@ drydock publishes two composite GitHub Actions:
 The PR action is a convenience wrapper around the CLI. It does not run image
 pull verification and does not pass GitHub tokens to the `drydock` subprocess.
 
+## Full Rendered Diff View
+
+The PR action turns rendered manifest changes into a compact pull request
+comment and a browser-openable Full Rendered Diff View artifact. Use it to
+review the desired state Argo CD would reconcile after merge.
+
+When `upload-artifacts: "true"` and a manifest diff exists, the manifest diff
+comment links to the Full Rendered Diff View. The raw unified diff artifact
+remains available for scripts and archival workflows. Artifact availability
+follows `artifact-retention-days`; GitHub controls whether the artifact link
+opens in the current tab or a new tab.
+
+Open a public sample:
+[Full Rendered Diff View](https://sholdee.github.io/drydock/examples/full-rendered-diff-view.html).
+
 ## Setup Action
 
 Use the setup action when you want to own every drydock command in workflow
@@ -102,15 +117,6 @@ By default the action:
 - uploads full raw diff and browser-openable Full Rendered Diff View artifacts
   when manifest differences are found;
 - writes sticky PR comments for trusted same-repository pull requests.
-
-The manifest diff comment links to the Full Rendered Diff View when
-`upload-artifacts: "true"` and a manifest diff exists. The raw unified diff
-artifact remains available for scripts and archival workflows. Artifact
-availability follows `artifact-retention-days`; GitHub controls whether the
-artifact link opens in the current tab or a new tab.
-
-Open a public sample:
-[Full Rendered Diff View](https://sholdee.github.io/drydock/examples/full-rendered-diff-view.html).
 
 Fork pull requests do not restore or save drydock render caches by default,
 because render caches can contain private repository, chart, remote source, or

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -668,8 +668,9 @@ a:hover {
 
 .github-comment-header {
   display: flex;
-  gap: 0.35rem;
   align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   min-height: 40px;
   border-bottom: 1px solid #30363d;
   border-top-left-radius: 6px;
@@ -677,6 +678,22 @@ a:hover {
   background: #161b22;
   color: #8b949e;
   padding: 0 16px;
+}
+
+.github-comment-header-left,
+.github-comment-header-actions {
+  display: flex;
+  align-items: center;
+}
+
+.github-comment-header-left {
+  min-width: 0;
+  gap: 0.35rem;
+}
+
+.github-comment-header-actions {
+  flex: none;
+  gap: 0.4rem;
 }
 
 .github-comment-author {
@@ -692,6 +709,38 @@ a:hover {
   font-weight: 500;
   line-height: 18px;
   padding: 0 7px;
+}
+
+.github-comment-timestamp {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.github-comment-role-badge {
+  border: 1px solid #3d444d;
+  border-radius: 2em;
+  color: #8b949e;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  padding: 0 6px;
+}
+
+.github-comment-menu-dots {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  width: 20px;
+  height: 20px;
+  margin-left: 2px;
+}
+
+.github-comment-menu-dots span {
+  width: 3px;
+  height: 3px;
+  border-radius: 999px;
+  background: #8b949e;
 }
 
 .github-markdown-body {
@@ -918,6 +967,10 @@ a:hover {
   .github-comment-avatar,
   .github-comment-box::before,
   .github-comment-box::after {
+    display: none;
+  }
+
+  .github-comment-header-actions {
     display: none;
   }
 }

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -7,13 +7,9 @@ runtime-offline Argo CD desired-state analysis. It discovers, renders, tests,
 diffs, and diagnoses GitOps Applications with native Go renderers, no Argo CD
 server, no Kubernetes credentials, and no default shellouts.
 
-Use it locally or in CI to see the rendered Kubernetes resources behind raw Git
-changes. For pull request review, drydock compares desired state rendered from
-the PR against desired state rendered from the base ref, then posts an inline
-diff and a link to a standalone
-[Full Rendered Diff View](/examples/full-rendered-diff-view.html) artifact.
-
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
+
+{{< pr-comment-example >}}
 
 ## Start Here
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -9,6 +9,8 @@ server, no Kubernetes credentials, and no default shellouts.
 
 **[Get Started](/getting-started/)** | **[Set Up PR Checks](/workflows/github-actions/)**
 
+Use drydock to review rendered PR diffs automatically:
+
 {{< pr-comment-example >}}
 
 ## Start Here

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -12,6 +12,17 @@ Use `setup-action` when you want to own the CLI commands. Use `pr-action` when
 you want the standard render test, markdown manifest diff, image diff, render
 cache, artifacts, and pull request comment workflow.
 
+## Full Rendered Diff View
+
+The PR action turns rendered manifest changes into a compact pull request
+comment and a standalone Full Rendered Diff View artifact:
+
+{{< pr-comment-example >}}
+
+Artifacts follow the workflow's retention settings. For a permanent sample:
+
+[Full Rendered Diff View](/examples/full-rendered-diff-view.html)
+
 ## Manual CLI Workflow
 
 ```yaml
@@ -77,22 +88,6 @@ When trusted container plugins are enabled, policy-managed plugin cache mounts
 live under the PR action cache root as `${cache-path}/plugin` and are restored
 or saved with that render cache. `drydock cache` lifecycle commands still manage
 only Git, chart, and remote-resource cache entry roots for now.
-
-## Full Rendered Diff View
-
-The PR action posts a compact markdown summary in the pull request. When a
-manifest diff exists and artifact upload is enabled, the summary links
-reviewers to a standalone Full Rendered Diff View artifact:
-
-{{< pr-comment-example >}}
-
-Use it to review the desired state Argo CD would reconcile after merge. drydock
-renders the PR and base refs, then compares the results without requiring Argo
-CD or Kubernetes credentials.
-
-Artifacts follow the workflow's retention settings. For a permanent sample:
-
-[Full Rendered Diff View](/examples/full-rendered-diff-view.html)
 
 ## Reporting And Gating
 

--- a/site/layouts/shortcodes/pr-comment-example.html
+++ b/site/layouts/shortcodes/pr-comment-example.html
@@ -8,9 +8,16 @@
     </div>
     <div class="github-comment-box">
       <div class="github-comment-header">
-        <span class="github-comment-author">drydock</span>
-        <span class="github-comment-bot-badge">Bot</span>
-        <span>commented now</span>
+        <div class="github-comment-header-left">
+          <span class="github-comment-author">drydock</span>
+          <span class="github-comment-bot-badge">Bot</span>
+          <span>commented <span class="github-comment-timestamp">now</span></span>
+        </div>
+        <div class="github-comment-header-actions" aria-hidden="true">
+          <span class="github-comment-role-badge">Contributor</span>
+          <span class="github-comment-role-badge">Author</span>
+          <span class="github-comment-menu-dots"><span></span><span></span><span></span></span>
+        </div>
       </div>
       <div class="github-markdown-body">
         <h2>drydock diff</h2>


### PR DESCRIPTION
## Summary
- move the Full Rendered Diff View docs closer to the GitHub Actions intro
- replace overview prose with a GitHub-style PR comment example
- tune the comment mock chrome to better match GitHub dark mode

## Validation
- mise run docs-check
- gomarklint site/content/_index.md site/content/workflows/github-actions.md docs/github-actions.md
- git diff --check