### PR TITLE
fix: support native AVP plugin compatibility

### DIFF
--- a/docs/plugin-policy.md
+++ b/docs/plugin-policy.md
@@ -14,7 +14,9 @@ uses the native Kustomize renderer automatically.
 Use plugin policy for these cases:
 
 - Deterministic argocd-vault-plugin (AVP) placeholder redaction with
-  `engine: avp-compat`.
+  `engine: avp-compat`. For explicit Application plugin sources named
+  `argocd-vault-plugin`, the CLI can use the same native compatibility behavior
+  with `--enable-avp-compat` and no policy.
 - Explicit native Kustomize overrides with `engine: native-kustomize`.
 - Trusted host-process compatibility with `engine: exec` and
   `--enable-plugins`.
@@ -35,13 +37,16 @@ are true:
 - The command-backed policy came from trusted policy provenance.
 
 No plugin command execution occurs unless `--enable-plugins` is passed. Native
-rendering paths do not execute plugin commands.
+rendering paths, including `engine: avp-compat`, `engine: native-kustomize`,
+and `--enable-avp-compat`, do not execute plugin commands.
 
 Discovered Argo CD CMP definitions that normalize to a safe `kustomize build`
 command are interpreted by drydock's native Kustomize renderer by default.
 `native-kustomize` policy entries remain available as explicit overrides.
 For native argocd-vault-plugin (AVP) compatibility, `avp-compat` performs
-deterministic placeholder redaction with drydock native renderers.
+deterministic placeholder redaction with drydock native renderers. The
+`--enable-avp-compat` flag enables the same behavior only for explicit
+Application plugin sources named `argocd-vault-plugin`.
 
 When a discovered sidecar CMP has static discovery rules and an Application
 does not name a plugin, drydock may warn that Argo CD sidecar auto-discovery
@@ -415,8 +420,19 @@ roots.
 ## Engines
 
 `avp-compat` renders the source with drydock's native renderer and replaces
-supported AVP placeholders with deterministic redacted values. It does not
-contact a secret backend and does not execute the AVP binary.
+supported AVP placeholders with deterministic redacted values. For explicit
+Application plugin sources named `argocd-vault-plugin`, `--enable-avp-compat`
+uses the same native compatibility path without requiring a policy entry.
+
+Native renderer selection follows drydock's normal source detection: Kustomize
+when a `kustomization` file exists, Helm when `Chart.yaml` exists, and
+Directory otherwise. Chart-only plugin sources use native chart rendering.
+
+AVP compatibility does not contact a secret backend and does not execute the
+AVP binary, the config-management plugin command, a shell, the Helm CLI, or the
+Kustomize CLI. Generic `<KEY>` placeholders are redacted only when the rendered
+manifest has `metadata.annotations["avp.kubernetes.io/path"]`; inline
+`<path:...#...>` placeholders remain supported.
 
 `native-kustomize` explicitly permits a named plugin to use drydock's native
 Kustomize adapter. The same adapter also runs by default when drydock discovers
@@ -445,6 +461,9 @@ Native engines must remain narrow compatibility paths. drydock may interpret
 discovered CMP definitions only when they map to a known in-process renderer
 with a fail-closed validator. Discovered CMP definitions are never ambient
 permission to execute commands or emulate arbitrary plugin behavior.
+`--enable-avp-compat` has the same boundary: it is not support for arbitrary
+sidecar CMPs or arbitrary plugin commands. Use `engine: exec` or
+`engine: container` for trusted command-backed plugins.
 
 ## Examples
 
@@ -454,7 +473,7 @@ Native argocd-vault-plugin (AVP) placeholder compatibility:
 apiVersion: drydock.sholdee.dev/v1alpha1
 kind: PluginPolicy
 plugins:
-  avp-directory-include:
+  argocd-vault-plugin:
     engine: avp-compat
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -124,6 +124,22 @@ Git refs, and Argo CD chart-only remote Helm sources. Path-based Git sources
 use the local `--path` tree when the source path exists there. Use
 `--repo-map URL=PATH` to force a source repository URL to a local checkout.
 
