### PR TITLE
feat: validate AppProject policy semantics

### DIFF
--- a/.github/workflows/argocd-parity-smoke.yml
+++ b/.github/workflows/argocd-parity-smoke.yml
@@ -130,5 +130,6 @@ jobs:
             ${{ runner.temp }}/argocd-parity-smoke/argocd-manifests
             ${{ runner.temp }}/argocd-parity-smoke/drydock-manifests
             ${{ runner.temp }}/argocd-parity-smoke/compare
+            ${{ runner.temp }}/argocd-parity-smoke/project-policy
             ${{ runner.temp }}/argocd-parity-smoke/logs
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             changed_files="$(git diff --name-only "${BASE_SHA}...HEAD")"
 
-            if grep -Eq '^(\.github/workflows/argocd-parity-smoke\.yml|internal/paritycompare/|scripts/argocd-parity-compare/|scripts/argocd-parity-smoke\.sh|testdata/argocd-parity/)' <<<"${changed_files}"; then
+            if grep -Eq '^(\.github/workflows/argocd-parity-smoke\.yml|internal/app/|internal/diagnostic/|internal/paritycompare/|internal/project/|scripts/argocd-parity-compare/|scripts/argocd-project-policy-smoke/|scripts/argocd-parity-smoke\.sh|testdata/argocd-parity/|testdata/argocd-project-policy/)' <<<"${changed_files}"; then
               run_smoke="true"
-              reason="render parity files changed"
+              reason="render parity, project policy, or diagnostic files changed"
             elif grep -qx 'go.mod' <<<"${changed_files}"; then
               go_mod_diff="$(git diff --unified=0 "${BASE_SHA}...HEAD" -- go.mod)"
               semantic_modules='(github\.com/argoproj/argo-cd/v3|github\.com/argoproj/argo-cd/gitops-engine|github\.com/google/go-jsonnet|helm\.sh/helm/|k8s\.io/|sigs\.k8s\.io/controller-runtime|sigs\.k8s\.io/json|sigs\.k8s\.io/kustomize/|sigs\.k8s\.io/structured-merge-diff/|sigs\.k8s\.io/yaml)'

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -96,8 +96,12 @@ or fingerprint cluster credential/config fields.
 Local `AppProject` manifests may produce offline diagnostics for Application
 project references, source repositories, destinations, source namespaces,
 repository Secret metadata matches, cluster Secret metadata matches, RBAC role
-metadata, and deferred project-scoped cluster metadata. Do not simulate live
-cluster existence or full Argo CD RBAC/Casbin authorization offline.
+metadata, rendered-resource policy, and deferred project-scoped cluster
+metadata. Do not simulate live cluster existence, full Argo CD RBAC/Casbin
+authorization, sync-window scheduling, orphaned-resource detection, source
+signature verification, or destination service account sync impersonation
+offline. Implementing any of those runtime AppProject semantics requires a new
+explicit design gate.
 
 ## Discovery And ApplicationSet Support
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,10 +21,16 @@ manually for maintainer validation and selectively in CI when render parity
 fixtures or semantic-rendering dependencies change. See `docs/release.md` for
 maintainer workflow details.
 
+It also runs a thin live AppProject Application-spec policy sanity check for
+source repository, destination, and source namespace outcomes against the real
+Argo CD instance.
+
 This check is scoped to generated desired state. Live-only runtime behavior
 such as Kubernetes defaulting, admission mutation, server-side diff, managed
 fields, health aggregation, sync behavior, and controller state remains outside
-drydock's runtime-offline boundary.
+drydock's runtime-offline boundary. It is not broad live authorization parity
+and excludes RBAC/Casbin, sync windows, orphaning, signatures, sync
+impersonation, and rendered-resource policy.
 
 ## Runtime Model
 
@@ -51,13 +57,17 @@ Not reproduced offline:
 - Live Argo CD Application health aggregation.
 - Live destination cluster existence checks.
 - Sync window enforcement.
+- Orphaned resource detection.
 - Source integrity signature verification.
+- Destination service account sync impersonation.
 - Project-scoped cluster Secret enforcement when cluster Secret metadata is not
   present in the analyzed desired state.
 - Full Argo CD RBAC/Casbin authorization simulation.
 
-These live-state behaviors must stay explicit runtime-boundary diagnostics, not
-silent approximations.
+These live-state behaviors must stay explicit runtime boundaries, not silent
+approximations. drydock may report deferred diagnostics when it can identify a
+specific unevaluated policy decision without creating strict-mode noise for
+valid runtime-only configuration.
 
 ## Applications And ApplicationSets
 
@@ -279,6 +289,11 @@ Supported:
   diagnostics and project-scoped cluster checks when the desired state includes
   the relevant cluster Secret metadata. Only `name`, `server`, `namespaces`,
   `clusterResources`, and `project` are decoded.
+- Project diagnostic modes. The default `actionable` mode reports local
+  AppProject denials that drydock can enforce offline and hides deferred or
+  metadata-only AppProject diagnostics. Use `--project-diagnostics=all` for full
+  compatibility audits, or `--project-diagnostics=off` to suppress AppProject
+  diagnostics.
 - `argocd-cmd-params-cm` runtime-boundary diagnostics for settings that imply
   live repo-server, controller, or ApplicationSet controller behavior. These
   settings are parsed as metadata and do not mutate render behavior.
@@ -289,6 +304,52 @@ Supported:
 - Warning diagnostics for version-specific `kustomize.buildOptions.<version>`
   and `kustomize.path.<version>` settings because drydock does not select
   external Kustomize binaries.
+
+### AppProject Field Semantics
+
+This matrix is audited against Argo CD `v3.4.3`
+(`1801122b4391cad4961301f787006dc9a88c2dd3`). It records current drydock
+behavior. Strict render tests promote visible project and repository warnings
+after the selected project diagnostic mode is applied.
+
+| Field | Upstream owner | drydock status | Current diagnostic | Offline input and next phase |
+| --- | --- | --- | --- | --- |
+| `spec.sourceRepos` | `types.go`, `IsSourcePermitted`, Argo repo metadata merge | Supported | `project` warning for denied sources; `repository` warning for mismatched repository Secret project metadata | Application sources plus redacted repository metadata; parity fixtures present, future gaps Phase 3 |
+| `spec.destinations` | `types.go`, `IsDestinationPermitted`, `isDestinationMatched` | Supported with named-cluster metadata caveats | `project` warning for denied destinations or unresolved name-only server policy | Application destination plus redacted cluster metadata; parity fixtures present, deferred metadata cases Phase 3 |
+| `spec.description` | `types.go` | Metadata-only | None | Decoded as typed metadata |
+| `spec.sourceNamespaces` | `types.go`, `IsAppNamespacePermitted` | Supported | `project` warning for denied Application source namespace | Application namespace plus controller namespace assumption; parity fixtures present |
+| `spec.permitOnlyProjectScopedClusters` | `types.go`, `IsDestinationPermitted` project-cluster check | Deferred when cluster metadata is unavailable; supported when redacted project-scoped cluster metadata is present | `project` warning for deferred metadata or known denial | Redacted cluster Secret `project` metadata; without it drydock reports a runtime-boundary deferral rather than a hard decision |
+| `spec.clusterResourceWhitelist` | `types.go`, `IsGroupKindNamePermitted`, `IsResourcePermitted` | Supported for render-backed workflows | `project.resource-denied` warning for denied rendered resources | Rendered objects plus offline scope knowledge; unknown custom-resource scope defers with `project.resource-scope-deferred` only when possible scopes change or defer the policy outcome |
+| `spec.clusterResourceBlacklist` | `types.go`, `IsGroupKindNamePermitted`, `IsResourcePermitted` | Supported for render-backed workflows | `project.resource-denied` warning for denied rendered resources | Rendered objects plus offline scope knowledge; unknown custom-resource scope defers with `project.resource-scope-deferred` only when possible scopes change or defer the policy outcome |
+| `spec.namespaceResourceWhitelist` | `types.go`, `IsGroupKindNamePermitted`, `IsResourcePermitted` | Supported for render-backed workflows | `project.resource-denied` warning for denied rendered resources; `project.resource-destination-denied` for rendered object namespace denials | Rendered objects plus destination namespace normalization; discovery-only workflows do not evaluate rendered resource policy |
+| `spec.namespaceResourceBlacklist` | `types.go`, `IsGroupKindNamePermitted`, `IsResourcePermitted` | Supported for render-backed workflows | `project.resource-denied` warning for denied rendered resources; `project.resource-destination-denied` for rendered object namespace denials | Rendered objects plus destination namespace normalization; discovery-only workflows do not evaluate rendered resource policy |
+| `spec.roles` | `types.go`, `ValidateProject`, `ProjectPoliciesString`, Argo RBAC runtime | Metadata-only | `project.rbac-metadata-only` warning when roles are present | Role presence only; no Casbin authorization, claims, scopes, or token-status simulation |
+| `spec.syncWindows` | `types.go`, `SyncWindow.Matches`, `SyncWindows.CanSync`, Argo sync runtime | Runtime-bound; documented only | None | Depends on clock, timezone, destination, and manual vs automated operation context |
+| `spec.orphanedResources` | `types.go`, Argo application controller live orphan scan | Unsupported live-cluster behavior | None | Requires live namespace inventory, ownership graph, orphan exclusions, and controller state |
+| `spec.signatureKeys` | `types.go`, Argo GPG verification in `controller/state.go` and repo-server verification | Unsupported runtime verification | None | Requires GPG keyring state, repo-server verification result, and resolved commit metadata |
+| `spec.destinationServiceAccounts` | `types.go`, `ValidateProject`, `controller/sync.go` sync impersonation runtime | Runtime-bound metadata | None | Sync impersonation is applied during controller sync; drydock does not mutate REST config or validate live service account authorization |
+
+### AppProject Current Behavior Traceability
+
+This table maps the current drydock code paths and tests to the semantics above.
+Future audit phases may replace current-behavior tests as deferred fields are
+implemented or documented as runtime boundaries.
+
+| Behavior | Current code path | Test coverage | Disposition |
+| --- | --- | --- | --- |
+| Local AppProject discovery | `discovery.Scan`, `appendDiscoveredProjects` | `TestScanDiscoversAppProjects`, `TestScanPreservesDocumentIdentityForTypedObjects` | No follow-up |
+| Rendered AppProject discovery | `applyExplicitKustomizeDiscovery`, `discoverRenderedFleet`, bootstrap discovery | Existing explicit-rendered and fleet discovery tests | Phase 2 fixture expansion |
+| Duplicate or conflicting projects | `mergeProjects`, `resolveDiscoveryConflict`, same-scan `projectIndex` last-wins | Existing rendered precedence coverage | Discovery-focused follow-up |
+| Implicit default project | `effectiveProject`, `implicitDefaultProject` | `TestValidateApplicationsAllowsImplicitDefaultProject`, `TestValidateApplicationsCurrentBehaviorAllowsImplicitDefaultProjectWhenOtherLocalProjectsExist` | No follow-up |
+| Missing non-default project | `ValidateApplications`, `projectIndex`, `applicationProject` | `TestValidateApplicationsCurrentBehaviorReportsMissingNonDefaultProject` | No follow-up |
+| Source repository matching | `validateSources`, Argo `IsSourcePermitted` | Existing source policy tests, source parity fixtures, `TestValidateApplicationsCurrentBehaviorReportsDeniedMultiSourceRepository` | Phase 3 remediation for any future parity gaps |
+| Destination matching | `validateDestination`, `destinationCluster`, Argo `IsDestinationPermitted` | Existing destination and project-scoped cluster tests, destination parity fixtures | Phase 3 remediation for deferred metadata cases |
+| Cluster Secret metadata | `clusterSecretSettings`, `projectScopedClusters` | Cluster parser tests, project-scoped destination tests, metadata integration fixtures | Phase 3 remediation for deferred metadata cases |
+| Repository Secret project metadata | `repositorySecretSettings`, `effectiveProject`, `repositoryMetadataDiagnostics` | Repository metadata tests, project-scoped repository tests, metadata integration fixtures | No follow-up |
+| Source namespace checks | `validateSourceNamespace` | Existing source namespace tests, source namespace parity fixtures, `TestValidateApplicationsCurrentBehaviorPhase3SourceNamespacesEmptyListDeniesNonControllerNamespace` | No follow-up |
+| RBAC role metadata | `rbacMetadataDiagnostics` | Existing source namespace and RBAC metadata test | Metadata-only warning; authorization is not simulated |
+| Resource policy fields | `ValidateRenderedResourcePolicy`, `renderOneApplication`, shared manifest scope helpers | Resource policy evaluator tests and `orchestrator_project_resource_policy_test.go` | Supported for render-backed workflows; discovery-only paths remain unevaluated |
+| Runtime-bound fields | No sync window, orphan, signature, or impersonation simulation | `TestValidateApplicationsRuntimeBoundFieldsDoNotSimulateLivePolicy` | Intentionally documented runtime boundary |
 
 Not supported:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,16 @@ When upgrading the Argo CD module:
 2. Run `mise run test-race`, `mise run vet`, and `mise run lint`.
 3. Run focused compatibility tests for ApplicationSet generators, global
    settings parsing, AppProject validation, and source acquisition.
-4. Update `docs/compatibility.md` in the same change.
+4. Run the focused AppProject parity smoke with `go test ./internal/project`.
+   This covers source repository, destination, source namespace, redacted
+   metadata, and rendered-resource policy semantics against imported Argo CD
+   helper behavior. It is intentionally not a live authorization, sync-window,
+   orphan, signature, or sync-impersonation smoke.
+5. Check whether new AppProject diagnostics belong in the default
+   `--project-diagnostics=actionable` path. Diagnostics that require live Argo
+   CD or cluster context should remain available through
+   `--project-diagnostics=all` without failing default strict render tests.
+6. Update `docs/compatibility.md` in the same change.
 
 ## Cache Compatibility
 
@@ -216,6 +225,12 @@ generated desired manifests with drydock generated manifests. The workflow
 installs `kubectl` through the pinned `Azure/setup-kubectl` action; Renovate
 manages both action digests and the kind/kubectl input versions.
 
+The same `scripts/argocd-parity-smoke.sh` run also checks thin live AppProject
+Application-spec policy sanity for source repository, destination, and source
+namespace outcomes against the real Argo CD instance. It is not broad live
+authorization parity and excludes RBAC/Casbin, sync windows, orphaning,
+signatures, sync impersonation, and rendered-resource policy.
+
 This workflow is intentionally outside ordinary pull request CI. It always runs
 when manually dispatched, and CI calls it as a reusable workflow only when
 render parity fixtures change or `go.mod` changes touch semantic-rendering
@@ -227,6 +242,7 @@ admission mutation, managed fields, and controller reconciliation stay outside
 the smoke's scope.
 
 The workflow uploads only whitelisted parity artifacts: Argo CD manifest
-output, drydock manifest output, canonical comparison output, diffs, and
-selected sanitized logs on failure. It does not upload kubeconfig, Argo CD CLI
-config, Secrets, or full cluster dumps.
+output, drydock manifest output, canonical comparison output, AppProject policy
+status and diagnostic evidence, diffs, and selected sanitized logs on failure.
+It does not upload kubeconfig, Argo CD CLI config, Secrets, or full cluster
+dumps.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -489,13 +489,83 @@ strings, or any live-cluster state.
 When local `AppProject` manifests are present, `build`, `test`, `diff`, and the
 Go API report source repository and destination validation diagnostics from
 those manifests. `diag --render` includes the same render-backed project
-diagnostics; default `diag` reports project and repository metadata discovered
-without rendering every Application. RBAC roles and policies are parsed and
-reported as metadata only; Argo CD authorization is not simulated. Repository
-credential matching diagnostics use discovered repository Secret metadata only
-and never read secret credential fields. Cluster Secret diagnostics likewise use
-only `name`, `server`, `namespaces`, `clusterResources`, and `project` metadata;
-credential/config fields are not decoded, retained, or printed.
+diagnostics, including rendered-resource allow/deny policy; default `diag`
+reports project and repository metadata discovered without rendering every
+Application.
+
+Project diagnostics default to `--project-diagnostics=actionable`. In this
+mode, drydock keeps known local denials visible, including missing projects,
+denied source repositories, denied destinations, denied source namespaces, and
+denied rendered resources. AppProject diagnostics that cannot be conclusively
+enforced offline are hidden by default, so strict render tests fail only on
+diagnostics drydock can act on locally. Use `--project-diagnostics=all` for full
+AppProject audit output during compatibility investigations, or
+`--project-diagnostics=off` to suppress AppProject diagnostics entirely.
+
+RBAC roles and policies are parsed and reported as metadata only when full
+project diagnostics are enabled; Argo CD authorization is not simulated. Sync
+windows, orphaned-resource tracking, source signature verification, and
+destination service account impersonation are runtime-bound and are not
+evaluated offline. Repository credential matching diagnostics use discovered
+repository Secret metadata only and never read secret credential fields. Cluster
+Secret diagnostics likewise use only `name`, `server`, `namespaces`,
+`clusterResources`, and `project` metadata; credential/config fields are not
+decoded, retained, or printed. Project-scoped cluster checks require the
+relevant redacted cluster Secret metadata; without it drydock treats the check
+as an offline boundary instead of inventing a hard allow or deny.
+
+Project diagnostics appear in the command path that has enough input to make
+the check. Text commands print diagnostics to stderr:
+
+```bash
+drydock test apps --path . --strict
+```
+
+```text
+error project: Application argocd/payments-api source repository "https://github.com/example/repo" is not permitted by AppProject "platform" (path: argocd/payments-api)
+```
+
+Rendered workflows can also report resource-policy diagnostics:
+
+```bash
+drydock build apps --path .
+```
+
+```text
+warning project: Application argocd/payments-api rendered resource ConfigMap kube-system/settings namespace "kube-system" is not permitted by AppProject "platform" (path: argocd/payments-api)
+```
+
+For non-markdown outputs, diff commands keep the same diagnostics separate from
+the diff body. Markdown output embeds successful diagnostics in the generated
+report. Use `--project-diagnostics=all` when you want deferred offline-boundary
+diagnostics as part of an audit:
+
+```bash
+drydock diff apps --path ./current --path-orig ./base --project-diagnostics=all
+```
+
+```text
+warning project: Application argocd/payments-api rendered resource example.com/Widget workloads/custom has unknown scope offline; AppProject resource policy validation is deferred (path: argocd/payments-api)
+```
+
+Use rendered structured diagnostics when CI needs stable diagnostic codes:
+
+```bash
+drydock diag --path . --render -o json
+```
+
+```json
+{
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "category": "project",
+      "code": "project.resource-destination-denied",
+      "message": "Application argocd/payments-api rendered resource ConfigMap kube-system/settings namespace \"kube-system\" is not permitted by AppProject \"platform\""
+    }
+  ]
+}
+```
 
 `argocd-cmd-params-cm` settings are parsed as runtime-boundary metadata when
 they imply live repo-server, controller, or ApplicationSet controller behavior.

--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -32,6 +32,9 @@ func newBuildSession(orchestrator Orchestrator, request BuildRequest) (*buildSes
 	if _, err := normalizeMaxDiscoveryDepth(request.MaxDiscoveryDepth, request.MaxDiscoveryDepthSet); err != nil {
 		return nil, err
 	}
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return nil, err
+	}
 	return &buildSession{
 		orchestrator:  orchestrator,
 		request:       request,
@@ -45,6 +48,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 	loadedRequest, policyDiags, cleanup, err := ensureBuildPluginPolicy(ctx, session.request, session.root)
 	defer cleanup()
 	session.request = loadedRequest
+	policyDiags = session.request.filterProjectDiagnostics(policyDiags)
 	if err != nil {
 		return BuildResult{Diagnostics: policyDiags, CacheEvents: session.cacheRecorder.Events()}, err
 	}
@@ -55,7 +59,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 		return result, err
 	}
 	projectDiags := project.ValidateApplications(result.Applications, result.Projects, result.Settings)
-	projectDiags = normalizeDiagnostics(projectDiags, session.request.Strict, false)
+	projectDiags = session.request.normalizeDiagnostics(projectDiags, false)
 	result.Diagnostics = append(result.Diagnostics, projectDiags...)
 	if err := diagnosticFailure(projectDiags, session.request.Strict); err != nil {
 		result.Statuses = skippedApplicationStatuses(result.Applications, err)
@@ -96,6 +100,8 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 		settingsSignature: result.renderSettingsSignature,
 		trackingOptions:   trackingOptionsFromSettings(result.Settings),
 		request:           session.request,
+		projects:          result.Projects,
+		settings:          result.Settings,
 		strict:            session.request.Strict,
 		statusOnly:        session.request.StatusOnly,
 		settingsFilter:    settingsFilter,
@@ -111,7 +117,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 	result.Statuses = append(result.Statuses, rendered.statuses...)
 	result.CacheEvents = append(result.CacheEvents, rendered.cacheEvents...)
 	result.PluginExecutions = append(result.PluginExecutions, rendered.pluginExecutions...)
-	result.Diagnostics = dedupeDiagnostics(result.Diagnostics)
+	result.Diagnostics = session.request.filterProjectDiagnostics(dedupeDiagnostics(result.Diagnostics))
 	if renderErr != nil {
 		return result, renderErr
 	}

--- a/internal/app/build_side.go
+++ b/internal/app/build_side.go
@@ -12,7 +12,7 @@ func (o Orchestrator) loadBuildSideDiscovery(ctx context.Context, root string, r
 	result.renderCache = renderCache
 	result.renderSettingsSignature = renderSettingsSignature
 	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
-	discoveryDiags = normalizeDiagnostics(discoveryDiags, request.Strict, false)
+	discoveryDiags = request.normalizeDiagnostics(discoveryDiags, false)
 	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)
 	return discovered, discoveryDiags, err
 }
@@ -23,7 +23,7 @@ func loadBuildSideSettings(root string, request BuildRequest, discovered discove
 		return nil, err
 	}
 	result.Settings = settings
