### PR TITLE
chore: add Renovate release age gates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,8 @@
     'helpers:pinGitHubActionDigests',
   ],
   platformAutomerge: true,
+  minimumReleaseAge: '3 days',
+  internalChecksFilter: 'strict',
   ignorePaths: ['testdata/**'],
   ignoreDeps: ['github.com/argoproj/argo-cd/gitops-engine'],
   postUpdateOptions: ['gomodTidy'],
@@ -20,6 +22,11 @@
     fileFilters: ['go.mod', 'go.sum'],
   },
   packageRules: [
+    {
+      description: 'Wait longer before GitHub Actions updates',
+      matchManagers: ['github-actions'],
+      minimumReleaseAge: '7 days',
+    },
     {
       description: 'Automerge minor/patch GitHub Actions updates',
       matchManagers: ['github-actions'],


### PR DESCRIPTION
## Summary
- add a repository-wide Renovate minimum release age of 3 days
- require a 7 day release age for GitHub Actions updates
- keep strict internal checks so pending release-age checks do not create update branches early

## Validation
- npx --yes --package renovate@43.150.0 -- renovate-config-validator --strict
- git diff --check
- review agent approval: no findings