### PR TITLE
perf: remediate render hot paths

### DIFF
--- a/internal/acquisition/session.go
+++ b/internal/acquisition/session.go
@@ -19,6 +19,10 @@ type Session struct {
 	SnapshotRoot       string
 	SnapshotCacheReads bool
 	SnapshotCache      *SnapshotCache
+	// PreserveGitDirInSnapshots keeps .git directories in Git source
+	// snapshots for plugin-enabled runs whose trusted plugins may inspect
+	// repository metadata. Built-in renderers use only worktree files.
+	PreserveGitDirInSnapshots bool
 }
 
 type TargetLocks struct {
@@ -121,11 +125,12 @@ func (session Session) GitAcquirer(delegate source.GitAcquirer) source.GitAcquir
 		return delegate
 	}
 	return cacheSafeGitAcquirer{
-		delegate:      delegate,
-		locks:         session.Locks,
-		snapshotRoot:  session.SnapshotRoot,
-		snapshot:      session.SnapshotCacheReads,
-		snapshotCache: session.SnapshotCache,
+		delegate:       delegate,
+		locks:          session.Locks,
+		snapshotRoot:   session.SnapshotRoot,
+		snapshot:       session.SnapshotCacheReads,
+		snapshotCache:  session.SnapshotCache,
+		preserveGitDir: session.PreserveGitDirInSnapshots,
 	}
 }
 
@@ -161,11 +166,12 @@ func (session Session) RemoteAcquirer(delegate remote.Acquirer) remote.Acquirer 
 }
 
 type cacheSafeGitAcquirer struct {
-	delegate      source.GitAcquirer
-	locks         *TargetLocks
-	snapshotRoot  string
-	snapshot      bool
-	snapshotCache *SnapshotCache
+	delegate       source.GitAcquirer
+	locks          *TargetLocks
+	snapshotRoot   string
+	snapshot       bool
+	snapshotCache  *SnapshotCache
+	preserveGitDir bool
 }
 
 func (acquirer cacheSafeGitAcquirer) Acquire(ctx context.Context, request source.GitRequest, opts source.GitOptions) (source.GitResult, error) {
@@ -186,7 +192,11 @@ func (acquirer cacheSafeGitAcquirer) Acquire(ctx context.Context, request source
 	if err != nil || !acquirer.snapshot {
 		return result, err
 	}
-	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "git", result.Path, false)
+	gitCopyOptions := snapshotCopyOptions{}
+	if !acquirer.preserveGitDir {
+		gitCopyOptions.skipDirNames = map[string]struct{}{".git": {}}
+	}
+	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "git", result.Path, gitCopyOptions)
 	if err != nil {
 		return source.GitResult{}, err
 	}
@@ -221,7 +231,7 @@ func (acquirer cacheSafeChartAcquirer) Acquire(ctx context.Context, request char
 	if err != nil || !acquirer.snapshot {
 		return result, err
 	}
-	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "chart", result.ChartDir, true)
+	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "chart", result.ChartDir, snapshotCopyOptions{linkRegularFiles: true})
 	if err != nil {
 		return chart.Result{}, err
 	}
@@ -266,7 +276,7 @@ func (acquirer cacheSafeRemoteAcquirer) Acquire(ctx context.Context, request rem
 	if !acquirer.snapshot {
 		return result, nil
 	}
-	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "remote", result.Path, false)
+	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "remote", result.Path, snapshotCopyOptions{})
 	if err != nil {
 		return remote.Result{}, err
 	}
@@ -321,7 +331,12 @@ func absoluteCacheLockKey(prefix, path string) (string, error) {
 	return prefix + ":" + filepath.Clean(abs), nil
 }
 