-	settingsDiags = normalizeDiagnostics(settingsDiags, request.Strict, false)
+	settingsDiags = request.normalizeDiagnostics(settingsDiags, false)
 	result.Diagnostics = append(result.Diagnostics, settingsDiags...)
 	return settingsDiags, nil
 }

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -31,6 +31,7 @@ type DiffRequest struct {
 	ChangedOnlyIncludeGlobs []string
 	ChangedOnlyIgnoreGlobs  []string
 	Strict                  bool
+	ProjectDiagnosticsMode  diagnostic.ProjectDiagnosticsMode
 	Unified                 int
 	StripAttrs              []string
 	ShowIgnoredFields       bool
@@ -76,15 +77,18 @@ func (o Orchestrator) DiffApps(ctx context.Context, request DiffRequest) (DiffRe
 	if err := validateDiffPaths(request); err != nil {
 		return DiffResult{}, err
 	}
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return DiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request)
 	defer policyCleanup()
 	if err != nil {
-		return DiffResult{Diagnostics: policyDiags}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
 	request = loadedRequest
 
 	leftBuild, rightBuild, diagnostics, err := o.buildDiffSides(ctx, request)
-	diagnostics = append(policyDiags, diagnostics...)
+	diagnostics = request.filterProjectDiagnostics(append(policyDiags, diagnostics...))
 	cacheEvents := cacheEventsFromBuilds(leftBuild, rightBuild)
 	buildErr := err
 	if buildErr != nil && !hasRenderedDiffInput(leftBuild, rightBuild) {
@@ -121,10 +125,13 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	if err := validateDiffPaths(request.DiffRequest); err != nil {
 		return DiffResult{}, err
 	}
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return DiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request.DiffRequest)
 	defer policyCleanup()
 	if err != nil {
-		return DiffResult{Diagnostics: policyDiags}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
 	request.DiffRequest = loadedRequest
 
@@ -140,28 +147,28 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	leftList, err := o.ListApplications(ctx, leftBuildRequest)
 	diagnostics = append(diagnostics, leftList.Diagnostics...)
 	if err != nil {
-		return DiffResult{Diagnostics: diagnostics}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
 	leftBuildRequest.renderCache = leftList.renderCache
 	leftBuildRequest.renderSettingsSignature = leftList.renderSettingsSignature
 	rightList, err := o.ListApplications(ctx, rightBuildRequest)
 	diagnostics = append(diagnostics, rightList.Diagnostics...)
 	if err != nil {
-		return DiffResult{Diagnostics: diagnostics}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
 	rightBuildRequest.renderCache = rightList.renderCache
 	rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
 
 	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.Applications, name)
 	if err != nil {
-		return DiffResult{Diagnostics: diagnostics}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
 	rightApp, rightOK, err := SelectOptionalApplicationByName(rightList.Applications, name)
 	if err != nil {
-		return DiffResult{Diagnostics: diagnostics}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
 	if !leftOK && !rightOK {
-		return DiffResult{Diagnostics: diagnostics}, fmt.Errorf("application %q not found in either tree", name)
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, fmt.Errorf("application %q not found in either tree", name)
 	}
 
 	leftBuildRequest.Applications = selectedApplications(leftApp, leftOK)
@@ -175,7 +182,7 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	rightErr := err
 	cacheEvents := cacheEventsFromBuilds(leftBuild, rightBuild)
 	if err := errors.Join(leftErr, rightErr); err != nil {
-		return DiffResult{Diagnostics: diagnostics, CacheEvents: cacheEvents}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics), CacheEvents: cacheEvents}, err
 	}
 
 	results, err := diffBuildResults(leftBuild, rightBuild, diff.Options{
@@ -184,9 +191,9 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 		ShowIgnoredFields: request.ShowIgnoredFields,
 	})
 	if err != nil {
-		return DiffResult{Diagnostics: diagnostics, CacheEvents: cacheEvents}, err
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics), CacheEvents: cacheEvents}, err
 	}
-	return DiffResult{Results: results, Diagnostics: diagnostics, CacheEvents: cacheEvents}, nil
+	return DiffResult{Results: results, Diagnostics: request.filterProjectDiagnostics(diagnostics), CacheEvents: cacheEvents}, nil
 }
 
 func (o Orchestrator) DiffImages(ctx context.Context, request DiffRequest) (ImageDiffResult, error) {
@@ -203,15 +210,18 @@ func (o Orchestrator) DiffImages(ctx context.Context, request DiffRequest) (Imag
 	if err := validateDiffPaths(request); err != nil {
 		return ImageDiffResult{}, err
 	}
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return ImageDiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request)
 	defer policyCleanup()
 	if err != nil {
-		return ImageDiffResult{Diagnostics: policyDiags}, err
+		return ImageDiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
 	request = loadedRequest
 
 	leftBuild, rightBuild, diagnostics, err := o.buildDiffSides(ctx, request)
-	diagnostics = append(policyDiags, diagnostics...)
+	diagnostics = request.filterProjectDiagnostics(append(policyDiags, diagnostics...))
 	cacheEvents := cacheEventsFromBuilds(leftBuild, rightBuild)
 	buildErr := err
 	if buildErr != nil && !hasRenderedDiffInput(leftBuild, rightBuild) {
@@ -379,14 +389,15 @@ func sameLocalPath(left, right string) bool {
 
 func (request DiffRequest) buildRequest(path string, forbiddenRoots []string) BuildRequest {
 	return BuildRequest{
-		Path:                  path,
-		Strict:                request.Strict,
-		DiscoveryOptions:      cloneDiscoveryOptions(request.DiscoveryOptions),
-		AcquisitionOptions:    request.buildAcquisitionOptions(forbiddenRoots),
-		PluginOptions:         request.PluginOptions,
-		ExecutionOptions:      request.ExecutionOptions,
-		FilterOptions:         cloneFilterOptions(request.FilterOptions),
-		ApplicationSetOptions: cloneApplicationSetOptions(request.ApplicationSetOptions),
+		Path:                   path,
+		Strict:                 request.Strict,
+		ProjectDiagnosticsMode: request.ProjectDiagnosticsMode,
+		DiscoveryOptions:       cloneDiscoveryOptions(request.DiscoveryOptions),
+		AcquisitionOptions:     request.buildAcquisitionOptions(forbiddenRoots),
+		PluginOptions:          request.PluginOptions,
+		ExecutionOptions:       request.ExecutionOptions,
+		FilterOptions:          cloneFilterOptions(request.FilterOptions),
+		ApplicationSetOptions:  cloneApplicationSetOptions(request.ApplicationSetOptions),
 	}
 }
 

--- a/internal/app/discovery_appset.go
+++ b/internal/app/discovery_appset.go
@@ -16,18 +16,18 @@ func expandApplicationSetDiscovery(root string, request BuildRequest, discovered
 		apps, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
 		if err != nil {
 			if errors.Is(err, appset.ErrUnsupportedGenerator) && len(diags) > 0 {
-				allDiags = append(allDiags, normalizeDiagnostics(diags, request.Strict, true)...)
+				allDiags = append(allDiags, request.normalizeDiagnostics(diags, true)...)
 				continue
 			}
 			allDiags = append(allDiags, diags...)
 			return discovered, allDiags, diagnosticsError(diags, err)
 		}
-		allDiags = append(allDiags, normalizeDiagnostics(diags, request.Strict, false)...)
+		allDiags = append(allDiags, request.normalizeDiagnostics(diags, false)...)
 		if len(apps) == 0 {
 			if len(diags) != 0 {
 				continue
 			}
-			diags := normalizeDiagnostics([]diagnostic.Diagnostic{emptyApplicationSetDiagnostic(appSetFile)}, request.Strict, false)
+			diags := request.normalizeDiagnostics([]diagnostic.Diagnostic{emptyApplicationSetDiagnostic(appSetFile)}, false)
 			allDiags = append(allDiags, diags...)
 			if err := diagnosticFailure(diags, request.Strict); err != nil {
 				return discovered, allDiags, err

--- a/internal/app/normalize.go
+++ b/internal/app/normalize.go
@@ -2,57 +2,10 @@ package app
 
 import (
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/manifest"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-type groupKind struct {
-	Group string
-	Kind  string
-}
-
-var builtInClusterScopedKinds = map[groupKind]struct{}{
-	{Kind: "ComponentStatus"}:  {},
-	{Kind: "Namespace"}:        {},
-	{Kind: "Node"}:             {},
-	{Kind: "PersistentVolume"}: {},
-
-	{Group: "admissionregistration.k8s.io", Kind: "MutatingAdmissionPolicy"}:          {},
-	{Group: "admissionregistration.k8s.io", Kind: "MutatingAdmissionPolicyBinding"}:   {},
-	{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration"}:     {},
-	{Group: "admissionregistration.k8s.io", Kind: "ValidatingAdmissionPolicy"}:        {},
-	{Group: "admissionregistration.k8s.io", Kind: "ValidatingAdmissionPolicyBinding"}: {},
-	{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration"}:   {},
-	{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:                 {},
-	{Group: "apiregistration.k8s.io", Kind: "APIService"}:                             {},
-	{Group: "apiserverinternal.k8s.io", Kind: "StorageVersion"}:                       {},
-	{Group: "authentication.k8s.io", Kind: "SelfSubjectReview"}:                       {},
-	{Group: "authentication.k8s.io", Kind: "TokenReview"}:                             {},
-	{Group: "authorization.k8s.io", Kind: "SelfSubjectAccessReview"}:                  {},
-	{Group: "authorization.k8s.io", Kind: "SelfSubjectRulesReview"}:                   {},
-	{Group: "authorization.k8s.io", Kind: "SubjectAccessReview"}:                      {},
-	{Group: "certificates.k8s.io", Kind: "CertificateSigningRequest"}:                 {},
-	{Group: "certificates.k8s.io", Kind: "ClusterTrustBundle"}:                        {},
-	{Group: "flowcontrol.apiserver.k8s.io", Kind: "FlowSchema"}:                       {},
-	{Group: "flowcontrol.apiserver.k8s.io", Kind: "PriorityLevelConfiguration"}:       {},
-	{Group: "imagepolicy.k8s.io", Kind: "ImageReview"}:                                {},
-	{Group: "networking.k8s.io", Kind: "IngressClass"}:                                {},
-	{Group: "networking.k8s.io", Kind: "IPAddress"}:                                   {},
-	{Group: "networking.k8s.io", Kind: "ServiceCIDR"}:                                 {},
-	{Group: "node.k8s.io", Kind: "RuntimeClass"}:                                      {},
-	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}:                         {},
-	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"}:                  {},
-	{Group: "resource.k8s.io", Kind: "DeviceClass"}:                                   {},
-	{Group: "resource.k8s.io", Kind: "DeviceTaintRule"}:                               {},
-	{Group: "resource.k8s.io", Kind: "ResourceSlice"}:                                 {},
-	{Group: "scheduling.k8s.io", Kind: "PriorityClass"}:                               {},
-	{Group: "storage.k8s.io", Kind: "CSIDriver"}:                                      {},
-	{Group: "storage.k8s.io", Kind: "CSINode"}:                                        {},
-	{Group: "storage.k8s.io", Kind: "StorageClass"}:                                   {},
-	{Group: "storage.k8s.io", Kind: "VolumeAttachment"}:                               {},
-	{Group: "storage.k8s.io", Kind: "VolumeAttributesClass"}:                          {},
-	{Group: "storagemigration.k8s.io", Kind: "StorageVersionMigration"}:               {},
-}
 
 func ApplyDestinationNamespace(application argoappv1.Application, obj *unstructured.Unstructured) {
 	if obj.GetNamespace() != "" {
@@ -69,6 +22,5 @@ func ApplyDestinationNamespace(application argoappv1.Application, obj *unstructu
 }
 
 func IsBuiltInClusterScoped(gvk schema.GroupVersionKind) bool {
-	_, ok := builtInClusterScopedKinds[groupKind{Group: gvk.Group, Kind: gvk.Kind}]
-	return ok
+	return manifest.IsBuiltInClusterScoped(gvk)
 }

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/appset"
@@ -15,12 +17,10 @@ import (
 	"github.com/sholdee/drydock/internal/manifest"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/project"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
-
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -31,8 +31,9 @@ const (
 )
 
 type BuildRequest struct {
-	Path   string
-	Strict bool
+	Path                   string
+	Strict                 bool
+	ProjectDiagnosticsMode diagnostic.ProjectDiagnosticsMode
 	// StatusOnly renders Applications for validation without retaining manifests.
 	StatusOnly bool
 	DiscoveryOptions
@@ -153,6 +154,9 @@ func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult
 }
 
 func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest) (BuildResult, error) {
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return BuildResult{}, err
+	}
 	root := request.Path
 	if root == "" {
 		root = "."
@@ -161,8 +165,10 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 	var result BuildResult
 	loadedRequest, policyDiags, cleanup, err := ensureBuildPluginPolicy(ctx, request, root)
 	defer cleanup()
+	policyDiags = request.filterProjectDiagnostics(policyDiags)
 	result.Diagnostics = append(result.Diagnostics, policyDiags...)
 	if err != nil {
+		result.Diagnostics = request.filterProjectDiagnostics(result.Diagnostics)
 		return result, err
 	}
 	request = loadedRequest
@@ -180,7 +186,7 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 		return result, err
 	}
 
-	result.Diagnostics = dedupeDiagnostics(result.Diagnostics)
+	result.Diagnostics = request.filterProjectDiagnostics(dedupeDiagnostics(result.Diagnostics))
 	if err := diagnosticFailure(result.Diagnostics, request.Strict); err != nil {
 		return result, err
 	}
@@ -295,6 +301,8 @@ type renderApplicationsRequest struct {
 	settingsSignature string
 	trackingOptions   TrackingOptions
 	request           BuildRequest
+	projects          []argoappv1.AppProject
+	settings          config.ArgoSettings
 	strict            bool
 	statusOnly        bool
 	settingsFilter    manifest.SettingsResourceFilter
@@ -413,7 +421,7 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 	}, application)
 	if err != nil {
 		out.pluginExecutions = append(out.pluginExecutions, pluginExecutions...)
-		out.diagnostics = append(out.diagnostics, normalizeDiagnostics(rendered.Diagnostics, request.strict, false)...)
+		out.diagnostics = append(out.diagnostics, request.request.normalizeDiagnostics(rendered.Diagnostics, false)...)
 		out.diagnostics = append(out.diagnostics, renderFailureDiagnostic(application, err))
 		out.statuses = append(out.statuses, applicationStatus(application, ApplicationStatusFail, err.Error()))
 		out.cacheEvents = append(out.cacheEvents, recorder.Events()...)
@@ -423,7 +431,7 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 		return out
 	}
 
-	rendered.Diagnostics = normalizeDiagnostics(rendered.Diagnostics, request.strict, false)
+	rendered.Diagnostics = request.request.normalizeDiagnostics(rendered.Diagnostics, false)
 	out.pluginExecutions = append(out.pluginExecutions, pluginExecutions...)
 	out.diagnostics = append(out.diagnostics, rendered.Diagnostics...)
 	if err := diagnosticFailure(rendered.Diagnostics, request.strict); err != nil {
@@ -433,11 +441,16 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 	}
 	cluster := applicationDestinationCluster(application)
 	filteredManifests := make([]render.Manifest, 0, len(rendered.Manifests))
+	policyResources := make([]project.RenderedResource, 0, len(rendered.Manifests))
 	for _, renderedManifest := range rendered.Manifests {
 		id := manifest.IdentityOf(renderedManifest.Object)
 		if request.settingsFilter.Drop(id, cluster) {
 			continue
 		}
+		policyResources = append(policyResources, project.RenderedResource{
+			Object:                       renderedManifest.Object,
+			NamespaceBeforeNormalization: renderedManifest.NamespaceBeforeNormalization,
+		})
 		if request.resourceFilter.Drop(renderedManifest.Object) {
 			continue
 		}
@@ -452,13 +465,22 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 			},
 			Manifests: filteredManifests,
 		})
-		healthDiags = normalizeDiagnostics(healthDiags, request.strict, false)
+		healthDiags = request.request.normalizeDiagnostics(healthDiags, false)
 		out.diagnostics = append(out.diagnostics, healthDiags...)
 		if err := diagnosticFailure(healthDiags, request.strict); err != nil {
 			out.statuses = append(out.statuses, applicationStatus(application, ApplicationStatusFail, err.Error()))
 			out.cacheEvents = append(out.cacheEvents, recorder.Events()...)
 			return out
 		}
+	}
+
+	resourcePolicyDiags := project.ValidateRenderedResourcePolicyResources(application, policyResources, request.projects, request.settings)
+	resourcePolicyDiags = request.request.normalizeDiagnostics(resourcePolicyDiags, false)
+	out.diagnostics = append(out.diagnostics, resourcePolicyDiags...)
+	if err := diagnosticFailure(resourcePolicyDiags, request.strict); err != nil {
+		out.statuses = append(out.statuses, applicationStatus(application, ApplicationStatusFail, err.Error()))
+		out.cacheEvents = append(out.cacheEvents, recorder.Events()...)
+		return out
 	}
 
 	if request.statusOnly {
@@ -509,7 +531,7 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 		result.Statuses = skippedApplicationStatuses(result.Applications, err)
 		return result, err
 	}
-	if err := diagnosticFailure(diags, request.Strict); err != nil {
+	if err := diagnosticFailure(request.filterProjectDiagnostics(diags), request.Strict); err != nil {
 		result.Statuses = skippedApplicationStatuses(result.Applications, err)
 		return result, err
 	}
@@ -571,7 +593,7 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	buildResult, err := o.Build(ctx, buildRequest)
 	buildResult.ApplicationInputs = selectApplicationInputsForApplication(listResult.ApplicationInputs, selected)
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
-	buildResult.Diagnostics = dedupeDiagnostics(buildResult.Diagnostics)
+	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
 	return buildResult, err
 }
 

--- a/internal/app/orchestrator_project_resource_policy_test.go
+++ b/internal/app/orchestrator_project_resource_policy_test.go
@@ -1,0 +1,282 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+)
+
+const (
+	renderedResourceDeniedCode        = "project.resource-denied"
+	renderedResourceScopeDeferredCode = "project.resource-scope-deferred"
+)
+
+func TestOrchestratorBuildReportsRenderedResourcePolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	diag := assertRenderedResourcePolicyDiagnostic(t, result.Diagnostics)
+	if diag.Severity != diagnostic.SeverityWarning {
+		t.Fatalf("resource policy diagnostic severity = %s, want warning", diag.Severity)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
+	})
+	if len(result.Manifests) != 1 {
+		t.Fatalf("len(Manifests) = %d, want 1", len(result.Manifests))
+	}
+}
+
+func TestOrchestratorBuildStrictFailsRenderedResourcePolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{Path: root, Strict: true})
+	assertBuildErrorContains(t, err, "1 Application failed", "argocd/demo", "diagnostic project")
+
+	diag := assertRenderedResourcePolicyDiagnostic(t, result.Diagnostics)
+	if diag.Severity != diagnostic.SeverityError {
+		t.Fatalf("resource policy diagnostic severity = %s, want error", diag.Severity)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusFail},
+	})
+	if len(result.Manifests) != 0 {
+		t.Fatalf("len(Manifests) = %d, want no manifests retained for failed application", len(result.Manifests))
+	}
+}
+
+func TestOrchestratorBuildStatusOnlyReportsRenderedResourcePolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{Path: root, StatusOnly: true})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	diag := assertRenderedResourcePolicyDiagnostic(t, result.Diagnostics)
+	if diag.Severity != diagnostic.SeverityWarning {
+		t.Fatalf("resource policy diagnostic severity = %s, want warning", diag.Severity)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
+	})
+	if len(result.Manifests) != 0 {
+		t.Fatalf("len(Manifests) = %d, want 0 for status-only build", len(result.Manifests))
+	}
+	if len(result.ApplicationManifests) != 0 {
+		t.Fatalf("len(ApplicationManifests) = %d, want 0 for status-only build", len(result.ApplicationManifests))
+	}
+}
+
+func TestOrchestratorBuildStatusOnlyStrictFailsRenderedResourcePolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{Path: root, Strict: true, StatusOnly: true})
+	assertBuildErrorContains(t, err, "1 Application failed", "argocd/demo", "diagnostic project")
+
+	diag := assertRenderedResourcePolicyDiagnostic(t, result.Diagnostics)
+	if diag.Severity != diagnostic.SeverityError {
+		t.Fatalf("resource policy diagnostic severity = %s, want error", diag.Severity)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusFail},
+	})
+	if len(result.Manifests) != 0 {
+		t.Fatalf("len(Manifests) = %d, want 0 for status-only build", len(result.Manifests))
+	}
+	if len(result.ApplicationManifests) != 0 {
+		t.Fatalf("len(ApplicationManifests) = %d, want 0 for status-only build", len(result.ApplicationManifests))
+	}
+}
+
+func TestOrchestratorBuildResourcePolicyDiagnosticsIgnoreOutputFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters FilterOptions
+	}{
+		{
+			name: "skip secrets",
+			filters: FilterOptions{
+				SkipSecrets: true,
+			},
+		},
+		{
+			name: "skip kind",
+			filters: FilterOptions{
+				SkipKinds: []string{"Secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeRenderedSecretResourcePolicyDeniedFixture(t, root)
+
+			result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+				Path:          root,
+				Strict:        true,
+				FilterOptions: tt.filters,
+			})
+			assertBuildErrorContains(t, err, "1 Application failed", "argocd/demo", "diagnostic project")
+
+			diag := assertRenderedResourcePolicyDiagnostic(t, result.Diagnostics)
+			if diag.Severity != diagnostic.SeverityError {
+				t.Fatalf("resource policy diagnostic severity = %s, want error", diag.Severity)
+			}
+			if len(result.Manifests) != 0 {
+				t.Fatalf("len(Manifests) = %d, want no manifests retained for failed application", len(result.Manifests))
+			}
+		})
+	}
+}
+
+func TestOrchestratorListApplicationsDoesNotReportRenderedResourcePolicyDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+
+	if hasDiagnosticCode(result.Diagnostics, renderedResourceDeniedCode) {
+		t.Fatalf("Diagnostics = %#v, want no rendered resource policy diagnostic during discovery", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildDefersUnknownCRScopeBeforeNamespaceNormalization(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedUnknownCRScopeFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:                   root,
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeAll,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if !hasDiagnosticCode(result.Diagnostics, renderedResourceScopeDeferredCode) {
+		t.Fatalf("Diagnostics = %#v, want %s", result.Diagnostics, renderedResourceScopeDeferredCode)
+	}
+	if len(result.Manifests) != 1 {
+		t.Fatalf("len(Manifests) = %d, want 1", len(result.Manifests))
+	}
+	if got := result.Manifests[0].Object.GetNamespace(); got != "workloads" {
+		t.Fatalf("rendered custom resource namespace = %q, want workloads", got)
+	}
+}
+
+func writeRenderedResourcePolicyDeniedFixture(t *testing.T, root string) {
+	t.Helper()
+	writeBuildApplicationWithProject(t, root, "demo", "denied-cm", "platform", "https://github.com/example/repo", "workloads")
+	writeTestFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: workloads
+  namespaceResourceWhitelist:
+    - group: apps
+      kind: Deployment
+`)
+}
+
+func writeRenderedSecretResourcePolicyDeniedFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: workloads
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "demo", "secret.yaml"), `apiVersion: v1
+kind: Secret
+metadata:
+  name: credentials
+stringData:
+  token: redacted
+`)
+	writeTestFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: workloads
+  namespaceResourceWhitelist:
+    - group: ""
+      kind: ConfigMap
+`)
+}
+
+func writeRenderedUnknownCRScopeFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: workloads
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "demo", "widget.yaml"), `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: custom
+`)
+	writeTestFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: workloads
+`)
+}
+
+func assertRenderedResourcePolicyDiagnostic(t *testing.T, diags []diagnostic.Diagnostic) diagnostic.Diagnostic {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == renderedResourceDeniedCode {
+			return diag
+		}
+	}
+	t.Fatalf("Diagnostics = %#v, want %s", diags, renderedResourceDeniedCode)
+	return diagnostic.Diagnostic{}
+}

--- a/internal/app/project_diagnostics.go
+++ b/internal/app/project_diagnostics.go
@@ -1,0 +1,15 @@
+package app
+
+import "github.com/sholdee/drydock/internal/diagnostic"
+
+func (request BuildRequest) filterProjectDiagnostics(diags []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	return diagnostic.FilterProjectDiagnostics(diags, request.ProjectDiagnosticsMode)
+}
+
+func (request BuildRequest) normalizeDiagnostics(diags []diagnostic.Diagnostic, forceWarning bool) []diagnostic.Diagnostic {
+	return normalizeDiagnostics(request.filterProjectDiagnostics(diags), request.Strict, forceWarning)
+}
+
+func (request DiffRequest) filterProjectDiagnostics(diags []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	return diagnostic.FilterProjectDiagnostics(diags, request.ProjectDiagnosticsMode)
+}

--- a/internal/app/project_diagnostics_mode_test.go
+++ b/internal/app/project_diagnostics_mode_test.go
@@ -1,0 +1,200 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+)
+
+func TestOrchestratorProjectDiagnosticsDefaultHidesDeferredBuildSessionDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeDeferredDestinationNameProjectFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:   root,
+		Strict: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v; diagnostics = %#v", err, result.Diagnostics)
+	}
+	if hasProjectDiagnostic(result.Diagnostics) {
+		t.Fatalf("Diagnostics = %#v, want no project diagnostics in default actionable mode", result.Diagnostics)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
+	})
+	if len(result.Manifests) != 1 {
+		t.Fatalf("len(Manifests) = %d, want 1", len(result.Manifests))
+	}
+}
+
+func TestOrchestratorProjectDiagnosticsAllRestoresStrictBuildSessionFailure(t *testing.T) {
+	root := t.TempDir()
+	writeDeferredDestinationNameProjectFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeAll,
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want strict deferred project diagnostic failure")
+	}
+	if !hasDiagnosticStableCode(result.Diagnostics, diagnostic.CodeProjectUnspecified) {
+		t.Fatalf("Diagnostics = %#v, want %s", result.Diagnostics, diagnostic.CodeProjectUnspecified)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusSkipped},
+	})
+}
+
+func TestOrchestratorProjectDiagnosticsDefaultHidesDeferredRenderedResourcePolicyDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedUnknownCRScopeFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:   root,
+		Strict: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v; diagnostics = %#v", err, result.Diagnostics)
+	}
+	if hasDiagnosticCode(result.Diagnostics, renderedResourceScopeDeferredCode) {
+		t.Fatalf("Diagnostics = %#v, want %s hidden in default actionable mode", result.Diagnostics, renderedResourceScopeDeferredCode)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
+	})
+}
+
+func TestOrchestratorProjectDiagnosticsAllRestoresStrictRenderedResourcePolicyFailure(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedUnknownCRScopeFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeAll,
+	})
+	assertBuildErrorContains(t, err, "1 Application failed", "argocd/demo", "diagnostic project")
+	if !hasDiagnosticCode(result.Diagnostics, renderedResourceScopeDeferredCode) {
+		t.Fatalf("Diagnostics = %#v, want %s", result.Diagnostics, renderedResourceScopeDeferredCode)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusFail},
+	})
+}
+
+func TestOrchestratorProjectDiagnosticsOffHidesActionableRenderedResourcePolicyDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeOff,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v; diagnostics = %#v", err, result.Diagnostics)
+	}
+	if hasProjectDiagnostic(result.Diagnostics) {
+		t.Fatalf("Diagnostics = %#v, want no project diagnostics in off mode", result.Diagnostics)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
+	})
+	if len(result.Manifests) != 1 {
+		t.Fatalf("len(Manifests) = %d, want 1", len(result.Manifests))
+	}
+}
+
+func TestOrchestratorProjectDiagnosticsActionableKeepsActionableRenderedResourcePolicyFailure(t *testing.T) {
+	root := t.TempDir()
+	writeRenderedResourcePolicyDeniedFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeActionable,
+	})
+	assertBuildErrorContains(t, err, "1 Application failed", "argocd/demo", "diagnostic project")
+	if !hasDiagnosticCode(result.Diagnostics, renderedResourceDeniedCode) {
+		t.Fatalf("Diagnostics = %#v, want %s", result.Diagnostics, renderedResourceDeniedCode)
+	}
+	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
+		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusFail},
+	})
+}
+
+func TestDiffRequestBuildRequestPropagatesProjectDiagnosticsMode(t *testing.T) {
+	request := DiffRequest{
+		ProjectDiagnosticsMode: diagnostic.ProjectDiagnosticsModeOff,
+	}
+
+	left := request.buildRequest("left", nil)
+	right := request.buildRequest("right", nil)
+
+	if left.ProjectDiagnosticsMode != diagnostic.ProjectDiagnosticsModeOff {
+		t.Fatalf("left ProjectDiagnosticsMode = %q, want off", left.ProjectDiagnosticsMode)
+	}
+	if right.ProjectDiagnosticsMode != diagnostic.ProjectDiagnosticsModeOff {
+		t.Fatalf("right ProjectDiagnosticsMode = %q, want off", right.ProjectDiagnosticsMode)
+	}
+}
+
+func hasProjectDiagnostic(diags []diagnostic.Diagnostic) bool {
+	for _, diag := range diags {
+		if diagnostic.ClassifyProjectDiagnostic(diag) != diagnostic.ProjectDiagnosticClassNonProject {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDiagnosticStableCode(diags []diagnostic.Diagnostic, code string) bool {
+	for _, diag := range diags {
+		if diag.Code == code || diagnostic.StableCode(diag) == code {
+			return true
+		}
+	}
+	return false
+}
+
+func writeDeferredDestinationNameProjectFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: workloads
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "demo", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  value: rendered
+`)
+	writeTestFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: '*'
+`)
+}

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -98,6 +98,7 @@ func RenderApplicationWithOptions(ctx context.Context, application argoappv1.App
 			}
 			rendered.SourceIndex = sourcePlan.Index
 			rendered.SourceName = sourcePlan.Name
+			recordNamespaceBeforeNormalization(&rendered)
 			ApplyDestinationNamespace(application, rendered.Object)
 			if err := applyTrackingMetadata(application, rendered.Object, trackingOpts); err != nil {
 				return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
@@ -122,6 +123,13 @@ func RenderApplicationWithOptions(ctx context.Context, application argoappv1.App
 		}
 	}
 	return result, nil
+}
+
+func recordNamespaceBeforeNormalization(rendered *render.Manifest) {
+	if rendered.Object == nil {
+		return
+	}
+	rendered.NamespaceBeforeNormalization = strings.TrimSpace(rendered.Object.GetNamespace())
 }
 
 func renderOptions(application argoappv1.Application, source argoappv1.ApplicationSource) (render.RenderOptions, error) {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/requestopts"
 	"github.com/sholdee/drydock/internal/source"
@@ -61,6 +62,7 @@ type commonFlags struct {
 	changedOnlyIgnores       []string
 	strictChangedOnly        bool
 	strict                   bool
+	projectDiagnostics       string
 	exitCode                 bool
 	output                   string
 	unified                  int
@@ -73,15 +75,16 @@ type commonFlags struct {
 
 func defaultCommonFlags() commonFlags {
 	return commonFlags{
-		path:              ".",
-		changedOnly:       true,
-		exitCode:          true,
-		output:            "diff",
-		unified:           3,
-		limitBytes:        65536,
-		parallelism:       1,
-		discoveryMode:     "fleet",
-		maxDiscoveryDepth: 4,
+		path:               ".",
+		changedOnly:        true,
+		exitCode:           true,
+		output:             "diff",
+		unified:            3,
+		limitBytes:         65536,
+		parallelism:        1,
+		discoveryMode:      "fleet",
+		maxDiscoveryDepth:  4,
+		projectDiagnostics: string(diagnostic.ProjectDiagnosticsModeActionable),
 	}
 }
 
@@ -94,6 +97,7 @@ func bindCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 	bindApplicationSetFixtureFlags(cmd, flags)
 	bindFilterFlags(cmd, flags)
 	bindStrictFlag(cmd, flags)
+	bindProjectDiagnosticsFlag(cmd, flags)
 	bindOutputFlags(cmd, flags)
 	bindDiagnosticsCacheEventFlags(cmd, flags)
 	bindParallelismFlags(cmd, flags)
@@ -173,6 +177,10 @@ func bindChangedOnlyPathFilterFlags(cmd *cobra.Command, flags *commonFlags) {
 
 func bindStrictFlag(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.strict, "strict", flags.strict, "promote diagnostics to errors")
+}
+
+func bindProjectDiagnosticsFlag(cmd *cobra.Command, flags *commonFlags) {
+	cmd.Flags().StringVar(&flags.projectDiagnostics, "project-diagnostics", flags.projectDiagnostics, "AppProject diagnostics mode: actionable, all, or off")
 }
 
 func bindDiffExitFlag(cmd *cobra.Command, flags *commonFlags) {
@@ -267,6 +275,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		ChangedOnlyIgnores:             append([]string(nil), flags.changedOnlyIgnores...),
 		StrictChangedOnly:              flags.strictChangedOnly,
 		Strict:                         flags.strict,
+		ProjectDiagnosticsMode:         diagnostic.ProjectDiagnosticsMode(flags.projectDiagnostics),
 		Unified:                        flags.unified,
 		StripAttrs:                     append([]string(nil), flags.stripAttrs...),
 		ShowIgnoredFields:              flags.showIgnoredFields,

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -42,22 +42,22 @@ func TestRepresentativeCommandsExposeFocusedFlagGroups(t *testing.T) {
 		{
 			name:    "build apps common acquisition discovery fixtures filters",
 			command: []string{"build", "apps"},
-			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-plugins", "plugin-cache-dir", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind"},
+			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-plugins", "plugin-cache-dir", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind", "project-diagnostics"},
 		},
 		{
 			name:    "diff apps common specialized diff flags",
 			command: []string{"diff", "apps"},
-			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "ref-orig", "show-ignored-fields"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "project-diagnostics", "ref-orig", "show-ignored-fields"},
 		},
 		{
 			name:    "test apps common specialized lua flag",
 			command: []string{"test", "apps"},
-			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "skip-lua-health"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "project-diagnostics", "skip-lua-health"},
 		},
 		{
 			name:    "diag common flags",
 			command: []string{"diag"},
-			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "project-diagnostics"},
 		},
 	}
 

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -94,11 +94,14 @@ func runDiagCommand(cmd *cobra.Command, deps Dependencies, flags commonFlags, op
 	if err := rejectBroadDiagPath(request.Path); err != nil {
 		return err
 	}
+	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
+		return err
+	}
 	request.RecordCacheEvents = flags.cacheEvents
 	result, err := runDiag(context.Background(), deps.Orchestrator, request, diagMode{
 		Render: options.includeRender || flags.cacheEvents || options.includePluginExecutions,
 	})
-	result.Diagnostics = diagnostic.WithStableCodes(result.Diagnostics)
+	result.Diagnostics = diagnostic.FilterProjectDiagnostics(diagnostic.WithStableCodes(result.Diagnostics), request.ProjectDiagnosticsMode)
 	if err != nil && len(result.Diagnostics) == 0 {
 		return err
 	}

--- a/internal/cli/diag_test.go
+++ b/internal/cli/diag_test.go
@@ -65,6 +65,79 @@ func TestDiagJSONCleanRepositoryUsesEmptyDiagnosticsArray(t *testing.T) {
 	}
 }
 
+func TestDiagStructuredProjectDiagnosticsModeFiltersStaticAndRenderDiagnostics(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		listResult app.BuildResult
+		diagResult app.DiagResult
+		want       string
+		forbid     string
+	}{
+		{
+			name: "default static json hides deferred project diagnostics",
+			args: []string{"diag", "--path", "repo", "-o", "json"},
+			listResult: app.BuildResult{Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "project",
+				Code:     diagnostic.CodeProjectResourceScopeDeferred,
+				Message:  "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred",
+			}}},
+			forbid: diagnostic.CodeProjectResourceScopeDeferred,
+		},
+		{
+			name: "all static yaml keeps deferred project diagnostics",
+			args: []string{"diag", "--path", "repo", "-o", "yaml", "--project-diagnostics", "all"},
+			listResult: app.BuildResult{Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "project",
+				Code:     diagnostic.CodeProjectResourceScopeDeferred,
+				Message:  "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred",
+			}}},
+			want: diagnostic.CodeProjectResourceScopeDeferred,
+		},
+		{
+			name: "off render json hides actionable project diagnostics",
+			args: []string{"diag", "--path", "repo", "-o", "json", "--render", "--project-diagnostics", "off"},
+			diagResult: app.DiagResult{Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "project",
+				Code:     diagnostic.CodeProjectSourceRepositoryDenied,
+				Message:  "Application argocd/demo source repository is not permitted by AppProject \"platform\"",
+			}}},
+			forbid: diagnostic.CodeProjectSourceRepositoryDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orchestrator := &recordingCLIOrchestrator{
+				listResult: tt.listResult,
+				diagResult: tt.diagResult,
+			}
+			cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{Orchestrator: orchestrator})
+			cmd.SetArgs(tt.args)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			}
+			if stderr.String() != "" {
+				t.Fatalf("stderr = %q, want empty for structured diag output", stderr.String())
+			}
+			if tt.want != "" && !strings.Contains(stdout.String(), tt.want) {
+				t.Fatalf("stdout = %q, want %q", stdout.String(), tt.want)
+			}
+			if tt.forbid != "" && strings.Contains(stdout.String(), tt.forbid) {
+				t.Fatalf("stdout = %q, did not want %q", stdout.String(), tt.forbid)
+			}
+		})
+	}
+}
+
 func TestDiagStructuredFatalErrorDoesNotWritePartialReport(t *testing.T) {
 	root := t.TempDir()
 	missing := filepath.Join(root, "missing")

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -250,6 +250,29 @@ func TestDiffAppHTMLOutputFile(t *testing.T) {
 	assertHTMLFileContainsAll(t, htmlPath, "ConfigMap default/demo")
 }
 
+func TestDiffAppsMarkdownAndHTMLHideQuietProjectDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	htmlPath := filepath.Join(root, "diff.html")
+	writeDeferredResourcePolicyForCLI(t, left)
+	writeDeferredResourcePolicyForCLI(t, right)
+
+	result := runCLI(t,
+		"diff", "apps",
+		"--path-orig", left,
+		"--path", right,
+		"--changed-only=false",
+		"--strict",
+		"-o", "markdown",
+		"--html-output-file", htmlPath,
+		"--exit-code=false",
+	)
+	assertStdoutExcludesAll(t, result, "Diagnostics:", "project.resource-scope-deferred", "AppProject resource policy validation is deferred")
+	assertStderrEmpty(t, result)
+	assertHTMLFileExcludesAll(t, htmlPath, "Diagnostics:", "project.resource-scope-deferred", "AppProject resource policy validation is deferred")
+}
+
 func TestDiffAppsHTMLOutputFileWriteError(t *testing.T) {
 	htmlPath := t.TempDir()
 	recorder := &recordingCLIOrchestrator{
@@ -1342,6 +1365,20 @@ func assertHTMLFileContainsAll(t *testing.T, path string, wants ...string) {
 	}
 }
 
+func assertHTMLFileExcludesAll(t *testing.T, path string, forbidden ...string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	text := string(data)
+	for _, item := range forbidden {
+		if strings.Contains(text, item) {
+			t.Fatalf("HTML output contains forbidden %q:\n%s", item, text)
+		}
+	}
+}
+
 func writeSimpleAppForCLI(t *testing.T, root, value string) {
 	t.Helper()
 	writeCLITestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
@@ -1364,6 +1401,41 @@ metadata:
   name: demo
 data:
   value: `+value+`
+`)
+}
+
+func writeDeferredResourcePolicyForCLI(t *testing.T, root string) {
+	t.Helper()
+	writeCLITestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: workloads
+`)
+	writeCLITestFile(t, filepath.Join(root, "manifests", "demo", "widget.yaml"), `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: custom
+`)
+	writeCLITestFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: workloads
 `)
 }
 

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -334,16 +334,20 @@ func TestGetImagesIncludesExactImageKey(t *testing.T) {
 
 	cmd := NewRootCommand(VersionInfo{})
 	cmd.SetArgs([]string{"get", "images", "--path", root, "-o", "name"})
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	want := "renovate/renovate:43.195.6@sha256:72d184865d505d5badc5c3b32a48410096e0d9d7e0d875dae28ee97832178f47\n"
-	if got := out.String(); got != want {
+	if got := stdout.String(); got != want {
 		t.Fatalf("get images -o name output = %q, want %q", got, want)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("get images stderr = %q, want empty", got)
 	}
 }
 

--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -104,6 +104,8 @@ func StableCode(diag Diagnostic) string {
 		return projectCode(diag.Message)
 	case "repository":
 		return repositoryCode(diag.Message)
+	case "cluster":
+		return clusterCode(diag.Message)
 	case "plugin":
 		return CodePluginUnspecified
 	case "render":
@@ -168,30 +170,47 @@ func settingsCode(message string) string {
 func projectCode(message string) string {
 	switch {
 	case strings.Contains(message, "source repository") && strings.Contains(message, "not permitted"):
-		return "project.source-repository-denied"
+		return CodeProjectSourceRepositoryDenied
 	case strings.Contains(message, "destination is not permitted"):
-		return "project.destination-denied"
+		return CodeProjectDestinationDenied
 	case strings.Contains(message, "source namespace"):
-		return "project.source-namespace-denied"
+		return CodeProjectSourceNamespaceDenied
+	case strings.Contains(message, "rendered resource") && strings.Contains(message, "namespace") && strings.Contains(message, "not permitted"):
+		return CodeProjectResourceDestinationDenied
+	case strings.Contains(message, "rendered resource") && strings.Contains(message, "not permitted"):
+		return CodeProjectResourceDenied
+	case strings.Contains(message, "unknown scope offline"):
+		return CodeProjectResourceScopeDeferred
 	case strings.Contains(message, "RBAC roles"):
-		return "project.rbac-metadata-only"
+		return CodeProjectRBACMetadataOnly
 	case strings.Contains(message, "permitOnlyProjectScopedClusters"):
-		return "project.project-scoped-clusters-deferred"
+		return CodeProjectScopedClustersDeferred
 	case strings.Contains(message, "references missing AppProject"):
-		return "project.missing"
+		return CodeProjectMissing
 	default:
-		return "project.unspecified"
+		return CodeProjectUnspecified
 	}
 }
 
 func repositoryCode(message string) string {
 	switch {
 	case strings.Contains(message, "missing repository metadata"):
-		return "repository.metadata-missing"
+		return CodeRepositoryMetadataMissing
 	case strings.Contains(message, "repository metadata"):
-		return "repository.project-mismatch"
+		return CodeRepositoryProjectMismatch
 	default:
 		return "repository.unspecified"
+	}
+}
+
+func clusterCode(message string) string {
+	switch {
+	case strings.Contains(message, "missing cluster metadata"):
+		return CodeClusterMetadataMissing
+	case strings.Contains(message, "cluster metadata"):
+		return CodeClusterProjectMismatch
+	default:
+		return "cluster.unspecified"
 	}
 }
 

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -1,6 +1,9 @@
 package diagnostic
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestReporterWarnAndStrict(t *testing.T) {
 	reporter := NewReporter(false)
@@ -90,9 +93,29 @@ func TestWithStableCodesAssignsKnownCodes(t *testing.T) {
 			want: "project.source-repository-denied",
 		},
 		{
+			name: "project rendered resource denied",
+			diag: Diagnostic{Severity: SeverityWarning, Category: "project", Message: "Application argocd/demo rendered resource ConfigMap workloads/settings is not permitted by AppProject \"platform\""},
+			want: "project.resource-denied",
+		},
+		{
+			name: "project rendered resource destination denied",
+			diag: Diagnostic{Severity: SeverityWarning, Category: "project", Message: "Application argocd/demo rendered resource ConfigMap kube-system/settings namespace \"kube-system\" is not permitted by AppProject \"platform\""},
+			want: "project.resource-destination-denied",
+		},
+		{
+			name: "project rendered resource scope deferred",
+			diag: Diagnostic{Severity: SeverityWarning, Category: "project", Message: "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred"},
+			want: "project.resource-scope-deferred",
+		},
+		{
 			name: "repository metadata missing",
 			diag: Diagnostic{Severity: SeverityWarning, Category: "repository", Message: "Application argocd/demo source repository \"https://github.com/example/repo\" is missing repository metadata from discovered repository Secrets"},
-			want: "repository.metadata-missing",
+			want: CodeRepositoryMetadataMissing,
+		},
+		{
+			name: "cluster metadata project mismatch",
+			diag: Diagnostic{Severity: SeverityWarning, Category: "cluster", Message: "Application argocd/demo cluster metadata for \"in-cluster\" is scoped to project \"infra\", not AppProject \"platform\""},
+			want: CodeClusterProjectMismatch,
 		},
 		{
 			name: "fallback",
@@ -107,6 +130,220 @@ func TestWithStableCodesAssignsKnownCodes(t *testing.T) {
 				t.Fatalf("Code = %q, want %q", got[0].Code, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseProjectDiagnosticsMode(t *testing.T) {
+	tests := []struct {
+		value string
+		want  ProjectDiagnosticsMode
+	}{
+		{value: "", want: ProjectDiagnosticsModeActionable},
+		{value: "actionable", want: ProjectDiagnosticsModeActionable},
+		{value: " ACTIONABLE ", want: ProjectDiagnosticsModeActionable},
+		{value: "all", want: ProjectDiagnosticsModeAll},
+		{value: "OFF", want: ProjectDiagnosticsModeOff},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := ParseProjectDiagnosticsMode(tt.value)
+			if err != nil {
+				t.Fatalf("ParseProjectDiagnosticsMode(%q) error = %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseProjectDiagnosticsMode(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+
+	var zero ProjectDiagnosticsMode
+	if got := zero.Normalize(); got != ProjectDiagnosticsModeActionable {
+		t.Fatalf("zero mode Normalize() = %q, want actionable", got)
+	}
+	if err := zero.Validate(); err != nil {
+		t.Fatalf("zero mode Validate() error = %v", err)
+	}
+}
+
+func TestParseProjectDiagnosticsModeRejectsInvalid(t *testing.T) {
+	_, err := ParseProjectDiagnosticsMode("verbose")
+	if err == nil {
+		t.Fatal("ParseProjectDiagnosticsMode() error = nil, want invalid mode error")
+	}
+	if !strings.Contains(err.Error(), `project diagnostics mode must be actionable, all, or off, got "verbose"`) {
+		t.Fatalf("ParseProjectDiagnosticsMode() error = %v, want invalid mode message", err)
+	}
+
+	if err := ProjectDiagnosticsMode("verbose").Validate(); err == nil {
+		t.Fatal("ProjectDiagnosticsMode.Validate() error = nil, want invalid mode error")
+	}
+}
+
+func TestFilterProjectDiagnosticsActionableKeepsLocalDenials(t *testing.T) {
+	diags := []Diagnostic{
+		projectDiagnostic(CodeProjectMissing, "Application argocd/demo references missing AppProject \"platform\""),
+		projectDiagnostic(CodeProjectSourceRepositoryDenied, "Application argocd/demo source repository \"https://github.com/example/repo\" is not permitted by AppProject \"platform\""),
+		projectDiagnostic(CodeProjectDestinationDenied, "Application argocd/demo destination is not permitted by AppProject \"platform\""),
+		projectDiagnostic(CodeProjectSourceNamespaceDenied, "Application argocd/demo source namespace \"team-a\" is not permitted by AppProject \"platform\""),
+		projectDiagnostic(CodeProjectResourceDenied, "Application argocd/demo rendered resource ConfigMap workloads/settings is not permitted by AppProject \"platform\""),
+		projectDiagnostic(CodeProjectResourceDestinationDenied, "Application argocd/demo rendered resource ConfigMap kube-system/settings namespace \"kube-system\" is not permitted by AppProject \"platform\""),
+		renderDiagnostic("Application argocd/demo failed to render: boom"),
+	}
+
+	got := FilterProjectDiagnostics(diags, "")
+	if len(got) != len(diags) {
+		t.Fatalf("FilterProjectDiagnostics(actionable) len = %d, want %d: %#v", len(got), len(diags), got)
+	}
+	for _, diag := range got {
+		if ClassifyProjectDiagnostic(diag) == ProjectDiagnosticClassDeferred || ClassifyProjectDiagnostic(diag) == ProjectDiagnosticClassMetadataOnly {
+			t.Fatalf("FilterProjectDiagnostics(actionable) kept hidden diagnostic: %#v", diag)
+		}
+	}
+}
+
+func TestFilterProjectDiagnosticsActionableUsesStableCodeFallback(t *testing.T) {
+	diags := []Diagnostic{
+		{
+			Severity: SeverityWarning,
+			Category: "project",
+			Message:  "Application argocd/demo source repository \"https://github.com/example/repo\" is not permitted by AppProject \"platform\"",
+		},
+		{
+			Severity: SeverityWarning,
+			Category: "project",
+			Message:  "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred",
+		},
+	}
+
+	got := FilterProjectDiagnostics(diags, ProjectDiagnosticsModeActionable)
+	if len(got) != 1 {
+		t.Fatalf("FilterProjectDiagnostics(actionable) len = %d, want 1: %#v", len(got), got)
+	}
+	if class := ClassifyProjectDiagnostic(diags[0]); class != ProjectDiagnosticClassActionable {
+		t.Fatalf("ClassifyProjectDiagnostic(source denial) = %q, want actionable", class)
+	}
+	if got[0].Message != diags[0].Message {
+		t.Fatalf("FilterProjectDiagnostics(actionable)[0] = %#v, want source denial", got[0])
+	}
+}
+
+func TestFilterProjectDiagnosticsActionableHidesDeferredAndMetadataOnly(t *testing.T) {
+	diags := []Diagnostic{
+		projectDiagnostic(CodeProjectResourceScopeDeferred, "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred"),
+		projectDiagnostic(CodeProjectScopedClustersDeferred, "AppProject \"platform\" enables permitOnlyProjectScopedClusters; project-scoped cluster Secrets enforcement is deferred offline"),
+		projectDiagnostic(CodeProjectRBACMetadataOnly, "AppProject \"platform\" defines RBAC roles; offline validation reports role presence but does not simulate authorization"),
+		projectDiagnostic(CodeProjectUnspecified, "Application argocd/demo destination could not be validated against AppProject \"platform\": cluster metadata is unavailable"),
+		projectDiagnostic(CodeProjectUnspecified, "Application argocd/demo destination name \"in-cluster\" cannot be resolved against AppProject server policy offline"),
+		{
+			Severity: SeverityWarning,
+			Category: "repository",
+			Message:  "Application argocd/demo repository metadata for \"https://github.com/example/repo\" is scoped to project \"infra\", not AppProject \"platform\"",
+		},
+		{
+			Code:     CodeRepositoryMetadataMissing,
+			Severity: SeverityWarning,
+			Category: "repository",
+			Message:  "Application argocd/demo source repository \"https://github.com/example/repo\" is missing repository metadata from discovered repository Secrets",
+		},
+		{
+			Code:     CodeClusterProjectMismatch,
+			Severity: SeverityWarning,
+			Category: "cluster",
+			Message:  "Application argocd/demo cluster metadata for \"in-cluster\" is scoped to project \"infra\", not AppProject \"platform\"",
+		},
+		renderDiagnostic("Application argocd/demo failed to render: boom"),
+	}
+
+	got := FilterProjectDiagnostics(diags, ProjectDiagnosticsModeActionable)
+	if len(got) != 1 {
+		t.Fatalf("FilterProjectDiagnostics(actionable) len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Category != "render" {
+		t.Fatalf("FilterProjectDiagnostics(actionable)[0] = %#v, want render diagnostic", got[0])
+	}
+}
+
+func TestFilterProjectDiagnosticsActionableHidesUnknownProjectAdjacentDiagnostics(t *testing.T) {
+	diags := []Diagnostic{
+		projectDiagnostic(CodeProjectUnspecified, "Application argocd/demo uses a project diagnostic with future wording"),
+		{
+			Severity: SeverityWarning,
+			Category: "project",
+			Message:  "Application argocd/demo uses a project diagnostic without a stable code yet",
+		},
+		renderDiagnostic("Application argocd/demo failed to render: boom"),
+	}
+
+	got := FilterProjectDiagnostics(diags, ProjectDiagnosticsModeActionable)
+	if len(got) != 1 {
+		t.Fatalf("FilterProjectDiagnostics(actionable) len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Category != "render" {
+		t.Fatalf("FilterProjectDiagnostics(actionable)[0] = %#v, want render diagnostic", got[0])
+	}
+}
+
+func TestFilterProjectDiagnosticsAllKeepsEverything(t *testing.T) {
+	diags := []Diagnostic{
+		projectDiagnostic(CodeProjectResourceScopeDeferred, "Application argocd/demo rendered resource example.com/Widget custom has unknown scope offline; AppProject resource policy validation is deferred"),
+		projectDiagnostic(CodeProjectDestinationDenied, "Application argocd/demo destination is not permitted by AppProject \"platform\""),
+		renderDiagnostic("Application argocd/demo failed to render: boom"),
+	}
+
+	got := FilterProjectDiagnostics(diags, ProjectDiagnosticsModeAll)
+	if len(got) != len(diags) {
+		t.Fatalf("FilterProjectDiagnostics(all) len = %d, want %d: %#v", len(got), len(diags), got)
+	}
+}
+
+func TestFilterProjectDiagnosticsOffDropsOnlyProjectAdjacent(t *testing.T) {
+	diags := []Diagnostic{
+		projectDiagnostic(CodeProjectDestinationDenied, "Application argocd/demo destination is not permitted by AppProject \"platform\""),
+		projectDiagnostic(CodeProjectUnspecified, "Application argocd/demo uses a project diagnostic with future wording"),
+		{
+			Code:     CodeRepositoryProjectMismatch,
+			Severity: SeverityWarning,
+			Category: "repository",
+			Message:  "Application argocd/demo repository metadata for \"https://github.com/example/repo\" is scoped to project \"infra\", not AppProject \"platform\"",
+		},
+		{
+			Code:     CodeClusterMetadataMissing,
+			Severity: SeverityWarning,
+			Category: "cluster",
+			Message:  "Application argocd/demo is missing cluster metadata for AppProject validation",
+		},
+		{
+			Code:     "repository.unspecified",
+			Severity: SeverityWarning,
+			Category: "repository",
+			Message:  "repository warning unrelated to AppProject validation",
+		},
+		renderDiagnostic("Application argocd/demo failed to render: boom"),
+	}
+
+	got := FilterProjectDiagnostics(diags, ProjectDiagnosticsModeOff)
+	if len(got) != 2 {
+		t.Fatalf("FilterProjectDiagnostics(off) len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Code != "repository.unspecified" || got[1].Category != "render" {
+		t.Fatalf("FilterProjectDiagnostics(off) = %#v, want non-project diagnostics only", got)
+	}
+}
+
+func projectDiagnostic(code, message string) Diagnostic {
+	return Diagnostic{
+		Code:     code,
+		Severity: SeverityWarning,
+		Category: "project",
+		Message:  message,
+	}
+}
+
+func renderDiagnostic(message string) Diagnostic {
+	return Diagnostic{
+		Severity: SeverityError,
+		Category: "render",
+		Message:  message,
 	}
 }
 

--- a/internal/diagnostic/project.go
+++ b/internal/diagnostic/project.go
@@ -1,0 +1,144 @@
+package diagnostic
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	CodeProjectMissing                        = "project.missing"
+	CodeProjectSourceRepositoryDenied         = "project.source-repository-denied"
+	CodeProjectDestinationDenied              = "project.destination-denied"
+	CodeProjectSourceNamespaceDenied          = "project.source-namespace-denied"
+	CodeProjectResourceDenied                 = "project.resource-denied"
+	CodeProjectResourceDestinationDenied      = "project.resource-destination-denied"
+	CodeProjectResourceScopeDeferred          = "project.resource-scope-deferred"
+	CodeProjectScopedClustersDeferred         = "project.project-scoped-clusters-deferred"
+	CodeProjectRBACMetadataOnly               = "project.rbac-metadata-only"
+	CodeProjectUnspecified                    = "project.unspecified"
+	CodeRepositoryMetadataMissing             = "repository.metadata-missing"
+	CodeRepositoryProjectMismatch             = "repository.project-mismatch"
+	CodeClusterMetadataMissing                = "cluster.metadata-missing"
+	CodeClusterProjectMismatch                = "cluster.project-mismatch"
+	projectDiagnosticsModeSupportedValuesText = "actionable, all, or off"
+)
+
+type ProjectDiagnosticsMode string
+
+const (
+	ProjectDiagnosticsModeActionable ProjectDiagnosticsMode = "actionable"
+	ProjectDiagnosticsModeAll        ProjectDiagnosticsMode = "all"
+	ProjectDiagnosticsModeOff        ProjectDiagnosticsMode = "off"
+)
+
+func ParseProjectDiagnosticsMode(value string) (ProjectDiagnosticsMode, error) {
+	mode := ProjectDiagnosticsMode(strings.ToLower(strings.TrimSpace(value)))
+	if mode == "" {
+		return ProjectDiagnosticsModeActionable, nil
+	}
+	if err := mode.Validate(); err != nil {
+		return "", fmt.Errorf("project diagnostics mode must be %s, got %q", projectDiagnosticsModeSupportedValuesText, value)
+	}
+	return mode, nil
+}
+
+func (mode ProjectDiagnosticsMode) Normalize() ProjectDiagnosticsMode {
+	if mode == "" {
+		return ProjectDiagnosticsModeActionable
+	}
+	return mode
+}
+
+func (mode ProjectDiagnosticsMode) Validate() error {
+	switch mode.Normalize() {
+	case ProjectDiagnosticsModeActionable, ProjectDiagnosticsModeAll, ProjectDiagnosticsModeOff:
+		return nil
+	default:
+		return fmt.Errorf("project diagnostics mode must be %s, got %q", projectDiagnosticsModeSupportedValuesText, string(mode))
+	}
+}
+
+type ProjectDiagnosticClass string
+
+const (
+	ProjectDiagnosticClassNonProject   ProjectDiagnosticClass = "non-project"
+	ProjectDiagnosticClassActionable   ProjectDiagnosticClass = "actionable"
+	ProjectDiagnosticClassDeferred     ProjectDiagnosticClass = "deferred"
+	ProjectDiagnosticClassMetadataOnly ProjectDiagnosticClass = "metadata-only"
+	ProjectDiagnosticClassOther        ProjectDiagnosticClass = "other"
+)
+
+func ClassifyProjectDiagnostic(diag Diagnostic) ProjectDiagnosticClass {
+	code := classificationCode(diag)
+	switch code {
+	case CodeProjectMissing,
+		CodeProjectSourceRepositoryDenied,
+		CodeProjectDestinationDenied,
+		CodeProjectSourceNamespaceDenied,
+		CodeProjectResourceDenied,
+		CodeProjectResourceDestinationDenied:
+		return ProjectDiagnosticClassActionable
+	case CodeProjectResourceScopeDeferred,
+		CodeProjectScopedClustersDeferred:
+		return ProjectDiagnosticClassDeferred
+	case CodeProjectRBACMetadataOnly,
+		CodeRepositoryMetadataMissing,
+		CodeRepositoryProjectMismatch,
+		CodeClusterMetadataMissing,
+		CodeClusterProjectMismatch:
+		return ProjectDiagnosticClassMetadataOnly
+	case CodeProjectUnspecified:
+		if projectUnspecifiedDeferredMessage(diag.Message) {
+			return ProjectDiagnosticClassDeferred
+		}
+		return ProjectDiagnosticClassOther
+	}
+	if strings.HasPrefix(code, "project.") || diag.Category == "project" {
+		return ProjectDiagnosticClassOther
+	}
+	return ProjectDiagnosticClassNonProject
+}
+
+func FilterProjectDiagnostics(diags []Diagnostic, mode ProjectDiagnosticsMode) []Diagnostic {
+	if len(diags) == 0 {
+		return nil
+	}
+	mode = mode.Normalize()
+	out := make([]Diagnostic, 0, len(diags))
+	for _, diag := range diags {
+		class := ClassifyProjectDiagnostic(diag)
+		switch mode {
+		case ProjectDiagnosticsModeAll:
+			out = append(out, diag)
+		case ProjectDiagnosticsModeOff:
+			if class == ProjectDiagnosticClassNonProject {
+				out = append(out, diag)
+			}
+		case ProjectDiagnosticsModeActionable:
+			if class == ProjectDiagnosticClassActionable || class == ProjectDiagnosticClassNonProject {
+				out = append(out, diag)
+			}
+		default:
+			if class == ProjectDiagnosticClassActionable || class == ProjectDiagnosticClassNonProject {
+				out = append(out, diag)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func classificationCode(diag Diagnostic) string {
+	if code := strings.TrimSpace(diag.Code); code != "" {
+		return code
+	}
+	return StableCode(diag)
+}
+
+func projectUnspecifiedDeferredMessage(message string) bool {
+	return strings.Contains(message, "could not be validated against AppProject") ||
+		(strings.Contains(message, "destination name") &&
+			strings.Contains(message, "cannot be resolved against AppProject server policy offline"))
+}

--- a/internal/manifest/scope.go
+++ b/internal/manifest/scope.go
@@ -1,0 +1,100 @@
+package manifest
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+type groupKind struct {
+	Group string
+	Kind  string
+}
+
+var builtInClusterScopedKinds = map[groupKind]struct{}{
+	{Kind: "ComponentStatus"}:  {},
+	{Kind: "Namespace"}:        {},
+	{Kind: "Node"}:             {},
+	{Kind: "PersistentVolume"}: {},
+
+	{Group: "admissionregistration.k8s.io", Kind: "MutatingAdmissionPolicy"}:          {},
+	{Group: "admissionregistration.k8s.io", Kind: "MutatingAdmissionPolicyBinding"}:   {},
+	{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration"}:     {},
+	{Group: "admissionregistration.k8s.io", Kind: "ValidatingAdmissionPolicy"}:        {},
+	{Group: "admissionregistration.k8s.io", Kind: "ValidatingAdmissionPolicyBinding"}: {},
+	{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration"}:   {},
+	{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:                 {},
+	{Group: "apiregistration.k8s.io", Kind: "APIService"}:                             {},
+	{Group: "authentication.k8s.io", Kind: "SelfSubjectReview"}:                       {},
+	{Group: "authentication.k8s.io", Kind: "TokenReview"}:                             {},
+	{Group: "authorization.k8s.io", Kind: "SelfSubjectAccessReview"}:                  {},
+	{Group: "authorization.k8s.io", Kind: "SelfSubjectRulesReview"}:                   {},
+	{Group: "authorization.k8s.io", Kind: "SubjectAccessReview"}:                      {},
+	{Group: "certificates.k8s.io", Kind: "CertificateSigningRequest"}:                 {},
+	{Group: "certificates.k8s.io", Kind: "ClusterTrustBundle"}:                        {},
+	{Group: "flowcontrol.apiserver.k8s.io", Kind: "FlowSchema"}:                       {},
+	{Group: "flowcontrol.apiserver.k8s.io", Kind: "PriorityLevelConfiguration"}:       {},
+	{Group: "imagepolicy.k8s.io", Kind: "ImageReview"}:                                {},
+	{Group: "internal.apiserver.k8s.io", Kind: "StorageVersion"}:                      {},
+	{Group: "networking.k8s.io", Kind: "IngressClass"}:                                {},
+	{Group: "networking.k8s.io", Kind: "IPAddress"}:                                   {},
+	{Group: "networking.k8s.io", Kind: "ServiceCIDR"}:                                 {},
+	{Group: "node.k8s.io", Kind: "RuntimeClass"}:                                      {},
+	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}:                         {},
+	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"}:                  {},
+	{Group: "resource.k8s.io", Kind: "DeviceClass"}:                                   {},
+	{Group: "resource.k8s.io", Kind: "DeviceTaintRule"}:                               {},
+	{Group: "resource.k8s.io", Kind: "ResourceSlice"}:                                 {},
+	{Group: "scheduling.k8s.io", Kind: "PriorityClass"}:                               {},
+	{Group: "storage.k8s.io", Kind: "CSIDriver"}:                                      {},
+	{Group: "storage.k8s.io", Kind: "CSINode"}:                                        {},
+	{Group: "storage.k8s.io", Kind: "StorageClass"}:                                   {},
+	{Group: "storage.k8s.io", Kind: "VolumeAttachment"}:                               {},
+	{Group: "storage.k8s.io", Kind: "VolumeAttributesClass"}:                          {},
+	{Group: "storagemigration.k8s.io", Kind: "StorageVersionMigration"}:               {},
+}
+
+var knownNamespacedBuiltInKinds = map[groupKind]struct{}{
+	{Kind: "Binding"}:                                       {},
+	{Kind: "ConfigMap"}:                                     {},
+	{Kind: "Endpoints"}:                                     {},
+	{Kind: "Event"}:                                         {},
+	{Kind: "LimitRange"}:                                    {},
+	{Kind: "PersistentVolumeClaim"}:                         {},
+	{Kind: "Pod"}:                                           {},
+	{Kind: "PodTemplate"}:                                   {},
+	{Kind: "ReplicationController"}:                         {},
+	{Kind: "ResourceQuota"}:                                 {},
+	{Kind: "Secret"}:                                        {},
+	{Kind: "Service"}:                                       {},
+	{Kind: "ServiceAccount"}:                                {},
+	{Group: "apps", Kind: "ControllerRevision"}:             {},
+	{Group: "apps", Kind: "DaemonSet"}:                      {},
+	{Group: "apps", Kind: "Deployment"}:                     {},
+	{Group: "apps", Kind: "ReplicaSet"}:                     {},
+	{Group: "apps", Kind: "StatefulSet"}:                    {},
+	{Group: "autoscaling", Kind: "HorizontalPodAutoscaler"}: {},
+	{Group: "batch", Kind: "CronJob"}:                       {},
+	{Group: "batch", Kind: "Job"}:                           {},
+	{Group: "authorization.k8s.io", Kind: "LocalSubjectAccessReview"}: {},
+	{Group: "coordination.k8s.io", Kind: "Lease"}:                     {},
+	{Group: "coordination.k8s.io", Kind: "LeaseCandidate"}:            {},
+	{Group: "discovery.k8s.io", Kind: "EndpointSlice"}:                {},
+	{Group: "events.k8s.io", Kind: "Event"}:                           {},
+	{Group: "networking.k8s.io", Kind: "Ingress"}:                     {},
+	{Group: "networking.k8s.io", Kind: "NetworkPolicy"}:               {},
+	{Group: "policy", Kind: "Eviction"}:                               {},
+	{Group: "policy", Kind: "PodDisruptionBudget"}:                    {},
+	{Group: "rbac.authorization.k8s.io", Kind: "Role"}:                {},
+	{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"}:         {},
+	{Group: "resource.k8s.io", Kind: "PodSchedulingContext"}:          {},
+	{Group: "resource.k8s.io", Kind: "ResourceClaim"}:                 {},
+	{Group: "resource.k8s.io", Kind: "ResourceClaimTemplate"}:         {},
+	{Group: "storage.k8s.io", Kind: "CSIStorageCapacity"}:             {},
+}
+
+func IsBuiltInClusterScoped(gvk schema.GroupVersionKind) bool {
+	_, ok := builtInClusterScopedKinds[groupKind{Group: gvk.Group, Kind: gvk.Kind}]
+	return ok
+}
+
+func IsKnownNamespacedBuiltIn(gvk schema.GroupVersionKind) bool {
+	_, ok := knownNamespacedBuiltInKinds[groupKind{Group: gvk.Group, Kind: gvk.Kind}]
+	return ok
+}

--- a/internal/manifest/scope_test.go
+++ b/internal/manifest/scope_test.go
@@ -1,0 +1,23 @@
+package manifest
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestBuiltInScopeRecognizesStorageVersionAPIGroup(t *testing.T) {
+	if !IsBuiltInClusterScoped(schema.GroupVersionKind{Group: "internal.apiserver.k8s.io", Version: "v1alpha1", Kind: "StorageVersion"}) {
+		t.Fatal("StorageVersion must be recognized as a built-in cluster-scoped resource")
+	}
+}
+
+func TestBuiltInScopeRecognizesLocalSubjectAccessReviewAsNamespaced(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "authorization.k8s.io", Version: "v1", Kind: "LocalSubjectAccessReview"}
+	if !IsKnownNamespacedBuiltIn(gvk) {
+		t.Fatal("LocalSubjectAccessReview must be recognized as a known namespaced resource")
+	}
+	if IsBuiltInClusterScoped(gvk) {
+		t.Fatal("LocalSubjectAccessReview must not be treated as cluster-scoped")
+	}
+}

--- a/internal/project/resource_policy.go
+++ b/internal/project/resource_policy.go
@@ -1,0 +1,383 @@
+package project
+
+import (
+	"fmt"
+	"strings"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/manifest"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	projectResourceDeniedCode            = "project.resource-denied"
+	projectResourceDestinationDeniedCode = "project.resource-destination-denied"
+	projectResourceScopeDeferredCode     = "project.resource-scope-deferred"
+)
+
+type renderedResourceScope struct {
+	namespaced bool
+	namespace  string
+	deferred   bool
+}
+
+type resourcePolicyOutcome int
+
+const (
+	resourcePolicyOutcomeAllowed resourcePolicyOutcome = iota
+	resourcePolicyOutcomeDenied
+	resourcePolicyOutcomeDeferred
+)
+
+// RenderedResource carries rendered object metadata that can be lost during Argo-style normalization.
+type RenderedResource struct {
+	Object                       *unstructured.Unstructured
+	NamespaceBeforeNormalization string
+}
+
+type renderedResourcePolicyValidator struct {
+	app                           argoappv1.Application
+	proj                          argoappv1.AppProject
+	resourcePolicyProject         argoappv1.AppProject
+	dest                          argoappv1.ApplicationDestination
+	destCluster                   *argoappv1.Cluster
+	destinationClusterKnown       bool
+	projectClusters               []*argoappv1.Cluster
+	projectScopedCheckDeferred    bool
+	projectScopedDeferralReported bool
+	nameOnlyDeferralReported      bool
+	appDestinationChecked         bool
+	appDestinationPermitted       bool
+	appDestinationPermittedErr    error
+}
+
+// ValidateRenderedResourcePolicy validates rendered Kubernetes objects for one Application against its effective AppProject resource policy.
+func ValidateRenderedResourcePolicy(app argoappv1.Application, objects []*unstructured.Unstructured, projects []argoappv1.AppProject, settings config.ArgoSettings) []diagnostic.Diagnostic {
+	resources := make([]RenderedResource, 0, len(objects))
+	for _, obj := range objects {
+		if obj == nil {
+			resources = append(resources, RenderedResource{})
+			continue
+		}
+		resources = append(resources, RenderedResource{
+			Object:                       obj,
+			NamespaceBeforeNormalization: strings.TrimSpace(obj.GetNamespace()),
+		})
+	}
+	return ValidateRenderedResourcePolicyResources(app, resources, projects, settings)
+}
+
+// ValidateRenderedResourcePolicyResources validates rendered Kubernetes objects with pre-normalization metadata.
+func ValidateRenderedResourcePolicyResources(app argoappv1.Application, resources []RenderedResource, projects []argoappv1.AppProject, settings config.ArgoSettings) []diagnostic.Diagnostic {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	validator, diags := newRenderedResourcePolicyValidator(app, projects, settings)
+	if len(diags) > 0 {
+		return diags
+	}
+	return validator.validate(resources)
+}
+
+func newRenderedResourcePolicyValidator(app argoappv1.Application, projects []argoappv1.AppProject, settings config.ArgoSettings) (*renderedResourcePolicyValidator, []diagnostic.Diagnostic) {
+	proj, ok := renderedResourcePolicyProject(app, projects, settings)
+	if !ok {
+		return nil, []diagnostic.Diagnostic{projectWarning(app, fmt.Sprintf("Application %s references missing AppProject %q", applicationName(app), applicationProject(app)))}
+	}
+
+	dest := app.Spec.Destination
+	destCluster, destinationClusterKnown := destinationCluster(dest, settings)
+	projectClusters, projectClusterMetadataAvailable := projectScopedClusters(proj.Name, settings)
+	projectScopedCheckAvailable := projectClusterMetadataAvailable || destinationClusterKnown
+
+	resourcePolicyProject := proj
+	projectScopedCheckDeferred := resourcePolicyProject.Spec.PermitOnlyProjectScopedClusters && !projectScopedCheckAvailable
+	if projectScopedCheckDeferred {
+		resourcePolicyProject.Spec.PermitOnlyProjectScopedClusters = false
+	}
+
+	return &renderedResourcePolicyValidator{
+		app:                           app,
+		proj:                          proj,
+		resourcePolicyProject:         resourcePolicyProject,
+		dest:                          dest,
+		destCluster:                   destCluster,
+		destinationClusterKnown:       destinationClusterKnown,
+		projectClusters:               projectClusters,
+		projectScopedCheckDeferred:    projectScopedCheckDeferred,
+		projectScopedDeferralReported: false,
+		nameOnlyDeferralReported:      false,
+	}, nil
+}
+
+func (v *renderedResourcePolicyValidator) validate(resources []RenderedResource) []diagnostic.Diagnostic {
+	diags := make([]diagnostic.Diagnostic, 0)
+	for _, resource := range resources {
+		if diag, ok := v.validateResource(resource); ok {
+			diags = append(diags, diag)
+		}
+	}
+	return dedupeDiagnostics(diags)
+}
+
+func (v *renderedResourcePolicyValidator) validateResource(resource RenderedResource) (diagnostic.Diagnostic, bool) {
+	obj := resource.Object
+	if obj == nil {
+		return diagnostic.Diagnostic{}, false
+	}
+
+	groupKind := obj.GroupVersionKind().GroupKind()
+	name := obj.GetName()
+	scope := renderedResourcePolicyScope(v.app, resource)
+	if scope.deferred {
+		return v.validateUnknownScopeResource(obj)
+	}
+
+	if !v.resourcePolicyProject.IsGroupKindNamePermitted(groupKind, name, scope.namespaced) {
+		return resourcePolicyDeniedWarning(v.app, obj, v.resourcePolicyProject), true
+	}
+
+	if !scope.namespaced {
+		return diagnostic.Diagnostic{}, false
+	}
+
+	return v.validateNamespacedResource(obj, scope)
+}
+
+func (v *renderedResourcePolicyValidator) validateUnknownScopeResource(obj *unstructured.Unstructured) (diagnostic.Diagnostic, bool) {
+	namespace := renderedResourceNamespace(v.app, obj)
+	namespaced := v.evaluateResourceScope(obj, true, namespace)
+	clusterScoped := v.evaluateResourceScope(obj, false, "")
+
+	switch {
+	case namespaced == resourcePolicyOutcomeAllowed && clusterScoped == resourcePolicyOutcomeAllowed:
+		return diagnostic.Diagnostic{}, false
+	case namespaced == resourcePolicyOutcomeDenied && clusterScoped == resourcePolicyOutcomeDenied:
+		return resourcePolicyDeniedWarning(v.app, obj, v.resourcePolicyProject), true
+	default:
+		return resourcePolicyDeferredWarning(v.app, fmt.Sprintf("Application %s rendered resource %s has unknown scope offline; AppProject resource policy validation is deferred", applicationName(v.app), renderedResourceDescription(obj))), true
+	}
+}
+
+func (v *renderedResourcePolicyValidator) evaluateResourceScope(obj *unstructured.Unstructured, namespaced bool, namespace string) resourcePolicyOutcome {
+	groupKind := obj.GroupVersionKind().GroupKind()
+	name := obj.GetName()
+	if !v.resourcePolicyProject.IsGroupKindNamePermitted(groupKind, name, namespaced) {
+		return resourcePolicyOutcomeDenied
+	}
+	if !namespaced {
+		return resourcePolicyOutcomeAllowed
+	}
+
+	if resourcePolicyNameOnlyDestinationDeferred(v.dest, namespace, v.proj, v.destinationClusterKnown) {
+		return resourcePolicyOutcomeDeferred
+	}
+	if resourcePolicyNameOnlyDestinationPermittedByWildcardServer(v.dest, namespace, v.proj, v.destinationClusterKnown) {
+		return v.projectScopedOutcome()
+	}
+	if namespace == strings.TrimSpace(v.dest.Namespace) {
+		return v.projectScopedOutcome()
+	}
+
+	permitted, err := v.applicationDestinationPermitted()
+	if err != nil {
+		return resourcePolicyOutcomeDeferred
+	}
+	if !permitted {
+		return resourcePolicyOutcomeDenied
+	}
+
+	permitted, err = v.resourcePolicyProject.IsResourcePermitted(groupKind, name, namespace, v.destCluster, v.projectClustersForResourcePolicy)
+	if err != nil {
+		return resourcePolicyOutcomeDeferred
+	}
+	if !permitted {
+		return resourcePolicyOutcomeDenied
+	}
+	return resourcePolicyOutcomeAllowed
+}
+
+func (v *renderedResourcePolicyValidator) projectScopedOutcome() resourcePolicyOutcome {
+	if v.projectScopedCheckDeferred {
+		return resourcePolicyOutcomeDeferred
+	}
+	return resourcePolicyOutcomeAllowed
+}
+
+func (v *renderedResourcePolicyValidator) validateNamespacedResource(obj *unstructured.Unstructured, scope renderedResourceScope) (diagnostic.Diagnostic, bool) {
+	if resourcePolicyNameOnlyDestinationDeferred(v.dest, scope.namespace, v.proj, v.destinationClusterKnown) {
+		return v.nameOnlyDestinationDeferralDiagnostic()
+	}
+	if resourcePolicyNameOnlyDestinationPermittedByWildcardServer(v.dest, scope.namespace, v.proj, v.destinationClusterKnown) {
+		return v.projectScopedDeferralDiagnostic()
+	}
+	if scope.namespace == strings.TrimSpace(v.dest.Namespace) {
+		return v.projectScopedDeferralDiagnostic()
+	}
+
+	permitted, err := v.applicationDestinationPermitted()
+	if err != nil {
+		return v.validationErrorDiagnostic(obj, err), true
+	}
+	if !permitted {
+		return diagnostic.Diagnostic{}, false
+	}
+
+	groupKind := obj.GroupVersionKind().GroupKind()
+	permitted, err = v.resourcePolicyProject.IsResourcePermitted(groupKind, obj.GetName(), scope.namespace, v.destCluster, v.projectClustersForResourcePolicy)
+	if err != nil {
+		return v.validationErrorDiagnostic(obj, err), true
+	}
+	if !permitted {
+		return resourcePolicyDestinationDeniedWarning(v.app, obj, scope.namespace, v.resourcePolicyProject), true
+	}
+	return diagnostic.Diagnostic{}, false
+}
+
+func (v *renderedResourcePolicyValidator) projectClustersForResourcePolicy(project string) ([]*argoappv1.Cluster, error) {
+	if project != v.resourcePolicyProject.Name {
+		return nil, nil
+	}
+	return v.projectClusters, nil
+}
+
+func (v *renderedResourcePolicyValidator) applicationDestinationPermitted() (bool, error) {
+	if v.appDestinationChecked {
+		return v.appDestinationPermitted, v.appDestinationPermittedErr
+	}
+	v.appDestinationChecked = true
+	v.appDestinationPermitted, v.appDestinationPermittedErr = v.resourcePolicyProject.IsDestinationPermitted(v.destCluster, v.dest.Namespace, v.projectClustersForResourcePolicy)
+	return v.appDestinationPermitted, v.appDestinationPermittedErr
+}
+
+func (v *renderedResourcePolicyValidator) nameOnlyDestinationDeferralDiagnostic() (diagnostic.Diagnostic, bool) {
+	if v.nameOnlyDeferralReported {
+		return diagnostic.Diagnostic{}, false
+	}
+	v.nameOnlyDeferralReported = true
+	return projectWarning(v.app, fmt.Sprintf("Application %s destination name %q cannot be resolved against AppProject server policy offline", applicationName(v.app), v.dest.Name)), true
+}
+
+func (v *renderedResourcePolicyValidator) projectScopedDeferralDiagnostic() (diagnostic.Diagnostic, bool) {
+	if !v.projectScopedCheckDeferred || v.projectScopedDeferralReported {
+		return diagnostic.Diagnostic{}, false
+	}
+	v.projectScopedDeferralReported = true
+	return projectWarning(v.app, fmt.Sprintf("AppProject %q enables permitOnlyProjectScopedClusters; project-scoped cluster Secrets enforcement is deferred offline", v.resourcePolicyProject.Name)), true
+}
+
+func (v *renderedResourcePolicyValidator) validationErrorDiagnostic(obj *unstructured.Unstructured, err error) diagnostic.Diagnostic {
+	return projectWarning(v.app, fmt.Sprintf("Application %s rendered resource %s could not be validated against AppProject %q: %v", applicationName(v.app), renderedResourceDescription(obj), v.resourcePolicyProject.Name, err))
+}
+
+func renderedResourcePolicyProject(app argoappv1.Application, projects []argoappv1.AppProject, settings config.ArgoSettings) (argoappv1.AppProject, bool) {
+	projectName := applicationProject(app)
+	index := projectIndex(projects)
+	proj, ok := index[projectName]
+	if !ok {
+		if projectName == argoappv1.DefaultAppProjectName || len(projects) == 0 {
+			return effectiveProject(implicitDefaultProject(), settings), true
+		}
+		return argoappv1.AppProject{}, false
+	}
+	return effectiveProject(proj, settings), true
+}
+
+func renderedResourcePolicyScope(app argoappv1.Application, resource RenderedResource) renderedResourceScope {
+	obj := resource.Object
+	gvk := obj.GroupVersionKind()
+	if manifest.IsBuiltInClusterScoped(gvk) {
+		return renderedResourceScope{}
+	}
+	if manifest.IsKnownNamespacedBuiltIn(gvk) {
+		return renderedResourceScope{namespaced: true, namespace: renderedResourceNamespace(app, obj)}
+	}
+	if strings.TrimSpace(resource.NamespaceBeforeNormalization) != "" {
+		namespace := strings.TrimSpace(obj.GetNamespace())
+		if namespace == "" {
+			namespace = strings.TrimSpace(resource.NamespaceBeforeNormalization)
+		}
+		return renderedResourceScope{namespaced: true, namespace: namespace}
+	}
+	return renderedResourceScope{deferred: true}
+}
+
+func renderedResourceNamespace(app argoappv1.Application, obj *unstructured.Unstructured) string {
+	if namespace := strings.TrimSpace(obj.GetNamespace()); namespace != "" {
+		return namespace
+	}
+	if namespace := strings.TrimSpace(app.Spec.Destination.Namespace); namespace != "" {
+		return namespace
+	}
+	return ""
+}
+
+func resourcePolicyNameOnlyDestinationDeferred(dest argoappv1.ApplicationDestination, namespace string, proj argoappv1.AppProject, destinationClusterKnown bool) bool {
+	if destinationClusterKnown || !isNameOnlyDestination(dest) {
+		return false
+	}
+	renderedDest := dest
+	renderedDest.Namespace = namespace
+	if nameOnlyDestinationExplicitlyDenied(renderedDest, proj) {
+		return false
+	}
+	if nameOnlyDestinationHasServerDenyPolicy(renderedDest, proj) {
+		return true
+	}
+	if nameOnlyDestinationHasServerScopedNamespaceDenyPolicy(renderedDest, proj) {
+		return true
+	}
+	if nameOnlyDestinationPermittedByWildcardServer(renderedDest, proj) {
+		return false
+	}
+	return nameOnlyDestinationHasServerSpecificPolicy(renderedDest, proj)
+}
+
+func resourcePolicyNameOnlyDestinationPermittedByWildcardServer(dest argoappv1.ApplicationDestination, namespace string, proj argoappv1.AppProject, destinationClusterKnown bool) bool {
+	if destinationClusterKnown || !isNameOnlyDestination(dest) {
+		return false
+	}
+	renderedDest := dest
+	renderedDest.Namespace = namespace
+	if nameOnlyDestinationExplicitlyDenied(renderedDest, proj) {
+		return false
+	}
+	return nameOnlyDestinationPermittedByWildcardServer(renderedDest, proj)
+}
+
+func resourcePolicyDeniedWarning(app argoappv1.Application, obj *unstructured.Unstructured, proj argoappv1.AppProject) diagnostic.Diagnostic {
+	diag := projectWarning(app, fmt.Sprintf("Application %s rendered resource %s is not permitted by AppProject %q", applicationName(app), renderedResourceDescription(obj), proj.Name))
+	diag.Code = projectResourceDeniedCode
+	return diag
+}
+
+func resourcePolicyDestinationDeniedWarning(app argoappv1.Application, obj *unstructured.Unstructured, namespace string, proj argoappv1.AppProject) diagnostic.Diagnostic {
+	diag := projectWarning(app, fmt.Sprintf("Application %s rendered resource %s namespace %q is not permitted by AppProject %q", applicationName(app), renderedResourceDescription(obj), namespace, proj.Name))
+	diag.Code = projectResourceDestinationDeniedCode
+	return diag
+}
+
+func resourcePolicyDeferredWarning(app argoappv1.Application, message string) diagnostic.Diagnostic {
+	diag := projectWarning(app, message)
+	diag.Code = projectResourceScopeDeferredCode
+	return diag
+}
+
+func renderedResourceDescription(obj *unstructured.Unstructured) string {
+	groupKind := obj.GetKind()
+	if group := obj.GroupVersionKind().Group; group != "" {
+		groupKind = group + "/" + obj.GetKind()
+	}
+	name := strings.TrimSpace(obj.GetName())
+	if name == "" {
+		name = "<unnamed>"
+	}
+	namespace := strings.TrimSpace(obj.GetNamespace())
+	if namespace != "" {
+		return fmt.Sprintf("%s %s/%s", groupKind, namespace, name)
+	}
+	return fmt.Sprintf("%s %s", groupKind, name)
+}

--- a/internal/project/resource_policy_test.go
+++ b/internal/project/resource_policy_test.go
@@ -1,0 +1,475 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestValidateRenderedResourcePolicyAllowsNamespacedResourcesByDefault(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDeniesNamespacedResourceOutsideWhitelist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "apps", Kind: "Deployment"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "ConfigMap workloads/settings")
+}
+
+func TestValidateRenderedResourcePolicyDeniesNamespacedResourceOnBlacklist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceBlacklist = []metav1.GroupKind{{Group: "", Kind: "Secret"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Secret", "workloads", "credentials"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "Secret workloads/credentials")
+}
+
+func TestValidateRenderedResourcePolicyPreservesNilVsEmptyNamespaceWhitelist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	nilWhitelistProject := resourcePolicyProject("platform")
+	nilWhitelistProject.Spec.NamespaceResourceWhitelist = nil
+
+	nilWhitelistDiags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("apps/v1", "Deployment", "workloads", "api"),
+	}, []argoappv1.AppProject{nilWhitelistProject}, config.DefaultSettings())
+	assertNoResourcePolicyDiagnostics(t, nilWhitelistDiags)
+
+	emptyWhitelistProject := resourcePolicyProject("platform")
+	emptyWhitelistProject.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{}
+	emptyWhitelistDiags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("apps/v1", "Deployment", "workloads", "api"),
+	}, []argoappv1.AppProject{emptyWhitelistProject}, config.DefaultSettings())
+	assertResourcePolicyDenied(t, emptyWhitelistDiags, "apps/Deployment workloads/api")
+}
+
+func TestValidateRenderedResourcePolicyTreatsKnownNamespacedBuiltInWithEmptyNamespaceAsNamespaced(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyTreatsLocalSubjectAccessReviewAsNamespaced(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("authorization.k8s.io/v1", "LocalSubjectAccessReview", "", "review"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "authorization.k8s.io/LocalSubjectAccessReview review")
+	assertNoDiagnostic(t, diags, "unknown scope offline")
+}
+
+func TestValidateRenderedResourcePolicyTreatsKnownNamespacedBuiltInWithoutDestinationNamespaceAsNamespaced(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	app.Spec.Destination.Namespace = ""
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "apps", Kind: "Deployment"}}
+	project.Spec.ClusterResourceWhitelist = []argoappv1.ClusterResourceRestrictionItem{{Group: "", Kind: "ConfigMap"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "ConfigMap settings")
+}
+
+func TestValidateRenderedResourcePolicyDoesNotFabricateDefaultNamespace(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	app.Spec.Destination.Namespace = ""
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{{
+		Name:      "in-cluster",
+		Namespace: "",
+	}}
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "", "settings"),
+	}, []argoappv1.AppProject{project}, settingsWithCluster("in-cluster", "https://kubernetes.default.svc", ""))
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyTreatsRenderedNamespacedObjectAsNamespaced(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("example.com/v1", "Widget", "workloads", "custom"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyAllowsClusterResourceOnWhitelist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.ClusterResourceWhitelist = []argoappv1.ClusterResourceRestrictionItem{{Group: "", Kind: "Namespace"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Namespace", "", "workloads"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyAllowsImplicitDefaultProjectClusterResource(t *testing.T) {
+	app := resourcePolicyApplication("demo", argoappv1.DefaultAppProjectName)
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Namespace", "", "workloads"),
+	}, nil, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDeniesClusterResourceWithoutWhitelist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Namespace", "", "workloads"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "Namespace workloads")
+}
+
+func TestValidateRenderedResourcePolicyDeniesClusterResourceOnBlacklist(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.ClusterResourceWhitelist = []argoappv1.ClusterResourceRestrictionItem{{Group: "*", Kind: "*"}}
+	project.Spec.ClusterResourceBlacklist = []argoappv1.ClusterResourceRestrictionItem{{Group: "", Kind: "Namespace"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Namespace", "", "workloads"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "Namespace workloads")
+}
+
+func TestValidateRenderedResourcePolicyAppliesClusterResourceNameGlobs(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.ClusterResourceWhitelist = []argoappv1.ClusterResourceRestrictionItem{{Group: "", Kind: "Namespace", Name: "team-*"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "Namespace", "", "team-a"),
+		renderedObject("v1", "Namespace", "", "other"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "Namespace other")
+	assertNoDiagnostic(t, diags, "Namespace team-a is not permitted")
+}
+
+func TestValidateRenderedResourcePolicyUsesProjectScopedClusterMetadata(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.PermitOnlyProjectScopedClusters = true
+
+	allowedDiags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, settingsWithCluster("in-cluster", "https://kubernetes.default.svc", "platform"))
+	assertNoResourcePolicyDiagnostics(t, allowedDiags)
+
+	deniedDiags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, settingsWithCluster("in-cluster", "https://kubernetes.default.svc", "other"))
+	assertNoResourcePolicyDenied(t, deniedDiags)
+	assertNoResourcePolicyDestinationDenied(t, deniedDiags)
+}
+
+func TestValidateRenderedResourcePolicyDeniesRenderedObjectNamespaceOutsideDestinations(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "kube-system", "settings"),
+	}, []argoappv1.AppProject{project}, settingsWithCluster("in-cluster", "https://kubernetes.default.svc", ""))
+
+	assertResourcePolicyDestinationDenied(t, diags, "ConfigMap kube-system/settings")
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDefersWhenProjectScopedClusterMetadataIsUnavailable(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.PermitOnlyProjectScopedClusters = true
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertDiagnostic(t, diags, "project-scoped cluster Secrets enforcement is deferred offline")
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyStillChecksNamespaceWhenProjectScopedMetadataIsUnavailable(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.PermitOnlyProjectScopedClusters = true
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{{
+		Name:      "*",
+		Namespace: "workloads",
+	}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "kube-system", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDestinationDenied(t, diags, "ConfigMap kube-system/settings")
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDefersNameOnlyDestinationServerPolicy(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{{
+		Server:    "https://kubernetes.default.svc",
+		Namespace: "*",
+	}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "workloads", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertDiagnostic(t, diags, "destination name \"in-cluster\" cannot be resolved against AppProject server policy offline")
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDefersNameOnlyDestinationServerPolicyForRenderedNamespace(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{
+		{
+			Name:      "in-cluster",
+			Namespace: "workloads",
+		},
+		{
+			Server:    "https://kubernetes.default.svc",
+			Namespace: "kube-system",
+		},
+	}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "kube-system", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertDiagnostic(t, diags, "destination name \"in-cluster\" cannot be resolved against AppProject server policy offline")
+	assertNoResourcePolicyDenied(t, diags)
+	assertNoResourcePolicyDestinationDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyAllowsNameOnlyRenderedNamespaceWithWildcardServer(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{
+		{
+			Name:      "in-cluster",
+			Namespace: "workloads",
+		},
+		{
+			Server:    "*",
+			Namespace: "kube-system",
+		},
+	}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "kube-system", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDoesNotBypassNameOnlyRenderedNamespaceDeny(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.Destinations = []argoappv1.ApplicationDestination{
+		{
+			Name:      "in-cluster",
+			Namespace: "workloads",
+		},
+		{
+			Server:    "*",
+			Namespace: "*",
+		},
+		{
+			Server:    "*",
+			Namespace: "!kube-system",
+		},
+	}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("v1", "ConfigMap", "kube-system", "settings"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDestinationDenied(t, diags, "ConfigMap kube-system/settings")
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDefersUnknownUnnamespacedCRScope(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("example.com/v1", "Widget", "", "custom"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertDiagnostic(t, diags, "unknown scope offline")
+	assertResourcePolicyScopeDeferred(t, diags)
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyAllowsUnknownCRWhenPossibleScopesPermit(t *testing.T) {
+	app := resourcePolicyApplication("demo", argoappv1.DefaultAppProjectName)
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("example.com/v1", "Widget", "", "custom"),
+	}, nil, config.DefaultSettings())
+
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyDeniesUnknownCRWhenPossibleScopesDeny(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+
+	diags := ValidateRenderedResourcePolicy(app, []*unstructured.Unstructured{
+		renderedObject("example.com/v1", "Widget", "", "custom"),
+	}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertResourcePolicyDenied(t, diags, "example.com/Widget custom")
+	assertNoDiagnostic(t, diags, "unknown scope offline")
+}
+
+func TestValidateRenderedResourcePolicyDefersUnknownCRNormalizedFromDestinationNamespace(t *testing.T) {
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+
+	diags := ValidateRenderedResourcePolicyResources(app, []RenderedResource{{
+		Object:                       renderedObject("example.com/v1", "Widget", "workloads", "custom"),
+		NamespaceBeforeNormalization: "",
+	}}, []argoappv1.AppProject{project}, config.DefaultSettings())
+
+	assertDiagnostic(t, diags, "unknown scope offline")
+	assertResourcePolicyScopeDeferred(t, diags)
+	assertNoResourcePolicyDenied(t, diags)
+}
+
+func resourcePolicyApplication(name, project string) argoappv1.Application {
+	return application(name, project, argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/" + name,
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})
+}
+
+func resourcePolicyProject(name string) argoappv1.AppProject {
+	return argoappv1.AppProject{
+		ObjectMeta: objectMeta(name),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}
+}
+
+func renderedObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	return obj
+}
+
+func assertNoResourcePolicyDiagnostics(t *testing.T, diags []diagnostic.Diagnostic) {
+	t.Helper()
+	if len(diags) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", diags)
+	}
+}
+
+func assertResourcePolicyDenied(t *testing.T, diags []diagnostic.Diagnostic, fragment string) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == projectResourceDeniedCode && strings.Contains(diag.Message, fragment) {
+			return
+		}
+	}
+	t.Fatalf("Diagnostics = %#v, want resource policy denial containing %q with code %q", diags, fragment, projectResourceDeniedCode)
+}
+
+func assertNoResourcePolicyDenied(t *testing.T, diags []diagnostic.Diagnostic) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == projectResourceDeniedCode {
+			t.Fatalf("Diagnostics = %#v, want no resource policy denial", diags)
+		}
+	}
+}
+
+func assertResourcePolicyDestinationDenied(t *testing.T, diags []diagnostic.Diagnostic, fragment string) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == projectResourceDestinationDeniedCode && strings.Contains(diag.Message, fragment) {
+			return
+		}
+	}
+	t.Fatalf("Diagnostics = %#v, want rendered resource destination denial containing %q with code %q", diags, fragment, projectResourceDestinationDeniedCode)
+}
+
+func assertNoResourcePolicyDestinationDenied(t *testing.T, diags []diagnostic.Diagnostic) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == projectResourceDestinationDeniedCode {
+			t.Fatalf("Diagnostics = %#v, want no rendered resource destination denial", diags)
+		}
+	}
+}
+
+func assertResourcePolicyScopeDeferred(t *testing.T, diags []diagnostic.Diagnostic) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Code == projectResourceScopeDeferredCode {
+			return
+		}
+	}
+	t.Fatalf("Diagnostics = %#v, want resource policy scope deferral code %q", diags, projectResourceScopeDeferredCode)
+}

--- a/internal/project/validation.go
+++ b/internal/project/validation.go
@@ -97,6 +97,10 @@ func implicitDefaultProject() argoappv1.AppProject {
 				Server:    "*",
 				Namespace: "*",
 			}},
+			ClusterResourceWhitelist: []argoappv1.ClusterResourceRestrictionItem{{
+				Group: "*",
+				Kind:  "*",
+			}},
 		},
 	}
 }
@@ -369,7 +373,7 @@ func destinationPatternMatch(pattern, value string) bool {
 }
 
 func validateSourceNamespace(app argoappv1.Application, proj argoappv1.AppProject) []diagnostic.Diagnostic {
-	if len(proj.Spec.SourceNamespaces) == 0 || proj.IsAppNamespacePermitted(&app, controllerNamespace(proj)) {
+	if proj.IsAppNamespacePermitted(&app, controllerNamespace(proj)) {
 		return nil
 	}
 	return []diagnostic.Diagnostic{projectWarning(app, fmt.Sprintf("Application %s source namespace %q is not permitted by AppProject %q", applicationName(app), app.Namespace, proj.Name))}

--- a/internal/project/validation_current_behavior_test.go
+++ b/internal/project/validation_current_behavior_test.go
@@ -1,0 +1,218 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateApplicationsCurrentBehaviorReportsDeniedMultiSourceRepository(t *testing.T) {
+	apps := []argoappv1.Application{applicationWithSources("multi-source", "platform", argoappv1.ApplicationSources{
+		{
+			RepoURL: "https://github.com/example/allowed",
+			Path:    "apps/allowed",
+		},
+		{
+			RepoURL: "https://github.com/example/denied",
+			Path:    "apps/denied",
+		},
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"https://github.com/example/allowed"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertDiagnosticCategoryAndMessage(t, diags, projectDiagnosticCategory, "source repository")
+	assertDiagnostic(t, diags, "https://github.com/example/denied")
+	assertNoDiagnostic(t, diags, "https://github.com/example/allowed")
+	assertNoDiagnostic(t, diags, "destination")
+}
+
+func TestValidateApplicationsCurrentBehaviorPhase3SourceNamespacesEmptyListDeniesNonControllerNamespace(t *testing.T) {
+	apps := []argoappv1.Application{applicationInNamespace("demo", "team-a", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/demo",
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:      []string{"*"},
+			Destinations:     []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+			SourceNamespaces: []string{},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertDiagnosticCategoryAndMessage(t, diags, projectDiagnosticCategory, "source namespace")
+	assertDiagnostic(t, diags, `"team-a"`)
+}
+
+func TestValidateApplicationsCurrentBehaviorPhase4ResourcePolicyFieldsEmitNoProjectDiagnostics(t *testing.T) {
+	apps := []argoappv1.Application{application("demo", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/demo",
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{
+				Name:      "*",
+				Namespace: "*",
+			}},
+			ClusterResourceWhitelist: []argoappv1.ClusterResourceRestrictionItem{{
+				Group: "",
+				Kind:  "Namespace",
+			}},
+			ClusterResourceBlacklist: []argoappv1.ClusterResourceRestrictionItem{{
+				Group: "",
+				Kind:  "Node",
+			}},
+			NamespaceResourceWhitelist: []metav1.GroupKind{{
+				Group: "apps",
+				Kind:  "Deployment",
+			}},
+			NamespaceResourceBlacklist: []metav1.GroupKind{{
+				Group: "",
+				Kind:  "Secret",
+			}},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertNoDiagnosticCategory(t, diags, projectDiagnosticCategory)
+}
+
+func TestValidateApplicationsRuntimeBoundFieldsDoNotSimulateLivePolicy(t *testing.T) {
+	warn := true
+	apps := []argoappv1.Application{application("demo", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/demo",
+	}, argoappv1.ApplicationDestination{
+		Server:    "https://kubernetes.default.svc",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			SyncWindows: argoappv1.SyncWindows{{
+				Kind:         "deny",
+				Schedule:     "* * * * *",
+				Duration:     "1h",
+				Applications: []string{"demo"},
+			}},
+			OrphanedResources: &argoappv1.OrphanedResourcesMonitorSettings{
+				Warn: &warn,
+				Ignore: []argoappv1.OrphanedResourceKey{{
+					Group: "apps",
+					Kind:  "Deployment",
+					Name:  "ignored",
+				}},
+			},
+			SignatureKeys: []argoappv1.SignatureKey{{
+				KeyID: "0123456789ABCDEF",
+			}},
+			DestinationServiceAccounts: []argoappv1.ApplicationDestinationServiceAccount{{
+				Server:                "https://kubernetes.default.svc",
+				Namespace:             "workloads",
+				DefaultServiceAccount: "deployer",
+			}},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertNoDiagnosticCategory(t, diags, projectDiagnosticCategory)
+}
+
+func TestValidateApplicationsCurrentBehaviorAllowsImplicitDefaultProjectWhenOtherLocalProjectsExist(t *testing.T) {
+	apps := []argoappv1.Application{application("demo", argoappv1.DefaultAppProjectName, argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/demo",
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"https://github.com/example/other"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertNoDiagnosticCategory(t, diags, projectDiagnosticCategory)
+}
+
+func TestValidateApplicationsCurrentBehaviorReportsMissingNonDefaultProject(t *testing.T) {
+	apps := []argoappv1.Application{application("demo", "missing", argoappv1.ApplicationSource{
+		RepoURL: "https://github.com/example/repo",
+		Path:    "apps/demo",
+	}, argoappv1.ApplicationDestination{
+		Name:      "in-cluster",
+		Namespace: "workloads",
+	})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}}
+
+	diags := ValidateApplications(apps, projects, config.DefaultSettings())
+	assertDiagnosticCategoryAndMessage(t, diags, projectDiagnosticCategory, "references missing AppProject")
+	assertDiagnostic(t, diags, `"missing"`)
+}
+
+func applicationWithSources(name, project string, sources argoappv1.ApplicationSources, destination argoappv1.ApplicationDestination) argoappv1.Application {
+	return argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Project:     project,
+			Sources:     sources,
+			Destination: destination,
+		},
+	}
+}
+
+func assertDiagnosticCategoryAndMessage(t *testing.T, diags []diagnostic.Diagnostic, category, fragment string) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Category == category && strings.Contains(diag.Message, fragment) {
+			return
+		}
+	}
+	t.Fatalf("Diagnostics = %#v, want category %q with message containing %q", diags, category, fragment)
+}
+
+func assertNoDiagnosticCategory(t *testing.T, diags []diagnostic.Diagnostic, category string) {
+	t.Helper()
+	for _, diag := range diags {
+		if diag.Category == category {
+			t.Fatalf("Diagnostics = %#v, want no diagnostics in category %q", diags, category)
+		}
+	}
+}

--- a/internal/project/validation_parity_destination_test.go
+++ b/internal/project/validation_parity_destination_test.go
@@ -1,0 +1,264 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+)
+
+func TestValidateApplicationsDestinationParityWithArgoCD(t *testing.T) {
+	const projectName = "platform"
+
+	tests := []struct {
+		name           string
+		destinations   []argoappv1.ApplicationDestination
+		appDestination argoappv1.ApplicationDestination
+		clusters       []destinationParityCluster
+		projectScoped  bool
+		expectDeferred bool
+	}{
+		{
+			name: "server-only destination",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			},
+		},
+		{
+			name: "name-only destination with known redacted cluster metadata",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "in-cluster",
+				Namespace: "workloads",
+			},
+			clusters: []destinationParityCluster{{
+				Name:    "in-cluster",
+				Server:  "https://kubernetes.default.svc",
+				Project: projectName,
+			}},
+		},
+		{
+			name: "name-only destination without metadata defers server policy resolution",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "in-cluster",
+				Namespace: "workloads",
+			},
+			expectDeferred: true,
+		},
+		{
+			name: "destination with both server and name",
+			destinations: []argoappv1.ApplicationDestination{{
+				Name:      "in-cluster",
+				Namespace: "workloads",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "in-cluster",
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			},
+		},
+		{
+			name: "namespace wildcard",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "*",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "kube-system",
+			},
+		},
+		{
+			name: "namespace deny pattern",
+			destinations: []argoappv1.ApplicationDestination{
+				{
+					Server:    "*",
+					Namespace: "*",
+				},
+				{
+					Server:    "*",
+					Namespace: "!kube-system",
+				},
+			},
+			appDestination: argoappv1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "kube-system",
+			},
+		},
+		{
+			name: "server deny pattern",
+			destinations: []argoappv1.ApplicationDestination{
+				{
+					Server:    "*",
+					Namespace: "*",
+				},
+				{
+					Server:    "!https://kubernetes.default.svc",
+					Namespace: "*",
+				},
+			},
+			appDestination: argoappv1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			},
+		},
+		{
+			name: "permitOnlyProjectScopedClusters explicit allow with matching metadata",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "prod",
+				Namespace: "workloads",
+			},
+			clusters: []destinationParityCluster{{
+				Name:    "prod",
+				Server:  "https://prod.example",
+				Project: projectName,
+			}},
+			projectScoped: true,
+		},
+		{
+			name: "permitOnlyProjectScopedClusters deny with mismatched metadata",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "prod",
+				Namespace: "workloads",
+			},
+			clusters: []destinationParityCluster{{
+				Name:    "prod",
+				Server:  "https://prod.example",
+				Project: "other",
+			}},
+			projectScoped: true,
+		},
+		{
+			name: "permitOnlyProjectScopedClusters without metadata defers enforcement",
+			destinations: []argoappv1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			appDestination: argoappv1.ApplicationDestination{
+				Name:      "prod",
+				Namespace: "workloads",
+			},
+			projectScoped:  true,
+			expectDeferred: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := argoappv1.AppProject{
+				ObjectMeta: objectMeta(projectName),
+				Spec: argoappv1.AppProjectSpec{
+					SourceRepos:                     []string{"*"},
+					Destinations:                    tt.destinations,
+					PermitOnlyProjectScopedClusters: tt.projectScoped,
+				},
+			}
+			settings := destinationParitySettings(tt.clusters)
+			expectedPermitted := destinationParityPermitted(t, project, tt.appDestination, settings)
+
+			apps := []argoappv1.Application{application("demo", projectName, argoappv1.ApplicationSource{
+				RepoURL: "https://github.com/example/repo",
+				Path:    "apps/demo",
+			}, tt.appDestination)}
+			diags := ValidateApplications(apps, []argoappv1.AppProject{project}, settings)
+
+			hasDestinationDeny := hasProjectDestinationDiagnostic(diags, "destination is not permitted")
+			hasDeferred := hasProjectDestinationDiagnostic(diags, "cannot be resolved against AppProject server policy offline") ||
+				hasProjectDestinationDiagnostic(diags, "project-scoped cluster Secrets enforcement is deferred offline")
+
+			if tt.expectDeferred {
+				if !hasDeferred {
+					t.Fatalf("Diagnostics = %#v, want deferred destination diagnostic", diags)
+				}
+				if hasDestinationDeny {
+					t.Fatalf("Diagnostics = %#v, want deferred validation without hard destination denial", diags)
+				}
+				return
+			}
+			if expectedPermitted && hasDestinationDeny {
+				t.Fatalf("Diagnostics = %#v, want no destination denial because Argo CD permits destination", diags)
+			}
+			if !expectedPermitted && !hasDestinationDeny {
+				t.Fatalf("Diagnostics = %#v, want destination denial because Argo CD denies destination", diags)
+			}
+			if hasDeferred {
+				t.Fatalf("Diagnostics = %#v, want no deferred destination diagnostic when metadata is sufficient", diags)
+			}
+		})
+	}
+}
+
+type destinationParityCluster struct {
+	Name    string
+	Server  string
+	Project string
+}
+
+func destinationParityPermitted(t *testing.T, project argoappv1.AppProject, dest argoappv1.ApplicationDestination, settings config.ArgoSettings) bool {
+	t.Helper()
+
+	destCluster, _ := destinationCluster(dest, settings)
+	permitted, err := project.IsDestinationPermitted(redactedClusterMetadata(destCluster), dest.Namespace, func(projectName string) ([]*argoappv1.Cluster, error) {
+		clusters, _ := projectScopedClusters(projectName, settings)
+		redacted := make([]*argoappv1.Cluster, 0, len(clusters))
+		for _, cluster := range clusters {
+			redacted = append(redacted, redactedClusterMetadata(cluster))
+		}
+		return redacted, nil
+	})
+	if err != nil {
+		t.Fatalf("Argo CD IsDestinationPermitted returned error: %v", err)
+	}
+	return permitted
+}
+
+func redactedClusterMetadata(cluster *argoappv1.Cluster) *argoappv1.Cluster {
+	if cluster == nil {
+		return nil
+	}
+	return cluster.Sanitized()
+}
+
+func destinationParitySettings(clusters []destinationParityCluster) config.ArgoSettings {
+	settings := config.DefaultSettings()
+	for _, cluster := range clusters {
+		server := strings.TrimRight(strings.TrimSpace(cluster.Server), "/")
+		settings.Clusters[server] = config.ClusterSettings{
+			Name:    cluster.Name,
+			Server:  server,
+			Project: cluster.Project,
+		}
+	}
+	return settings
+}
+
+func hasProjectDestinationDiagnostic(diags []diagnostic.Diagnostic, fragment string) bool {
+	for _, diag := range diags {
+		if diag.Category == projectDiagnosticCategory && strings.Contains(diag.Message, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/project/validation_parity_metadata_test.go
+++ b/internal/project/validation_parity_metadata_test.go
@@ -1,0 +1,246 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+)
+
+func TestValidateApplicationsUsesDiscoveredRepositorySecretProjectMetadataForHelmAndOCI(t *testing.T) {
+	settings, diags := loadRepositorySecretFixture(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: platform-helm
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: platform-helm
+  type: helm
+  url: https://charts.example.invalid/platform
+  project: platform
+  username: REDACTED_TEST_REPO_USERNAME
+  password: REDACTED_TEST_REPO_PASSWORD
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: platform-oci
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: platform-oci
+  type: helm
+  url: ghcr.io/redacted/platform-charts
+  enableOCI: "true"
+  project: platform
+  bearerToken: REDACTED_TEST_REPO_BEARER_TOKEN
+`)
+	assertNoMetadataFixtureCredentialLeak(t, settings, diags)
+	assertRepositoryProject(t, settings, "https://charts.example.invalid/platform", "platform")
+	assertRepositoryProject(t, settings, "ghcr.io/redacted/platform-charts", "platform")
+
+	apps := []argoappv1.Application{
+		application("http-chart", "platform", argoappv1.ApplicationSource{
+			RepoURL:        "https://charts.example.invalid/platform",
+			Chart:          "demo",
+			TargetRevision: "1.2.3",
+		}, argoappv1.ApplicationDestination{Name: "in-cluster", Namespace: "workloads"}),
+		application("oci-chart", "platform", argoappv1.ApplicationSource{
+			RepoURL:        "ghcr.io/redacted/platform-charts",
+			Chart:          "demo",
+			TargetRevision: "1.2.3",
+		}, argoappv1.ApplicationDestination{Name: "in-cluster", Namespace: "workloads"}),
+	}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"https://git.example.invalid/platform.git"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}}
+
+	validationDiags := ValidateApplications(apps, projects, settings)
+	assertNoDiagnostic(t, validationDiags, "source repository")
+	assertNoDiagnostic(t, validationDiags, "repository metadata")
+}
+
+func TestValidateApplicationsReportsRepositorySecretProjectMismatchFromMetadata(t *testing.T) {
+	settings, diags := loadRepositorySecretFixture(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-helm
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: shared-helm
+  type: helm
+  url: https://charts.example.invalid/shared
+  project: shared
+  username: REDACTED_TEST_REPO_USERNAME
+  password: REDACTED_TEST_REPO_PASSWORD
+`)
+	assertNoMetadataFixtureCredentialLeak(t, settings, diags)
+
+	apps := []argoappv1.Application{application("shared-chart", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://charts.example.invalid/shared",
+		Chart:   "demo",
+	}, argoappv1.ApplicationDestination{Name: "in-cluster", Namespace: "workloads"})}
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:  []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{Name: "*", Namespace: "*"}},
+		},
+	}}
+
+	validationDiags := ValidateApplications(apps, projects, settings)
+	assertDiagnostic(t, validationDiags, "repository metadata")
+	assertDiagnostic(t, validationDiags, "scoped to project \"shared\"")
+	assertNoDiagnostic(t, validationDiags, "source repository")
+}
+
+func TestValidateApplicationsUsesDiscoveredClusterSecretProjectMetadataForProjectScopedDestinations(t *testing.T) {
+	settings, diags := loadClusterSecretFixture(t, `apiVersion: v1
+kind: Secret
+metadata:
+  name: platform-cluster
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+stringData:
+  name: platform-cluster
+  server: https://cluster-platform.example.invalid/
+  namespaces: workloads,platform-system
+  clusterResources: "true"
+  project: platform
+  config: '{"bearerToken":"REDACTED_TEST_CLUSTER_TOKEN"}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-cluster
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+stringData:
+  name: shared-cluster
+  server: https://cluster-shared.example.invalid/
+  namespaces: workloads
+  clusterResources: "true"
+  project: shared
+  config: '{"tlsClientConfig":{"certData":"REDACTED_TEST_CLUSTER_CERT"}}'
+`)
+	assertNoMetadataFixtureCredentialLeak(t, settings, diags)
+	assertClusterProject(t, settings, "https://cluster-platform.example.invalid", "platform")
+	assertClusterProject(t, settings, "https://cluster-shared.example.invalid", "shared")
+
+	projects := []argoappv1.AppProject{{
+		ObjectMeta: objectMeta("platform"),
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos:                     []string{"*"},
+			Destinations:                    []argoappv1.ApplicationDestination{{Server: "*", Namespace: "workloads"}},
+			PermitOnlyProjectScopedClusters: true,
+		},
+	}}
+
+	allowedDiags := ValidateApplications([]argoappv1.Application{application("platform-workload", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.invalid/platform.git",
+		Path:    "apps/platform-workload",
+	}, argoappv1.ApplicationDestination{Name: "platform-cluster", Namespace: "workloads"})}, projects, settings)
+	assertNoDiagnostic(t, allowedDiags, "project-scoped cluster Secrets")
+	assertNoDiagnostic(t, allowedDiags, "destination is not permitted")
+	assertNoDiagnostic(t, allowedDiags, "cannot be resolved")
+
+	deniedDiags := ValidateApplications([]argoappv1.Application{application("shared-workload", "platform", argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.invalid/platform.git",
+		Path:    "apps/shared-workload",
+	}, argoappv1.ApplicationDestination{Name: "shared-cluster", Namespace: "workloads"})}, projects, settings)
+	assertDiagnostic(t, deniedDiags, "destination is not permitted")
+	assertNoDiagnostic(t, deniedDiags, "project-scoped cluster Secrets")
+	assertNoDiagnostic(t, deniedDiags, "cannot be resolved")
+}
+
+func loadRepositorySecretFixture(t *testing.T, content string) (config.ArgoSettings, []diagnostic.Diagnostic) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "repository-secrets.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	settings, diags, err := config.LoadRepositorySecret(path)
+	if err != nil {
+		t.Fatalf("LoadRepositorySecret() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("repository Secret diagnostics = %#v, want none", diags)
+	}
+	return settings, diags
+}
+
+func loadClusterSecretFixture(t *testing.T, content string) (config.ArgoSettings, []diagnostic.Diagnostic) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cluster-secrets.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	settings, diags, err := config.LoadClusterSecret(path)
+	if err != nil {
+		t.Fatalf("LoadClusterSecret() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("cluster Secret diagnostics = %#v, want none", diags)
+	}
+	return settings, diags
+}
+
+func assertRepositoryProject(t *testing.T, settings config.ArgoSettings, repoURL, project string) {
+	t.Helper()
+	repo, ok := settings.HelmRepositories[repoURL]
+	if !ok {
+		t.Fatalf("repository %q missing from settings: %#v", repoURL, settings.HelmRepositories)
+	}
+	if repo.Project != project {
+		t.Fatalf("repository %q project = %q, want %q", repoURL, repo.Project, project)
+	}
+}
+
+func assertClusterProject(t *testing.T, settings config.ArgoSettings, server, project string) {
+	t.Helper()
+	cluster, ok := settings.Clusters[server]
+	if !ok {
+		t.Fatalf("cluster %q missing from settings: %#v", server, settings.Clusters)
+	}
+	if cluster.Project != project {
+		t.Fatalf("cluster %q project = %q, want %q", server, cluster.Project, project)
+	}
+}
+
+func assertNoMetadataFixtureCredentialLeak(t *testing.T, settings config.ArgoSettings, diags []diagnostic.Diagnostic) {
+	t.Helper()
+	serialized, err := json.Marshal(struct {
+		Settings    config.ArgoSettings     `json:"settings"`
+		Diagnostics []diagnostic.Diagnostic `json:"diagnostics"`
+	}{
+		Settings:    settings,
+		Diagnostics: diags,
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	for _, forbidden := range []string{
+		"REDACTED_TEST_",
+		"username",
+		"password",
+		"bearerToken",
+		"tlsClientConfig",
+		"certData",
+		"config",
+	} {
+		if strings.Contains(string(serialized), forbidden) {
+			t.Fatalf("Secret fixture credential data was retained or leaked: %s", serialized)
+		}
+	}
+}

--- a/internal/project/validation_parity_source_namespace_test.go
+++ b/internal/project/validation_parity_source_namespace_test.go
@@ -1,0 +1,120 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateApplicationsSourceNamespaceParityWithArgoCD(t *testing.T) {
+	tests := []struct {
+		name             string
+		appNamespace     string
+		sourceNamespaces []string
+	}{
+		{
+			name:             "controller namespace default allow",
+			appNamespace:     "argocd",
+			sourceNamespaces: []string{"team-a"},
+		},
+		{
+			name:             "explicit project source namespace allow",
+			appNamespace:     "team-a",
+			sourceNamespaces: []string{"team-a"},
+		},
+		{
+			name:             "wildcard source namespace allow",
+			appNamespace:     "team-prod",
+			sourceNamespaces: []string{"team-*"},
+		},
+		{
+			name:             "empty source namespaces deny non-controller namespace",
+			appNamespace:     "team-a",
+			sourceNamespaces: []string{},
+		},
+		{
+			name:             "empty source namespaces allow controller namespace",
+			appNamespace:     "argocd",
+			sourceNamespaces: []string{},
+		},
+		{
+			name:             "denied source namespace warning",
+			appNamespace:     "team-b",
+			sourceNamespaces: []string{"team-a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := sourceNamespaceParityApplication(tt.appNamespace)
+			proj := sourceNamespaceParityProject(tt.sourceNamespaces)
+			expectedPermitted := proj.IsAppNamespacePermitted(&app, "argocd")
+
+			diags := ValidateApplications([]argoappv1.Application{app}, []argoappv1.AppProject{proj}, config.DefaultSettings())
+
+			assertSourceNamespaceDiagnosticsMatchPermit(t, diags, expectedPermitted)
+		})
+	}
+}
+
+func sourceNamespaceParityApplication(namespace string) argoappv1.Application {
+	return argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: namespace},
+		Spec: argoappv1.ApplicationSpec{
+			Project: "platform",
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://github.com/example/repo",
+				Path:    "apps/demo",
+			},
+			Destination: argoappv1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "workloads",
+			},
+		},
+	}
+}
+
+func sourceNamespaceParityProject(sourceNamespaces []string) argoappv1.AppProject {
+	return argoappv1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform"},
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos: []string{"*"},
+			Destinations: []argoappv1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			SourceNamespaces: sourceNamespaces,
+		},
+	}
+}
+
+func assertSourceNamespaceDiagnosticsMatchPermit(t *testing.T, diags []diagnostic.Diagnostic, permitted bool) {
+	t.Helper()
+
+	sourceNamespaceDiagnostics := 0
+	unexpectedProjectDiagnostics := make([]diagnostic.Diagnostic, 0)
+	for _, diag := range diags {
+		if diag.Category != projectDiagnosticCategory {
+			continue
+		}
+		if strings.Contains(diag.Message, "source namespace") {
+			sourceNamespaceDiagnostics++
+			continue
+		}
+		unexpectedProjectDiagnostics = append(unexpectedProjectDiagnostics, diag)
+	}
+	if len(unexpectedProjectDiagnostics) > 0 {
+		t.Fatalf("Diagnostics = %#v, want no non-source-namespace project diagnostics", diags)
+	}
+
+	if permitted && sourceNamespaceDiagnostics != 0 {
+		t.Fatalf("Diagnostics = %#v, want no source namespace diagnostics for Argo CD-permitted namespace", diags)
+	}
+	if !permitted && sourceNamespaceDiagnostics != 1 {
+		t.Fatalf("Diagnostics = %#v, want one source namespace diagnostic for Argo CD-denied namespace", diags)
+	}
+}

