### PR TITLE
docs: align image comment header

### DIFF
--- a/site/layouts/shortcodes/image-comment-example.html
+++ b/site/layouts/shortcodes/image-comment-example.html
@@ -7,9 +7,16 @@
     </div>
     <div class="github-comment-box">
       <div class="github-comment-header">
-        <span class="github-comment-author">drydock</span>
-        <span class="github-comment-bot-badge">Bot</span>
-        <span>commented now</span>
+        <div class="github-comment-header-left">
+          <span class="github-comment-author">drydock</span>
+          <span class="github-comment-bot-badge">Bot</span>
+          <span>commented <span class="github-comment-timestamp">now</span></span>
+        </div>
+        <div class="github-comment-header-actions" aria-hidden="true">
+          <span class="github-comment-role-badge">Contributor</span>
+          <span class="github-comment-role-badge">Author</span>
+          <span class="github-comment-menu-dots"><span></span><span></span><span></span></span>
+        </div>
       </div>
       <div class="github-markdown-body">
         <h2>drydock image diff</h2>


### PR DESCRIPTION
## Summary
- update the image diff comment example to use the same GitHub-style header structure as the rendered diff comment example
- keep the author, Bot badge, Contributor/Author badges, and menu dots aligned consistently across both examples

## Validation
- mise run docs-check
- gomarklint site/content/workflows/github-actions.md
- git diff --check
- verified generated GitHub Actions HTML includes the shared header actions for the image comment example