### PR TITLE
docs: port docs header github card

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -100,7 +100,7 @@ a:hover {
 
 .header-nav {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) minmax(220px, 340px);
+  grid-template-columns: auto minmax(0, 1fr) minmax(220px, 340px) auto;
   align-items: center;
   gap: clamp(0.75rem, 1.6vw, 1.2rem);
   min-height: var(--header-height);
@@ -179,6 +179,12 @@ a:hover {
   color: var(--navy-deep);
 }
 
+.search-panel .search-status span {
+  color: var(--muted);
+  font-weight: 700;
+  padding: 0.55rem 0.65rem;
+}
+
 .search-panel span {
   display: block;
   font-size: 0.9rem;
@@ -241,6 +247,82 @@ a:hover {
 .header-links a:hover {
   background: rgba(105, 215, 194, 0.09);
   color: var(--navy-deep);
+}
+
+.github-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 0.58rem;
+  row-gap: 0.12rem;
+  align-items: center;
+  justify-self: end;
+  min-width: 0;
+  max-width: 100%;
+  color: var(--ink);
+  line-height: 1;
+  padding: 0.08rem 0;
+  text-decoration: none;
+}
+
+.github-card:hover {
+  color: var(--link-hover);
+  text-decoration: none;
+}
+
+.github-card:hover .github-card-repo {
+  color: var(--link-hover);
+}
+
+.github-card svg {
+  flex: 0 0 auto;
+  width: 0.84rem;
+  height: 0.84rem;
+  color: currentColor;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+.github-card .github-card-mark {
+  grid-row: 1 / 3;
+  width: 1.55rem;
+  height: 1.55rem;
+  color: var(--navy-deep);
+  stroke: none;
+}
+
+.github-card-repo {
+  grid-column: 2;
+  overflow: hidden;
+  max-width: 16rem;
+  color: var(--navy-deep);
+  font-size: 0.9rem;
+  font-weight: 750;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-card-meta,
+.github-card-stat {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.github-card-meta {
+  grid-column: 2;
+  gap: 0.52rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.github-card-stat {
+  gap: 0.22rem;
 }
 
 .site-shell {
@@ -1243,16 +1325,16 @@ a.workflow-heading:hover {
   font-size: 0.85rem;
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1280px) {
   :root {
     --header-height: 104px;
   }
 
   .header-nav {
-    grid-template-columns: auto minmax(210px, 320px);
+    grid-template-columns: auto minmax(220px, 1fr) auto;
     grid-template-areas:
-      "brand search"
-      "links links";
+      "brand search github"
+      "links links links";
     row-gap: 0.35rem;
   }
 
@@ -1264,11 +1346,17 @@ a.workflow-heading:hover {
     grid-area: search;
   }
 
+  .github-card {
+    grid-area: github;
+  }
+
   .header-links {
     grid-area: links;
     justify-content: flex-start;
   }
+}
 
+@media (max-width: 1120px) {
   .site-shell {
     grid-template-columns: minmax(180px, 235px) minmax(0, 1fr);
   }
@@ -1278,11 +1366,7 @@ a.workflow-heading:hover {
   }
 }
 
-@media (max-width: 760px) {
-  :root {
-    --header-height: 132px;
-  }
-
+@media (max-width: 720px) {
   html {
     scroll-padding-top: 1rem;
   }
@@ -1292,24 +1376,39 @@ a.workflow-heading:hover {
   }
 
   .header-nav {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
-      "brand"
-      "search"
-      "links";
-    align-items: start;
-    row-gap: 0.5rem;
+      "brand github"
+      "search search"
+      "links links";
+    gap: 0.7rem;
   }
 
-  .header-links {
-    justify-content: flex-start;
+  .github-card {
+    display: inline-flex;
+    width: 2.35rem;
+    height: 2.35rem;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .github-card .github-card-mark {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .github-card-repo,
+  .github-card-meta {
+    display: none;
   }
 
   .site-search {
     width: 100%;
     max-width: none;
   }
+}
 
+@media (max-width: 760px) {
   .site-shell {
     display: block;
     padding: 0;

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -13,6 +13,8 @@ document.addEventListener("DOMContentLoaded", () => {
     initSidebarPersistence(sidebar);
   }
 
+  initGitHubCard();
+
   let copyButtonIndex = 0;
   document.querySelectorAll(".doc-content pre").forEach((block) => {
     if (block.closest(".github-comment-preview")) {
@@ -71,6 +73,113 @@ const shellCommandNames = new Set([
   "kubectl",
   "mise",
 ]);
+
+const GITHUB_CARD_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+function initGitHubCard() {
+  const card = document.querySelector(".github-card");
+  if (!card || !card.dataset.githubRepo || !card.dataset.githubRepositoryApi || !window.fetch) {
+    return;
+  }
+
+  const cacheKey = `drydock.github-card.${card.dataset.githubRepo}`;
+  const cached = githubCardCachedData(cacheKey);
+  if (cached && Date.now() - cached.cachedAt < GITHUB_CARD_CACHE_TTL_MS) {
+    renderGitHubCard(card, cached);
+    return;
+  }
+
+  refreshGitHubCard(card, cacheKey);
+}
+
+async function refreshGitHubCard(card, cacheKey) {
+  try {
+    const repo = await fetchGitHubJSON(card.dataset.githubRepositoryApi);
+    let release = null;
+    if (card.dataset.githubReleaseApi) {
+      try {
+        release = await fetchGitHubJSON(card.dataset.githubReleaseApi);
+      } catch {
+        release = null;
+      }
+    }
+
+    const data = {
+      repo: repo.full_name || card.dataset.githubRepo,
+      stars: normalizeGitHubCount(repo.stargazers_count),
+      forks: normalizeGitHubCount(repo.forks_count),
+      version: normalizeGitHubVersion(release?.tag_name || githubFieldText(card, "version")),
+      cachedAt: Date.now(),
+    };
+    renderGitHubCard(card, data);
+    storageSet("localStorage", cacheKey, JSON.stringify(data));
+  } catch {
+    // The fallback card remains useful when GitHub is unavailable or rate-limited.
+  }
+}
+
+async function fetchGitHubJSON(url) {
+  const response = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API unavailable: ${response.status}`);
+  }
+  return response.json();
+}
+
+function githubCardCachedData(cacheKey) {
+  try {
+    const parsed = JSON.parse(storageGet("localStorage", cacheKey) || "null");
+    if (!parsed || typeof parsed !== "object" || !Number.isFinite(parsed.cachedAt)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function renderGitHubCard(card, data) {
+  const repo = data.repo || card.dataset.githubRepo || githubFieldText(card, "repo");
+  const version = normalizeGitHubVersion(data.version || githubFieldText(card, "version"));
+  const stars = formatGitHubCount(data.stars ?? githubFieldText(card, "stars"));
+  const forks = formatGitHubCount(data.forks ?? githubFieldText(card, "forks"));
+
+  setGitHubFieldText(card, "repo", repo);
+  setGitHubFieldText(card, "version", version);
+  setGitHubFieldText(card, "stars", stars);
+  setGitHubFieldText(card, "forks", forks);
+  card.setAttribute("aria-label", `${repo} on GitHub, latest release ${version}, ${stars} stars, ${forks} forks`);
+}
+
+function setGitHubFieldText(card, field, value) {
+  const target = card.querySelector(`[data-github-field='${field}']`);
+  if (target) {
+    target.textContent = value;
+  }
+}
+
+function githubFieldText(card, field) {
+  return card.querySelector(`[data-github-field='${field}']`)?.textContent.trim() || "";
+}
+
+function normalizeGitHubVersion(value) {
+  return String(value || "").trim().replace(/^v(?=\d)/i, "");
+}
+
+function normalizeGitHubCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+function formatGitHubCount(value) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number >= 0) {
+    return number.toLocaleString("en-US");
+  }
+  return String(value || "0");
+}
 
 function enhanceShellCommands(block) {
   const code = block.querySelector("code.language-bash, code.language-sh, code.language-zsh");
@@ -280,6 +389,11 @@ function initSearch(form) {
 
   const renderResults = (matches, terms) => {
     resultsList.replaceChildren();
+    if (matches.length === 0) {
+      renderStatusResult("No results");
+      return;
+    }
+
     matches.forEach((match, index) => {
       const page = match.page;
       const item = document.createElement("li");
@@ -297,8 +411,24 @@ function initSearch(form) {
       resultsList.append(item);
     });
 
-    panel.hidden = matches.length === 0;
-    input.setAttribute("aria-expanded", matches.length === 0 ? "false" : "true");
+    panel.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const renderStatusResult = (message) => {
+    resultsList.replaceChildren();
+    const item = document.createElement("li");
+    const status = document.createElement("span");
+    item.className = "search-status";
+    item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", "false");
+    status.textContent = message;
+    item.append(status);
+    resultsList.append(item);
+    panel.hidden = false;
+    input.setAttribute("aria-expanded", "true");
     input.removeAttribute("aria-activedescendant");
     activeIndex = -1;
   };
@@ -330,7 +460,7 @@ function initSearch(form) {
 
       renderResults(matches, terms);
     } catch {
-      closeResults();
+      renderStatusResult("Search unavailable");
     }
   };
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -8,6 +8,10 @@ disableKinds:
 params:
   description: "Runtime-offline desired-state analysis for Argo CD GitOps repositories."
   repositoryURL: "https://github.com/sholdee/drydock"
+  repositoryName: "sholdee/drydock"
+  repositoryLatestVersion: "0.1.19"
+  repositoryStars: "9"
+  repositoryForks: "0"
   editBranch: "main"
 
 outputs:

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -8,12 +8,6 @@
       <a href="{{ relURL "getting-started/" }}">Getting Started</a>
       <a href="{{ relURL "workflows/github-actions/" }}">PR Checks</a>
       <a href="{{ relURL "reference/" }}">Reference</a>
-      <a class="github-link" href="https://github.com/sholdee/drydock">
-        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
-          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
-        </svg>
-        <span>GitHub</span>
-      </a>
     </div>
     <form class="site-search" role="search" data-search-index="{{ "index.search.json" | relURL }}">
       <label class="visually-hidden" for="site-search-input">Search documentation</label>
@@ -21,8 +15,10 @@
         id="site-search-input"
         name="q"
         type="search"
+        role="combobox"
         autocomplete="off"
         placeholder="Search docs"
+        aria-autocomplete="list"
         aria-controls="site-search-results"
         aria-expanded="false"
       >
@@ -30,5 +26,43 @@
         <ul id="site-search-results" role="listbox" aria-label="Search results"></ul>
       </div>
     </form>
+    <a
+      class="github-card"
+      href="{{ site.Params.repositoryURL }}"
+      data-github-repo="{{ site.Params.repositoryName }}"
+      data-github-repository-api="https://api.github.com/repos/{{ site.Params.repositoryName }}"
+      data-github-release-api="https://api.github.com/repos/{{ site.Params.repositoryName }}/releases/latest"
+      aria-label="{{ site.Params.repositoryName }} on GitHub, latest release {{ site.Params.repositoryLatestVersion }}, {{ site.Params.repositoryStars }} stars, {{ site.Params.repositoryForks }} forks"
+    >
+      <svg class="github-card-mark" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+        <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
+      </svg>
+      <span class="github-card-repo" data-github-field="repo">{{ site.Params.repositoryName }}</span>
+      <span class="github-card-meta">
+        <span class="github-card-stat github-card-version">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <path d="M2.25 2.25h4.1L13.75 9.65l-4.1 4.1-7.4-7.4v-4.1Z"/>
+            <path d="M4.9 5.15h.01"/>
+          </svg>
+          <span data-github-field="version">{{ site.Params.repositoryLatestVersion }}</span>
+        </span>
+        <span class="github-card-stat">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <path d="m8 1.75 1.93 3.91 4.32.63-3.13 3.05.74 4.3L8 11.61l-3.86 2.03.74-4.3-3.13-3.05 4.32-.63L8 1.75Z"/>
+          </svg>
+          <span data-github-field="stars">{{ site.Params.repositoryStars }}</span>
+        </span>
+        <span class="github-card-stat">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <circle cx="4" cy="3.5" r="1.5"/>
+            <circle cx="12" cy="3.5" r="1.5"/>
+            <circle cx="4" cy="12.5" r="1.5"/>
+            <path d="M4 5v6"/>
+            <path d="M12 5c-.25 2-1.7 3-4.35 3H6.5A2.5 2.5 0 0 0 4 10.5"/>
+          </svg>
+          <span data-github-field="forks">{{ site.Params.repositoryForks }}</span>
+        </span>
+      </span>
+    </a>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- port the crd-schema-publisher docs header search and live GitHub card layout to drydock
- add drydock repository fallback metadata plus cached GitHub API refresh for version, stars, and forks
- preserve drydock responsive header navigation while matching the new search/card placement

## Verification
- `mise run docs-check`
- `git diff --check`
- `mise exec -- hugo --source site --destination /tmp/drydock-docs-verify --cleanDestinationDir --minify`
- clean-build grep confirmed the new GitHub card/search hooks and no old `github-link`

## Review
- sub-agent spec compliance review: approved
- sub-agent code quality review: approved after preserving responsive nav links

Preview server used during review: `http://127.0.0.1:1314/`