--- a/internal/project/validation_parity_source_test.go
+++ b/internal/project/validation_parity_source_test.go
@@ -1,0 +1,166 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateApplicationsSourceRepositoryParityWithArgoCD(t *testing.T) {
+	tests := []struct {
+		name                    string
+		sourceRepos             []string
+		sources                 argoappv1.ApplicationSources
+		wantArgoCDDeniedSources int
+	}{
+		{
+			name:        "exact repository allow",
+			sourceRepos: []string{"https://github.com/example/gitops"},
+			sources:     sourceParitySources("https://github.com/example/gitops"),
+		},
+		{
+			name:        "wildcard repository allow",
+			sourceRepos: []string{"https://github.com/example/*"},
+			sources:     sourceParitySources("https://github.com/example/service"),
+		},
+		{
+			name:                    "deny pattern takes precedence over allow pattern",
+			sourceRepos:             []string{"https://github.com/example/*", "!https://github.com/example/private"},
+			sources:                 sourceParitySources("https://github.com/example/private"),
+			wantArgoCDDeniedSources: 1,
+		},
+		{
+			name: "normalized Git URL variants upstream allows",
+			sourceRepos: []string{
+				"https://GITHUB.com/example/gitops.git",
+				"git@GITHUB.com:example/platform.git",
+			},
+			sources: sourceParitySources(
+				"https://github.com/example/gitops",
+				"ssh://git@github.com/example/platform",
+			),
+		},
+		{
+			name:        "multi-source application with one denied source",
+			sourceRepos: []string{"https://github.com/example/allowed"},
+			sources: sourceParitySources(
+				"https://github.com/example/allowed",
+				"https://github.com/example/denied",
+			),
+			wantArgoCDDeniedSources: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proj := sourceParityProject(tt.sourceRepos)
+			app := sourceParityApplication(tt.sources)
+
+			diags := ValidateApplications(
+				[]argoappv1.Application{app},
+				[]argoappv1.AppProject{proj},
+				config.DefaultSettings(),
+			)
+
+			assertSourceRepositoryParityWithArgoCD(t, app, proj, diags, tt.wantArgoCDDeniedSources)
+		})
+	}
+}
+
+func sourceParityProject(sourceRepos []string) argoappv1.AppProject {
+	return argoappv1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform", Namespace: "argocd"},
+		Spec: argoappv1.AppProjectSpec{
+			SourceRepos: append([]string(nil), sourceRepos...),
+			Destinations: []argoappv1.ApplicationDestination{{
+				Name:      "*",
+				Namespace: "*",
+			}},
+		},
+	}
+}
+
+func sourceParityApplication(sources argoappv1.ApplicationSources) argoappv1.Application {
+	return argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-parity", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Project: "platform",
+			Sources: sources,
+			Destination: argoappv1.ApplicationDestination{
+				Name:      "in-cluster",
+				Namespace: "workloads",
+			},
+		},
+	}
+}
+
+func sourceParitySources(repoURLs ...string) argoappv1.ApplicationSources {
+	sources := make(argoappv1.ApplicationSources, 0, len(repoURLs))
+	for _, repoURL := range repoURLs {
+		sources = append(sources, argoappv1.ApplicationSource{
+			RepoURL: repoURL,
+			Path:    "apps/source-parity",
+		})
+	}
+	return sources
+}
+
+func assertSourceRepositoryParityWithArgoCD(t *testing.T, app argoappv1.Application, proj argoappv1.AppProject, diags []diagnostic.Diagnostic, wantArgoCDDeniedSources int) {
+	t.Helper()
+
+	sourceDiags := sourceRepositoryProjectDiagnostics(diags)
+	deniedSources := 0
+	for _, source := range app.Spec.GetSources() {
+		permittedByArgoCD := proj.IsSourcePermitted(source)
+		hasDrydockDiagnostic := hasSourceRepositoryDiagnosticForRepo(sourceDiags, source.RepoURL)
+		if permittedByArgoCD && hasDrydockDiagnostic {
+			t.Fatalf("Argo CD permits source %q, but drydock emitted source repository diagnostics: %#v", source.RepoURL, sourceDiags)
+		}
+		if !permittedByArgoCD {
+			deniedSources++
+			if !hasDrydockDiagnostic {
+				t.Fatalf("Argo CD denies source %q, but drydock diagnostics = %#v", source.RepoURL, diags)
+			}
+		}
+	}
+
+	if deniedSources != wantArgoCDDeniedSources {
+		t.Fatalf("Argo CD denied %d sources for fixture, want %d", deniedSources, wantArgoCDDeniedSources)
+	}
+	if len(sourceDiags) != deniedSources {
+		t.Fatalf("source repository diagnostics = %#v, want %d diagnostics derived from Argo CD", sourceDiags, deniedSources)
+	}
+	for _, diag := range diags {
+		if diag.Category == projectDiagnosticCategory && !isSourceRepositoryProjectDiagnostic(diag) {
+			t.Fatalf("unexpected non-source project diagnostic in source parity fixture: %#v", diag)
+		}
+	}
+}
+
+func sourceRepositoryProjectDiagnostics(diags []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	out := make([]diagnostic.Diagnostic, 0)
+	for _, diag := range diags {
+		if isSourceRepositoryProjectDiagnostic(diag) {
+			out = append(out, diag)
+		}
+	}
+	return out
+}
+
+func isSourceRepositoryProjectDiagnostic(diag diagnostic.Diagnostic) bool {
+	return diag.Category == projectDiagnosticCategory && strings.Contains(diag.Message, "source repository")
+}
+
+func hasSourceRepositoryDiagnosticForRepo(diags []diagnostic.Diagnostic, repoURL string) bool {
+	repoDisplay := displayRepoURL(repoURL)
+	for _, diag := range diags {
+		if strings.Contains(diag.Message, repoDisplay) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -103,10 +103,11 @@ type PluginRenderer interface {
 var ErrUnsupportedPlugin = errors.New("unsupported config management plugin")
 
 type Manifest struct {
-	SourceIndex int
-	SourceName  string
-	Path        string
-	Object      *unstructured.Unstructured
+	SourceIndex                  int
+	SourceName                   string
+	Path                         string
+	NamespaceBeforeNormalization string
+	Object                       *unstructured.Unstructured
 }
 
 type Renderer interface {

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sholdee/drydock/internal/app"
 	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/source"
 )
@@ -27,6 +28,7 @@ type Options struct {
 	ChangedOnlyIgnores             []string
 	StrictChangedOnly              bool
 	Strict                         bool
+	ProjectDiagnosticsMode         diagnostic.ProjectDiagnosticsMode
 	ValidateLuaHealth              bool
 	Unified                        int
 	StripAttrs                     []string
@@ -64,15 +66,16 @@ type Options struct {
 
 func (options Options) Build() app.BuildRequest {
 	return app.BuildRequest{
-		Path:                  options.Path,
-		Strict:                options.Strict,
-		DiscoveryOptions:      options.discoveryOptions(),
-		ValidateLuaHealth:     options.ValidateLuaHealth,
-		AcquisitionOptions:    options.acquisitionOptions(),
-		PluginOptions:         options.pluginOptions(),
-		ExecutionOptions:      options.executionOptions(),
-		FilterOptions:         options.filterOptions(),
-		ApplicationSetOptions: options.applicationSetOptions(),
+		Path:                   options.Path,
+		Strict:                 options.Strict,
+		ProjectDiagnosticsMode: options.ProjectDiagnosticsMode,
+		DiscoveryOptions:       options.discoveryOptions(),
+		ValidateLuaHealth:      options.ValidateLuaHealth,
+		AcquisitionOptions:     options.acquisitionOptions(),
+		PluginOptions:          options.pluginOptions(),
+		ExecutionOptions:       options.executionOptions(),
+		FilterOptions:          options.filterOptions(),
+		ApplicationSetOptions:  options.applicationSetOptions(),
 	}
 }
 
@@ -93,6 +96,7 @@ func (options Options) Diff() app.DiffRequest {
 		ChangedOnlyIgnoreGlobs:  append([]string(nil), options.ChangedOnlyIgnores...),
 		StrictChangedOnly:       options.StrictChangedOnly,
 		Strict:                  options.Strict,
+		ProjectDiagnosticsMode:  options.ProjectDiagnosticsMode,
 		Unified:                 options.Unified,
 		StripAttrs:              append([]string(nil), options.StripAttrs...),
 		ShowIgnoredFields:       options.ShowIgnoredFields,

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/source"
 )
@@ -18,6 +19,7 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 
 	assertDeepEqual(t, "Path", request.Path, "repo")
 	assertDeepEqual(t, "Strict", request.Strict, true)
+	assertDeepEqual(t, "ProjectDiagnosticsMode", request.ProjectDiagnosticsMode, diagnostic.ProjectDiagnosticsModeAll)
 	assertDeepEqual(t, "DiscoveryMode", request.DiscoveryMode, "fleet")
 	assertDeepEqual(t, "MaxDiscoveryDepth", request.MaxDiscoveryDepth, 2)
 	assertDeepEqual(t, "MaxDiscoveryDepthSet", request.MaxDiscoveryDepthSet, true)
@@ -80,6 +82,7 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "ChangedOnlyIgnoreGlobs", request.ChangedOnlyIgnoreGlobs, []string{".github/**"})
 	assertDeepEqual(t, "StrictChangedOnly", request.StrictChangedOnly, true)
 	assertDeepEqual(t, "Strict", request.Strict, true)
+	assertDeepEqual(t, "ProjectDiagnosticsMode", request.ProjectDiagnosticsMode, diagnostic.ProjectDiagnosticsModeAll)
 	assertDeepEqual(t, "Unified", request.Unified, 0)
 	assertDeepEqual(t, "StripAttrs", request.StripAttrs, []string{"metadata.annotations.checksum/config"})
 	assertDeepEqual(t, "ShowIgnoredFields", request.ShowIgnoredFields, true)
@@ -147,6 +150,7 @@ func fixtureOptions() Options {
 		ChangedOnlyIgnores:           []string{".github/**"},
 		StrictChangedOnly:            true,
 		Strict:                       true,
+		ProjectDiagnosticsMode:       diagnostic.ProjectDiagnosticsModeAll,
 		StripAttrs:                   []string{"metadata.annotations.checksum/config"},
 		ShowIgnoredFields:            true,
 		Offline:                      true,

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -7,7 +7,18 @@ import (
 	"time"
 
 	"github.com/sholdee/drydock/internal/app"
+	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/requestopts"
+)
+
+// ProjectDiagnosticsMode controls which AppProject-adjacent diagnostics are
+// returned and allowed to affect strict render/test/diff outcomes.
+type ProjectDiagnosticsMode string
+
+const (
+	ProjectDiagnosticsModeActionable ProjectDiagnosticsMode = "actionable"
+	ProjectDiagnosticsModeAll        ProjectDiagnosticsMode = "all"
+	ProjectDiagnosticsModeOff        ProjectDiagnosticsMode = "off"
 )
 
 // Config controls render, list, and diff operations.
@@ -25,6 +36,7 @@ type Config struct {
 	MaxDiscoveryDepth      *int
 	DiscoverKustomizePaths []string
 	Strict                 bool
+	ProjectDiagnosticsMode ProjectDiagnosticsMode
 	Offline                bool
 	RefreshCharts          bool
 	ChartCacheDir          string
@@ -198,6 +210,7 @@ func (client *Client) requestOptions() requestopts.Options {
 		ChangedOnlyIgnores:             append([]string(nil), client.config.ChangedOnlyIgnores...),
 		StrictChangedOnly:              client.config.StrictChangedOnly,
 		Strict:                         client.config.Strict,
+		ProjectDiagnosticsMode:         projectDiagnosticsModeToInternal(client.config.ProjectDiagnosticsMode),
 		Unified:                        unified,
 		StripAttrs:                     append([]string(nil), client.config.StripAttrs...),
 		ShowIgnoredFields:              client.config.ShowIgnoredFields,
@@ -230,4 +243,8 @@ func (client *Client) requestOptions() requestopts.Options {
 		ApplicationSetProviderData:     applicationSetProviderDataToInternal(client.config.ApplicationSetProviderData),
 		RecordCacheEvents:              client.config.RecordCacheEvents,
 	}
+}
+
+func projectDiagnosticsModeToInternal(mode ProjectDiagnosticsMode) diagnostic.ProjectDiagnosticsMode {
+	return diagnostic.ProjectDiagnosticsMode(mode)
 }

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -215,6 +215,91 @@ spec:
 		t.Fatalf("Diagnostics = %#v, want project source warning", result.Diagnostics)
 	}
 }
+
+func TestRenderProjectDiagnosticsDefaultHidesDeferredDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeAPIDeferredResourcePolicyTree(t, root)
+
+	result, err := Render(context.Background(), Config{
+		Path:   root,
+		Strict: true,
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v; diagnostics = %#v", err, result.Diagnostics)
+	}
+	if hasDiagnosticCode(result.Diagnostics, "project.resource-scope-deferred") {
+		t.Fatalf("Diagnostics = %#v, want deferred project diagnostic hidden by default", result.Diagnostics)
+	}
+	if !hasStatus(result.Statuses, "demo", "PASS") {
+		t.Fatalf("Statuses = %#v, want PASS", result.Statuses)
+	}
+}
+
+func TestRenderProjectDiagnosticsAllRestoresDeferredStrictFailure(t *testing.T) {
+	root := t.TempDir()
+	writeAPIDeferredResourcePolicyTree(t, root)
+
+	result, err := Render(context.Background(), Config{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: ProjectDiagnosticsModeAll,
+	})
+	if err == nil {
+		t.Fatal("Render() error = nil, want strict deferred project diagnostic failure")
+	}
+	if !hasDiagnosticCode(result.Diagnostics, "project.resource-scope-deferred") {
+		t.Fatalf("Diagnostics = %#v, want deferred project diagnostic in all mode", result.Diagnostics)
+	}
+	if !hasStatus(result.Statuses, "demo", "FAIL") {
+		t.Fatalf("Statuses = %#v, want FAIL", result.Statuses)
+	}
+}
+
+func TestRenderProjectDiagnosticsOffHidesActionableDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeAPIAppTreeWithProject(t, root, "demo", "platform", "https://github.com/example/denied")
+	writeAPIFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/allowed
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+`)
+
+	result, err := Render(context.Background(), Config{
+		Path:                   root,
+		Strict:                 true,
+		ProjectDiagnosticsMode: ProjectDiagnosticsModeOff,
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v; diagnostics = %#v", err, result.Diagnostics)
+	}
+	if hasDiagnostic(result.Diagnostics, "project", "source repository") {
+		t.Fatalf("Diagnostics = %#v, want actionable project diagnostic hidden in off mode", result.Diagnostics)
+	}
+}
+
+func TestRenderRejectsInvalidPublicProjectDiagnosticsModeAtOperationTime(t *testing.T) {
+	root := t.TempDir()
+	writeAPIAppTree(t, root, "demo", configMapBody("demo", "v1"))
+	client := NewClient(Config{
+		Path:                   root,
+		ProjectDiagnosticsMode: ProjectDiagnosticsMode("verbose"),
+	})
+
+	_, err := client.Render(context.Background())
+	if err == nil {
+		t.Fatal("Render() error = nil, want invalid project diagnostics mode error")
+	}
+	if !strings.Contains(err.Error(), `project diagnostics mode`) {
+		t.Fatalf("Render() error = %v, want project diagnostics mode validation", err)
+	}
+}
+
 func TestRenderReturnsDiagnosticCodes(t *testing.T) {
 	root := t.TempDir()
 	writeAPIFile(t, filepath.Join(root, "appset.yaml"), `apiVersion: argoproj.io/v1alpha1

--- a/pkg/drydock/drydock_test_helpers_test.go
+++ b/pkg/drydock/drydock_test_helpers_test.go
@@ -430,6 +430,42 @@ spec:
 `)
 	writeAPIFile(t, filepath.Join(root, "manifests", appName, "cm.yaml"), configMapBody(appName, "v1"))
 }
+
+func writeAPIDeferredResourcePolicyTree(t *testing.T, root string) {
+	t.Helper()
+	writeAPIFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: workloads
+`)
+	writeAPIFile(t, filepath.Join(root, "manifests", "demo", "widget.yaml"), `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: custom
+`)
+	writeAPIFile(t, filepath.Join(root, "projects", "platform.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform
+spec:
+  sourceRepos:
+    - https://github.com/example/repo
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: workloads
+`)
+}
+
 func configMapBody(name, version string) string {
 	return `apiVersion: v1
 kind: ConfigMap

--- a/scripts/argocd-parity-smoke.sh
+++ b/scripts/argocd-parity-smoke.sh
@@ -8,9 +8,12 @@ ARGOCD_MODULE="github.com/argoproj/argo-cd/v3"
 FIXTURE_REPO_URL="git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git"
 FIXTURE_REPO_PATH="${REPO_ROOT}/testdata/argocd-parity/repo"
 IGNORE_FILE="${REPO_ROOT}/testdata/argocd-parity/compare-ignore.yaml"
+PROJECT_POLICY_REPO_PATH="${REPO_ROOT}/testdata/argocd-project-policy/repo"
+PROJECT_POLICY_EXPECTED="${REPO_ROOT}/testdata/argocd-project-policy/expected.yaml"
 OUT_DIR="${REPO_ROOT}/argocd-parity-smoke"
 KEEP_CLUSTER="false"
 CREATE_CLUSTER="true"
+RUN_PROJECT_POLICY_SMOKE="true"
 CLUSTER_NAME="drydock-argocd-parity-${GITHUB_RUN_ID:-$$}"
 DRYDOCK_CMD=(go run ./cmd/drydock)
 PORT_FORWARD_PID=""
@@ -57,6 +60,15 @@ TRACKING_APPLICATIONS=(
   parity-tracking
 )
 
+PROJECT_POLICY_CASES=(
+  "argocd|project-policy-source-allowed|none"
+  "argocd|project-policy-source-denied|source"
+  "argocd|project-policy-destination-allowed|none"
+  "argocd|project-policy-destination-denied|destination"
+  "project-policy-tenant|project-policy-source-namespace-allowed|none"
+  "project-policy-tenant|project-policy-source-namespace-denied|source-namespace"
+)
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/argocd-parity-smoke.sh [options]
@@ -66,6 +78,8 @@ Options:
   --out <dir>           output artifact directory (default: ./argocd-parity-smoke)
   --cluster-name <name> kind cluster name
   --existing-cluster    use an already-created kind cluster with --cluster-name
+  --skip-project-policy-smoke
+                        skip default project-policy smoke after parity checks
   --keep-cluster        leave the kind cluster running for debugging
   -h, --help            show this help
 USAGE
@@ -107,6 +121,10 @@ while [[ "$#" -gt 0 ]]; do
       CREATE_CLUSTER="false"
       shift
       ;;
+    --skip-project-policy-smoke)
+      RUN_PROJECT_POLICY_SMOKE="false"
+      shift
+      ;;
     --keep-cluster)
       KEEP_CLUSTER="true"
       shift
@@ -131,6 +149,8 @@ done
 
 [[ -d "${FIXTURE_REPO_PATH}" ]] || fail "fixture repo not found: ${FIXTURE_REPO_PATH}"
 [[ -f "${IGNORE_FILE}" ]] || fail "compare ignore file not found: ${IGNORE_FILE}"
+[[ -d "${PROJECT_POLICY_REPO_PATH}" ]] || fail "project policy fixture repo not found: ${PROJECT_POLICY_REPO_PATH}"
+[[ -f "${PROJECT_POLICY_EXPECTED}" ]] || fail "project policy expected file not found: ${PROJECT_POLICY_EXPECTED}"
 
 OUT_DIR="$(mkdir -p "${OUT_DIR}" && cd "${OUT_DIR}" && pwd)"
 WORK_DIR="$(mktemp -d)"
@@ -200,6 +220,7 @@ prepare_fixture_git_image() {
   image="drydock-argocd-parity-git:${CLUSTER_NAME}"
   mkdir -p "${git_work}"
   cp -R "${FIXTURE_REPO_PATH}/." "${git_work}/"
+  cp -R "${PROJECT_POLICY_REPO_PATH}/." "${git_work}/"
   git -C "${git_work}" init --initial-branch=main >/dev/null
   git -C "${git_work}" config user.email "drydock@example.invalid"
   git -C "${git_work}" config user.name "drydock render parity smoke"
@@ -380,6 +401,159 @@ compare_tracking_manifests() {
     --out-dir "${OUT_DIR}/compare-tracking")
 }
 
+ensure_namespace() {
+  local namespace="$1"
+  kubectl get namespace "${namespace}" >/dev/null 2>&1 || kubectl create namespace "${namespace}" >/dev/null
+}
+
+configure_project_policy_application_namespaces() {
+  kubectl -n argocd patch configmap argocd-cmd-params-cm --type merge \
+    -p '{"data":{"application.namespaces":"project-policy-tenant"}}' >/dev/null
+  kubectl -n argocd rollout restart deployment/argocd-server >/dev/null
+  kubectl -n argocd rollout restart statefulset/argocd-application-controller >/dev/null
+  kubectl -n argocd rollout status deployment/argocd-server --timeout=300s
+  kubectl -n argocd rollout status statefulset/argocd-application-controller --timeout=300s
+}
+
+prepare_project_policy_namespaces() {
+  ensure_namespace project-policy-tenant
+  ensure_namespace project-policy-workloads
+}
+
+apply_project_policy_apps() {
+  kubectl apply -f "${PROJECT_POLICY_REPO_PATH}/project-policy/projects.yaml" >/dev/null
+  kubectl apply -f "${PROJECT_POLICY_REPO_PATH}/project-policy/applications.yaml" >/dev/null
+}
+
+project_policy_condition_categories() {
+  local namespace="$1"
+  local app="$2"
+  local conditions condition_type message normalized category
+  conditions="$(kubectl -n "${namespace}" get application "${app}" -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.message}{"\n"}{end}' 2>/dev/null || true)"
+  while IFS=$'\t' read -r condition_type message; do
+    [[ -n "${message}" ]] || continue
+    normalized="$(printf '%s' "${message}" | tr '[:upper:]' '[:lower:]')"
+    category="unknown"
+    if [[ "${condition_type}" == "UnknownError" && "${normalized}" == *" in namespace "* && "${normalized}" == *" is not permitted to use project "* ]]; then
+      category="source-namespace"
+    elif [[ "${condition_type}" == "InvalidSpecError" ]]; then
+      if [[ "${normalized}" == *"source namespace"* ]]; then
+        category="source-namespace"
+      elif [[ "${normalized}" == *destination* ]]; then
+        category="destination"
+      elif [[ "${normalized}" == *source* || "${normalized}" == *repo* ]]; then
+        category="source"
+      fi
+    else
+      continue
+    fi
+    printf '%s\n' "${category}"
+  done <<< "${conditions}"
+}
+
+project_policy_has_condition_category() {
+  local namespace="$1"
+  local app="$2"
+  local expected="$3"
+  local category
+  while IFS= read -r category; do
+    [[ "${category}" == "${expected}" ]] && return 0
+  done < <(project_policy_condition_categories "${namespace}" "${app}")
+  return 1
+}
+
+project_policy_has_condition() {
+  local namespace="$1"
+  local app="$2"
+  [[ -n "$(project_policy_condition_categories "${namespace}" "${app}")" ]]
+}
+
+wait_for_project_policy_application() {
+  local namespace="$1"
+  local app="$2"
+  local expected_category="$3"
+  local reconciled_at
+  for _ in {1..180}; do
+    if ! kubectl -n "${namespace}" get application "${app}" >/dev/null 2>&1; then
+      sleep 2
+      continue
+    fi
+    if [[ "${expected_category}" == "none" ]]; then
+      reconciled_at="$(kubectl -n "${namespace}" get application "${app}" -o jsonpath='{.status.reconciledAt}' 2>/dev/null || true)"
+      if [[ -n "${reconciled_at}" ]] && ! project_policy_has_condition "${namespace}" "${app}"; then
+        return 0
+      fi
+    elif project_policy_has_condition_category "${namespace}" "${app}" "${expected_category}"; then
+      return 0
+    fi
+    sleep 2
+  done
+  local failure_dir
+  failure_dir="$(artifact_dir project-policy)"
+  kubectl -n "${namespace}" get application "${app}" -o yaml > "${failure_dir}/${app}.yaml" 2>&1 || true
+  fail "project-policy Application ${namespace}/${app} did not reach expected policy condition category ${expected_category}; see ${failure_dir}/${app}.yaml"
+}
+
+wait_for_project_policy_applications() {
+  local case_entry namespace app expected_category
+  for case_entry in "${PROJECT_POLICY_CASES[@]}"; do
+    IFS='|' read -r namespace app expected_category <<< "${case_entry}"
+    wait_for_project_policy_application "${namespace}" "${app}" "${expected_category}"
+  done
+}
+
+capture_project_policy_argocd_applications() {
+  local case_entry namespace app expected_category output_dir
+  output_dir="$(artifact_dir project-policy/argocd-applications)"
+  for case_entry in "${PROJECT_POLICY_CASES[@]}"; do
+    IFS='|' read -r namespace app expected_category <<< "${case_entry}"
+    kubectl -n "${namespace}" get application "${app}" -o json > "${output_dir}/${app}.json"
+  done
+}
+
+capture_project_policy_drydock_diagnostics() {
+  local output_dir stderr_file
+  output_dir="$(artifact_dir project-policy)"
+  stderr_file="${output_dir}/drydock-diagnostics.stderr"
+  (cd "${REPO_ROOT}" && "${DRYDOCK_CMD[@]}" diag \
+    --path "${PROJECT_POLICY_REPO_PATH}" \
+    --repo-map "${FIXTURE_REPO_URL}=${PROJECT_POLICY_REPO_PATH}" \
+    --offline \
+    --render \
+    --project-diagnostics all \
+    -o json > "${output_dir}/drydock-diagnostics.json" 2> "${stderr_file}")
+  rm -f "${stderr_file}"
+}
+
+compare_project_policy_smoke() {
+  local output_dir stderr_file
+  output_dir="$(artifact_dir project-policy)"
+  stderr_file="${output_dir}/summary.stderr"
+  (cd "${REPO_ROOT}" && go run ./scripts/argocd-project-policy-smoke \
+    --argocd-app-dir "${output_dir}/argocd-applications" \
+    --drydock-diagnostics "${output_dir}/drydock-diagnostics.json" \
+    --expected "${PROJECT_POLICY_EXPECTED}" \
+    --out "${output_dir}/summary.txt" 2> "${stderr_file}")
+  rm -f "${stderr_file}"
+}
+
+run_project_policy_smoke() {
+  log_step "Configuring Argo CD project-policy Application namespaces"
+  configure_project_policy_application_namespaces
+  log_step "Preparing project-policy namespaces"
+  prepare_project_policy_namespaces
+  log_step "Applying project-policy AppProjects and Applications"
+  apply_project_policy_apps
+  log_step "Waiting for project-policy Application policy outcomes"
+  wait_for_project_policy_applications
+  log_step "Capturing project-policy Argo CD Application status"
+  capture_project_policy_argocd_applications
+  log_step "Capturing project-policy drydock diagnostics"
+  capture_project_policy_drydock_diagnostics
+  log_step "Comparing project-policy outcomes"
+  compare_project_policy_smoke
+}
+
 main() {
   local argocd_version
   argocd_version="$(resolve_argocd_version)"
@@ -411,6 +585,11 @@ main() {
   capture_drydock_manifests
   compare_manifests
   compare_tracking_manifests
+  if [[ "${RUN_PROJECT_POLICY_SMOKE}" == "true" ]]; then
+    run_project_policy_smoke
+  else
+    log_step "Skipping project-policy smoke"
+  fi
   echo "Argo CD render parity smoke complete: ${OUT_DIR}" >&2
 }
 

--- a/scripts/argocd-project-policy-smoke/main.go
+++ b/scripts/argocd-project-policy-smoke/main.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"go.yaml.in/yaml/v4"
+)
+
+type conditionCategory string
+
+const (
+	conditionCategoryNone            conditionCategory = "none"
+	conditionCategorySource          conditionCategory = "source"
+	conditionCategoryDestination     conditionCategory = "destination"
+	conditionCategorySourceNamespace conditionCategory = "source-namespace"
+)
+
+var monitoredDrydockCodes = map[string]struct{}{
+	diagnostic.CodeProjectSourceRepositoryDenied: {},
+	diagnostic.CodeProjectDestinationDenied:      {},
+	diagnostic.CodeProjectSourceNamespaceDenied:  {},
+}
+
+type options struct {
+	ArgoCDAppDir       string
+	DrydockDiagnostics string
+	Expected           string
+	Out                string
+}
+
+type expectedFile struct {
+	Cases []expectedCase `yaml:"cases"`
+}
+
+type expectedCase struct {
+	Name                  string            `yaml:"name"`
+	Namespace             string            `yaml:"namespace"`
+	ArgoCDCondition       conditionCategory `yaml:"argocdCondition"`
+	DrydockDiagnosticCode string            `yaml:"drydockDiagnosticCode"`
+}
+
+type appStatusFile struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Status struct {
+		Conditions []appCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type appCondition struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type drydockDiagnosticFile struct {
+	Diagnostics []diagnostic.Diagnostic `json:"diagnostics"`
+}
+
+type comparisonResult struct {
+	Cases    int
+	Failures []string
+	Lines    []string
+}
+
+func main() {
+	var opts options
+	flag.StringVar(&opts.ArgoCDAppDir, "argocd-app-dir", "", "directory containing captured Argo CD Application JSON files")
+	flag.StringVar(&opts.DrydockDiagnostics, "drydock-diagnostics", "", "drydock diag --render -o json output file")
+	flag.StringVar(&opts.Expected, "expected", "", "YAML file describing expected project policy outcomes")
+	flag.StringVar(&opts.Out, "out", "", "optional path for a text summary")
+	flag.Parse()
+
+	result, err := compare(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "argocd project policy smoke: %v\n", err)
+		os.Exit(2)
+	}
+	summary := result.Summary()
+	if opts.Out != "" {
+		if err := os.WriteFile(opts.Out, []byte(summary), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "argocd project policy smoke: write summary: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	fmt.Print(summary)
+	if len(result.Failures) > 0 {
+		os.Exit(1)
+	}
+}
+
+func compare(opts options) (comparisonResult, error) {
+	if err := opts.validate(); err != nil {
+		return comparisonResult{}, err
+	}
+	expected, err := readExpected(opts.Expected)
+	if err != nil {
+		return comparisonResult{}, err
+	}
+	apps, err := readApplicationStatusFiles(opts.ArgoCDAppDir)
+	if err != nil {
+		return comparisonResult{}, err
+	}
+	drydockDiagnostics, err := readDrydockDiagnostics(opts.DrydockDiagnostics)
+	if err != nil {
+		return comparisonResult{}, err
+	}
+	return evaluate(expected, apps, drydockDiagnostics), nil
+}
+
+func (opts options) validate() error {
+	missing := make([]string, 0, 3)
+	if strings.TrimSpace(opts.ArgoCDAppDir) == "" {
+		missing = append(missing, "--argocd-app-dir")
+	}
+	if strings.TrimSpace(opts.DrydockDiagnostics) == "" {
+		missing = append(missing, "--drydock-diagnostics")
+	}
+	if strings.TrimSpace(opts.Expected) == "" {
+		missing = append(missing, "--expected")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required flags: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func readExpected(path string) ([]expectedCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read expected file: %w", err)
+	}
+	var expected expectedFile
+	if err := yaml.Unmarshal(data, &expected); err != nil {
+		return nil, fmt.Errorf("parse expected file: %w", err)
+	}
+	if err := validateExpected(expected.Cases); err != nil {
+		return nil, err
+	}
+	return expected.Cases, nil
+}
+
+func validateExpected(cases []expectedCase) error {
+	if len(cases) == 0 {
+		return errors.New("expected file contains no cases")
+	}
+	seen := make(map[string]struct{}, len(cases))
+	for _, tc := range cases {
+		key := appKey(tc.Namespace, tc.Name)
+		if strings.TrimSpace(tc.Name) == "" || strings.TrimSpace(tc.Namespace) == "" {
+			return fmt.Errorf("expected case must include name and namespace: %#v", tc)
+		}
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate expected case: %s", key)
+		}
+		seen[key] = struct{}{}
+		if !validConditionCategory(tc.ArgoCDCondition) {
+			return fmt.Errorf("expected case %s has unsupported argocdCondition %q", key, tc.ArgoCDCondition)
+		}
+	}
+	return nil
+}
+
+func validConditionCategory(category conditionCategory) bool {
+	switch category {
+	case conditionCategoryNone, conditionCategorySource, conditionCategoryDestination, conditionCategorySourceNamespace:
+		return true
+	default:
+		return false
+	}
+}
+
+func readApplicationStatusFiles(dir string) (map[string]appStatusFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read Argo CD Application directory: %w", err)
+	}
+	apps := make(map[string]appStatusFile)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		app, err := readApplicationStatusFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(app.Metadata.Name) == "" || strings.TrimSpace(app.Metadata.Namespace) == "" {
+			return nil, fmt.Errorf("argocd application file %s is missing metadata.name or metadata.namespace", entry.Name())
+		}
+		key := appKey(app.Metadata.Namespace, app.Metadata.Name)
+		if _, ok := apps[key]; ok {
+			return nil, fmt.Errorf("duplicate Argo CD Application capture for %s", key)
+		}
+		apps[key] = app
+	}
+	if len(apps) == 0 {
+		return nil, fmt.Errorf("no Argo CD Application JSON files found in %s", dir)
+	}
+	return apps, nil
+}
+
+func readApplicationStatusFile(path string) (appStatusFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return appStatusFile{}, fmt.Errorf("read Argo CD Application file %s: %w", path, err)
+	}
+	var app appStatusFile
+	if err := json.Unmarshal(data, &app); err != nil {
+		return appStatusFile{}, fmt.Errorf("parse Argo CD Application file %s: %w", path, err)
+	}
+	return app, nil
+}
+
+func readDrydockDiagnostics(path string) ([]diagnostic.Diagnostic, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read drydock diagnostics: %w", err)
+	}
+	var report drydockDiagnosticFile
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse drydock diagnostics: %w", err)
+	}
+	return report.Diagnostics, nil
+}
+
+func evaluate(expected []expectedCase, apps map[string]appStatusFile, drydockDiagnostics []diagnostic.Diagnostic) comparisonResult {
+	result := comparisonResult{
+		Cases: len(expected),
+		Lines: make([]string, 0, len(expected)),
+	}
+	for _, tc := range expected {
+		failures := evaluateCase(tc, apps[appKey(tc.Namespace, tc.Name)], drydockDiagnostics)
+		if len(failures) > 0 {
+			for _, failure := range failures {
+				result.Failures = append(result.Failures, fmt.Sprintf("%s: %s", appKey(tc.Namespace, tc.Name), failure))
+			}
+			result.Lines = append(result.Lines, fmt.Sprintf("FAIL %s", appKey(tc.Namespace, tc.Name)))
+			continue
+		}
+		result.Lines = append(result.Lines, fmt.Sprintf("ok %s", appKey(tc.Namespace, tc.Name)))
+	}
+	return result
+}
+
+func evaluateCase(tc expectedCase, app appStatusFile, drydockDiagnostics []diagnostic.Diagnostic) []string {
+	failures := make([]string, 0, 2)
+	if app.Metadata.Name == "" {
+		failures = append(failures, "missing Argo CD Application JSON capture")
+	} else if failure := evaluateArgoCDCondition(tc, app); failure != "" {
+		failures = append(failures, failure)
+	}
+	if failure := evaluateDrydockDiagnostics(tc, drydockDiagnostics); failure != "" {
+		failures = append(failures, failure)
+	}
+	return failures
+}
+
+func evaluateArgoCDCondition(tc expectedCase, app appStatusFile) string {
+	actual := policyConditionCategories(app.Status.Conditions)
+	expected := expectedConditionCategories(tc.ArgoCDCondition)
+	if equalStringSets(categoryStrings(actual), categoryStrings(expected)) {
+		return ""
+	}
+	return fmt.Sprintf("Argo CD policy condition categories got %s, want %s", strings.Join(categoryStrings(actual), ", "), strings.Join(categoryStrings(expected), ", "))
+}
+
+func expectedConditionCategories(category conditionCategory) []conditionCategory {
+	if category == conditionCategoryNone {
+		return nil
+	}
+	return []conditionCategory{category}
+}
+
+func policyConditionCategories(conditions []appCondition) []conditionCategory {
+	categories := make([]conditionCategory, 0)
+	for _, condition := range conditions {
+		switch {
+		case strings.EqualFold(condition.Type, "InvalidSpecError"):
+			categories = append(categories, classifyInvalidSpecMessage(condition.Message))
+		case strings.EqualFold(condition.Type, "UnknownError") && isSourceNamespacePolicyMessage(condition.Message):
+			categories = append(categories, conditionCategorySourceNamespace)
+		default:
+			continue
+		}
+	}
+	return categories
+}
+
+func classifyInvalidSpecMessage(message string) conditionCategory {
+	normalized := strings.ToLower(message)
+	switch {
+	case strings.Contains(normalized, "source namespace"):
+		return conditionCategorySourceNamespace
+	case strings.Contains(normalized, "destination"):
+		return conditionCategoryDestination
+	case strings.Contains(normalized, "source") || strings.Contains(normalized, "repo"):
+		return conditionCategorySource
+	default:
+		return conditionCategory("unknown")
+	}
+}
+
+func isSourceNamespacePolicyMessage(message string) bool {
+	normalized := strings.ToLower(message)
+	return strings.Contains(normalized, " in namespace ") &&
+		strings.Contains(normalized, " is not permitted to use project ")
+}
+
+func categoryStrings(categories []conditionCategory) []string {
+	if len(categories) == 0 {
+		return []string{"none"}
+	}
+	seen := make(map[string]struct{}, len(categories))
+	for _, category := range categories {
+		seen[string(category)] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for category := range seen {
+		out = append(out, category)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func evaluateDrydockDiagnostics(tc expectedCase, diagnostics []diagnostic.Diagnostic) string {
+	actual := monitoredDrydockCodesForCase(tc, diagnostics)
+	expected := expectedDrydockCodes(tc.DrydockDiagnosticCode)
+	if equalStringSets(actual, expected) {
+		return ""
+	}
+	return fmt.Sprintf("drydock diagnostic codes got %s, want %s", strings.Join(displaySet(actual), ", "), strings.Join(displaySet(expected), ", "))
+}
+
+func expectedDrydockCodes(code string) []string {
+	if strings.TrimSpace(code) == "" {
+		return nil
+	}
+	return []string{code}
+}
+
+func monitoredDrydockCodesForCase(tc expectedCase, diagnostics []diagnostic.Diagnostic) []string {
+	seen := make(map[string]struct{})
+	for _, diag := range diagnostics {
+		if diag.Provenance.Path != appKey(tc.Namespace, tc.Name) {
+			continue
+		}
+		if _, ok := monitoredDrydockCodes[diag.Code]; ok {
+			seen[diag.Code] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for code := range seen {
+		out = append(out, code)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStringSets(left, right []string) bool {
+	left = normalizeStringSet(left)
+	right = normalizeStringSet(right)
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeStringSet(values []string) []string {
+	if len(values) == 0 || len(values) == 1 && values[0] == "none" {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" && value != "none" {
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func displaySet(values []string) []string {
+	values = normalizeStringSet(values)
+	if len(values) == 0 {
+		return []string{"none"}
+	}
+	return values
+}
+
+func appKey(namespace, name string) string {
+	return strings.TrimSpace(namespace) + "/" + strings.TrimSpace(name)
+}
+
+func (result comparisonResult) Summary() string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "Cases: %d\n", result.Cases)
+	fmt.Fprintf(&builder, "Failures: %d\n", len(result.Failures))
+	for _, line := range result.Lines {
+		fmt.Fprintf(&builder, "%s\n", line)
+	}
+	for _, failure := range result.Failures {
+		fmt.Fprintf(&builder, "FAILURE %s\n", failure)
+	}
+	return builder.String()
+}

--- a/scripts/argocd-project-policy-smoke/main_test.go
+++ b/scripts/argocd-project-policy-smoke/main_test.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompareProjectPolicySmokePassesExpectedCases(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "apps")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-source-allowed")
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-source-denied", invalidSpecCondition("source repo is not permitted"))
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-destination-allowed")
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-destination-denied", invalidSpecCondition("destination is not permitted"))
+	writeApplicationJSON(t, appDir, "project-policy-tenant", "project-policy-source-namespace-allowed")
+	writeApplicationJSON(t, appDir, "project-policy-tenant", "project-policy-source-namespace-denied", unknownErrorCondition("application 'project-policy-source-namespace-denied' in namespace 'project-policy-tenant' is not permitted to use project 'project-policy-source-namespace-denied'"))
+
+	expectedPath := filepath.Join(root, "expected.yaml")
+	writeFile(t, expectedPath, `cases:
+  - name: project-policy-source-allowed
+    namespace: argocd
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-source-denied
+    namespace: argocd
+    argocdCondition: source
+    drydockDiagnosticCode: project.source-repository-denied
+  - name: project-policy-destination-allowed
+    namespace: argocd
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-destination-denied
+    namespace: argocd
+    argocdCondition: destination
+    drydockDiagnosticCode: project.destination-denied
+  - name: project-policy-source-namespace-allowed
+    namespace: project-policy-tenant
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-source-namespace-denied
+    namespace: project-policy-tenant
+    argocdCondition: source-namespace
+    drydockDiagnosticCode: project.source-namespace-denied
+`)
+	diagnosticsPath := filepath.Join(root, "drydock.json")
+	writeFile(t, diagnosticsPath, `{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    },
+    {
+      "code": "project.destination-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-destination-denied destination is not permitted",
+      "provenance": {"path": "argocd/project-policy-destination-denied"}
+    },
+    {
+      "code": "project.source-namespace-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application project-policy-tenant/project-policy-source-namespace-denied source namespace is not permitted",
+      "provenance": {"path": "project-policy-tenant/project-policy-source-namespace-denied"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 0 {
+		t.Fatalf("Failures = %#v, want none\n%s", result.Failures, result.Summary())
+	}
+	if !strings.Contains(result.Summary(), "Cases: 6\nFailures: 0\n") {
+		t.Fatalf("Summary() = %q, want case and failure counts", result.Summary())
+	}
+}
+
+func TestCompareReportsArgoCDCategoryMismatch(t *testing.T) {
+	root, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(t, invalidSpecCondition("destination is not permitted"), `{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "Argo CD policy condition categories got destination, want source") {
+		t.Fatalf("Failures = %#v, want source category mismatch in %s", result.Failures, root)
+	}
+}
+
+func TestCompareReportsExtraArgoCDCategoryForDeniedCase(t *testing.T) {
+	root, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(
+		t,
+		invalidSpecCondition("source repo is not permitted"),
+		`{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    }
+  ]
+}`,
+	)
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-source-denied",
+		invalidSpecCondition("source repo is not permitted"),
+		invalidSpecCondition("destination is not permitted"),
+	)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "Argo CD policy condition categories got destination, source, want source") {
+		t.Fatalf("Failures = %#v, want extra Argo CD category failure in %s", result.Failures, root)
+	}
+}
+
+func TestCompareReportsMissingDrydockDiagnosticCode(t *testing.T) {
+	_, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(t, invalidSpecCondition("source repo is not permitted"), `{"diagnostics": []}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "drydock diagnostic codes got none, want project.source-repository-denied") {
+		t.Fatalf("Failures = %#v, want missing drydock code", result.Failures)
+	}
+}
+
+func TestCompareReportsExtraDrydockDiagnosticForDeniedCase(t *testing.T) {
+	_, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(t, invalidSpecCondition("source repo is not permitted"), `{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    },
+    {
+      "code": "project.destination-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied destination is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "drydock diagnostic codes got project.destination-denied, project.source-repository-denied, want project.source-repository-denied") {
+		t.Fatalf("Failures = %#v, want extra drydock code", result.Failures)
+	}
+}
+
+func TestCompareMatchesDrydockDiagnosticsByExactProvenance(t *testing.T) {
+	_, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(t, invalidSpecCondition("source repo is not permitted"), `{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "other/project-policy-source-denied"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "drydock diagnostic codes got none, want project.source-repository-denied") {
+		t.Fatalf("Failures = %#v, want exact provenance failure", result.Failures)
+	}
+}
+
+func TestCompareRequiresExplicitDrydockDiagnosticCode(t *testing.T) {
+	_, appDir, expectedPath, diagnosticsPath := writeSingleCaseInputs(t, invalidSpecCondition("source repo is not permitted"), `{
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-denied source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-denied"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "drydock diagnostic codes got none, want project.source-repository-denied") {
+		t.Fatalf("Failures = %#v, want explicit code failure", result.Failures)
+	}
+}
+
+func TestCompareReportsUnexpectedDrydockDiagnosticForAllowedCase(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "apps")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-source-allowed")
+	expectedPath := filepath.Join(root, "expected.yaml")
+	writeFile(t, expectedPath, `cases:
+  - name: project-policy-source-allowed
+    namespace: argocd
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+`)
+	diagnosticsPath := filepath.Join(root, "drydock.json")
+	writeFile(t, diagnosticsPath, `{
+  "diagnostics": [
+    {
+      "code": "project.source-repository-denied",
+      "severity": "warning",
+      "category": "project",
+      "message": "Application argocd/project-policy-source-allowed source repository is not permitted",
+      "provenance": {"path": "argocd/project-policy-source-allowed"}
+    }
+  ]
+}`)
+
+	result, err := compare(options{
+		ArgoCDAppDir:       appDir,
+		DrydockDiagnostics: diagnosticsPath,
+		Expected:           expectedPath,
+	})
+	if err != nil {
+		t.Fatalf("compare() error = %v", err)
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0], "drydock diagnostic codes got project.source-repository-denied, want none") {
+		t.Fatalf("Failures = %#v, want unexpected drydock code", result.Failures)
+	}
+}
+
+func writeSingleCaseInputs(t *testing.T, condition appCondition, diagnosticsJSON string) (string, string, string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "apps")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	writeApplicationJSON(t, appDir, "argocd", "project-policy-source-denied", condition)
+	expectedPath := filepath.Join(root, "expected.yaml")
+	writeFile(t, expectedPath, `cases:
+  - name: project-policy-source-denied
+    namespace: argocd
+    argocdCondition: source
+    drydockDiagnosticCode: project.source-repository-denied
+`)
+	diagnosticsPath := filepath.Join(root, "drydock.json")
+	writeFile(t, diagnosticsPath, diagnosticsJSON)
+	return root, appDir, expectedPath, diagnosticsPath
+}
+
+func writeApplicationJSON(t *testing.T, dir, namespace, name string, conditions ...appCondition) {
+	t.Helper()
+
+	payload := appStatusFile{}
+	payload.Metadata.Namespace = namespace
+	payload.Metadata.Name = name
+	payload.Status.Conditions = conditions
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	writeFile(t, filepath.Join(dir, namespace+"_"+name+".json"), string(data))
+}
+
+func invalidSpecCondition(message string) appCondition {
+	return appCondition{
+		Type:    "InvalidSpecError",
+		Message: message,
+	}
+}
+
+func unknownErrorCondition(message string) appCondition {
+	return appCondition{
+		Type:    "UnknownError",
+		Message: message,
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -29,7 +29,7 @@ behavior, edge cases, and regression expectations.
 | Rendering | Native | Directory, Kustomize, Helm, Jsonnet, Kustomize Helm charts, Argo CD tracking metadata, namespace normalization, and custom health Lua validation. | No `kubectl`, `argocd`, Helm CLI, Kustomize CLI, repo-server wrapper, or live API defaulting. |
 | Plugins | Supported with input | Native safe Kustomize CMP compatibility, argocd-vault-plugin placeholder compatibility, in-process public API renderers, trusted exec or container policy with `--enable-plugins`, and `bootstrap.entrypoints` for plugin-rendered app discovery. | No default sidecar plugin execution, ambient plugin loading, or plugin credential injection. |
 | Diffs and images | Native | Desired-vs-desired manifest diffs, Git ref diffs, ignored-field normalization, markdown diff previews, and image extraction from PodSpecs and exact `image` keys. | No live managed-fields prediction, server-side diff, or arbitrary string image scanning. |
-| Projects and settings | Native and supported with input | Local `AppProject` checks, rendered project discovery, repository Secret metadata, cluster Secret metadata, Argo CD settings metadata, and structured diagnostics. | No full RBAC/Casbin simulation, live cluster existence checks, or secret credential reads. |
+| Projects and settings | Native and supported with input | Local `AppProject` checks, rendered project discovery, rendered-resource project policy checks, repository Secret metadata, cluster Secret metadata, Argo CD settings metadata, and structured diagnostics. | No full RBAC/Casbin simulation, sync-window scheduling, orphan detection, source signature verification, sync impersonation, live cluster existence checks, or secret credential reads. |
 | API and release shape | Native | Public Go API, stable diagnostics, cache event hooks, cache commands, static binary, setup action, PR action, and container image. | Argo CD dependency updates are deliberate compatibility work. |
 
 ## Can drydock handle my repo?
@@ -100,11 +100,23 @@ See [plugin policy](/plugin-policy/) and
 
 drydock compares desired state to desired state. It supports manifest diffs,
 image diffs, markdown output for review comments, structured diagnostics,
-AppProject checks from local manifests, and redacted Argo CD settings metadata.
+AppProject checks from local manifests, rendered-resource project policy
+checks, and redacted Argo CD settings metadata.
+
+Project diagnostics are render-aware when they need rendered resources. The
+default `--project-diagnostics=actionable` mode keeps known local denials
+visible and hides AppProject findings that cannot be conclusively enforced
+offline. Use `--project-diagnostics=all` for full audit output, or
+`--project-diagnostics=off` to suppress AppProject diagnostics. `test` and
+`build` print visible AppProject warnings and strict failures on stderr. `diff`
+uses stderr for non-markdown output and embeds successful diagnostics in
+markdown reports; `diag --render -o json` exposes the same visible findings with
+stable diagnostic codes for CI.
 
 It does not predict live API defaulting, admission mutation, server-side apply
-ownership, live health aggregation, sync windows, source signature
-verification, or full RBAC authorization.
+ownership, live health aggregation, sync windows, orphaned resources, source
+signature verification, destination service account impersonation, or full RBAC
+authorization.
 
 See [output workflows](/workflows/output/), [local diffs](/workflows/local-diffs/),
 and [troubleshooting](/troubleshooting/).

--- a/site/content/concepts/runtime-offline.md
+++ b/site/content/concepts/runtime-offline.md
@@ -22,6 +22,8 @@ command runs. It does not call:
 - Kubernetes defaulting or admission webhooks.
 - Live managed-fields ownership data.
 - Live Application health aggregation.
+- Argo CD RBAC/Casbin authorization, sync-window scheduling, orphan-resource
+  detection, source signature verification, or sync impersonation.
 
 Those behaviors stay runtime-boundary diagnostics or documented gaps; drydock
 does not silently approximate them from live state.

--- a/testdata/argocd-project-policy/expected.yaml
+++ b/testdata/argocd-project-policy/expected.yaml
@@ -1,0 +1,25 @@
+cases:
+  - name: project-policy-source-allowed
+    namespace: argocd
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-source-denied
+    namespace: argocd
+    argocdCondition: source
+    drydockDiagnosticCode: project.source-repository-denied
+  - name: project-policy-destination-allowed
+    namespace: argocd
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-destination-denied
+    namespace: argocd
+    argocdCondition: destination
+    drydockDiagnosticCode: project.destination-denied
+  - name: project-policy-source-namespace-allowed
+    namespace: project-policy-tenant
+    argocdCondition: none
+    drydockDiagnosticCode: ""
+  - name: project-policy-source-namespace-denied
+    namespace: project-policy-tenant
+    argocdCondition: source-namespace
+    drydockDiagnosticCode: project.source-namespace-denied

--- a/testdata/argocd-project-policy/repo/project-policy/applications.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/applications.yaml
@@ -1,0 +1,101 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-source-allowed
+  namespace: argocd
+spec:
+  project: project-policy-source-allowed
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/source-allowed
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-source-denied
+  namespace: argocd
+spec:
+  project: project-policy-source-denied
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/source-denied
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-destination-allowed
+  namespace: argocd
+spec:
+  project: project-policy-destination-allowed
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/destination-allowed
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-destination-denied
+  namespace: argocd
+spec:
+  project: project-policy-destination-denied
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/destination-denied
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-source-namespace-allowed
+  namespace: project-policy-tenant
+spec:
+  project: project-policy-source-namespace-allowed
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/source-namespace-allowed
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: project-policy-source-namespace-denied
+  namespace: project-policy-tenant
+spec:
+  project: project-policy-source-namespace-denied
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: project-policy/workloads/source-namespace-denied
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: project-policy-workloads

--- a/testdata/argocd-project-policy/repo/project-policy/projects.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/projects.yaml
@@ -1,0 +1,83 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-source-allowed
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-workloads
+  sourceNamespaces:
+    - argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-source-denied
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://example.invalid/not-the-fixture.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-workloads
+  sourceNamespaces:
+    - argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-destination-allowed
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-workloads
+  sourceNamespaces:
+    - argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-destination-denied
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-other
+  sourceNamespaces:
+    - argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-source-namespace-allowed
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-workloads
+  sourceNamespaces:
+    - project-policy-tenant
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-policy-source-namespace-denied
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: project-policy-workloads
+  sourceNamespaces:
+    - argocd

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/destination-allowed/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/destination-allowed/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-destination-allowed
+data:
+  case: destination-allowed

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/destination-denied/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/destination-denied/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-destination-denied
+data:
+  case: destination-denied

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/source-allowed/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/source-allowed/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-source-allowed
+data:
+  case: source-allowed

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/source-denied/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/source-denied/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-source-denied
+data:
+  case: source-denied

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/source-namespace-allowed/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/source-namespace-allowed/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-source-namespace-allowed
+data:
+  case: source-namespace-allowed

--- a/testdata/argocd-project-policy/repo/project-policy/workloads/source-namespace-denied/configmap.yaml
+++ b/testdata/argocd-project-policy/repo/project-policy/workloads/source-namespace-denied/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-policy-source-namespace-denied
+data:
+  case: source-namespace-denied


### PR DESCRIPTION
## Summary
- audit and align AppProject source, destination, source namespace, and rendered resource policy semantics
- add project diagnostic modes and public/API plumbing
- add a default-on live AppProject policy smoke inside the Argo CD render parity smoke, with project-policy artifacts and CI relevance wiring
- document AppProject compatibility boundaries and release validation scope

## Validation
- go test ./...
- mise run lint
- mise run docs-check
- mise run actionlint
- mise run zizmor
- git diff --check origin/main..HEAD
- full live scripts/argocd-parity-smoke.sh --binary /private/tmp/drydock-appproject-smoke --out /private/tmp/drydock-argocd-project-policy-smoke-20260607-170200 passed: render parity differences 0; project-policy Cases 6, Failures 0