### PR TITLE
docs: improve docs code block highlighting

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -17,8 +17,24 @@
   --focus: #69b8ff;
   --link: #8ec8ff;
   --link-hover: #ffad73;
-  --code-bg: #050b12;
-  --code-ink: #edf5ff;
+  --code-bg: #0d1117;
+  --code-ink: #e6edf3;
+  --inline-code-bg: rgba(110, 118, 129, 0.18);
+  --inline-code-border: rgba(240, 246, 252, 0.1);
+  --inline-code-ink: #e6edf3;
+  --syntax-text: #e6edf3;
+  --syntax-comment: #8190a3;
+  --syntax-keyword: #f08a51;
+  --syntax-markup: #f08a51;
+  --syntax-constant: #f5c56f;
+  --syntax-function: #69d7c2;
+  --syntax-string: #8ec8ff;
+  --syntax-number: #f5c56f;
+  --syntax-type: #a7e8dc;
+  --syntax-property: #69d7c2;
+  --syntax-variable: #c6d4e3;
+  --syntax-operator: #a5b4c6;
+  --syntax-escape: #ffad73;
   --shadow: rgba(0, 0, 0, 0.32);
   --max-width: 1480px;
   --header-height: 72px;
@@ -645,10 +661,10 @@ a:hover {
 }
 
 .doc-content code {
-  border: 1px solid var(--line);
+  border: 1px solid var(--inline-code-border);
   border-radius: 5px;
-  background: rgba(5, 11, 18, 0.72);
-  color: #dcecff;
+  background: var(--inline-code-bg);
+  color: var(--inline-code-ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 0.92em;
   padding: 0.08rem 0.28rem;
@@ -657,8 +673,8 @@ a:hover {
 .doc-content pre {
   position: relative;
   overflow-x: auto;
-  border: 1px solid #213149;
-  border-radius: 8px;
+  border: 1px solid #30363d;
+  border-radius: 6px;
   background: var(--code-bg);
   color: var(--code-ink);
   padding: 2.65rem 1rem 1rem;
@@ -667,13 +683,13 @@ a:hover {
 .doc-content pre code {
   border: 0;
   background: transparent;
-  color: inherit;
+  color: var(--syntax-text);
   padding: 0;
 }
 
 .doc-content pre code .shell-command {
-  color: var(--teal);
-  font-weight: 850;
+  color: var(--syntax-function);
+  font-weight: 700;
 }
 
 .github-comment-preview {
@@ -1061,20 +1077,21 @@ a:hover {
   position: absolute;
   top: 0.7rem;
   right: 0.7rem;
-  border: 1px solid var(--line-strong);
+  border: 1px solid #30363d;
   border-radius: 6px;
-  background: rgba(20, 33, 51, 0.94);
-  color: var(--navy-deep);
+  background: #161b22;
+  color: #8b949e;
   cursor: pointer;
   font: inherit;
   font-size: 0.78rem;
-  font-weight: 800;
+  font-weight: 700;
   padding: 0.25rem 0.5rem;
 }
 
 .copy-button:hover {
-  border-color: var(--rust-bright);
-  color: var(--link-hover);
+  border-color: #58a6ff;
+  background: #0d1117;
+  color: #58a6ff;
 }
 
 .mermaid-figure {
@@ -1198,23 +1215,142 @@ a.workflow-heading:hover {
   padding: 0.22rem 0.48rem;
 }
 
-.highlight .c,
-.highlight .c1,
-.highlight .cm,
-.highlight .cp,
-.highlight .cs {
-  color: #a7b3c2 !important;
+:is(.highlight, .chroma) .c,
+:is(.highlight, .chroma) .c1,
+:is(.highlight, .chroma) .ch,
+:is(.highlight, .chroma) .cm,
+:is(.highlight, .chroma) .cp,
+:is(.highlight, .chroma) .cpf,
+:is(.highlight, .chroma) .cs {
+  color: var(--syntax-comment);
+  font-style: italic;
 }
 
-.highlight .k,
-.highlight .kc,
-.highlight .kd,
-.highlight .kn,
-.highlight .kp,
-.highlight .kr,
-.highlight .nt,
-.highlight .o {
-  color: #ff92b2 !important;
+:is(.highlight, .chroma) .k,
+:is(.highlight, .chroma) .kd,
+:is(.highlight, .chroma) .kn,
+:is(.highlight, .chroma) .kp,
+:is(.highlight, .chroma) .kr {
+  color: var(--syntax-keyword);
+}
+
+:is(.highlight, .chroma) .kc,
+:is(.highlight, .chroma) .l,
+:is(.highlight, .chroma) .nb {
+  color: var(--syntax-constant);
+}
+
+:is(.highlight, .chroma) .kt,
+:is(.highlight, .chroma) .nc,
+:is(.highlight, .chroma) .ne {
+  color: var(--syntax-type);
+}
+
+:is(.highlight, .chroma) .nf,
+:is(.highlight, .chroma) .fm,
+:is(.highlight, .chroma) .shell-command {
+  color: var(--syntax-function);
+  font-weight: 700;
+}
+
+:is(.highlight, .chroma) .s,
+:is(.highlight, .chroma) .s1,
+:is(.highlight, .chroma) .s2,
+:is(.highlight, .chroma) .sb,
+:is(.highlight, .chroma) .sc,
+:is(.highlight, .chroma) .sd,
+:is(.highlight, .chroma) .sh,
+:is(.highlight, .chroma) .sx,
+:is(.highlight, .chroma) .dl {
+  color: var(--syntax-string);
+}
+
+:is(.highlight, .chroma) .se,
+:is(.highlight, .chroma) .si {
+  color: var(--syntax-escape);
+}
+
+:is(.highlight, .chroma) .m,
+:is(.highlight, .chroma) .mb,
+:is(.highlight, .chroma) .mf,
+:is(.highlight, .chroma) .mh,
+:is(.highlight, .chroma) .mi,
+:is(.highlight, .chroma) .il,
+:is(.highlight, .chroma) .mo {
+  color: var(--syntax-number);
+}
+
+:is(.highlight, .chroma) .na,
+:is(.highlight, .chroma) .nt,
+:is(.highlight, .chroma) .nv,
+:is(.highlight, .chroma) .vc,
+:is(.highlight, .chroma) .vg,
+:is(.highlight, .chroma) .vi,
+:is(.highlight, .chroma) .vm {
+  color: var(--syntax-variable);
+}
+
+:is(.highlight, .chroma) .o,
+:is(.highlight, .chroma) .ow,
+:is(.highlight, .chroma) .p {
+  color: var(--syntax-operator);
+}
+
+:is(.highlight, .chroma) code.language-yaml .na,
+:is(.highlight, .chroma) code.language-yaml .nt {
+  color: var(--syntax-property);
+}
+
+:is(.highlight, .chroma) code.language-yaml .l {
+  color: var(--syntax-string);
+}
+
+:is(.highlight, .chroma) code:is(.language-bash, .language-sh, .language-zsh) .nb {
+  color: var(--syntax-text);
+  font-weight: 400;
+}
+
+:is(.highlight, .chroma) code:is(.language-bash, .language-sh, .language-zsh) .shell-command {
+  color: var(--syntax-function);
+  font-weight: 700;
+}
+
+:is(.highlight, .chroma) code.language-markdown .gh,
+:is(.highlight, .chroma) code.language-markdown .gu,
+:is(.highlight, .chroma) code.language-md .gh,
+:is(.highlight, .chroma) code.language-md .gu {
+  color: var(--syntax-markup);
+  font-weight: 700;
+}
+
+:is(.highlight, .chroma) code.language-markdown .k,
+:is(.highlight, .chroma) code.language-md .k {
+  color: var(--syntax-operator);
+  font-weight: 600;
+}
+
+:is(.highlight, .chroma) code.language-markdown .sb,
+:is(.highlight, .chroma) code.language-md .sb {
+  color: var(--syntax-function);
+  font-weight: 600;
+}
+
+:is(.highlight, .chroma) code.language-markdown .ge,
+:is(.highlight, .chroma) code.language-md .ge {
+  color: var(--syntax-text);
+  font-style: italic;
+}
+
+:is(.highlight, .chroma) code.language-markdown .gs,
+:is(.highlight, .chroma) code.language-md .gs {
+  color: var(--syntax-text);
+  font-weight: 700;
+}
+
+:is(.highlight, .chroma) code.language-markdown .gt,
+:is(.highlight, .chroma) code.language-md .gt {
+  color: var(--syntax-comment);
+  font-style: italic;
 }
 
 .doc-content blockquote {

--- a/site/assets/js/site.js
+++ b/site/assets/js/site.js
@@ -14,6 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   initGitHubCard();
+  initShellCommandHighlighting();
 
   let copyButtonIndex = 0;
   document.querySelectorAll(".doc-content pre").forEach((block) => {
@@ -22,8 +23,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     copyButtonIndex += 1;
     const copyButtonNumber = copyButtonIndex;
-
-    enhanceShellCommands(block);
 
     const button = document.createElement("button");
     button.type = "button";
@@ -58,21 +57,6 @@ document.addEventListener("DOMContentLoaded", () => {
     heading.append(" ", link);
   });
 });
-
-const shellCommandNames = new Set([
-  "bash",
-  "brew",
-  "curl",
-  "docker",
-  "drydock",
-  "git",
-  "go",
-  "helm",
-  "hugo",
-  "kind",
-  "kubectl",
-  "mise",
-]);
 
 const GITHUB_CARD_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
@@ -181,43 +165,148 @@ function formatGitHubCount(value) {
   return String(value || "0");
 }
 
-function enhanceShellCommands(block) {
-  const code = block.querySelector("code.language-bash, code.language-sh, code.language-zsh");
-  if (!code || code.dataset.shellCommandsEnhanced === "true") {
-    return;
-  }
+function initShellCommandHighlighting() {
+  document.querySelectorAll(".doc-content code.language-bash, .doc-content code.language-sh, .doc-content code.language-zsh").forEach((block) => {
+    if (block.closest(".github-comment-preview") || block.dataset.shellCommandsEnhanced === "true") {
+      return;
+    }
 
-  code.dataset.shellCommandsEnhanced = "true";
-  const lines = Array.from(code.children).filter((child) => child.tagName === "SPAN");
-  if (lines.length === 0) {
-    wrapShellCommandRanges(code, shellCommandRanges(code.textContent || ""));
-    return;
-  }
+    block.dataset.shellCommandsEnhanced = "true";
+    const chromaLines = Array.from(block.querySelectorAll(".cl"));
+    const legacyLines = Array.from(block.children).filter((child) => child.tagName === "SPAN");
+    const targets = chromaLines.length > 0 ? chromaLines : legacyLines.length > 0 ? legacyLines : [block];
 
-  lines.forEach((line) => {
-    const ranges = shellCommandRanges(line.textContent || "");
-    wrapShellCommandRanges(line, ranges);
+    targets.forEach((line) => {
+      wrapTextRanges(line, shellCommandRanges(line.textContent || ""), "shell-command");
+    });
   });
 }
 
-function shellCommandRanges(line) {
+function shellCommandRanges(text) {
   const ranges = [];
-  const commandPattern = /(^\s*(?:[$%]\s*)?|\|\s*|&&\s*|\|\|\s*|;\s*|\(\s*)([A-Za-z][A-Za-z0-9_-]*)\b/g;
+  let index = 0;
+  let expectingCommand = true;
 
-  let match = commandPattern.exec(line);
-  while (match) {
-    const command = match[2];
-    if (shellCommandNames.has(command)) {
-      const start = match.index + match[1].length;
-      ranges.push({ start, end: start + command.length });
+  while (index < text.length) {
+    const skipped = skipShellWhitespace(text, index);
+    if (skipped > index && text.slice(index, skipped).includes("\n")) {
+      expectingCommand = true;
     }
-    match = commandPattern.exec(line);
+    index = skipped;
+
+    if (index >= text.length) {
+      break;
+    }
+
+    if (text[index] === "#") {
+      const nextLine = text.indexOf("\n", index);
+      if (nextLine === -1) {
+        break;
+      }
+      expectingCommand = true;
+      index = nextLine + 1;
+      continue;
+    }
+
+    if (expectingCommand) {
+      if (isShellPromptToken(text, index)) {
+        index += 1;
+        continue;
+      }
+
+      const assignmentEnd = shellAssignmentEnd(text, index);
+      if (assignmentEnd > index) {
+        index = assignmentEnd;
+        continue;
+      }
+
+      const end = shellTokenEnd(text, index);
+      const token = text.slice(index, end);
+      if (isShellCommandToken(token)) {
+        ranges.push({ start: index, end });
+      }
+      expectingCommand = false;
+      index = end;
+      continue;
+    }
+
+    const separatorEnd = shellSeparatorEnd(text, index);
+    if (separatorEnd > index) {
+      expectingCommand = true;
+      index = separatorEnd;
+      continue;
+    }
+
+    index += 1;
   }
 
   return ranges;
 }
 
-function wrapShellCommandRanges(root, ranges) {
+function skipShellWhitespace(text, index) {
+  let next = index;
+  while (next < text.length && /\s/.test(text[next])) {
+    next += 1;
+  }
+  return next;
+}
+
+function isShellPromptToken(text, index) {
+  return (text[index] === "$" || text[index] === "%") && /\s/.test(text[index + 1] || "");
+}
+
+function shellAssignmentEnd(text, index) {
+  const match = text.slice(index).match(/^[A-Za-z_][A-Za-z0-9_]*=/);
+  if (!match) {
+    return index;
+  }
+  return shellTokenEnd(text, index + match[0].length);
+}
+
+function shellTokenEnd(text, index) {
+  let next = index;
+  let quote = "";
+  while (next < text.length) {
+    const char = text[next];
+    if (quote) {
+      if (char === "\\" && quote !== "'") {
+        next += 2;
+        continue;
+      }
+      if (char === quote) {
+        quote = "";
+      }
+      next += 1;
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      quote = char;
+      next += 1;
+      continue;
+    }
+
+    if (/\s/.test(char) || /[|;&]/.test(char)) {
+      break;
+    }
+    next += 1;
+  }
+  return next;
+}
+
+function shellSeparatorEnd(text, index) {
+  const nextTwo = text.slice(index, index + 2);
+  if (nextTwo === "&&" || nextTwo === "||") {
+    return index + 2;
+  }
+  return /[|;]/.test(text[index] || "") ? index + 1 : index;
+}
+
+function isShellCommandToken(token) {
+  return /^[A-Za-z_./][A-Za-z0-9_./:-]*$/.test(token) && !token.startsWith("-");
+}
+
+function wrapTextRanges(root, ranges, className) {
   if (ranges.length === 0) {
     return;
   }
@@ -252,10 +341,10 @@ function wrapShellCommandRanges(root, ranges) {
         fragment.append(document.createTextNode(textNode.nodeValue.slice(cursor, range.start)));
       }
 
-      const command = document.createElement("span");
-      command.className = "shell-command";
-      command.textContent = textNode.nodeValue.slice(range.start, range.end);
-      fragment.append(command);
+      const span = document.createElement("span");
+      span.className = className;
+      span.textContent = textNode.nodeValue.slice(range.start, range.end);
+      fragment.append(span);
       cursor = range.end;
     });
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -114,6 +114,8 @@ markup:
     startLevel: 2
     endLevel: 3
     ordered: false
+  highlight:
+    noClasses: false
 
 module:
   mounts:


### PR DESCRIPTION
## Summary
- enable class-based Chroma highlighting for the Hugo docs site
- curate dark syntax colors for YAML, shell, Markdown, and inline code
- replace shell command allowlist highlighting with parser-style bash/sh/zsh command detection

## Review
- independent review agent approval obtained after fixing zsh `%` prompt handling

## Verification
- `mise run docs-check`
- `git diff --check`
- `node --check site/assets/js/site.js`
- focused Node VM smoke test for shell command range parsing