+Use `--enable-avp-compat` when an Application explicitly names the
+`argocd-vault-plugin` plugin and you want drydock to render it without running
+AVP. drydock renders the source through its native renderers, then replaces
+supported AVP placeholders with deterministic redacted values. Native renderer
+selection follows normal drydock source detection: Kustomize when a
+`kustomization` file exists, Helm when `Chart.yaml` exists, and Directory
+otherwise. Chart-only AVP plugin sources use native chart rendering.
+
+AVP compatibility does not execute the AVP binary, a config-management plugin
+command, a shell, the Helm CLI, or the Kustomize CLI. Generic `<KEY>`
+placeholders are redacted only when the rendered manifest has
+`metadata.annotations["avp.kubernetes.io/path"]`; inline `<path:...#...>`
+placeholders remain supported. For trusted command-backed plugins, use
+[`plugin-policy.md`](plugin-policy.md) with `engine: exec` or
+`engine: container` and `--enable-plugins`.
+
 Repositories tagged with `argocd` or `gitops` are not always Argo CD
 Application fleet repositories. `drydock test apps` reports zero applications
 when no `Application` or supported `ApplicationSet` objects are discovered.
@@ -205,7 +221,9 @@ plugin name or trusted static discovery for an unnamed plugin source. Exec and
 container policy require trusted provenance and `--enable-plugins`; Application
 plugin parameters for command-backed engines must be allowlisted by policy.
 Native policy engines such as `avp-compat` and `native-kustomize` do not