-func snapshotCachePath(root, prefix, sourcePath string, linkRegularFiles bool) (string, error) {
+type snapshotCopyOptions struct {
+	linkRegularFiles bool
+	skipDirNames     map[string]struct{}
+}
+
+func snapshotCachePath(root, prefix, sourcePath string, opts snapshotCopyOptions) (string, error) {
 	if strings.TrimSpace(root) == "" || strings.TrimSpace(sourcePath) == "" {
 		return sourcePath, nil
 	}
@@ -330,14 +345,14 @@ func snapshotCachePath(root, prefix, sourcePath string, linkRegularFiles bool) (
 		return "", err
 	}
 	snapshotPath := filepath.Join(snapshotRoot, filepath.Base(sourcePath))
-	if err := copyCachePath(sourcePath, snapshotPath, linkRegularFiles); err != nil {
+	if err := copyCachePath(sourcePath, snapshotPath, opts); err != nil {
 		_ = os.RemoveAll(snapshotRoot)
 		return "", err
 	}
 	return snapshotPath, nil
 }
 
-func copyCachePath(src, dst string, linkRegularFiles bool) error {
+func copyCachePath(src, dst string, opts snapshotCopyOptions) error {
 	info, err := os.Lstat(src)
 	if err != nil {
 		return err
@@ -358,7 +373,12 @@ func copyCachePath(src, dst string, linkRegularFiles bool) error {
 			return err
 		}
 		for _, entry := range entries {
-			if err := copyCachePath(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name()), linkRegularFiles); err != nil {
+			if entry.IsDir() {
+				if _, skip := opts.skipDirNames[entry.Name()]; skip {
+					continue
+				}
+			}
+			if err := copyCachePath(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name()), opts); err != nil {
 				return err
 			}
 		}
@@ -367,7 +387,7 @@ func copyCachePath(src, dst string, linkRegularFiles bool) error {
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err
 		}
-		return copyRegularCacheFile(src, dst, info.Mode().Perm(), linkRegularFiles)
+		return copyRegularCacheFile(src, dst, info.Mode().Perm(), opts.linkRegularFiles)
 	default:
 		return fmt.Errorf("cache path %q is not a regular file, directory, or symlink", src)
 	}

--- a/internal/acquisition/session.go
+++ b/internal/acquisition/session.go
@@ -25,6 +25,14 @@ type Session struct {
 	PreserveGitDirInSnapshots bool
 }
 
+// SnapshotSession owns one snapshot root and cache shared by every provider
+// in a single command invocation.
+type SnapshotSession struct {
+	Root      string
+	Cache     *SnapshotCache
+	closeOnce sync.Once
+}
+
 type TargetLocks struct {
 	mu    sync.Mutex
 	locks map[string]*targetLock
@@ -50,6 +58,21 @@ func NewSnapshotCache() *SnapshotCache {
 		gits:   map[string]source.GitResult{},
 		charts: map[string]chart.Result{},
 	}
+}
+
+func NewSnapshotSession(prefix string) (*SnapshotSession, error) {
+	root, err := os.MkdirTemp("", prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &SnapshotSession{Root: root, Cache: NewSnapshotCache()}, nil
+}
+
+func (session *SnapshotSession) Close() {
+	if session == nil {
+		return
+	}
+	session.closeOnce.Do(func() { _ = os.RemoveAll(session.Root) })
 }
 
 func (cache *SnapshotCache) git(key string) (source.GitResult, bool) {

--- a/internal/acquisition/session_test.go
+++ b/internal/acquisition/session_test.go
@@ -2,7 +2,9 @@ package acquisition
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -200,6 +202,48 @@ func TestSessionGitSnapshotCopiesRegularFiles(t *testing.T) {
 		t.Fatalf("Acquire() error = %v", err)
 	}
 	assertDifferentSnapshotFile(t, manifestPath, filepath.Join(result.Path, "manifest.yaml"))
+}
+
+func TestGitSnapshotExcludesDotGit(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, ".git", "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".git", "objects", "pack"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "app.yaml"), []byte("kind: ConfigMap\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := snapshotCachePath(t.TempDir(), "git", src, snapshotCopyOptions{skipDirNames: map[string]struct{}{".git": {}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(snapshot, "app.yaml")); err != nil {
+		t.Fatalf("worktree file missing from snapshot: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(snapshot, ".git")); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf(".git present in snapshot, want excluded (stat err = %v)", err)
+	}
+}
+
+func TestGitSnapshotPreservesDotGitWhenNotSkipped(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, ".git", "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".git", "objects", "pack"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := snapshotCachePath(t.TempDir(), "git", src, snapshotCopyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(snapshot, ".git", "objects", "pack")); err != nil {
+		t.Fatalf(".git file missing from snapshot: %v", err)
+	}
 }
 
 type countingChartAcquirer struct {

--- a/internal/acquisition/session_test.go
+++ b/internal/acquisition/session_test.go
@@ -25,6 +25,28 @@ type blockingGitAcquirer struct {
 	calls         int
 }
 
+func TestSnapshotSessionCloseRemovesRootOnce(t *testing.T) {
+	session, err := NewSnapshotSession("drydock-test-snapshots-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Root == "" {
+		t.Fatal("Root = empty")
+	}
+	if session.Cache == nil {
+		t.Fatal("Cache = nil")
+	}
+	if _, err := os.Stat(session.Root); err != nil {
+		t.Fatalf("snapshot root does not exist: %v", err)
+	}
+
+	session.Close()
+	if _, err := os.Stat(session.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot root still exists after Close: %v", err)
+	}
+	session.Close()
+}
+
 func (a *blockingGitAcquirer) Acquire(_ context.Context, request source.GitRequest, _ source.GitOptions) (source.GitResult, error) {
 	a.mu.Lock()
 	a.calls++

--- a/internal/app/benchmark_test.go
+++ b/internal/app/benchmark_test.go
@@ -43,6 +43,41 @@ data:
 	}
 }
 
+func BenchmarkOrchestratorBuildManyLocalApplicationsParallel(b *testing.B) {
+	root := b.TempDir()
+	for i := range 100 {
+		name := fmt.Sprintf("demo-%03d", i)
+		writeBenchmarkApplication(b, root, name)
+		writeBenchmarkFile(b, filepath.Join(root, "manifests", name, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+		writeBenchmarkFile(b, filepath.Join(root, "manifests", name, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: benchmark
+`)
+	}
+	orchestrator := Orchestrator{}
+	request := BuildRequest{Path: root}
+	request.Parallelism = 8
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result, err := orchestrator.Build(context.Background(), request)
+		if err != nil {
+			b.Fatalf("Build() error = %v", err)
+		}
+		if len(result.ApplicationManifests) != 100 {
+			b.Fatalf("ApplicationManifests = %d, want 100", len(result.ApplicationManifests))
+		}
+	}
+}
+
 func BenchmarkOrchestratorExpandApplicationSetList(b *testing.B) {
 	root := b.TempDir()
 	writeBenchmarkApplicationSetList(b, root, 250)

--- a/internal/app/build_side.go
+++ b/internal/app/build_side.go
@@ -11,6 +11,7 @@ func (o Orchestrator) loadBuildSideDiscovery(ctx context.Context, root string, r
 	discovered, discoveryDiags, cacheEvents, renderCache, renderSettingsSignature, err := o.discoverRepository(ctx, root, request)
 	result.renderCache = renderCache
 	result.renderSettingsSignature = renderSettingsSignature
+	result.discovered = &discovered
 	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
 	discoveryDiags = request.normalizeDiagnostics(discoveryDiags, false)
 	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)

--- a/internal/app/build_side.go
+++ b/internal/app/build_side.go
@@ -12,6 +12,7 @@ func (o Orchestrator) loadBuildSideDiscovery(ctx context.Context, root string, r
 	result.renderCache = renderCache
 	result.renderSettingsSignature = renderSettingsSignature
 	result.discovered = &discovered
+	result.pluginOptions = request.PluginOptions
 	result.CacheEvents = append(result.CacheEvents, cacheEvents...)
 	discoveryDiags = request.normalizeDiagnostics(discoveryDiags, false)
 	result.Diagnostics = append(result.Diagnostics, discoveryDiags...)

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -174,16 +174,9 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
 	rightBuildRequest.discovered = rightList.result.discovered
 
-	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.result.Applications, name)
+	leftApp, leftOK, rightApp, rightOK, err := selectDiffAppApplications(leftList.result.Applications, rightList.result.Applications, name)
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
-	}
-	rightApp, rightOK, err := SelectOptionalApplicationByName(rightList.result.Applications, name)
-	if err != nil {
-		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
-	}
-	if !leftOK && !rightOK {
-		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, fmt.Errorf("application %q not found in either tree", name)
 	}
 
 	leftBuildRequest.Applications = selectedApplications(leftApp, leftOK)
@@ -313,24 +306,13 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 	}
 
 	if computeChangedPaths && request.ChangedOnly {
-		changedPaths, ok, err := gitRefChangedPaths(ctx, request, repoPath)
+		resolved, done, err := resolveEmptyChangedOnlyRefDiff(ctx, request, repoPath)
 		if err != nil {
 			return request, cleanup, err
 		}
-		if ok {
-			request.changedPaths = changedPaths
-			filtered, err := filteredChangedOnlyPaths(request)
-			if err != nil {
-				return request, cleanup, err
-			}
-			if len(filtered) == 0 {
-				// Nothing relevant changed between the refs. Point both sides
-				// at the repository tree and skip snapshot materialization;
-				// buildDiffSides returns before any discovery or render.
-				request.LeftPath = repoPath
-				request.RightPath = repoPath
-				return request, cleanup, nil
-			}
+		request = resolved
+		if done {
+			return request, cleanup, nil
 		}
 	}
 
@@ -361,6 +343,27 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 		cleanups = append(cleanups, result.Cleanup)
 	}
 	return request, cleanup, nil
+}
+
+func resolveEmptyChangedOnlyRefDiff(ctx context.Context, request DiffRequest, repoPath string) (DiffRequest, bool, error) {
+	changedPaths, ok, err := gitRefChangedPaths(ctx, request, repoPath)
+	if err != nil || !ok {
+		return request, false, err
+	}
+	request.changedPaths = changedPaths
+	filtered, err := filteredChangedOnlyPaths(request)
+	if err != nil {
+		return request, false, err
+	}
+	if len(filtered) > 0 {
+		return request, false, nil
+	}
+	// Nothing relevant changed between the refs. Point both sides at the
+	// repository tree and skip snapshot materialization; buildDiffSides returns
+	// before any discovery or render.
+	request.LeftPath = repoPath
+	request.RightPath = repoPath
+	return request, true, nil
 }
 
 func validateDiffRefOptions(request DiffRequest, hasRef bool) error {
@@ -497,6 +500,21 @@ func selectedApplications(application argoappv1.Application, ok bool) []argoappv
 		return []argoappv1.Application{}
 	}
 	return []argoappv1.Application{application}
+}
+
+func selectDiffAppApplications(leftApps, rightApps []argoappv1.Application, name string) (argoappv1.Application, bool, argoappv1.Application, bool, error) {
+	leftApp, leftOK, err := SelectOptionalApplicationByName(leftApps, name)
+	if err != nil {
+		return argoappv1.Application{}, false, argoappv1.Application{}, false, err
+	}
+	rightApp, rightOK, err := SelectOptionalApplicationByName(rightApps, name)
+	if err != nil {
+		return argoappv1.Application{}, false, argoappv1.Application{}, false, err
+	}
+	if !leftOK && !rightOK {
+		return argoappv1.Application{}, false, argoappv1.Application{}, false, fmt.Errorf("application %q not found in either tree", name)
+	}
+	return leftApp, leftOK, rightApp, rightOK, nil
 }
 
 func diffBuildResults(leftBuild, rightBuild BuildResult, opts diff.Options) ([]diff.Result, error) {

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -159,8 +159,10 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	}
 	leftBuildRequest.renderCache = leftList.result.renderCache
 	leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
+	leftBuildRequest.discovered = leftList.result.discovered
 	rightBuildRequest.renderCache = rightList.result.renderCache
 	rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
+	rightBuildRequest.discovered = rightList.result.discovered
 
 	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.result.Applications, name)
 	if err != nil {
@@ -178,6 +180,8 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	rightBuildRequest.Applications = selectedApplications(rightApp, rightOK)
 
 	leftBuild, rightBuild := runDiffSidePair(ctx, concurrent, o.Build, leftBuildRequest, rightBuildRequest)
+	leftBuild.result.CacheEvents = append(append([]cacheevent.Event(nil), leftList.result.CacheEvents...), leftBuild.result.CacheEvents...)
+	rightBuild.result.CacheEvents = append(append([]cacheevent.Event(nil), rightList.result.CacheEvents...), rightBuild.result.CacheEvents...)
 	diagnostics = append(diagnostics, leftBuild.result.Diagnostics...)
 	diagnostics = append(diagnostics, rightBuild.result.Diagnostics...)
 	cacheEvents := cacheEventsFromBuilds(leftBuild.result, rightBuild.result)

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -305,6 +305,18 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 		}
 		if ok {
 			request.changedPaths = changedPaths
+			filtered, err := filteredChangedOnlyPaths(request)
+			if err != nil {
+				return request, cleanup, err
+			}
+			if len(filtered) == 0 {
+				// Nothing relevant changed between the refs. Point both sides
+				// at the repository tree and skip snapshot materialization;
+				// buildDiffSides returns before any discovery or render.
+				request.LeftPath = repoPath
+				request.RightPath = repoPath
+				return request, cleanup, nil
+			}
 		}
 	}
 

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -142,28 +142,31 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 
 	leftBuildRequest := request.buildRequest(request.LeftPath, forbiddenRoots)
 	rightBuildRequest := request.buildRequest(request.RightPath, forbiddenRoots)
+	parallelism, err := normalizeParallelism(request.Parallelism)
+	if err != nil {
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
+	}
+	leftParallelism, rightParallelism, concurrent := splitSideParallelism(parallelism)
+	leftBuildRequest.Parallelism = leftParallelism
+	rightBuildRequest.Parallelism = rightParallelism
 
 	diagnostics := append([]diagnostic.Diagnostic(nil), policyDiags...)
-	leftList, err := o.ListApplications(ctx, leftBuildRequest)
-	diagnostics = append(diagnostics, leftList.Diagnostics...)
-	if err != nil {
+	leftList, rightList := runDiffSidePair(ctx, concurrent, o.ListApplications, leftBuildRequest, rightBuildRequest)
+	diagnostics = append(diagnostics, leftList.result.Diagnostics...)
+	diagnostics = append(diagnostics, rightList.result.Diagnostics...)
+	if err := errors.Join(leftList.err, rightList.err); err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
-	leftBuildRequest.renderCache = leftList.renderCache
-	leftBuildRequest.renderSettingsSignature = leftList.renderSettingsSignature
-	rightList, err := o.ListApplications(ctx, rightBuildRequest)
-	diagnostics = append(diagnostics, rightList.Diagnostics...)
-	if err != nil {
-		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
-	}
-	rightBuildRequest.renderCache = rightList.renderCache
-	rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
+	leftBuildRequest.renderCache = leftList.result.renderCache
+	leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
+	rightBuildRequest.renderCache = rightList.result.renderCache
+	rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
 
-	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.Applications, name)
+	leftApp, leftOK, err := SelectOptionalApplicationByName(leftList.result.Applications, name)
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
-	rightApp, rightOK, err := SelectOptionalApplicationByName(rightList.Applications, name)
+	rightApp, rightOK, err := SelectOptionalApplicationByName(rightList.result.Applications, name)
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
@@ -174,18 +177,15 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	leftBuildRequest.Applications = selectedApplications(leftApp, leftOK)
 	rightBuildRequest.Applications = selectedApplications(rightApp, rightOK)
 
-	leftBuild, err := o.Build(ctx, leftBuildRequest)
-	diagnostics = append(diagnostics, leftBuild.Diagnostics...)
-	leftErr := err
-	rightBuild, err := o.Build(ctx, rightBuildRequest)
-	diagnostics = append(diagnostics, rightBuild.Diagnostics...)
-	rightErr := err
-	cacheEvents := cacheEventsFromBuilds(leftBuild, rightBuild)
-	if err := errors.Join(leftErr, rightErr); err != nil {
+	leftBuild, rightBuild := runDiffSidePair(ctx, concurrent, o.Build, leftBuildRequest, rightBuildRequest)
+	diagnostics = append(diagnostics, leftBuild.result.Diagnostics...)
+	diagnostics = append(diagnostics, rightBuild.result.Diagnostics...)
+	cacheEvents := cacheEventsFromBuilds(leftBuild.result, rightBuild.result)
+	if err := errors.Join(leftBuild.err, rightBuild.err); err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics), CacheEvents: cacheEvents}, err
 	}
 
-	results, err := diffBuildResults(leftBuild, rightBuild, diff.Options{
+	results, err := diffBuildResults(leftBuild.result, rightBuild.result, diff.Options{
 		Unified:           request.Unified,
 		StripAttrs:        request.StripAttrs,
 		ShowIgnoredFields: request.ShowIgnoredFields,

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/diagnostic"
@@ -149,6 +150,13 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	leftParallelism, rightParallelism, concurrent := splitSideParallelism(parallelism)
 	leftBuildRequest.Parallelism = leftParallelism
 	rightBuildRequest.Parallelism = rightParallelism
+	snapshotSession, err := acquisition.NewSnapshotSession("drydock-cache-snapshots-*")
+	if err != nil {
+		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
+	}
+	defer snapshotSession.Close()
+	leftBuildRequest.snapshotSession = snapshotSession
+	rightBuildRequest.snapshotSession = snapshotSession
 
 	diagnostics := append([]diagnostic.Diagnostic(nil), policyDiags...)
 	leftList, rightList := runDiffSidePair(ctx, concurrent, o.ListApplications, leftBuildRequest, rightBuildRequest)

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -157,9 +157,11 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	if err := errors.Join(leftList.err, rightList.err); err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(diagnostics)}, err
 	}
+	leftBuildRequest.PluginOptions = leftList.result.pluginOptions
 	leftBuildRequest.renderCache = leftList.result.renderCache
 	leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
 	leftBuildRequest.discovered = leftList.result.discovered
+	rightBuildRequest.PluginOptions = rightList.result.pluginOptions
 	rightBuildRequest.renderCache = rightList.result.renderCache
 	rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
 	rightBuildRequest.discovered = rightList.result.discovered

--- a/internal/app/diff_concurrent.go
+++ b/internal/app/diff_concurrent.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"context"
+	"sync"
+)
+
+// splitSideParallelism divides one render-parallelism budget across the two
+// diff sides. Below 2 there is nothing to split and sides run sequentially.
+func splitSideParallelism(parallelism int) (left, right int, concurrent bool) {
+	if parallelism < 2 {
+		return parallelism, parallelism, false
+	}
+	left = (parallelism + 1) / 2
+	return left, parallelism - left, true
+}
+
+type diffSideOutcome struct {
+	result BuildResult
+	err    error
+}
+
+func runDiffSidePair(ctx context.Context, concurrent bool, run func(context.Context, BuildRequest) (BuildResult, error), leftRequest, rightRequest BuildRequest) (diffSideOutcome, diffSideOutcome) {
+	if !concurrent {
+		var left, right diffSideOutcome
+		left.result, left.err = run(ctx, leftRequest)
+		right.result, right.err = run(ctx, rightRequest)
+		return left, right
+	}
+	var left, right diffSideOutcome
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		left.result, left.err = run(ctx, leftRequest)
+	}()
+	go func() {
+		defer wg.Done()
+		right.result, right.err = run(ctx, rightRequest)
+	}()
+	wg.Wait()
+	return left, right
+}

--- a/internal/app/diff_concurrent_test.go
+++ b/internal/app/diff_concurrent_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestSplitSideParallelism(t *testing.T) {
+	tests := []struct {
+		in, left, right int
+		concurrent      bool
+	}{
+		{0, 0, 0, false},
+		{1, 1, 1, false},
+		{2, 1, 1, true},
+		{3, 2, 1, true},
+		{8, 4, 4, true},
+	}
+	for _, test := range tests {
+		left, right, concurrent := splitSideParallelism(test.in)
+		if left != test.left || right != test.right || concurrent != test.concurrent {
+			t.Fatalf("splitSideParallelism(%d) = (%d, %d, %t), want (%d, %d, %t)",
+				test.in, left, right, concurrent, test.left, test.right, test.concurrent)
+		}
+	}
+}
+
+func TestDiffAppsParallelSideBuildsMatchSequential(t *testing.T) {
+	root := t.TempDir()
+	left := root + "/left"
+	right := root + "/right"
+	writeSimpleApp(t, left, "old")
+	writeSimpleApp(t, right, "new")
+
+	sequential, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:         left,
+		RightPath:        right,
+		ExecutionOptions: ExecutionOptions{Parallelism: 1},
+		Unified:          3,
+	})
+	if err != nil {
+		t.Fatalf("sequential DiffApps() error = %v", err)
+	}
+	parallel, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:         left,
+		RightPath:        right,
+		ExecutionOptions: ExecutionOptions{Parallelism: 8},
+		Unified:          3,
+	})
+	if err != nil {
+		t.Fatalf("parallel DiffApps() error = %v", err)
+	}
+	if !reflect.DeepEqual(parallel.Results, sequential.Results) {
+		t.Fatalf("parallel Results = %#v, want %#v", parallel.Results, sequential.Results)
+	}
+}

--- a/internal/app/diff_side.go
+++ b/internal/app/diff_side.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/change"
 	"github.com/sholdee/drydock/internal/diagnostic"
 )
@@ -27,6 +28,7 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 	rightBuildRequest.Parallelism = rightParallelism
 
 	var diagnostics []diagnostic.Diagnostic
+	var leftList, rightList diffSideOutcome
 	if request.ChangedOnly {
 		changedPaths, err := filteredChangedOnlyPaths(request)
 		if err != nil {
@@ -36,7 +38,7 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 			return BuildResult{}, BuildResult{}, diagnostics, nil
 		}
 
-		leftList, rightList := runDiffSidePair(ctx, concurrent, o.ListApplications, leftBuildRequest, rightBuildRequest)
+		leftList, rightList = runDiffSidePair(ctx, concurrent, o.ListApplications, leftBuildRequest, rightBuildRequest)
 		diagnostics = append(diagnostics, leftList.result.Diagnostics...)
 		diagnostics = append(diagnostics, rightList.result.Diagnostics...)
 		if err := errors.Join(leftList.err, rightList.err); err != nil {
@@ -44,8 +46,10 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 		}
 		leftBuildRequest.renderCache = leftList.result.renderCache
 		leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
+		leftBuildRequest.discovered = leftList.result.discovered
 		rightBuildRequest.renderCache = rightList.result.renderCache
 		rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
+		rightBuildRequest.discovered = rightList.result.discovered
 
 		leftSelected, leftUnowned := SelectChangedApplicationInputs(leftList.result.ApplicationInputs, changedPaths)
 		rightSelected, rightUnowned := SelectChangedApplicationInputs(rightList.result.ApplicationInputs, changedPaths)
@@ -70,6 +74,8 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 	}
 
 	leftBuild, rightBuild := runDiffSidePair(ctx, concurrent, o.Build, leftBuildRequest, rightBuildRequest)
+	leftBuild.result.CacheEvents = append(append([]cacheevent.Event(nil), leftList.result.CacheEvents...), leftBuild.result.CacheEvents...)
+	rightBuild.result.CacheEvents = append(append([]cacheevent.Event(nil), rightList.result.CacheEvents...), rightBuild.result.CacheEvents...)
 	diagnostics = append(diagnostics, leftBuild.result.Diagnostics...)
 	diagnostics = append(diagnostics, rightBuild.result.Diagnostics...)
 	if err := errors.Join(leftBuild.err, rightBuild.err); err != nil {

--- a/internal/app/diff_side.go
+++ b/internal/app/diff_side.go
@@ -44,9 +44,11 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 		if err := errors.Join(leftList.err, rightList.err); err != nil {
 			return BuildResult{}, BuildResult{}, diagnostics, err
 		}
+		leftBuildRequest.PluginOptions = leftList.result.pluginOptions
 		leftBuildRequest.renderCache = leftList.result.renderCache
 		leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
 		leftBuildRequest.discovered = leftList.result.discovered
+		rightBuildRequest.PluginOptions = rightList.result.pluginOptions
 		rightBuildRequest.renderCache = rightList.result.renderCache
 		rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
 		rightBuildRequest.discovered = rightList.result.discovered

--- a/internal/app/diff_side.go
+++ b/internal/app/diff_side.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/change"
 	"github.com/sholdee/drydock/internal/diagnostic"
@@ -26,6 +27,13 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 	leftParallelism, rightParallelism, concurrent := splitSideParallelism(parallelism)
 	leftBuildRequest.Parallelism = leftParallelism
 	rightBuildRequest.Parallelism = rightParallelism
+	snapshotSession, err := acquisition.NewSnapshotSession("drydock-cache-snapshots-*")
+	if err != nil {
+		return BuildResult{}, BuildResult{}, nil, err
+	}
+	defer snapshotSession.Close()
+	leftBuildRequest.snapshotSession = snapshotSession
+	rightBuildRequest.snapshotSession = snapshotSession
 
 	var diagnostics []diagnostic.Diagnostic
 	var leftList, rightList diffSideOutcome

--- a/internal/app/diff_side.go
+++ b/internal/app/diff_side.go
@@ -18,6 +18,13 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 
 	leftBuildRequest := request.buildRequest(request.LeftPath, forbiddenRoots)
 	rightBuildRequest := request.buildRequest(request.RightPath, forbiddenRoots)
+	parallelism, err := normalizeParallelism(request.Parallelism)
+	if err != nil {
+		return BuildResult{}, BuildResult{}, nil, err
+	}
+	leftParallelism, rightParallelism, concurrent := splitSideParallelism(parallelism)
+	leftBuildRequest.Parallelism = leftParallelism
+	rightBuildRequest.Parallelism = rightParallelism
 
 	var diagnostics []diagnostic.Diagnostic
 	if request.ChangedOnly {
@@ -29,23 +36,19 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 			return BuildResult{}, BuildResult{}, diagnostics, nil
 		}
 
-		leftList, err := o.ListApplications(ctx, leftBuildRequest)
-		diagnostics = append(diagnostics, leftList.Diagnostics...)
-		if err != nil {
+		leftList, rightList := runDiffSidePair(ctx, concurrent, o.ListApplications, leftBuildRequest, rightBuildRequest)
+		diagnostics = append(diagnostics, leftList.result.Diagnostics...)
+		diagnostics = append(diagnostics, rightList.result.Diagnostics...)
+		if err := errors.Join(leftList.err, rightList.err); err != nil {
 			return BuildResult{}, BuildResult{}, diagnostics, err
 		}
-		leftBuildRequest.renderCache = leftList.renderCache
-		leftBuildRequest.renderSettingsSignature = leftList.renderSettingsSignature
-		rightList, err := o.ListApplications(ctx, rightBuildRequest)
-		diagnostics = append(diagnostics, rightList.Diagnostics...)
-		if err != nil {
-			return BuildResult{}, BuildResult{}, diagnostics, err
-		}
-		rightBuildRequest.renderCache = rightList.renderCache
-		rightBuildRequest.renderSettingsSignature = rightList.renderSettingsSignature
+		leftBuildRequest.renderCache = leftList.result.renderCache
+		leftBuildRequest.renderSettingsSignature = leftList.result.renderSettingsSignature
+		rightBuildRequest.renderCache = rightList.result.renderCache
+		rightBuildRequest.renderSettingsSignature = rightList.result.renderSettingsSignature
 
-		leftSelected, leftUnowned := SelectChangedApplicationInputs(leftList.ApplicationInputs, changedPaths)
-		rightSelected, rightUnowned := SelectChangedApplicationInputs(rightList.ApplicationInputs, changedPaths)
+		leftSelected, leftUnowned := SelectChangedApplicationInputs(leftList.result.ApplicationInputs, changedPaths)
+		rightSelected, rightUnowned := SelectChangedApplicationInputs(rightList.result.ApplicationInputs, changedPaths)
 		unowned := unownedByNeitherSide(leftUnowned, rightUnowned)
 		if len(unowned) > 0 {
 			diag := diagnostic.Diagnostic{
@@ -58,24 +61,21 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 				diagnostics[len(diagnostics)-1].Severity = diagnostic.SeverityError
 				return BuildResult{}, BuildResult{}, diagnostics, fmt.Errorf("changed-only input ownership incomplete")
 			}
-			leftBuildRequest.Applications = leftList.Applications
-			rightBuildRequest.Applications = rightList.Applications
+			leftBuildRequest.Applications = leftList.result.Applications
+			rightBuildRequest.Applications = rightList.result.Applications
 		} else {
 			leftBuildRequest.Applications = leftSelected
 			rightBuildRequest.Applications = rightSelected
 		}
 	}
 
-	leftBuild, err := o.Build(ctx, leftBuildRequest)
-	diagnostics = append(diagnostics, leftBuild.Diagnostics...)
-	leftErr := err
-	rightBuild, err := o.Build(ctx, rightBuildRequest)
-	diagnostics = append(diagnostics, rightBuild.Diagnostics...)
-	rightErr := err
-	if err := errors.Join(leftErr, rightErr); err != nil {
-		return leftBuild, rightBuild, diagnostics, err
+	leftBuild, rightBuild := runDiffSidePair(ctx, concurrent, o.Build, leftBuildRequest, rightBuildRequest)
+	diagnostics = append(diagnostics, leftBuild.result.Diagnostics...)
+	diagnostics = append(diagnostics, rightBuild.result.Diagnostics...)
+	if err := errors.Join(leftBuild.err, rightBuild.err); err != nil {
+		return leftBuild.result, rightBuild.result, diagnostics, err
 	}
-	return leftBuild, rightBuild, diagnostics, nil
+	return leftBuild.result, rightBuild.result, diagnostics, nil
 }
 
 func filteredChangedOnlyPaths(request DiffRequest) ([]string, error) {

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -712,6 +712,35 @@ func TestDiffAppsRefAndRefOrigCompareCommittedRefs(t *testing.T) {
 	}
 }
 
+func TestResolveDiffRequestPathsSkipsSnapshotsWhenChangedOnlyIsEmpty(t *testing.T) {
+	repoPath := t.TempDir()
+	repo, wt := initDiffGitRepo(t, repoPath)
+	writeTestFile(t, filepath.Join(repoPath, "app.yaml"), "kind: ConfigMap\n")
+	hash := commitDiffGitRepo(t, repo, wt, "init")
+
+	request := DiffRequest{
+		RightPath:   repoPath,
+		Ref:         hash.String(),
+		RefOrig:     hash.String(),
+		ChangedOnly: true,
+	}
+	resolved, cleanup, err := resolveDiffRequestPaths(context.Background(), request, true)
+	if err != nil {
+		t.Fatalf("resolveDiffRequestPaths() error = %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	if resolved.LeftPath != repoPath {
+		t.Fatalf("LeftPath = %q, want repo path %q (snapshot must be skipped)", resolved.LeftPath, repoPath)
+	}
+	if resolved.RightPath != repoPath {
+		t.Fatalf("RightPath = %q, want repo path %q (snapshot must be skipped)", resolved.RightPath, repoPath)
+	}
+	if resolved.changedPaths == nil {
+		t.Fatal("changedPaths = nil, want empty non-nil so change.Detect is skipped")
+	}
+}
+
 func TestDiffAppsRefOrigChangedOnlyUsesGitTrackedPaths(t *testing.T) {
 	root := t.TempDir()
 	repo, wt := initDiffGitRepo(t, root)

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -1007,8 +1007,8 @@ func TestDiffAppsPassesChartForbiddenRootsToBuilds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiffApps() error = %v", err)
 	}
-	if len(acquirer.options) != 2 {
-		t.Fatalf("chart options = %d, want 2", len(acquirer.options))
+	if len(acquirer.options) != 1 {
+		t.Fatalf("chart options = %d, want 1", len(acquirer.options))
 	}
 	wantRoots := []string{explicitRoot, left, right, mappedRoot}
 	for _, opts := range acquirer.options {

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 
 	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/cacheevent"
@@ -27,6 +28,8 @@ func (o Orchestrator) discoverRepository(ctx context.Context, root string, reque
 	if renderCache == nil {
 		renderCache = newApplicationRenderCache()
 	}
+	request.discoveryPathMemo = &sync.Map{}
+	request.appsetGenerationMemo = &sync.Map{}
 
 	discovered, err := discovery.Scan(root, discovery.Options{})
 	if err != nil {

--- a/internal/app/discovery_appset.go
+++ b/internal/app/discovery_appset.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/diagnostic"
@@ -13,7 +16,7 @@ func expandApplicationSetDiscovery(root string, request BuildRequest, discovered
 	var generated discovery.Result
 	var allDiags []diagnostic.Diagnostic
 	for _, appSetFile := range discovered.ApplicationSets {
-		apps, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
+		apps, diags, err := generateApplicationSetCached(request.appsetGenerationMemo, root, appSetFile, appsetOptions)
 		if err != nil {
 			if errors.Is(err, appset.ErrUnsupportedGenerator) && len(diags) > 0 {
 				allDiags = append(allDiags, request.normalizeDiagnostics(diags, true)...)
@@ -47,6 +50,69 @@ func expandApplicationSetDiscovery(root string, request BuildRequest, discovered
 	merged, mergeDiags := mergeDiscoveryResultsWithDiagnostics(discovered, generated)
 	allDiags = append(allDiags, mergeDiags...)
 	return merged, allDiags, nil
+}
+
+type appsetGenerationOutcome struct {
+	apps  []appset.GeneratedApplication
+	diags []diagnostic.Diagnostic
+	err   error
+}
+
+func generateApplicationSetCached(memo *sync.Map, root string, appSetFile discovery.ApplicationSetFile, appsetOptions appset.Options) ([]appset.GeneratedApplication, []diagnostic.Diagnostic, error) {
+	key, keyErr := appsetGenerationMemoKey(appSetFile, appsetOptions)
+	if memo == nil || keyErr != nil {
+		return appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
+	}
+	if cached, ok := memo.Load(key); ok {
+		outcome := cached.(appsetGenerationOutcome)
+		return copyGeneratedApplications(outcome.apps), copyDiagnostics(outcome.diags), outcome.err
+	}
+	apps, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
+	memo.Store(key, appsetGenerationOutcome{
+		apps:  copyGeneratedApplications(apps),
+		diags: copyDiagnostics(diags),
+		err:   err,
+	})
+	return copyGeneratedApplications(apps), copyDiagnostics(diags), err
+}
+
+func appsetGenerationMemoKey(appSetFile discovery.ApplicationSetFile, appsetOptions appset.Options) (string, error) {
+	content, err := json.Marshal(struct {
+		ApplicationSet any            `json:"applicationSet"`
+		Options        appset.Options `json:"options"`
+	}{
+		ApplicationSet: appSetFile.ApplicationSet,
+		Options:        appsetOptions,
+	})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%s|%d|%x", appSetFile.Path, appSetFile.DocumentIndex, sum[:]), nil
+}
+
+func copyGeneratedApplications(apps []appset.GeneratedApplication) []appset.GeneratedApplication {
+	if len(apps) == 0 {
+		return nil
+	}
+	out := make([]appset.GeneratedApplication, len(apps))
+	for i, app := range apps {
+		out[i] = app
+		if copy := app.Application.DeepCopy(); copy != nil {
+			out[i].Application = *copy
+		}
+		out[i].SourcePaths = append([]string(nil), app.SourcePaths...)
+	}
+	return out
+}
+
+func copyDiagnostics(diags []diagnostic.Diagnostic) []diagnostic.Diagnostic {
+	if len(diags) == 0 {
+		return nil
+	}
+	out := make([]diagnostic.Diagnostic, len(diags))
+	copy(out, diags)
+	return out
 }
 
 func emptyApplicationSetDiagnostic(appSetFile discovery.ApplicationSetFile) diagnostic.Diagnostic {

--- a/internal/app/discovery_appset.go
+++ b/internal/app/discovery_appset.go
@@ -64,8 +64,9 @@ func generateApplicationSetCached(memo *sync.Map, root string, appSetFile discov
 		return appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
 	}
 	if cached, ok := memo.Load(key); ok {
-		outcome := cached.(appsetGenerationOutcome)
-		return copyGeneratedApplications(outcome.apps), copyDiagnostics(outcome.diags), outcome.err
+		if outcome, ok := cached.(appsetGenerationOutcome); ok {
+			return copyGeneratedApplications(outcome.apps), copyDiagnostics(outcome.diags), outcome.err
+		}
 	}
 	apps, diags, err := appset.GenerateWithOptions(root, appSetFile.Path, appSetFile.ApplicationSet, appsetOptions)
 	memo.Store(key, appsetGenerationOutcome{

--- a/internal/app/discovery_appset_test.go
+++ b/internal/app/discovery_appset_test.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/appset"
+	"github.com/sholdee/drydock/internal/discovery"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestGenerateApplicationSetCachedReturnsIndependentApplications(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "apps", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appSetFile := discovery.ApplicationSetFile{
+		Path:           "appset.yaml",
+		DocumentIndex:  1,
+		ApplicationSet: testApplicationSet(t),
+	}
+	memo := &sync.Map{}
+
+	first, _, err := generateApplicationSetCached(memo, root, appSetFile, appset.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("len(first) = %d, want 1", len(first))
+	}
+	first[0].Application.Name = "mutated"
+	first[0].Application.Spec.Source.Path = "mutated"
+	first[0].SourcePaths[0] = "mutated"
+
+	second, _, err := generateApplicationSetCached(memo, root, appSetFile, appset.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := second[0].Application.Name, "api"; got != want {
+		t.Fatalf("cached application name = %q, want %q", got, want)
+	}
+	if got, want := second[0].Application.Spec.GetSource().Path, "apps/api"; got != want {
+		t.Fatalf("cached application path = %q, want %q", got, want)
+	}
+	if got, want := second[0].SourcePaths[0], "apps/api"; got != want {
+		t.Fatalf("cached source path = %q, want %q", got, want)
+	}
+}
+
+func TestApplicationSetGenerationMemoKeyIncludesProviderOptions(t *testing.T) {
+	appSetFile := discovery.ApplicationSetFile{
+		Path:           "appset.yaml",
+		DocumentIndex:  1,
+		ApplicationSet: testApplicationSet(t),
+	}
+	left, err := appsetGenerationMemoKey(appSetFile, appset.Options{
+		Provider: appset.ProviderOptions{Data: appset.ProviderData{Clusters: []appset.ClusterInput{{Name: "dev"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := appsetGenerationMemoKey(appSetFile, appset.Options{
+		Provider: appset.ProviderOptions{Data: appset.ProviderData{Clusters: []appset.ClusterInput{{Name: "prod"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left == right {
+		t.Fatalf("memo keys should differ when provider options differ: %q", left)
+	}
+}
+
+func testApplicationSet(t *testing.T) argoappv1.ApplicationSet {
+	t.Helper()
+	data := []byte(`
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        directories:
+          - path: apps/*
+  template:
+    metadata:
+      name: "{{.path.basename}}"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: default
+`)
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	normalized, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var appSet argoappv1.ApplicationSet
+	if err := json.Unmarshal(normalized, &appSet); err != nil {
+		t.Fatal(err)
+	}
+	return appSet
+}

--- a/internal/app/discovery_frontier.go
+++ b/internal/app/discovery_frontier.go
@@ -146,7 +146,7 @@ func applicationMayRenderDiscoveryObjects(root string, request BuildRequest, dis
 		if !ok {
 			continue
 		}
-		matches, err := pathMayContainDiscoveryObjects(sourceRoot)
+		matches, err := pathMayContainDiscoveryObjectsCached(request.discoveryPathMemo, sourceRoot)
 		if err != nil || matches {
 			if localSourceAlreadyDiscovered(root, sourceRoot, discovered) && !sourceRootHasLocalChart(sourceRoot) {
 				continue

--- a/internal/app/discovery_memo.go
+++ b/internal/app/discovery_memo.go
@@ -15,8 +15,9 @@ func pathMayContainDiscoveryObjectsCached(memo *sync.Map, root string) (bool, er
 		return pathMayContainDiscoveryObjects(root)
 	}
 	if cached, ok := memo.Load(root); ok {
-		verdict := cached.(discoveryPathVerdict)
-		return verdict.matches, verdict.err
+		if verdict, ok := cached.(discoveryPathVerdict); ok {
+			return verdict.matches, verdict.err
+		}
 	}
 	matches, err := pathMayContainDiscoveryObjects(root)
 	memo.Store(root, discoveryPathVerdict{matches: matches, err: err})

--- a/internal/app/discovery_memo.go
+++ b/internal/app/discovery_memo.go
@@ -1,0 +1,24 @@
+package app
+
+import "sync"
+
+type discoveryPathVerdict struct {
+	matches bool
+	err     error
+}
+
+// pathMayContainDiscoveryObjectsCached memoizes per source root for one
+// discoverRepository invocation. Source trees are static during discovery;
+// renders write only to temporary workspaces.
+func pathMayContainDiscoveryObjectsCached(memo *sync.Map, root string) (bool, error) {
+	if memo == nil {
+		return pathMayContainDiscoveryObjects(root)
+	}
+	if cached, ok := memo.Load(root); ok {
+		verdict := cached.(discoveryPathVerdict)
+		return verdict.matches, verdict.err
+	}
+	matches, err := pathMayContainDiscoveryObjects(root)
+	memo.Store(root, discoveryPathVerdict{matches: matches, err: err})
+	return matches, err
+}

--- a/internal/app/discovery_paths_test.go
+++ b/internal/app/discovery_paths_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -27,5 +28,24 @@ metadata:
 	}
 	if found {
 		t.Fatal("pathMayContainDiscoveryObjects() = true, want false for skipped trash directory")
+	}
+}
+
+func TestPathMayContainDiscoveryObjectsCachedMemoizes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "app.yaml"), []byte("kind: Application\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	memo := &sync.Map{}
+	first, err := pathMayContainDiscoveryObjectsCached(memo, root)
+	if err != nil || !first {
+		t.Fatalf("first = %t, %v; want true, nil", first, err)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	second, err := pathMayContainDiscoveryObjectsCached(memo, root)
+	if err != nil || !second {
+		t.Fatalf("second = %t, %v; want memoized true, nil", second, err)
 	}
 }

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -40,6 +40,7 @@ type localProvider struct {
 	remoteResourceGitCredentials remote.GitCredentials
 	helmValueFileSchemes         []string
 	helmValueFileSchemesSet      bool
+	helmChartLoadCache           *render.HelmChartLoadCache
 	pluginTimeout                time.Duration
 	pluginCacheDir               string
 	pluginPolicy                 pluginpolicy.Policy
@@ -73,6 +74,7 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 	opts.ChartForbiddenRoots = append([]string(nil), p.chartForbiddenRoots...)
 	opts.ChartForbiddenRoots = appendUniqueString(opts.ChartForbiddenRoots, sourceRoot)
 	opts.ChartCredentials = p.chartCredentials
+	opts.HelmChartLoadCache = p.helmChartLoadCache
 	opts.OCIChartRepositories = p.ociChartRepositories
 	opts.RemoteResourceAcquirer = p.acquisition.RemoteAcquirer(p.remoteResourceAcquirer)
 	opts.RemoteResourceCacheDir = p.remoteResourceCacheDir

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -53,6 +54,7 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		remoteResourceGitCredentials: request.RemoteResourceGitCredentials,
 		helmValueFileSchemes:         settingsHelmValueFileSchemes(settings),
 		helmValueFileSchemesSet:      settings.HelmValuesFileSchemesSet,
+		helmChartLoadCache:           render.NewHelmChartLoadCache(),
 		pluginTimeout:                request.PluginTimeout,
 		pluginCacheDir:               request.PluginCacheDir,
 		pluginPolicy:                 request.pluginPolicy,

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -69,10 +69,11 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		return provider, func() {}, err
 	}
 	provider.acquisition = acquisition.Session{
-		Locks:              processCacheTargetLocks,
-		SnapshotRoot:       snapshotRoot,
-		SnapshotCacheReads: true,
-		SnapshotCache:      acquisition.NewSnapshotCache(),
+		Locks:                     processCacheTargetLocks,
+		SnapshotRoot:              snapshotRoot,
+		SnapshotCacheReads:        true,
+		SnapshotCache:             acquisition.NewSnapshotCache(),
+		PreserveGitDirInSnapshots: request.EnablePlugins,
 	}
 	return provider, func() { _ = os.RemoveAll(snapshotRoot) }, nil
 }

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -64,6 +64,16 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		configManagementPlugins:      settings.ConfigManagementPlugins,
 		cacheEvents:                  recorder,
 	}
+	if request.snapshotSession != nil {
+		provider.acquisition = acquisition.Session{
+			Locks:                     processCacheTargetLocks,
+			SnapshotRoot:              request.snapshotSession.Root,
+			SnapshotCacheReads:        true,
+			SnapshotCache:             request.snapshotSession.Cache,
+			PreserveGitDirInSnapshots: request.EnablePlugins,
+		}
+		return provider, func() {}, nil
+	}
 	snapshotRoot, err := os.MkdirTemp("", snapshotPrefix)
 	if err != nil {
 		return provider, func() {}, err

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/appset"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
@@ -49,6 +50,7 @@ type BuildRequest struct {
 	renderCache             *applicationRenderCache
 	renderSettingsSignature string
 	discovered              *discovery.Result
+	snapshotSession         *acquisition.SnapshotSession
 }
 
 type BuildAppRequest struct {
@@ -140,6 +142,18 @@ type Orchestrator struct {
 	PluginContainerRunner  plugincontainer.Runner
 }
 
+func ensureSnapshotSession(request BuildRequest) (BuildRequest, func(), error) {
+	if request.snapshotSession != nil {
+		return request, func() {}, nil
+	}
+	session, err := acquisition.NewSnapshotSession("drydock-cache-snapshots-*")
+	if err != nil {
+		return request, func() {}, err
+	}
+	request.snapshotSession = session
+	return request, session.Close, nil
+}
+
 func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult, error) {
 	result, err := o.Build(ctx, request)
 	diagResult := DiagResult{
@@ -159,6 +173,12 @@ func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult
 }
 
 func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest) (BuildResult, error) {
+	request, releaseSnapshots, err := ensureSnapshotSession(request)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	defer releaseSnapshots()
+
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return BuildResult{}, err
 	}
@@ -260,6 +280,12 @@ func applicationSetOptionsForRequest(request BuildRequest) (appset.Options, []di
 }
 
 func (o Orchestrator) Build(ctx context.Context, request BuildRequest) (BuildResult, error) {
+	request, releaseSnapshots, err := ensureSnapshotSession(request)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	defer releaseSnapshots()
+
 	session, err := newBuildSession(o, request)
 	if err != nil {
 		return BuildResult{}, err
@@ -600,6 +626,12 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	}
 
 	buildRequest := request.BuildRequest
+	buildRequest, releaseSnapshots, err := ensureSnapshotSession(buildRequest)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	defer releaseSnapshots()
+
 	listResult, err := o.ListApplications(ctx, buildRequest)
 	if err != nil {
 		listResult.Statuses = skippedStatusesForRequestedApplication(listResult.Applications, name, err)
@@ -627,6 +659,12 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 // BuildSelection lists Applications, narrows them with selectApps, and builds
 // the selection while reusing the list phase's discovery and render caches.
 func (o Orchestrator) BuildSelection(ctx context.Context, request BuildRequest, selectApps ApplicationSelector) (BuildResult, error) {
+	request, releaseSnapshots, err := ensureSnapshotSession(request)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	defer releaseSnapshots()
+
 	listResult, err := o.ListApplications(ctx, request)
 	if err != nil {
 		listResult.Statuses = skippedApplicationStatuses(listResult.Applications, err)

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -66,6 +66,8 @@ type ApplicationSelectionInput struct {
 	Paths       []string
 }
 
+type ApplicationSelector func([]argoappv1.Application) []argoappv1.Application
+
 const (
 	ApplicationStatusPass    = "PASS"
 	ApplicationStatusFail    = "FAIL"
@@ -116,6 +118,7 @@ type BuildResult struct {
 	renderCache             *applicationRenderCache
 	renderSettingsSignature string
 	discovered              *discovery.Result
+	pluginOptions           PluginOptions
 }
 
 type DiagRequest = BuildRequest
@@ -174,6 +177,7 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 		return result, err
 	}
 	request = loadedRequest
+	result.pluginOptions = request.PluginOptions
 	discovered, discoveryDiags, err := o.loadBuildSideDiscovery(ctx, root, request, &result)
 	if err != nil {
 		return result, diagnosticsError(discoveryDiags, err)
@@ -527,6 +531,7 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 		result.renderCache = request.renderCache
 		result.renderSettingsSignature = request.renderSettingsSignature
 		result.discovered = request.discovered
+		result.pluginOptions = request.PluginOptions
 		result.Projects = appendDiscoveredProjects(result.Projects, discovered)
 		diags, err := loadBuildSideSettings(root, request, discovered, &result)
 		if err != nil {
@@ -607,11 +612,42 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	}
 
 	buildRequest.Applications = []argoappv1.Application{selected}
+	buildRequest.PluginOptions = listResult.pluginOptions
 	buildRequest.renderCache = listResult.renderCache
 	buildRequest.renderSettingsSignature = listResult.renderSettingsSignature
 	buildRequest.discovered = listResult.discovered
 	buildResult, err := o.Build(ctx, buildRequest)
 	buildResult.ApplicationInputs = selectApplicationInputsForApplication(listResult.ApplicationInputs, selected)
+	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
+	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
+	buildResult.CacheEvents = append(append([]cacheevent.Event(nil), listResult.CacheEvents...), buildResult.CacheEvents...)
+	return buildResult, err
+}
+
+// BuildSelection lists Applications, narrows them with selectApps, and builds
+// the selection while reusing the list phase's discovery and render caches.
+func (o Orchestrator) BuildSelection(ctx context.Context, request BuildRequest, selectApps ApplicationSelector) (BuildResult, error) {
+	listResult, err := o.ListApplications(ctx, request)
+	if err != nil {
+		listResult.Statuses = skippedApplicationStatuses(listResult.Applications, err)
+		return listResult, err
+	}
+
+	buildRequest := request
+	buildRequest.PluginOptions = listResult.pluginOptions
+	if selectApps != nil {
+		buildRequest.Applications = selectApps(listResult.Applications)
+	} else {
+		buildRequest.Applications = append([]argoappv1.Application(nil), listResult.Applications...)
+	}
+	if buildRequest.Applications == nil {
+		buildRequest.Applications = []argoappv1.Application{}
+	}
+	buildRequest.renderCache = listResult.renderCache
+	buildRequest.renderSettingsSignature = listResult.renderSettingsSignature
+	buildRequest.discovered = listResult.discovered
+	buildResult, err := o.Build(ctx, buildRequest)
+	buildResult.ApplicationInputs = selectApplicationInputsForApplications(listResult.ApplicationInputs, buildRequest.Applications)
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
 	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
 	buildResult.CacheEvents = append(append([]cacheevent.Event(nil), listResult.CacheEvents...), buildResult.CacheEvents...)
@@ -693,6 +729,27 @@ func selectApplicationInputsForApplication(inputs []ApplicationSelectionInput, s
 		}
 	}
 	return nil
+}
+
+func selectApplicationInputsForApplications(inputs []ApplicationSelectionInput, selected []argoappv1.Application) []ApplicationSelectionInput {
+	if len(inputs) == 0 || len(selected) == 0 {
+		return nil
+	}
+	selectedByKey := make(map[string]struct{}, len(selected))
+	for _, application := range selected {
+		selectedByKey[applicationKey(application)] = struct{}{}
+	}
+	out := make([]ApplicationSelectionInput, 0, len(selected))
+	for _, input := range inputs {
+		if _, ok := selectedByKey[applicationKey(input.Application)]; ok {
+			out = append(out, cloneApplicationSelectionInput(input))
+		}
+	}
+	return out
+}
+
+func applicationKey(application argoappv1.Application) string {
+	return application.Namespace + "\x00" + application.Name
 }
 
 func cloneApplicationSelectionInput(input ApplicationSelectionInput) ApplicationSelectionInput {

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/acquisition"
@@ -51,6 +52,8 @@ type BuildRequest struct {
 	renderSettingsSignature string
 	discovered              *discovery.Result
 	snapshotSession         *acquisition.SnapshotSession
+	discoveryPathMemo       *sync.Map
+	appsetGenerationMemo    *sync.Map
 }
 
 type BuildAppRequest struct {

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -48,6 +48,7 @@ type BuildRequest struct {
 	StatusCallback          ApplicationStatusCallback
 	renderCache             *applicationRenderCache
 	renderSettingsSignature string
+	discovered              *discovery.Result
 }
 
 type BuildAppRequest struct {
@@ -114,6 +115,7 @@ type BuildResult struct {
 	PluginExecutions        []PluginExecution
 	renderCache             *applicationRenderCache
 	renderSettingsSignature string
+	discovered              *discovery.Result
 }
 
 type DiagRequest = BuildRequest
@@ -520,6 +522,23 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 
 	var result BuildResult
 	result.Applications = append(result.Applications, request.Applications...)
+	if request.discovered != nil {
+		discovered := *request.discovered
+		result.renderCache = request.renderCache
+		result.renderSettingsSignature = request.renderSettingsSignature
+		result.discovered = request.discovered
+		result.Projects = appendDiscoveredProjects(result.Projects, discovered)
+		diags, err := loadBuildSideSettings(root, request, discovered, &result)
+		if err != nil {
+			result.Statuses = skippedApplicationStatuses(result.Applications, err)
+			return result, err
+		}
+		if err := diagnosticFailure(request.filterProjectDiagnostics(diags), request.Strict); err != nil {
+			result.Statuses = skippedApplicationStatuses(result.Applications, err)
+			return result, err
+		}
+		return result, nil
+	}
 	discovered, discoveryDiags, err := o.loadBuildSideDiscovery(ctx, root, request, &result)
 	if err != nil {
 		result.Statuses = skippedApplicationStatuses(result.Applications, err)
@@ -590,10 +609,12 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	buildRequest.Applications = []argoappv1.Application{selected}
 	buildRequest.renderCache = listResult.renderCache
 	buildRequest.renderSettingsSignature = listResult.renderSettingsSignature
+	buildRequest.discovered = listResult.discovered
 	buildResult, err := o.Build(ctx, buildRequest)
 	buildResult.ApplicationInputs = selectApplicationInputsForApplication(listResult.ApplicationInputs, selected)
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
 	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
+	buildResult.CacheEvents = append(append([]cacheevent.Event(nil), listResult.CacheEvents...), buildResult.CacheEvents...)
 	return buildResult, err
 }
 

--- a/internal/app/orchestrator_selection_test.go
+++ b/internal/app/orchestrator_selection_test.go
@@ -2,15 +2,20 @@ package app
 
 import (
 	"context"
-	"github.com/sholdee/drydock/internal/appset"
-	"github.com/sholdee/drydock/internal/chart"
-	"github.com/sholdee/drydock/internal/diagnostic"
 	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/appset"
+	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestOrchestratorBuildAppRendersOnlyNamedApplication(t *testing.T) {
@@ -66,6 +71,115 @@ func TestOrchestratorBuildAppPreservesSelectedApplicationInputs(t *testing.T) {
 	}
 	if strings.Contains(strings.Join(input.Paths, ","), "first") {
 		t.Fatalf("ApplicationInputs[0].Paths = %#v, want no first app paths", input.Paths)
+	}
+}
+
+func TestOrchestratorBuildSelectionRendersSelectedApplications(t *testing.T) {
+	root := t.TempDir()
+	writeBuildApplication(t, root, "first", "one")
+	writeBuildApplication(t, root, "second", "two")
+
+	result, err := Orchestrator{}.BuildSelection(context.Background(), BuildRequest{Path: root}, func(apps []argoappv1.Application) []argoappv1.Application {
+		for _, application := range apps {
+			if application.Name == "second" {
+				return []argoappv1.Application{application}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BuildSelection() error = %v", err)
+	}
+	if len(result.Applications) != 1 || result.Applications[0].Name != "second" {
+		t.Fatalf("Applications = %#v, want only second", result.Applications)
+	}
+	if len(result.ApplicationManifests) != 1 {
+		t.Fatalf("ApplicationManifests = %d, want 1", len(result.ApplicationManifests))
+	}
+	if result.ApplicationManifests[0].Manifest.Object.GetName() != "two" {
+		t.Fatalf("rendered object name = %q, want two", result.ApplicationManifests[0].Manifest.Object.GetName())
+	}
+	if len(result.ApplicationInputs) != 1 {
+		t.Fatalf("ApplicationInputs = %#v, want one selected input", result.ApplicationInputs)
+	}
+	wantPath := filepath.ToSlash(filepath.Join("apps", "second.yaml"))
+	if got := result.ApplicationInputs[0].Paths; len(got) != 1 || got[0] != wantPath {
+		t.Fatalf("ApplicationInputs[0].Paths = %#v, want [%q]", got, wantPath)
+	}
+}
+
+func TestOrchestratorBuildSelectionReusesListPhaseRenderCache(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "root.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: manifests/root
+    plugin:
+      name: app-of-apps
+  destination:
+    name: in-cluster
+    namespace: argocd
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "root", "marker.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+`)
+
+	var calls atomic.Int32
+	renderer := internalPluginRendererFunc(func(_ context.Context, _ render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		calls.Add(1)
+		return []render.Manifest{{
+			Path: "templates/child.yaml",
+			Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind":       "Application",
+				"metadata": map[string]any{
+					"name":      "child",
+					"namespace": "argocd",
+				},
+				"spec": map[string]any{
+					"project": "default",
+					"source": map[string]any{
+						"repoURL":        "https://github.com/example/repo",
+						"targetRevision": "main",
+						"path":           "workloads/child",
+					},
+					"destination": map[string]any{
+						"name":      "in-cluster",
+						"namespace": "child",
+					},
+				},
+			}},
+		}}, nil, nil
+	})
+
+	result, err := (Orchestrator{PluginRenderer: renderer}).BuildSelection(context.Background(), BuildRequest{Path: root}, func(apps []argoappv1.Application) []argoappv1.Application {
+		for _, application := range apps {
+			if application.Name == "root" {
+				return []argoappv1.Application{application}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BuildSelection() error = %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("plugin render calls = %d, want list-phase render cache reused for selected build", got)
+	}
+	if len(result.Applications) != 1 || result.Applications[0].Name != "root" {
+		t.Fatalf("Applications = %#v, want only root", result.Applications)
+	}
+	if len(result.Manifests) != 1 || result.Manifests[0].Object.GetKind() != "Application" || result.Manifests[0].Object.GetName() != "child" {
+		t.Fatalf("Manifests = %#v, want cached child Application manifest", result.Manifests)
 	}
 }
 

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sholdee/drydock/internal/acquisition"
+	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
@@ -115,6 +117,32 @@ func TestNewLocalProviderPreservesGitDirInSnapshotsWhenPluginsEnabled(t *testing
 	}
 	if !provider.acquisition.PreserveGitDirInSnapshots {
 		t.Fatal("PreserveGitDirInSnapshots = false, want true when plugins are enabled")
+	}
+}
+
+func TestNewLocalProviderReusesRequestSnapshotSession(t *testing.T) {
+	session, err := acquisition.NewSnapshotSession("drydock-test-snapshots-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	request := BuildRequest{}
+	request.snapshotSession = session
+
+	provider, cleanup, err := newLocalProvider(Orchestrator{}, t.TempDir(), config.DefaultSettings(), request, cacheevent.NewRecorder(false), "unused-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if provider.acquisition.SnapshotRoot != session.Root {
+		t.Fatalf("SnapshotRoot = %q, want shared session root %q", provider.acquisition.SnapshotRoot, session.Root)
+	}
+	if provider.acquisition.SnapshotCache != session.Cache {
+		t.Fatal("SnapshotCache does not reuse request snapshot session cache")
+	}
+	cleanup()
+	if _, statErr := os.Stat(session.Root); statErr != nil {
+		t.Fatalf("shared session root must survive provider cleanup: %v", statErr)
 	}
 }
 

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -150,6 +151,37 @@ func TestOrchestratorBuildStatusOnlyDoesNotCollectManifests(t *testing.T) {
 	assertApplicationStatuses(t, result.Statuses, []ApplicationStatus{
 		{Namespace: "argocd", Name: "demo", Status: ApplicationStatusPass},
 	})
+}
+
+func TestPrepareBuildResultReusesProvidedDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeBuildApplication(t, root, "demo", "demo")
+
+	orchestrator := Orchestrator{}
+	listResult, err := orchestrator.ListApplications(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := BuildRequest{Path: root}
+	request.Applications = listResult.Applications
+	request.renderCache = listResult.renderCache
+	request.renderSettingsSignature = listResult.renderSettingsSignature
+	request.discovered = listResult.discovered
+
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := orchestrator.prepareBuildResult(context.Background(), request, root)
+	if err != nil {
+		t.Fatalf("prepareBuildResult must reuse provided discovery without re-scanning: %v", err)
+	}
+	if result.renderCache != listResult.renderCache {
+		t.Fatal("prepareBuildResult must reuse the provided render cache")
+	}
+	if len(result.Projects) != len(listResult.Projects) {
+		t.Fatalf("Projects = %d, want %d", len(result.Projects), len(listResult.Projects))
+	}
 }
 
 func TestOrchestratorDiagIncludesSettings(t *testing.T) {

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -105,6 +105,19 @@ func TestNewLocalProviderCarriesHelmValuesFileSchemes(t *testing.T) {
 	}
 }
 
+func TestNewLocalProviderPreservesGitDirInSnapshotsWhenPluginsEnabled(t *testing.T) {
+	provider, cleanup, err := newLocalProvider(Orchestrator{}, t.TempDir(), config.DefaultSettings(), BuildRequest{
+		PluginOptions: PluginOptions{EnablePlugins: true},
+	}, nil, "drydock-test-*")
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("newLocalProvider() error = %v", err)
+	}
+	if !provider.acquisition.PreserveGitDirInSnapshots {
+		t.Fatal("PreserveGitDirInSnapshots = false, want true when plugins are enabled")
+	}
+}
+
 func TestOrchestratorReportsMissingSourcePathClearly(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "apps", "missing", "app.yaml"), `apiVersion: argoproj.io/v1alpha1

--- a/internal/app/render_cache.go
+++ b/internal/app/render_cache.go
@@ -17,7 +17,7 @@ import (
 )
 
 type applicationRenderCache struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	entries map[string]applicationRenderCacheEntry
 }
 
@@ -34,12 +34,14 @@ func (cache *applicationRenderCache) get(key string) (RenderResult, error, bool)
 	if cache == nil || key == "" {
 		return RenderResult{}, nil, false
 	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
+	cache.mu.RLock()
 	entry, ok := cache.entries[key]
+	cache.mu.RUnlock()
 	if !ok {
 		return RenderResult{}, nil, false
 	}
+	// Clone outside the lock: entries are write-once, and DeepCopy of large
+	// manifest sets must not serialize parallel render workers.
 	return cloneRenderResult(entry.result), entry.err, true
 }
 
@@ -47,12 +49,13 @@ func (cache *applicationRenderCache) set(key string, result RenderResult, err er
 	if cache == nil || key == "" {
 		return
 	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-	cache.entries[key] = applicationRenderCacheEntry{
+	entry := applicationRenderCacheEntry{
 		result: cloneRenderResult(result),
 		err:    err,
 	}
+	cache.mu.Lock()
+	cache.entries[key] = entry
+	cache.mu.Unlock()
 }
 
 func cloneRenderResult(result RenderResult) RenderResult {

--- a/internal/appset/generator_git.go
+++ b/internal/appset/generator_git.go
@@ -217,6 +217,9 @@ func matchGitFiles(repoRoot string, includes, excludes []string, manifestPath st
 			return nil
 		}
 		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		candidates = append(candidates, rel)

--- a/internal/appset/generator_git_files_test.go
+++ b/internal/appset/generator_git_files_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"testing"
 )
 
@@ -62,6 +63,24 @@ spec:
 		t.Fatalf("generated names = %#v, want prod", got)
 	}
 }
+
+func TestMatchGitFilesSkipsDotGitDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeAppsetTestFile(t, filepath.Join(root, ".git", "config.json"), `{}`)
+	writeAppsetTestFile(t, filepath.Join(root, ".github", "config.json"), `{}`)
+	writeAppsetTestFile(t, filepath.Join(root, "apps", "config.json"), `{}`)
+
+	matches, _, err := matchGitFiles(root, []string{"**/config.json"}, nil, "appset.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(matches)
+	want := []string{".github/config.json", "apps/config.json"}
+	if !slices.Equal(matches, want) {
+		t.Fatalf("matches = %v, want %v", matches, want)
+	}
+}
+
 func TestGenerateGitFilesGeneratorOrdersExcludesAndSetsGoTemplateParams(t *testing.T) {
 	root := t.TempDir()
 	writeAppsetTestFile(t, filepath.Join(root, "configs", "b", "app.yaml"), `cluster:

--- a/internal/change/benchmark_test.go
+++ b/internal/change/benchmark_test.go
@@ -12,7 +12,7 @@ func BenchmarkDetectLargeIdenticalTrees(b *testing.B) {
 	current := b.TempDir()
 	for i := range 400 {
 		rel := filepath.Join(fmt.Sprintf("dir-%02d", i%20), fmt.Sprintf("file-%03d.yaml", i))
-		content := []byte(fmt.Sprintf("kind: ConfigMap\nmetadata:\n  name: f-%03d\n", i))
+		content := fmt.Appendf(nil, "kind: ConfigMap\nmetadata:\n  name: f-%03d\n", i)
 		for _, root := range []string{base, current} {
 			if err := os.MkdirAll(filepath.Dir(filepath.Join(root, rel)), 0o755); err != nil {
 				b.Fatal(err)

--- a/internal/change/benchmark_test.go
+++ b/internal/change/benchmark_test.go
@@ -1,0 +1,37 @@
+package change
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkDetectLargeIdenticalTrees(b *testing.B) {
+	base := b.TempDir()
+	current := b.TempDir()
+	for i := range 400 {
+		rel := filepath.Join(fmt.Sprintf("dir-%02d", i%20), fmt.Sprintf("file-%03d.yaml", i))
+		content := []byte(fmt.Sprintf("kind: ConfigMap\nmetadata:\n  name: f-%03d\n", i))
+		for _, root := range []string{base, current} {
+			if err := os.MkdirAll(filepath.Dir(filepath.Join(root, rel)), 0o755); err != nil {
+				b.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, rel), content, 0o644); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		changed, err := Detect(base, current)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(changed) != 0 {
+			b.Fatalf("changed = %d, want 0", len(changed))
+		}
+	}
+}

--- a/internal/change/detect.go
+++ b/internal/change/detect.go
@@ -74,14 +74,16 @@ func pathChanged(baseRoot, currentRoot, rel string) (bool, error) {
 	basePath := filepath.Join(baseRoot, filepath.FromSlash(rel))
 	currentPath := filepath.Join(currentRoot, filepath.FromSlash(rel))
 	baseInfo, baseErr := os.Lstat(basePath)
-	if baseErr != nil && !errors.Is(baseErr, fs.ErrNotExist) {
+	baseMissing := errors.Is(baseErr, fs.ErrNotExist)
+	if baseErr != nil && !baseMissing {
 		return false, baseErr
 	}
 	currentInfo, currentErr := os.Lstat(currentPath)
-	if currentErr != nil && !errors.Is(currentErr, fs.ErrNotExist) {
+	currentMissing := errors.Is(currentErr, fs.ErrNotExist)
+	if currentErr != nil && !currentMissing {
 		return false, currentErr
 	}
-	if baseErr != nil || currentErr != nil {
+	if baseMissing || currentMissing {
 		return true, nil
 	}
 	return pathsChanged(basePath, currentPath, baseInfo, currentInfo)

--- a/internal/change/detect.go
+++ b/internal/change/detect.go
@@ -5,7 +5,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync"
 
 	"github.com/sholdee/drydock/internal/streamcmp"
 )
@@ -19,33 +21,70 @@ func Detect(baseRoot, currentRoot string) ([]string, error) {
 		return nil, err
 	}
 
-	var changed []string
+	relPaths := make([]string, 0, len(paths))
 	for rel := range paths {
-		basePath := filepath.Join(baseRoot, filepath.FromSlash(rel))
-		currentPath := filepath.Join(currentRoot, filepath.FromSlash(rel))
-		baseInfo, baseErr := os.Lstat(basePath)
-		if baseErr != nil && !errors.Is(baseErr, fs.ErrNotExist) {
-			return nil, baseErr
+		relPaths = append(relPaths, rel)
+	}
+	sort.Strings(relPaths)
+
+	changed := make([]bool, len(relPaths))
+	errs := make([]error, len(relPaths))
+	workers := detectParallelism(len(relPaths))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				changed[i], errs[i] = pathChanged(baseRoot, currentRoot, relPaths[i])
+			}
+		}()
+	}
+	for i := range relPaths {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+
+	var out []string
+	for i, rel := range relPaths {
+		if errs[i] != nil {
+			return nil, errs[i]
 		}
-		currentInfo, currentErr := os.Lstat(currentPath)
-		if currentErr != nil && !errors.Is(currentErr, fs.ErrNotExist) {
-			return nil, currentErr
-		}
-		if baseErr != nil || currentErr != nil {
-			changed = append(changed, rel)
-			continue
-		}
-		fileChanged, err := pathsChanged(basePath, currentPath, baseInfo, currentInfo)
-		if err != nil {
-			return nil, err
-		}
-		if fileChanged {
-			changed = append(changed, rel)
+		if changed[i] {
+			out = append(out, rel)
 		}
 	}
+	return out, nil
+}
 
-	sort.Strings(changed)
-	return changed, nil
+const maxDetectWorkers = 16
+
+func detectParallelism(pathCount int) int {
+	if pathCount <= 1 {
+		return 1
+	}
+	workers := max(runtime.GOMAXPROCS(0), 1)
+	workers = min(workers, maxDetectWorkers)
+	return min(workers, pathCount)
+}
+
+func pathChanged(baseRoot, currentRoot, rel string) (bool, error) {
+	basePath := filepath.Join(baseRoot, filepath.FromSlash(rel))
+	currentPath := filepath.Join(currentRoot, filepath.FromSlash(rel))
+	baseInfo, baseErr := os.Lstat(basePath)
+	if baseErr != nil && !errors.Is(baseErr, fs.ErrNotExist) {
+		return false, baseErr
+	}
+	currentInfo, currentErr := os.Lstat(currentPath)
+	if currentErr != nil && !errors.Is(currentErr, fs.ErrNotExist) {
+		return false, currentErr
+	}
+	if baseErr != nil || currentErr != nil {
+		return true, nil
+	}
+	return pathsChanged(basePath, currentPath, baseInfo, currentInfo)
 }
 
 func collectFiles(root string, paths map[string]struct{}) error {

--- a/internal/change/index_test.go
+++ b/internal/change/index_test.go
@@ -217,6 +217,35 @@ func TestDetectChangedPaths(t *testing.T) {
 	}
 }
 
+func TestDetectParallelismBounds(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths int
+	}{
+		{name: "empty", paths: 0},
+		{name: "one", paths: 1},
+		{name: "two", paths: 2},
+		{name: "many", paths: maxDetectWorkers * 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectParallelism(tt.paths)
+			if got < 1 {
+				t.Fatalf("detectParallelism(%d) = %d, want at least 1", tt.paths, got)
+			}
+			if got > tt.paths && tt.paths > 0 {
+				t.Fatalf("detectParallelism(%d) = %d, want no more than path count", tt.paths, got)
+			}
+			if got > maxDetectWorkers {
+				t.Fatalf("detectParallelism(%d) = %d, want no more than %d", tt.paths, got, maxDetectWorkers)
+			}
+			if tt.paths <= 1 && got != 1 {
+				t.Fatalf("detectParallelism(%d) = %d, want 1", tt.paths, got)
+			}
+		})
+	}
+}
+
 func TestDetectReportsDeletedPaths(t *testing.T) {
 	base := t.TempDir()
 	current := t.TempDir()

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -20,6 +20,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 	}
 
 	appsFlags := defaultCommonFlags()
+	appsFlags.parallelism = defaultRenderAppsParallelism()
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Render all Applications",
@@ -42,6 +43,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 	bindCommonFlags(apps, &appsFlags)
 
 	appFlags := defaultCommonFlags()
+	appFlags.parallelism = defaultRenderAppsParallelism()
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Render one Application",

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -59,6 +59,7 @@ type diagResourceActions struct {
 
 func newDiagCommand(deps Dependencies) *cobra.Command {
 	flags := defaultCommonFlags()
+	flags.parallelism = defaultRenderAppsParallelism()
 	options := diagCommandOptions{}
 	cmd := &cobra.Command{
 		Use:   "diag",

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -90,6 +90,7 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 
 func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	appFlags := defaultCommonFlags()
+	appFlags.parallelism = defaultRenderAppsParallelism()
 	appColor := diffColorAuto
 	appMarkdownMaxBytes := report.DefaultMaxBytes
 	appRawOutputFile := ""

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
@@ -82,18 +81,10 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 				return err
 			}
 			buildRequest := buildRequestFromFlags(cmd, imagesFlags, repoMaps)
-			listResult, err := deps.Orchestrator.ListApplications(context.Background(), buildRequest)
-			if err != nil {
-				if renderErr := renderDiagnostics(cmd.ErrOrStderr(), listResult.Diagnostics); renderErr != nil {
-					return renderErr
-				}
-				return err
-			}
-			buildRequest.Applications = filterApplicationsBySelector(listResult.Applications, selector)
-			buildResult, err := deps.Orchestrator.Build(context.Background(), buildRequest)
-			diagnostics := slices.Clone(listResult.Diagnostics)
-			diagnostics = append(diagnostics, buildResult.Diagnostics...)
-			if renderErr := renderDiagnostics(cmd.ErrOrStderr(), diagnostics); renderErr != nil {
+			buildResult, err := deps.Orchestrator.BuildSelection(context.Background(), buildRequest, func(apps []argoappv1.Application) []argoappv1.Application {
+				return filterApplicationsBySelector(apps, selector)
+			})
+			if renderErr := renderDiagnostics(cmd.ErrOrStderr(), buildResult.Diagnostics); renderErr != nil {
 				return renderErr
 			}
 			if err != nil {

--- a/internal/cli/home_ops_patterns_test.go
+++ b/internal/cli/home_ops_patterns_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sholdee/drydock/internal/remote"
@@ -150,7 +151,8 @@ func TestDiffAppsRemoteKustomizePatternFixture(t *testing.T) {
 		"+  value: current",
 	)
 	assertStderrEmpty(t, result)
-	if got, want := len(acquirer.requests), 8; got != want {
+	requests, options := acquirer.records()
+	if got, want := len(requests), 8; got != want {
 		t.Fatalf("remote acquire calls = %d, want %d", got, want)
 	}
 	for _, want := range []string{
@@ -159,12 +161,12 @@ func TestDiffAppsRemoteKustomizePatternFixture(t *testing.T) {
 		"https://github.com/example/remote-patch.git",
 		"https://raw.githubusercontent.com/example/remote/resource.yaml",
 	} {
-		if !recordedRemoteRequest(acquirer.requests, want) {
-			t.Fatalf("remote acquire requests missing %q: %#v", want, acquirer.requests)
+		if !recordedRemoteRequest(requests, want) {
+			t.Fatalf("remote acquire requests missing %q: %#v", want, requests)
 		}
 	}
-	if !recordedHTTPRemoteCredential(acquirer.requests, acquirer.options, "https://raw.githubusercontent.com/example/remote/resource.yaml", "fixture-token") {
-		t.Fatalf("remote HTTP credential was not passed to fake acquirer: requests=%#v options=%#v", acquirer.requests, acquirer.options)
+	if !recordedHTTPRemoteCredential(requests, options, "https://raw.githubusercontent.com/example/remote/resource.yaml", "fixture-token") {
+		t.Fatalf("remote HTTP credential was not passed to fake acquirer: requests=%#v options=%#v", requests, options)
 	}
 }
 
@@ -190,14 +192,17 @@ func TestDiffAppsApplicationSetCombinationPatternFixture(t *testing.T) {
 }
 
 type recordingCLIRemoteAcquirer struct {
+	mu       sync.Mutex
 	paths    map[string]string
 	requests []remote.Request
 	options  []remote.Options
 }
 
 func (acquirer *recordingCLIRemoteAcquirer) Acquire(_ context.Context, request remote.Request, opts remote.Options) (remote.Result, error) {
+	acquirer.mu.Lock()
 	acquirer.requests = append(acquirer.requests, request)
 	acquirer.options = append(acquirer.options, opts)
+	acquirer.mu.Unlock()
 	for _, key := range []string{request.RepoURL, request.URL} {
 		if key == "" {
 			continue
@@ -207,6 +212,14 @@ func (acquirer *recordingCLIRemoteAcquirer) Acquire(_ context.Context, request r
 		}
 	}
 	return remote.Result{}, &remoteFixtureMiss{request: request}
+}
+
+func (acquirer *recordingCLIRemoteAcquirer) records() ([]remote.Request, []remote.Options) {
+	acquirer.mu.Lock()
+	defer acquirer.mu.Unlock()
+	requests := append([]remote.Request(nil), acquirer.requests...)
+	options := append([]remote.Options(nil), acquirer.options...)
+	return requests, options
 }
 
 type remoteFixtureMiss struct {

--- a/internal/cli/parallelism_test.go
+++ b/internal/cli/parallelism_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/app"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBuildAppsParallelismFlag(t *testing.T) {
@@ -81,14 +83,20 @@ func TestTestAppsRequestsStatusOnlyBuild(t *testing.T) {
 }
 
 func TestTestAppsSelectorRequestsStatusOnlyBuild(t *testing.T) {
-	recorder := &recordingCLIOrchestrator{}
+	recorder := &recordingCLIOrchestrator{listResult: app.BuildResult{Applications: []argoappv1.Application{
+		{ObjectMeta: metav1.ObjectMeta{Name: "selected", Labels: map[string]string{"app": "demo"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "unselected", Labels: map[string]string{"app": "other"}}},
+	}}}
 	executeParallelismCommand(t, recorder, "test", "apps", "--selector", "app=demo")
 
-	if got := len(recorder.buildRequests); got != 1 {
-		t.Fatalf("build requests = %d, want 1", got)
+	if got := len(recorder.buildSelectionRequests); got != 1 {
+		t.Fatalf("build selection requests = %d, want 1", got)
 	}
-	if got := recorder.buildRequests[0].StatusOnly; !got {
-		t.Fatalf("BuildRequest.StatusOnly = %t, want true", got)
+	if got := recorder.buildSelectionRequests[0].StatusOnly; !got {
+		t.Fatalf("BuildSelection BuildRequest.StatusOnly = %t, want true", got)
+	}
+	if got := recorder.buildSelectionResultApplications; len(got) != 1 || got[0].Name != "selected" {
+		t.Fatalf("BuildSelection selected applications = %#v, want selected", got)
 	}
 }
 
@@ -151,7 +159,7 @@ func TestNonTestCommandsDoNotRequestStatusOnlyBuild(t *testing.T) {
 			name: "get images",
 			args: []string{"get", "images"},
 			statusOnly: func(recorder *recordingCLIOrchestrator) bool {
-				return recorder.listRequests[0].StatusOnly || recorder.buildRequests[0].StatusOnly
+				return recorder.buildSelectionRequests[0].StatusOnly
 			},
 		},
 		{
@@ -244,11 +252,8 @@ func TestGetImagesParallelismFlag(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}
 	executeParallelismCommand(t, recorder, "get", "images", "--parallelism", "7")
 
-	if got := recorder.listRequests[0].Parallelism; got != 7 {
-		t.Fatalf("ListApplications BuildRequest.Parallelism = %d, want 7", got)
-	}
-	if got := recorder.buildRequests[0].Parallelism; got != 7 {
-		t.Fatalf("BuildRequest.Parallelism = %d, want 7", got)
+	if got := recorder.buildSelectionRequests[0].Parallelism; got != 7 {
+		t.Fatalf("BuildSelection BuildRequest.Parallelism = %d, want 7", got)
 	}
 }
 
@@ -305,26 +310,28 @@ func executeParallelismCommand(t *testing.T, recorder *recordingCLIOrchestrator,
 }
 
 type recordingCLIOrchestrator struct {
-	buildRequests      []app.BuildRequest
-	buildAppRequests   []app.BuildAppRequest
-	listRequests       []app.BuildRequest
-	diffAppsRequests   []app.DiffRequest
-	diffAppRequests    []app.DiffAppRequest
-	diffImagesRequests []app.DiffRequest
-	diagRequests       []app.DiagRequest
-	buildResult        app.BuildResult
-	buildError         error
-	buildHook          func(app.BuildRequest) error
-	diffAppsResult     app.DiffResult
-	diffAppsError      error
-	diffAppResult      app.DiffResult
-	diffAppError       error
-	diffImagesResult   app.ImageDiffResult
-	diffImagesError    error
-	listResult         app.BuildResult
-	listError          error
-	diagResult         app.DiagResult
-	diagError          error
+	buildRequests                    []app.BuildRequest
+	buildAppRequests                 []app.BuildAppRequest
+	buildSelectionRequests           []app.BuildRequest
+	buildSelectionResultApplications []argoappv1.Application
+	listRequests                     []app.BuildRequest
+	diffAppsRequests                 []app.DiffRequest
+	diffAppRequests                  []app.DiffAppRequest
+	diffImagesRequests               []app.DiffRequest
+	diagRequests                     []app.DiagRequest
+	buildResult                      app.BuildResult
+	buildError                       error
+	buildHook                        func(app.BuildRequest) error
+	diffAppsResult                   app.DiffResult
+	diffAppsError                    error
+	diffAppResult                    app.DiffResult
+	diffAppError                     error
+	diffImagesResult                 app.ImageDiffResult
+	diffImagesError                  error
+	listResult                       app.BuildResult
+	listError                        error
+	diagResult                       app.DiagResult
+	diagError                        error
 }
 
 func (orchestrator *recordingCLIOrchestrator) Build(_ context.Context, request app.BuildRequest) (app.BuildResult, error) {
@@ -340,6 +347,16 @@ func (orchestrator *recordingCLIOrchestrator) Build(_ context.Context, request a
 func (orchestrator *recordingCLIOrchestrator) BuildApp(_ context.Context, request app.BuildAppRequest) (app.BuildResult, error) {
 	orchestrator.buildAppRequests = append(orchestrator.buildAppRequests, request)
 	return app.BuildResult{}, nil
+}
+
+func (orchestrator *recordingCLIOrchestrator) BuildSelection(_ context.Context, request app.BuildRequest, selectApps app.ApplicationSelector) (app.BuildResult, error) {
+	orchestrator.buildSelectionRequests = append(orchestrator.buildSelectionRequests, request)
+	result := orchestrator.buildResult
+	if selectApps != nil {
+		result.Applications = selectApps(orchestrator.listResult.Applications)
+		orchestrator.buildSelectionResultApplications = result.Applications
+	}
+	return result, orchestrator.buildError
 }
 
 func (orchestrator *recordingCLIOrchestrator) ListApplications(_ context.Context, request app.BuildRequest) (app.BuildResult, error) {

--- a/internal/cli/parallelism_test.go
+++ b/internal/cli/parallelism_test.go
@@ -19,12 +19,32 @@ func TestBuildAppsParallelismFlag(t *testing.T) {
 	}
 }
 
+func TestBuildAppsDefaultParallelismIsAuto(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "build", "apps")
+
+	want := defaultRenderAppsParallelism()
+	if got := recorder.buildRequests[0].Parallelism; got != want {
+		t.Fatalf("BuildRequest.Parallelism = %d, want %d", got, want)
+	}
+}
+
 func TestBuildAppParallelismFlag(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}
 	executeParallelismCommand(t, recorder, "build", "app", "demo", "--parallelism", "7")
 
 	if got := recorder.buildAppRequests[0].Parallelism; got != 7 {
 		t.Fatalf("BuildAppRequest.Parallelism = %d, want 7", got)
+	}
+}
+
+func TestBuildAppDefaultParallelismIsAuto(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "build", "app", "demo")
+
+	want := defaultRenderAppsParallelism()
+	if got := recorder.buildAppRequests[0].Parallelism; got != want {
+		t.Fatalf("BuildAppRequest.Parallelism = %d, want %d", got, want)
 	}
 }
 
@@ -78,6 +98,16 @@ func TestTestAppParallelismFlag(t *testing.T) {
 
 	if got := recorder.buildAppRequests[0].Parallelism; got != 7 {
 		t.Fatalf("BuildAppRequest.Parallelism = %d, want 7", got)
+	}
+}
+
+func TestTestAppDefaultParallelismIsAuto(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "test", "app", "demo")
+
+	want := defaultRenderAppsParallelism()
+	if got := recorder.buildAppRequests[0].Parallelism; got != want {
+		t.Fatalf("BuildAppRequest.Parallelism = %d, want %d", got, want)
 	}
 }
 
@@ -172,12 +202,13 @@ func TestDiffAppParallelismFlag(t *testing.T) {
 	}
 }
 
-func TestDiffAppDefaultParallelismRemainsSingleApplication(t *testing.T) {
+func TestDiffAppDefaultParallelismIsAuto(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}
 	executeParallelismCommand(t, recorder, "diff", "app", "demo", "--path-orig", "left", "--path", "right")
 
-	if got := recorder.diffAppRequests[0].Parallelism; got != 1 {
-		t.Fatalf("DiffAppRequest.Parallelism = %d, want 1", got)
+	want := defaultRenderAppsParallelism()
+	if got := recorder.diffAppRequests[0].Parallelism; got != want {
+		t.Fatalf("DiffAppRequest.Parallelism = %d, want %d", got, want)
 	}
 }
 
@@ -227,6 +258,16 @@ func TestDiagParallelismFlag(t *testing.T) {
 
 	if got := recorder.listRequests[0].Parallelism; got != 7 {
 		t.Fatalf("ListApplications BuildRequest.Parallelism = %d, want 7", got)
+	}
+}
+
+func TestDiagDefaultParallelismIsAuto(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeParallelismCommand(t, recorder, "diag")
+
+	want := defaultRenderAppsParallelism()
+	if got := recorder.listRequests[0].Parallelism; got != want {
+		t.Fatalf("ListApplications BuildRequest.Parallelism = %d, want %d", got, want)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,7 @@ type Dependencies struct {
 type Orchestrator interface {
 	Build(context.Context, app.BuildRequest) (app.BuildResult, error)
 	BuildApp(context.Context, app.BuildAppRequest) (app.BuildResult, error)
+	BuildSelection(context.Context, app.BuildRequest, app.ApplicationSelector) (app.BuildResult, error)
 	ListApplications(context.Context, app.BuildRequest) (app.BuildResult, error)
 	DiffApps(context.Context, app.DiffRequest) (app.DiffResult, error)
 	DiffApp(context.Context, app.DiffAppRequest) (app.DiffResult, error)

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/app"
 	cliformat "github.com/sholdee/drydock/internal/format"
 	"github.com/sholdee/drydock/internal/source"
@@ -49,21 +50,18 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 				liveReporter = newTestLiveReporter(cmd.OutOrStdout(), cmd.ErrOrStderr(), deps.isTerminal(cmd.ErrOrStderr()))
 				buildRequest.StatusCallback = liveReporter.Handle
 			}
+			var result app.BuildResult
 			if strings.TrimSpace(appsFlags.selector) != "" {
-				selector, err := parseApplicationSelector(appsFlags.selector)
-				if err != nil {
-					return err
+				selector, parseErr := parseApplicationSelector(appsFlags.selector)
+				if parseErr != nil {
+					return parseErr
 				}
-				listResult, err := deps.Orchestrator.ListApplications(context.Background(), buildRequest)
-				if err != nil {
-					if renderErr := renderDiagnostics(cmd.ErrOrStderr(), listResult.Diagnostics); renderErr != nil {
-						return renderErr
-					}
-					return err
-				}
-				buildRequest.Applications = filterApplicationsBySelector(listResult.Applications, selector)
+				result, err = deps.Orchestrator.BuildSelection(context.Background(), buildRequest, func(apps []argoappv1.Application) []argoappv1.Application {
+					return filterApplicationsBySelector(apps, selector)
+				})
+			} else {
+				result, err = deps.Orchestrator.Build(context.Background(), buildRequest)
 			}
-			result, err := deps.Orchestrator.Build(context.Background(), buildRequest)
 			if liveReporter != nil {
 				var liveErr liveTestOutputError
 				if errors.As(err, &liveErr) {

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -96,6 +96,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 
 	appFlags := defaultCommonFlags()
 	appFlags.output = testOutputText
+	appFlags.parallelism = defaultRenderAppsParallelism()
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Test one Application",

--- a/internal/diff/benchmark_test.go
+++ b/internal/diff/benchmark_test.go
@@ -1,0 +1,44 @@
+package diff
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkRunMostlyUnchangedHelmDocuments(b *testing.B) {
+	const docs = 500
+	left := make([]Document, 0, docs)
+	right := make([]Document, 0, docs)
+	for i := range docs {
+		body := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-%03d
+  namespace: default
+  labels:
+    helm.sh/chart: demo-1.0.0
+    app.kubernetes.io/version: "1.0.0"
+data:
+  value: benchmark
+`, i)
+		doc := Document{
+			Resource: Resource{Kind: "ConfigMap", Name: fmt.Sprintf("demo-%03d", i), Namespace: "default"},
+			Body:     body,
+		}
+		left = append(left, doc)
+		right = append(right, doc)
+	}
+	right[0].Body += "  extra: changed\n"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		results, err := Run(left, right, Options{})
+		if err != nil {
+			b.Fatalf("Run() error = %v", err)
+		}
+		if len(results) != 1 {
+			b.Fatalf("results = %d, want 1", len(results))
+		}
+	}
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -72,7 +72,7 @@ func diffResultForKey(leftByKey, rightByKey map[string]Document, key string, opt
 	left, hasLeft := leftByKey[key]
 	right, hasRight := rightByKey[key]
 	left, right = documentsWithSharedNormalization(left, right, hasLeft, hasRight)
-	if hasLeft && hasRight && left.Body == right.Body && canSkipNormalizationForIdentical(left.Normalization, opts) {
+	if hasLeft && hasRight && left.Body == right.Body {
 		// Both sides share one merged normalization, so identical bodies always
 		// normalize identically and can never produce a diff.
 		return Result{}, false, nil
@@ -87,15 +87,6 @@ func diffResultForKey(leftByKey, rightByKey map[string]Document, key string, opt
 	}
 	result, err := resultFor(doc, change, leftBody, rightBody, opts)
 	return result, true, err
-}
-
-func canSkipNormalizationForIdentical(normalization Normalization, opts Options) bool {
-	return len(stripAttrSet(opts.StripAttrs)) == 0 &&
-		len(normalization.JSONPointers) == 0 &&
-		len(normalization.JQPathExpressions) == 0 &&
-		len(normalization.KnownTypeFields) == 0 &&
-		len(normalization.ManagedFieldsManagers) == 0 &&
-		!normalization.CompareOptions.IgnoreAggregatedRoles
 }
 
 func documentsWithSharedNormalization(left, right Document, hasLeft, hasRight bool) (Document, Document) {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -72,6 +72,11 @@ func diffResultForKey(leftByKey, rightByKey map[string]Document, key string, opt
 	left, hasLeft := leftByKey[key]
 	right, hasRight := rightByKey[key]
 	left, right = documentsWithSharedNormalization(left, right, hasLeft, hasRight)
+	if hasLeft && hasRight && left.Body == right.Body && canSkipNormalizationForIdentical(left.Normalization, opts) {
+		// Both sides share one merged normalization, so identical bodies always
+		// normalize identically and can never produce a diff.
+		return Result{}, false, nil
+	}
 	leftBody, rightBody, err := normalizedDocumentBodies(left, right, hasLeft, hasRight, opts)
 	if err != nil {
 		return Result{}, false, err
@@ -83,6 +88,16 @@ func diffResultForKey(leftByKey, rightByKey map[string]Document, key string, opt
 	result, err := resultFor(doc, change, leftBody, rightBody, opts)
 	return result, true, err
 }
+
+func canSkipNormalizationForIdentical(normalization Normalization, opts Options) bool {
+	return len(stripAttrSet(opts.StripAttrs)) == 0 &&
+		len(normalization.JSONPointers) == 0 &&
+		len(normalization.JQPathExpressions) == 0 &&
+		len(normalization.KnownTypeFields) == 0 &&
+		len(normalization.ManagedFieldsManagers) == 0 &&
+		!normalization.CompareOptions.IgnoreAggregatedRoles
+}
+
 func documentsWithSharedNormalization(left, right Document, hasLeft, hasRight bool) (Document, Document) {
 	normalization := Normalization{}
 	var compareOptions CompareOptions

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -842,7 +842,7 @@ func TestRunIgnoreJSONPointerInvalidPointersReturnClearError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			left := []Document{deploymentDocument("1", []string{tt.pointer})}
-			right := []Document{deploymentDocument("1", nil)}
+			right := []Document{deploymentDocument("2", nil)}
 
 			_, err := Run(left, right, Options{Unified: 3})
 			if err == nil {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -109,6 +109,21 @@ func TestRunUsesZeroLineRangeForAddedAndRemovedResources(t *testing.T) {
 	}
 }
 
+func TestRunSkipsNormalizationForIdenticalBodies(t *testing.T) {
+	body := "kind: ConfigMap\nmetadata:\n  labels:\n    helm.sh/chart: demo-1.0.0\n  name: demo\n\t: invalid"
+	doc := Document{
+		Resource: Resource{Kind: "ConfigMap", Name: "demo", Namespace: "default"},
+		Body:     body,
+	}
+	results, err := Run([]Document{doc}, []Document{doc}, Options{})
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil (identical bodies must short-circuit before normalization)", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Run() results = %d, want 0", len(results))
+	}
+}
+
 func TestRunIgnoresSourceMetadataInIdentity(t *testing.T) {
 	left := []Document{{
 		Parent: Parent{

--- a/internal/gitref/changes.go
+++ b/internal/gitref/changes.go
@@ -118,16 +118,31 @@ func addTrackedWorktreeChanges(repo *git.Repository, headTree *object.Tree, path
 	if err != nil {
 		return err
 	}
-	root := wt.Filesystem.Root()
+	files, err := headTreeFiles(headTree)
+	if err != nil {
+		return err
+	}
+	changed, err := changedWorktreeFiles(wt.Filesystem.Root(), files)
+	if err != nil {
+		return err
+	}
+	headPaths := recordChangedHeadPaths(paths, files, changed)
+	return addIndexChanges(repo, headPaths, paths)
+}
+
+func headTreeFiles(headTree *object.Tree) ([]object.File, error) {
 	files := make([]object.File, 0)
 	if err := headTree.Files().ForEach(func(file *object.File) error {
 		files = append(files, *file)
 		return nil
 	}); err != nil {
-		return err
+		return nil, err
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Name < files[j].Name })
+	return files, nil
+}
 
+func changedWorktreeFiles(root string, files []object.File) ([]bool, error) {
 	changed := make([]bool, len(files))
 	errs := make([]error, len(files))
 	workers := materializeTreeParallelism(len(files))
@@ -149,19 +164,27 @@ func addTrackedWorktreeChanges(repo *git.Repository, headTree *object.Tree, path
 		close(jobs)
 		wg.Wait()
 	}
-
-	headPaths := make(map[string]object.File, len(files))
 	for i := range files {
 		if errs[i] != nil {
-			return errs[i]
+			return nil, errs[i]
 		}
+	}
+	return changed, nil
+}
+
+func recordChangedHeadPaths(paths map[string]struct{}, files []object.File, changed []bool) map[string]object.File {
+	headPaths := make(map[string]object.File, len(files))
+	for i := range files {
 		name := filepath.ToSlash(files[i].Name)
 		headPaths[name] = files[i]
 		if changed[i] {
 			paths[name] = struct{}{}
 		}
 	}
+	return headPaths
+}
 
+func addIndexChanges(repo *git.Repository, headPaths map[string]object.File, paths map[string]struct{}) error {
 	idx, err := repo.Storer.Index()
 	if err != nil {
 		return err

--- a/internal/gitref/changes.go
+++ b/internal/gitref/changes.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
@@ -118,20 +119,47 @@ func addTrackedWorktreeChanges(repo *git.Repository, headTree *object.Tree, path
 		return err
 	}
 	root := wt.Filesystem.Root()
-	headPaths := make(map[string]object.File)
+	files := make([]object.File, 0)
 	if err := headTree.Files().ForEach(func(file *object.File) error {
-		name := filepath.ToSlash(file.Name)
-		headPaths[name] = *file
-		changed, err := worktreeFileChanged(root, file)
-		if err != nil {
-			return err
-		}
-		if changed {
-			paths[name] = struct{}{}
-		}
+		files = append(files, *file)
 		return nil
 	}); err != nil {
 		return err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Name < files[j].Name })
+
+	changed := make([]bool, len(files))
+	errs := make([]error, len(files))
+	workers := materializeTreeParallelism(len(files))
+	if workers > 0 {
+		jobs := make(chan int)
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for range workers {
+			go func() {
+				defer wg.Done()
+				for i := range jobs {
+					changed[i], errs[i] = worktreeFileChanged(root, &files[i])
+				}
+			}()
+		}
+		for i := range files {
+			jobs <- i
+		}
+		close(jobs)
+		wg.Wait()
+	}
+
+	headPaths := make(map[string]object.File, len(files))
+	for i := range files {
+		if errs[i] != nil {
+			return errs[i]
+		}
+		name := filepath.ToSlash(files[i].Name)
+		headPaths[name] = files[i]
+		if changed[i] {
+			paths[name] = struct{}{}
+		}
 	}
 
 	idx, err := repo.Storer.Index()

--- a/internal/gitref/changes_test.go
+++ b/internal/gitref/changes_test.go
@@ -1,6 +1,7 @@
 package gitref
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -108,6 +109,30 @@ func TestChangedPathsFromRefToWorktreeReportsStagedDeletionWithRestoredFile(t *t
 	}
 
 	want := []string{"apps/demo/cm.yaml"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ChangedPathsFromRefToWorktree() = %#v, want %#v", got, want)
+	}
+}
+
+func TestChangedPathsFromRefToWorktreeReportsManyTrackedWorktreeChanges(t *testing.T) {
+	repoPath, _, wt := newSnapshotRepo(t)
+	for i := range maxMaterializeTreeWorkers * 2 {
+		rel := filepath.Join("apps", "many", fmt.Sprintf("cm-%02d.yaml", i))
+		writeChangedPathFileForTest(t, filepath.Join(repoPath, rel), fmt.Sprintf("value: old-%02d\n", i))
+	}
+	base := commitAllSnapshotFiles(t, wt, "baseline")
+
+	want := make([]string, 0, maxMaterializeTreeWorkers*2)
+	for i := range maxMaterializeTreeWorkers * 2 {
+		rel := filepath.Join("apps", "many", fmt.Sprintf("cm-%02d.yaml", i))
+		writeChangedPathFileForTest(t, filepath.Join(repoPath, rel), fmt.Sprintf("value: new-%02d\n", i))
+		want = append(want, filepath.ToSlash(rel))
+	}
+
+	got, err := ChangedPathsFromRefToWorktree(t.Context(), repoPath, base)
+	if err != nil {
+		t.Fatalf("ChangedPathsFromRefToWorktree() error = %v", err)
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ChangedPathsFromRefToWorktree() = %#v, want %#v", got, want)
 	}

--- a/internal/render/helm.go
+++ b/internal/render/helm.go
@@ -17,7 +17,6 @@ import (
 	helmchart "helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/common"
 	chartutil "helm.sh/helm/v4/pkg/chart/common/util"
-	"helm.sh/helm/v4/pkg/chart/loader"
 	chartv2 "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/engine"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,11 +39,7 @@ func (HelmRenderer) Render(ctx context.Context, source ResolvedSource, opts Rend
 		return nil, nil, err
 	}
 
-	if err := validateHelmChartTree(chartPath); err != nil {
-		return nil, nil, err
-	}
-
-	chart, err := loader.Load(chartPath)
+	chart, err := opts.HelmChartLoadCache.Load(chartPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load helm chart %s: %w", manifestPath, err)
 	}

--- a/internal/render/helm_chart_cache.go
+++ b/internal/render/helm_chart_cache.go
@@ -1,0 +1,110 @@
+package render
+
+import (
+	"sync"
+	"time"
+
+	helmchart "helm.sh/helm/v4/pkg/chart"
+	"helm.sh/helm/v4/pkg/chart/loader"
+	"helm.sh/helm/v4/pkg/chart/loader/archive"
+	chartv2 "helm.sh/helm/v4/pkg/chart/v2"
+	chartv2loader "helm.sh/helm/v4/pkg/chart/v2/loader"
+)
+
+// HelmChartLoadCache memoizes chart file reads and tree validation for the
+// lifetime of one render session. Load returns a freshly parsed chart on every
+// call so Helm dependency processing cannot leak mutations between renders.
+type HelmChartLoadCache struct {
+	mu      sync.Mutex
+	entries map[string]*helmChartCacheEntry
+}
+
+type helmChartCacheEntry struct {
+	once        sync.Once
+	files       []helmChartRawFile
+	cacheable   bool
+	validateErr error
+	loadErr     error
+}
+
+type helmChartRawFile struct {
+	name    string
+	modTime time.Time
+	data    []byte
+}
+
+func NewHelmChartLoadCache() *HelmChartLoadCache {
+	return &HelmChartLoadCache{entries: map[string]*helmChartCacheEntry{}}
+}
+
+func (cache *HelmChartLoadCache) Load(chartPath string) (helmchart.Charter, error) {
+	if cache == nil {
+		return loadValidatedHelmChart(chartPath)
+	}
+	cache.mu.Lock()
+	entry, ok := cache.entries[chartPath]
+	if !ok {
+		entry = &helmChartCacheEntry{}
+		cache.entries[chartPath] = entry
+	}
+	cache.mu.Unlock()
+
+	entry.once.Do(func() {
+		entry.validateErr = validateHelmChartTree(chartPath)
+		if entry.validateErr != nil {
+			return
+		}
+		loaded, err := loader.Load(chartPath)
+		if err != nil {
+			entry.loadErr = err
+			return
+		}
+		v2chart, ok := loaded.(*chartv2.Chart)
+		if !ok {
+			return
+		}
+		entry.files = rawFilesFromV2Chart(v2chart)
+		entry.cacheable = true
+	})
+	if entry.validateErr != nil {
+		return nil, entry.validateErr
+	}
+	if entry.loadErr != nil {
+		return nil, entry.loadErr
+	}
+	if !entry.cacheable {
+		return loader.Load(chartPath)
+	}
+	return chartv2loader.LoadFiles(bufferedFilesFromRawFiles(entry.files))
+}
+
+func loadValidatedHelmChart(chartPath string) (helmchart.Charter, error) {
+	if err := validateHelmChartTree(chartPath); err != nil {
+		return nil, err
+	}
+	return loader.Load(chartPath)
+}
+
+func rawFilesFromV2Chart(chart *chartv2.Chart) []helmChartRawFile {
+	files := make([]helmChartRawFile, 0, len(chart.Raw))
+	for _, file := range chart.Raw {
+		files = append(files, helmChartRawFile{
+			name:    file.Name,
+			modTime: file.ModTime,
+			data:    append([]byte(nil), file.Data...),
+		})
+	}
+	return files
+}
+
+func bufferedFilesFromRawFiles(files []helmChartRawFile) []*archive.BufferedFile {
+	out := make([]*archive.BufferedFile, 0, len(files))
+	for _, file := range files {
+		out = append(out, &archive.BufferedFile{
+			Name:    file.name,
+			ModTime: file.modTime,
+			Data:    append([]byte(nil), file.data...),
+		})
+	}
+	return out
+}

--- a/internal/render/helm_chart_cache_test.go
+++ b/internal/render/helm_chart_cache_test.go
@@ -1,0 +1,144 @@
+package render
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	helmchart "helm.sh/helm/v4/pkg/chart"
+	chartv2 "helm.sh/helm/v4/pkg/chart/v2"
+)
+
+func TestHelmChartLoadCacheReturnsIndependentCharts(t *testing.T) {
+	chartDir := writeCacheTestChart(t)
+	cache := NewHelmChartLoadCache()
+	first, err := cache.Load(chartDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := cache.Load(chartDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("Load must return a fresh chart per call")
+	}
+
+	firstChart := mustV2Chart(t, first)
+	secondChart := mustV2Chart(t, second)
+	firstChart.Metadata.Name = "mutated"
+	if secondChart.Metadata.Name == "mutated" {
+		t.Fatal("Load returned charts sharing mutable metadata")
+	}
+	firstChart.Raw[0].Data[0] = 'X'
+	if secondChart.Raw[0].Data[0] == 'X' {
+		t.Fatal("Load returned charts sharing mutable raw file bytes")
+	}
+}
+
+func TestHelmChartLoadCacheMatchesDirectLoad(t *testing.T) {
+	chartDir := writeCacheTestChart(t)
+	cached, err := NewHelmChartLoadCache().Load(chartDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	direct, err := loadValidatedHelmChart(chartDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertChartsEquivalent(t, cached, direct)
+}
+
+func BenchmarkHelmRendererSharedChart(b *testing.B) {
+	chartDir := writeCacheTestChart(b)
+	source := ResolvedSource{RepoRoot: chartDir, Path: "."}
+	renderer := HelmRenderer{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		cache := NewHelmChartLoadCache()
+		for app := range 25 {
+			manifests, diags, err := renderer.Render(context.Background(), source, RenderOptions{
+				AppName:            "demo",
+				ReleaseName:        "demo",
+				HelmChartLoadCache: cache,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(diags) != 0 {
+				b.Fatalf("diagnostics = %#v, want none", diags)
+			}
+			if len(manifests) != 2 {
+				b.Fatalf("render %d manifests = %d, want 2", app, len(manifests))
+			}
+		}
+	}
+}
+
+func writeCacheTestChart(t testing.TB) string {
+	t.Helper()
+	chartDir := t.TempDir()
+	writeCacheTestChartFile(t, filepath.Join(chartDir, "Chart.yaml"), `apiVersion: v2
+name: demo
+version: 1.2.3
+`)
+	writeCacheTestChartFile(t, filepath.Join(chartDir, "templates", "manifest.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+`)
+	subDir := filepath.Join(chartDir, "charts", "sub")
+	writeCacheTestChartFile(t, filepath.Join(subDir, "Chart.yaml"), `apiVersion: v2
+name: sub
+version: 0.1.0
+`)
+	writeCacheTestChartFile(t, filepath.Join(subDir, "templates", "manifest.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sub-cm
+`)
+	return chartDir
+}
+
+func writeCacheTestChartFile(t testing.TB, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertChartsEquivalent(t *testing.T, got, want helmchart.Charter) {
+	t.Helper()
+	gotChart := mustV2Chart(t, got)
+	wantChart := mustV2Chart(t, want)
+	if gotChart.Name() != wantChart.Name() {
+		t.Fatalf("Name() = %q, want %q", gotChart.Name(), wantChart.Name())
+	}
+	if gotChart.Metadata.Version != wantChart.Metadata.Version {
+		t.Fatalf("Metadata.Version = %q, want %q", gotChart.Metadata.Version, wantChart.Metadata.Version)
+	}
+	if len(gotChart.Templates) != len(wantChart.Templates) {
+		t.Fatalf("len(Templates) = %d, want %d", len(gotChart.Templates), len(wantChart.Templates))
+	}
+	if len(gotChart.Dependencies()) != len(wantChart.Dependencies()) {
+		t.Fatalf("len(Dependencies()) = %d, want %d", len(gotChart.Dependencies()), len(wantChart.Dependencies()))
+	}
+	if len(gotChart.Raw) != len(wantChart.Raw) {
+		t.Fatalf("len(Raw) = %d, want %d", len(gotChart.Raw), len(wantChart.Raw))
+	}
+}
+
+func mustV2Chart(t *testing.T, chart helmchart.Charter) *chartv2.Chart {
+	t.Helper()
+	v2chart, ok := chart.(*chartv2.Chart)
+	if !ok {
+		t.Fatalf("chart = %T, want *chartv2.Chart", chart)
+	}
+	return v2chart
+}

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -383,6 +383,7 @@ func renderOptionsForKustomizeHelmChart(ctx context.Context, helmChart types.Hel
 		ChartForbiddenRoots:          append([]string(nil), opts.ChartForbiddenRoots...),
 		ChartCredentials:             opts.ChartCredentials,
 		ChartAcquirer:                acquirer,
+		HelmChartLoadCache:           opts.HelmChartLoadCache,
 		RemoteResourceAcquirer:       opts.RemoteResourceAcquirer,
 		RemoteResourceCacheDir:       opts.RemoteResourceCacheDir,
 		OfflineRemoteResources:       opts.OfflineRemoteResources,

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -62,6 +62,7 @@ type RenderOptions struct {
 	ChartForbiddenRoots          []string
 	ChartCredentials             chart.ChartCredentials
 	ChartAcquirer                chart.Acquirer
+	HelmChartLoadCache           *HelmChartLoadCache
 	OCIChartRepositories         map[string]bool
 	RemoteResourceCacheDir       string
 	OfflineRemoteResources       bool


### PR DESCRIPTION
## Summary
- default render-heavy commands to automatic parallelism
- reduce repeated discovery, snapshot, Helm chart load, and diff normalization work
- parallelize diff sides and change-detection content comparisons

## Validation
- go build ./...
- go test ./...
- mise run test-race
- mise run lint
- go test ./internal/app/ ./internal/diff/ ./internal/change/ -bench . -benchtime 5x -run '^$'

## Local performance check
Compared branch binary against v0.1.20 on ~/git/home-ops and ~/git/argocd-repos/home-ops. Median wall-clock improvement ranged from about 8% to 31% across tested commands, with changed-only diff stress case around 23% faster on the larger repo.