-execute plugin commands and reject Application plugin env and parameters.
+execute plugin commands and reject Application plugin env and parameters. The
+`--enable-avp-compat` flag for explicit `argocd-vault-plugin` sources also
+does not execute plugin commands.
 Embedders can pass a renderer directly or
 use `drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to
 dispatch in-process renderers by `plugin.name`. The public plugin request
@@ -641,7 +659,9 @@ These source paths are outside the current default runtime contract:
 - Arbitrary CLI config management plugin execution outside trusted exec or
   container policy plus `--enable-plugins`, Argo CD repo-server sidecar plugin
   discovery, ambient plugin configuration, ambient plugin environment loading,
-  and plugin credential injection.
+  and plugin credential injection. `--enable-avp-compat` is limited to native
+  rendering and deterministic redaction for explicit `argocd-vault-plugin`
+  sources; it is not a general sidecar CMP or plugin-command executor.
 - Live cluster and Argo CD API sources.
 - Live destination cluster existence, sync windows, source integrity
   verification, project-scoped cluster Secret enforcement beyond discovered

--- a/internal/app/local_provider_plugin.go
+++ b/internal/app/local_provider_plugin.go
@@ -17,6 +17,9 @@ func (p localProvider) renderPluginSource(ctx context.Context, source render.Res
 		if manifests, diags, handled, err := p.renderPolicyPluginSource(ctx, source, opts); handled {
 			return manifests, diags, err
 		}
+		if manifests, diags, handled, err := p.renderDefaultAVPCompatPluginSource(ctx, source, opts); handled {
+			return manifests, diags, err
+		}
 		if manifests, diags, handled, err := p.renderNativeKustomizePluginSource(ctx, source, opts); handled {
 			return manifests, diags, err
 		}

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestOrchestratorBuildFailsClosedForPluginSourceWithoutRenderer(t *testing.T) {
@@ -270,6 +271,289 @@ data:
 	}
 }
 
+func TestOrchestratorBuildRendersDefaultAVPCompatPluginDirectory(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avp-directory
+  annotations:
+    avp.kubernetes.io/path: vaults/K8s/items/cloudflare-tunnel-secret
+data:
+  target: <CLOUDFLARE_TUNNEL_ID>.cfargotunnel.com
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertRedactedDataValue(t, result.Manifests, "avp-directory", "target", ".cfargotunnel.com")
+	if !hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, want AVP compatibility diagnostic", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRendersDefaultAVPCompatPluginKustomizePath(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avp-kustomize
+  annotations:
+    avp.kubernetes.io/path: vaults/K8s/items/ip-address
+data:
+  address: <COMPARTILHADO_IP>:2049
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertRedactedDataValue(t, result.Manifests, "avp-kustomize", "address", ":2049")
+	if !hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, want AVP compatibility diagnostic", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRendersDefaultAVPCompatPluginChartAtPath(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "Chart.yaml"), `apiVersion: v2
+name: avp-chart
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avp-chart-path
+  annotations:
+    avp.kubernetes.io/path: vaults/K8s/items/chart-secret
+data:
+  value: <CHART_VALUE>
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertRedactedDataValue(t, result.Manifests, "avp-chart-path", "value", "")
+	if !hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, want AVP compatibility diagnostic", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRendersDefaultAVPCompatPluginChartOnly(t *testing.T) {
+	root := t.TempDir()
+	chartDir := filepath.Join(t.TempDir(), "demo")
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: chart-only-plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.example.test
+    targetRevision: 1.2.3
+    chart: demo
+    plugin:
+      name: argocd-vault-plugin
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(chartDir, "Chart.yaml"), `apiVersion: v2
+name: demo
+version: 1.2.3
+`)
+	writeTestFile(t, filepath.Join(chartDir, "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avp-chart-only
+  annotations:
+    avp.kubernetes.io/path: vaults/K8s/items/chart-secret
+data:
+  value: <CHART_ONLY_VALUE>
+`)
+
+	result, err := (Orchestrator{ChartAcquirer: &recordingChartAcquirer{chartDir: chartDir}}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertRedactedDataValue(t, result.Manifests, "avp-chart-only", "value", "")
+	if !hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, want AVP compatibility diagnostic", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildFailsClosedForAVPPluginWithoutCompatFlag(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-not-render
+data:
+  value: <path:vaults/K8s/items/demo#value>
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root})
+	if err == nil {
+		t.Fatal("Build() error = nil, want unsupported plugin error")
+	}
+	if _, ok := manifestByName(result.Manifests, "should-not-render"); ok {
+		t.Fatalf("Manifests = %#v, AVP plugin source rendered without --enable-avp-compat", result.Manifests)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
+		t.Fatalf("Diagnostics = %#v, want plugin.unsupported", result.Diagnostics)
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "--enable-avp-compat") {
+		t.Fatalf("Diagnostics = %#v, want --enable-avp-compat guidance", result.Diagnostics)
+	}
+	if hasDiagnosticMessage(result.Diagnostics, "native Kustomize adapter") {
+		t.Fatalf("Diagnostics = %#v, did not want native Kustomize adapter guidance", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildDoesNotUseAVPCompatForOtherPluginNames(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "cue")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-not-render
+data:
+  value: <path:vaults/K8s/items/demo#value>
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err == nil {
+		t.Fatal("Build() error = nil, want unsupported plugin error")
+	}
+	if _, ok := manifestByName(result.Manifests, "should-not-render"); ok {
+		t.Fatalf("Manifests = %#v, non-AVP plugin source rendered by AVP compatibility", result.Manifests)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
+		t.Fatalf("Diagnostics = %#v, want plugin.unsupported", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildRejectsDefaultAVPCompatPluginEnv(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "plugin.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugin
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin
+      env:
+        - name: AVP_TYPE
+          value: 1password
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-not-render
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err == nil {
+		t.Fatal("Build() error = nil, want env rejection")
+	}
+	if _, ok := manifestByName(result.Manifests, "should-not-render"); ok {
+		t.Fatalf("Manifests = %#v, env-bearing AVP plugin source rendered", result.Manifests)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
+		t.Fatalf("Diagnostics = %#v, want plugin.unsupported", result.Diagnostics)
+	}
+	if !hasDiagnosticMessage(result.Diagnostics, "env or parameters") {
+		t.Fatalf("Diagnostics = %#v, want env/parameters rejection", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildUsesPolicyBeforeDefaultAVPCompat(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writePluginPolicy(t, root, argocdVaultPluginName, "avp-compat")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: avp-policy
+data:
+  domain: argocd.<path:vaults/Kubernetes/items/cluster#domain>
+`)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertRedactedDataValue(t, result.Manifests, "avp-policy", "domain", "")
+	if hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, trusted policy AVP should stay quiet", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorInjectedPluginRendererOverridesDefaultAVPCompat(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", argocdVaultPluginName)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-not-render
+data:
+  value: <path:vaults/K8s/items/demo#value>
+`)
+
+	rendered := false
+	result, err := (Orchestrator{PluginRenderer: internalPluginRendererFunc(func(_ context.Context, request render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		rendered = true
+		if request.Plugin.Name != argocdVaultPluginName {
+			t.Fatalf("Plugin.Name = %q, want %s", request.Plugin.Name, argocdVaultPluginName)
+		}
+		return []render.Manifest{{
+			Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name": "injected-avp-renderer",
+				},
+			}},
+		}}, nil, nil
+	})}).Build(context.Background(), BuildRequest{Path: root, PluginOptions: PluginOptions{EnableAVPCompat: true}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !rendered {
+		t.Fatal("injected plugin renderer was not called")
+	}
+	if _, ok := manifestByName(result.Manifests, "injected-avp-renderer"); !ok {
+		t.Fatalf("Manifests = %#v, want injected renderer manifest", result.Manifests)
+	}
+	if _, ok := manifestByName(result.Manifests, "should-not-render"); ok {
+		t.Fatalf("Manifests = %#v, default AVP compat hijacked injected renderer", result.Manifests)
+	}
+	if hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, injected renderer should own plugin source", result.Diagnostics)
+	}
+}
+
 func TestOrchestratorBuildRejectsAVPCompatPolicyPluginEnv(t *testing.T) {
 	root := t.TempDir()
 	writePluginPolicy(t, root, "avp-directory-include", "avp-compat")
@@ -308,6 +592,24 @@ metadata:
 	}
 	if !hasDiagnosticMessage(result.Diagnostics, "env or parameters") {
 		t.Fatalf("Diagnostics = %#v, want env/parameters rejection", result.Diagnostics)
+	}
+}
+
+func assertRedactedDataValue(t *testing.T, manifests []render.Manifest, name string, key string, suffix string) {
+	t.Helper()
+	manifest, ok := manifestByName(manifests, name)
+	if !ok {
+		t.Fatalf("Manifests = %#v, want %s", manifests, name)
+	}
+	value, found, err := unstructured.NestedString(manifest.Object.Object, "data", key)
+	if err != nil || !found {
+		t.Fatalf("data.%s = %q, found %v, err %v", key, value, found, err)
+	}
+	if strings.Contains(value, "<") || !strings.Contains(value, "drydock-redacted-") {
+		t.Fatalf("data.%s = %q, want redacted AVP value", key, value)
+	}
+	if suffix != "" && !strings.HasSuffix(value, suffix) {
+		t.Fatalf("data.%s = %q, want suffix %q", key, value, suffix)
 	}
 }
 

--- a/internal/app/plugin_render_native.go
+++ b/internal/app/plugin_render_native.go
@@ -3,10 +3,54 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/render"
 )
+
+const argocdVaultPluginName = "argocd-vault-plugin"
+
+func (p localProvider) renderDefaultAVPCompatPluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, bool, error) {
+	if opts.Plugin == nil || !isArgocdVaultPluginName(opts.Plugin.Name) {
+		return nil, nil, false, nil
+	}
+	if !opts.EnableAVPCompat {
+		message := fmt.Sprintf("config management plugin %s requires --enable-avp-compat for native AVP placeholder redaction, or a trusted PluginPolicy for command-backed rendering", pluginDisplayName(opts.Plugin.Name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	if len(opts.Plugin.Env) != 0 || len(opts.Plugin.Parameters) != 0 {
+		message := fmt.Sprintf("config management plugin %s uses env or parameters, which are unsupported by AVP compatibility", pluginDisplayName(opts.Plugin.Name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	if source.Path == "" && source.Chart == "" {
+		message := fmt.Sprintf("config management plugin %s must define path or chart for AVP compatibility", pluginDisplayName(opts.Plugin.Name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+	if source.Path != "" && source.Chart != "" {
+		message := fmt.Sprintf("config management plugin %s cannot define both path and chart for AVP compatibility", pluginDisplayName(opts.Plugin.Name))
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
+
+	nativeOptions := opts
+	nativeOptions.Plugin = nil
+	nativeOptions.EnableAVPCompat = false
+	nativeOptions.QuietAVPCompat = false
+	if source.Path != "" {
+		renderer, err := selectLocalRenderer(source)
+		if err != nil {
+			return nil, nil, true, err
+		}
+		manifests, diags, err := renderer.Render(ctx, source, nativeOptions)
+		return manifests, diags, true, err
+	}
+	manifests, diags, err := p.renderChartOnlySource(ctx, source, nativeOptions)
+	return manifests, diags, true, err
+}
+
+func isArgocdVaultPluginName(name string) bool {
+	return strings.TrimSpace(name) == argocdVaultPluginName
+}
 
 func (p localProvider) renderAVPCompatPolicyPluginSource(ctx context.Context, source render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, bool, error) {
 	nativeOptions := opts

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -219,7 +219,11 @@ func applyAVPCompatToManifest(manifest *render.Manifest, opts render.RenderOptio
 	if !opts.EnableAVPCompat || manifest == nil || manifest.Object == nil {
 		return false
 	}
-	value, changed := avpcompat.ReplaceValue(manifest.Object.Object)
+	defaultPath := ""
+	if annotations := manifest.Object.GetAnnotations(); annotations != nil {
+		defaultPath = annotations["avp.kubernetes.io/path"]
+	}
+	value, changed := avpcompat.ReplaceValueWithPath(manifest.Object.Object, defaultPath)
 	if !changed {
 		return false
 	}

--- a/internal/avpcompat/avpcompat.go
+++ b/internal/avpcompat/avpcompat.go
@@ -16,7 +16,20 @@ func ContainsPlaceholder(value string) bool {
 
 // ReplaceString replaces supported AVP placeholders with stable redacted values.
 func ReplaceString(value string) (string, bool) {
-	if !strings.Contains(value, "<") || !strings.Contains(value, "path:") {
+	return replaceString(value, "")
+}
+
+// ReplaceStringWithPath replaces inline path placeholders and annotation-scoped
+// generic placeholders with stable redacted values.
+func ReplaceStringWithPath(value string, defaultPath string) (string, bool) {
+	return replaceString(value, strings.TrimSpace(defaultPath))
+}
+
+func replaceString(value string, defaultPath string) (string, bool) {
+	if !strings.Contains(value, "<") || !strings.Contains(value, ">") {
+		return value, false
+	}
+	if defaultPath == "" && !strings.Contains(value, "path:") {
 		return value, false
 	}
 
@@ -38,7 +51,7 @@ func ReplaceString(value string) (string, bool) {
 		end := start + 1 + endRel
 		token := value[start : end+1]
 
-		identity, ok := pathPlaceholderIdentity(token)
+		identity, ok := placeholderIdentity(token, defaultPath)
 		if ok {
 			if !changed {
 				out.Grow(len(value))
@@ -61,29 +74,40 @@ func ReplaceString(value string) (string, bool) {
 
 // ReplaceValue replaces supported AVP placeholders through decoded YAML/JSON values.
 func ReplaceValue(value any) (any, bool) {
+	return replaceValue(value, "")
+}
+
+// ReplaceValueWithPath replaces supported AVP placeholders through decoded
+// YAML/JSON values, including generic placeholders scoped to an AVP path
+// annotation.
+func ReplaceValueWithPath(value any, defaultPath string) (any, bool) {
+	return replaceValue(value, strings.TrimSpace(defaultPath))
+}
+
+func replaceValue(value any, defaultPath string) (any, bool) {
 	switch typed := value.(type) {
 	case string:
-		return ReplaceString(typed)
+		return replaceString(typed, defaultPath)
 	case []any:
-		return replaceAnySlice(typed)
+		return replaceAnySlice(typed, defaultPath)
 	case []string:
-		return replaceStringSlice(typed)
+		return replaceStringSlice(typed, defaultPath)
 	case map[string]any:
-		return replaceStringAnyMap(typed)
+		return replaceStringAnyMap(typed, defaultPath)
 	case map[string]string:
-		return replaceStringStringMap(typed)
+		return replaceStringStringMap(typed, defaultPath)
 	case map[any]any:
-		return replaceAnyMap(typed)
+		return replaceAnyMap(typed, defaultPath)
 	default:
 		return value, false
 	}
 }
 
-func replaceAnySlice(values []any) (any, bool) {
+func replaceAnySlice(values []any, defaultPath string) (any, bool) {
 	replaced := make([]any, len(values))
 	changed := false
 	for i, item := range values {
-		next, itemChanged := ReplaceValue(item)
+		next, itemChanged := replaceValue(item, defaultPath)
 		replaced[i] = next
 		changed = changed || itemChanged
 	}
@@ -93,11 +117,11 @@ func replaceAnySlice(values []any) (any, bool) {
 	return replaced, true
 }
 
-func replaceStringSlice(values []string) (any, bool) {
+func replaceStringSlice(values []string, defaultPath string) (any, bool) {
 	replaced := make([]string, len(values))
 	changed := false
 	for i, item := range values {
-		next, itemChanged := ReplaceString(item)
+		next, itemChanged := replaceString(item, defaultPath)
 		replaced[i] = next
 		changed = changed || itemChanged
 	}
@@ -107,11 +131,11 @@ func replaceStringSlice(values []string) (any, bool) {
 	return replaced, true
 }
 
-func replaceStringAnyMap(values map[string]any) (any, bool) {
+func replaceStringAnyMap(values map[string]any, defaultPath string) (any, bool) {
 	replaced := make(map[string]any, len(values))
 	changed := false
 	for key, item := range values {
-		next, itemChanged := ReplaceValue(item)
+		next, itemChanged := replaceValue(item, defaultPath)
 		replaced[key] = next
 		changed = changed || itemChanged
 	}
@@ -121,11 +145,11 @@ func replaceStringAnyMap(values map[string]any) (any, bool) {
 	return replaced, true
 }
 
-func replaceStringStringMap(values map[string]string) (any, bool) {
+func replaceStringStringMap(values map[string]string, defaultPath string) (any, bool) {
 	replaced := make(map[string]string, len(values))
 	changed := false
 	for key, item := range values {
-		next, itemChanged := ReplaceString(item)
+		next, itemChanged := replaceString(item, defaultPath)
 		replaced[key] = next
 		changed = changed || itemChanged
 	}
@@ -135,11 +159,11 @@ func replaceStringStringMap(values map[string]string) (any, bool) {
 	return replaced, true
 }
 
-func replaceAnyMap(values map[any]any) (any, bool) {
+func replaceAnyMap(values map[any]any, defaultPath string) (any, bool) {
 	replaced := make(map[any]any, len(values))
 	changed := false
 	for key, item := range values {
-		next, itemChanged := ReplaceValue(item)
+		next, itemChanged := replaceValue(item, defaultPath)
 		replaced[key] = next
 		changed = changed || itemChanged
 	}
@@ -147,6 +171,20 @@ func replaceAnyMap(values map[any]any) (any, bool) {
 		return values, false
 	}
 	return replaced, true
+}
+
+func placeholderIdentity(token string, defaultPath string) (string, bool) {
+	if identity, ok := pathPlaceholderIdentity(token); ok {
+		return identity, true
+	}
+	if defaultPath == "" {
+		return "", false
+	}
+	key, ok := genericPlaceholderKey(token)
+	if !ok {
+		return "", false
+	}
+	return "path:" + defaultPath + "#" + key, true
 }
 
 func pathPlaceholderIdentity(token string) (string, bool) {
@@ -165,6 +203,32 @@ func pathPlaceholderIdentity(token string) (string, bool) {
 		return "", false
 	}
 	return "path:" + selector, true
+}
+
+func genericPlaceholderKey(token string) (string, bool) {
+	if len(token) < len("<a>") || token[0] != '<' || token[len(token)-1] != '>' {
+		return "", false
+	}
+	key := strings.TrimSpace(token[1 : len(token)-1])
+	if key == "" || strings.HasPrefix(key, "path:") {
+		return "", false
+	}
+	for _, r := range key {
+		if !isGenericPlaceholderKeyRune(r) {
+			return "", false
+		}
+	}
+	return key, true
+}
+
+func isGenericPlaceholderKeyRune(r rune) bool {
+	return r >= 'a' && r <= 'z' ||
+		r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' ||
+		r == '_' ||
+		r == '-' ||
+		r == '.' ||
+		r == '/'
 }
 
 func redactedValue(identity string) string {

--- a/internal/avpcompat/avpcompat_test.go
+++ b/internal/avpcompat/avpcompat_test.go
@@ -65,6 +65,47 @@ func TestReplaceStringIgnoresUnsupportedAngleTokens(t *testing.T) {
 	}
 }
 
+func TestReplaceStringWithPathSubstitutesGenericPlaceholder(t *testing.T) {
+	got, changed := ReplaceStringWithPath("<CLOUDFLARE_TUNNEL_ID>.cfargotunnel.com", "vaults/K8s/items/cloudflare-tunnel-secret")
+	if !changed {
+		t.Fatal("ReplaceStringWithPath() changed = false, want true")
+	}
+	if !strings.HasPrefix(got, redactedPrefix) || !strings.HasSuffix(got, ".cfargotunnel.com") {
+		t.Fatalf("ReplaceStringWithPath() = %q, want redacted prefix and preserved suffix", got)
+	}
+	assertNoSecretMaterial(t, got)
+
+	again, againChanged := ReplaceStringWithPath("<CLOUDFLARE_TUNNEL_ID>.cfargotunnel.com", "vaults/K8s/items/cloudflare-tunnel-secret")
+	if !againChanged {
+		t.Fatal("ReplaceStringWithPath() second call changed = false, want true")
+	}
+	if again != got {
+		t.Fatalf("ReplaceStringWithPath() = %q, want deterministic %q", again, got)
+	}
+}
+
+func TestReplaceStringLeavesGenericPlaceholderWithoutPath(t *testing.T) {
+	const input = "<CLOUDFLARE_TUNNEL_ID>.cfargotunnel.com"
+	got, changed := ReplaceStringWithPath(input, "")
+	if changed {
+		t.Fatal("ReplaceStringWithPath() changed = true, want false")
+	}
+	if got != input {
+		t.Fatalf("ReplaceStringWithPath() = %q, want unchanged %q", got, input)
+	}
+}
+
+func TestReplaceStringWithPathIgnoresUnsaneGenericPlaceholder(t *testing.T) {
+	const input = "keep <not an avp token>"
+	got, changed := ReplaceStringWithPath(input, "vaults/K8s/items/demo")
+	if changed {
+		t.Fatal("ReplaceStringWithPath() changed = true, want false")
+	}
+	if got != input {
+		t.Fatalf("ReplaceStringWithPath() = %q, want unchanged %q", got, input)
+	}
+}
+
 func TestContainsPlaceholder(t *testing.T) {
 	if !ContainsPlaceholder("value=<path:secret/data/app#password>") {
 		t.Fatal("ContainsPlaceholder() = false, want true")


### PR DESCRIPTION
## Summary
- render explicit argocd-vault-plugin sources through drydock native renderers when --enable-avp-compat is set
- add annotation-scoped generic AVP placeholder redaction for manifests with avp.kubernetes.io/path
- preserve fail-closed behavior, PluginPolicy precedence, injected plugin renderer precedence, and docs for the command-execution boundary

## Validation
- go test ./internal/app ./internal/avpcompat
- go build -o /private/tmp/drydock-avp-compat ./cmd/drydock
- mise run lint
- /private/tmp/drydock-avp-compat test apps --enable-avp-compat in /Users/ethan.shold/git/argocd-repos/atoca.house

In the atoca.house validation, blackbox-exporter-lan and cloudflare-tunnel now pass with AVP redaction warnings. Remaining failures are repo-side: crunchy-postgres-cluster has a Kustomize,Plugin source conflict and rook-ceph-cluster renders duplicate cephVersion.