### PR TITLE
feat(cache): persistent render output cache with per-application keying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@ when the user-facing task requires it.
   applies only inside one Application and must emit a diagnostic.
 - Keep caches outside current and baseline repository trees, protected roots,
   and symlink-resolved equivalents.
+- Persistent render cache keys must cover every input the renderers read.
+  Extend the digest enumerators and the read-coverage tripwire together, prove
+  digest byte-identity when refactoring digest internals, and degrade to
+  re-rendering — never to serving unverified cached content.
 - Keep stdout machine-parseable for structured/list outputs. Diagnostics and
   failure summaries belong on stderr unless status text is the primary output.
 
@@ -112,6 +116,7 @@ when the user-facing task requires it.
 | Git, chart, remote acquisition | `site/content/concepts/source-acquisition.md`, then `internal/source`, `internal/chart`, `internal/remote`, `internal/acquisition` |
 | Manifest diffs and image extraction | `internal/diff`, `internal/manifest` |
 | Cache lifecycle and cache events | `internal/cache`, `internal/cacheevent`, `internal/cli/cache.go` |
+| Persistent render cache and input digests | `docs/agent-reference.md` render-cache section, then `internal/rendercache`, `internal/app/render_cache_persistent.go`, `internal/filedigest`, `internal/gitref`, `internal/digestpath` |
 | Path containment and symlink rules | `internal/pathsafety`, then caller-specific checks |
 | Documentation site | `site/`, `docs/README.md`, then canonical `docs/*.md` owner |
 
@@ -130,6 +135,16 @@ mise run test-race
 mise run lint
 mise run markdownlint
 ```
+
+Render-cache changes must keep the guard suite green: the sabotage-validated
+tests in `internal/app/render_cache_verify_test.go`, the read-coverage
+tripwires in `internal/app/render_input_coverage_test.go`, and the integration
+matrix in `internal/app/persistent_cache_integration_test.go`. Never weaken a
+guard assertion to make a change pass; a red guard means the change is unsafe.
+Changes that touch cache keying or verification follow a written implementation
+plan reviewed independently before code, with per-change review after, and any
+new guard test is validated by deliberate sabotage (break the guarded property,
+confirm the test fails, restore).
 
 Portable integration fixtures should model real repository behavior without
 depending on a maintainer-provided `home-ops` checkout. Optional

--- a/cmd/drydock/buildinfo.go
+++ b/cmd/drydock/buildinfo.go
@@ -1,14 +1,18 @@
 package main
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+
+	"github.com/sholdee/drydock/internal/rendercache"
+)
 
 const (
-	argoCDModulePath       = "github.com/argoproj/argo-cd/v3"
-	gitOpsEngineModulePath = "github.com/argoproj/argo-cd/gitops-engine"
-	helmModulePath         = "helm.sh/helm/v4"
-	kustomizeModulePath    = "sigs.k8s.io/kustomize/api"
-	jsonnetModulePath      = "github.com/google/go-jsonnet"
-	kubernetesModulePath   = "k8s.io/apimachinery"
+	argoCDModulePath       = rendercache.ArgoCDModulePath
+	gitOpsEngineModulePath = rendercache.GitOpsEngineModulePath
+	helmModulePath         = rendercache.HelmModulePath
+	kustomizeModulePath    = rendercache.KustomizeModulePath
+	jsonnetModulePath      = rendercache.JsonnetModulePath
+	kubernetesModulePath   = rendercache.KubernetesModulePath
 )
 
 func moduleLabel(modulePath string) string {
@@ -16,21 +20,5 @@ func moduleLabel(modulePath string) string {
 	if !ok {
 		return modulePath
 	}
-	for _, dep := range info.Deps {
-		if dep.Path == modulePath {
-			return formatModuleLabel(*dep)
-		}
-	}
-	return modulePath
-}
-
-func formatModuleLabel(module debug.Module) string {
-	label := module.Path
-	if module.Version != "" {
-		label += "@" + module.Version
-	}
-	if module.Replace != nil {
-		label += " => " + formatModuleLabel(*module.Replace)
-	}
-	return label
+	return rendercache.ModuleLabel(info, modulePath)
 }

--- a/cmd/drydock/main_test.go
+++ b/cmd/drydock/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -24,20 +23,5 @@ func TestModuleLabelIncludesRuntimeModuleVersions(t *testing.T) {
 				t.Fatalf("moduleLabel(%q) = %q, want non-empty version", modulePath, label)
 			}
 		})
-	}
-}
-
-func TestFormatModuleLabelIncludesReplacement(t *testing.T) {
-	label := formatModuleLabel(debug.Module{
-		Path:    "example.test/module",
-		Version: "v1.2.3",
-		Replace: &debug.Module{
-			Path:    "../module",
-			Version: "v1.2.4-local",
-		},
-	})
-	want := "example.test/module@v1.2.3 => ../module@v1.2.4-local"
-	if label != want {
-		t.Fatalf("formatModuleLabel() = %q, want %q", label, want)
 	}
 }

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -196,6 +196,48 @@ Authenticated source handling is explicit and non-interactive:
 Never print password, bearer token, SSH private key, SSH passphrase, remote
 resource credential, registry credential, or credential-bearing URL values.
 
+## Persistent Render Cache
+
+Canonical references:
+
+- `internal/rendercache` (store, eviction, engine fingerprint)
+- `internal/app/render_cache_persistent.go` (keying, eligibility, store-time
+  verification)
+- `internal/filedigest`, `internal/gitref`, `internal/digestpath` (the two
+  digest schemes and their shared canonicalization)
+- `site/content/concepts/source-acquisition.md` (operator-facing behavior)
+
+The cache key is a model of every input the renderers read. The load-bearing
+invariants:
+
+- Any new render input (a new kustomize field, Helm option, override file, or
+  classification probe) must be added to the digest enumerators, and the
+  read-coverage tripwires in `internal/app/render_input_coverage_test.go`
+  should gain a fixture exercising it.
+- Tool classification for digest paths derives from `selectLocalRenderer`;
+  never fork it. The kustomization filename list is shared via
+  `render.KustomizationFileNames`.
+- Refactors of digest internals must prove digest byte-identity: existing
+  digest-sensitive suites pass unmodified, or the change rotates keys and says
+  so in the commit body.
+- Every eligibility decision fails closed: errors, globs in dirty worktrees,
+  symlinks, gitlinks, nested `.git`, duplicate Application keys, and unknown
+  roots degrade to re-rendering without persistence, never to serving
+  unverified content.
+- Stores are re-verified at store time (`renderInputsUnchanged`); committed
+  keys verify the worktree against the pinned revision, filesystem keys
+  re-digest with the run-scoped memo bypassed. The sabotage-validated tests in
+  `internal/app/render_cache_verify_test.go` pin this wiring — never weaken
+  them.
+- Engine fingerprint module paths live only in `internal/rendercache`
+  (`FingerprintFromBuildInfo`); dev builds without VCS stamping or ldflags
+  disable persistence by design.
+
+Changes to keying or verification follow a written implementation plan with an
+independent review before code and per-change review after; new guard tests
+are sabotage-validated (break the guarded property, confirm the test fails,
+restore exactly).
+
 ## Application Planning And Diff Semantics
 
 Canonical references:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -128,7 +128,8 @@ Supported:
 - Cache event API/reporting for Git, Helm, and remote Kustomize acquisition,
   with redacted targets and errors.
 - Local cache lifecycle commands for recognized Git, chart, and remote
-  Kustomize cache layouts.
+  Kustomize cache layouts; render output entries are not listed, pruned, or
+  deleted.
 
 Important boundaries:
 

--- a/internal/app/acquisition_records_test.go
+++ b/internal/app/acquisition_records_test.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+)
+
+func TestResolveSourceRootRecordsGitAcquisition(t *testing.T) {
+	acquired := t.TempDir()
+	collector := cacheevent.NewAcquisitionCollector()
+	provider := localProvider{
+		repoRoot:       t.TempDir(),
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		gitAcquirer: &recordingGitAcquirer{
+			path:     acquired,
+			revision: "0123456789abcdef0123456789abcdef01234567",
+		},
+		acquisitions: collector,
+	}
+
+	root, err := provider.resolveSourceRoot(context.Background(), render.ResolvedSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "manifests/demo",
+		TargetRevision: "main",
+	})
+	if err != nil {
+		t.Fatalf("resolveSourceRoot() error = %v", err)
+	}
+	if root != acquired {
+		t.Fatalf("resolveSourceRoot() = %s, want %s", root, acquired)
+	}
+	want := []cacheevent.AcquisitionRecord{{
+		Kind:              cacheevent.AcquisitionGit,
+		RequestedRevision: "main",
+		ResolvedRevision:  "0123456789abcdef0123456789abcdef01234567",
+	}}
+	if got := collector.Records(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Records() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveSourceRootLocalPathRecordsNothing(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	collector := cacheevent.NewAcquisitionCollector()
+	provider := localProvider{
+		repoRoot:       root,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		acquisitions:   collector,
+	}
+
+	if _, err := provider.resolveSourceRoot(context.Background(), render.ResolvedSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "manifests/demo",
+		TargetRevision: "main",
+	}); err != nil {
+		t.Fatalf("resolveSourceRoot() error = %v", err)
+	}
+	if got := collector.Records(); len(got) != 0 {
+		t.Fatalf("Records() = %#v, want none for local path resolution", got)
+	}
+}

--- a/internal/app/benchmark_test.go
+++ b/internal/app/benchmark_test.go
@@ -6,7 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/render"
+	"github.com/sholdee/drydock/internal/rendercache"
 )
 
 func BenchmarkOrchestratorBuildManyLocalApplications(b *testing.B) {
@@ -95,6 +102,112 @@ func BenchmarkOrchestratorExpandApplicationSetList(b *testing.B) {
 			b.Fatalf("Applications = %d, want 250", len(result.Applications))
 		}
 	}
+}
+
+func BenchmarkOrchestratorBuildPersistentCacheCold(b *testing.B) {
+	root := b.TempDir()
+	writePersistentCacheBenchmarkFleet(b, root, 50)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		b.StopTimer()
+		cacheDir := b.TempDir()
+		b.StartTimer()
+		result, err := (Orchestrator{}).Build(context.Background(), persistentCacheBenchmarkRequest(root, cacheDir))
+		if err != nil {
+			b.Fatalf("Build() error = %v", err)
+		}
+		if len(result.ApplicationManifests) != 50 {
+			b.Fatalf("ApplicationManifests = %d, want 50", len(result.ApplicationManifests))
+		}
+	}
+}
+
+func BenchmarkOrchestratorBuildPersistentCacheWarm(b *testing.B) {
+	root := b.TempDir()
+	writePersistentCacheBenchmarkFleet(b, root, 50)
+	cacheDir := b.TempDir()
+	if _, err := (Orchestrator{}).Build(context.Background(), persistentCacheBenchmarkRequest(root, cacheDir)); err != nil {
+		b.Fatalf("cold prime Build() error = %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var renders atomic.Int64
+		orchestrator := Orchestrator{}
+		orchestrator.renderObserver = func(render.ResolvedSource) { renders.Add(1) }
+		result, err := orchestrator.Build(context.Background(), persistentCacheBenchmarkRequest(root, cacheDir))
+		if err != nil {
+			b.Fatalf("Build() error = %v", err)
+		}
+		if len(result.ApplicationManifests) != 50 {
+			b.Fatalf("ApplicationManifests = %d, want 50", len(result.ApplicationManifests))
+		}
+		if got := renders.Load(); got != 0 {
+			b.Fatalf("warm render-engine invocations = %d, want 0", got)
+		}
+	}
+}
+
+func writePersistentCacheBenchmarkFleet(b *testing.B, root string, count int) {
+	b.Helper()
+	for i := range count {
+		name := fmt.Sprintf("demo-%03d", i)
+		writeBenchmarkApplication(b, root, name)
+		writeBenchmarkFile(b, filepath.Join(root, "manifests", name, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+		writeBenchmarkFile(b, filepath.Join(root, "manifests", name, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: benchmark
+`)
+	}
+	gitCommitAllBench(b, root)
+}
+
+func gitCommitAllBench(b *testing.B, root string) {
+	b.Helper()
+	repo, err := git.PlainInit(root, false)
+	if err != nil {
+		b.Fatalf("PlainInit() error = %v", err)
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		b.Fatalf("Worktree() error = %v", err)
+	}
+	if err := worktree.AddWithOptions(&git.AddOptions{All: true}); err != nil {
+		b.Fatalf("AddWithOptions() error = %v", err)
+	}
+	signature := &object.Signature{Name: "Bench", Email: "bench@example.invalid", When: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	if _, err := worktree.Commit("benchmark fixture", &git.CommitOptions{Author: signature, Committer: signature}); err != nil {
+		b.Fatalf("Commit() error = %v", err)
+	}
+}
+
+func persistentCacheBenchmarkRequest(root, cacheDir string) BuildRequest {
+	request := BuildRequest{Path: root}
+	request.RenderCacheOptions = RenderCacheOptions{
+		RenderCacheEnabled: true,
+		RenderCacheDir:     cacheDir,
+		EngineFingerprint: rendercache.EngineFingerprint{
+			Version:            "bench",
+			Commit:             "0123456789abcdef0123456789abcdef01234567",
+			ArgoCDModule:       "github.com/argoproj/argo-cd/v3@bench",
+			GitOpsEngineModule: "github.com/argoproj/argo-cd/gitops-engine@bench",
+			HelmModule:         "helm.sh/helm/v4@bench",
+			KustomizeModule:    "sigs.k8s.io/kustomize/api@bench",
+			JsonnetModule:      "github.com/google/go-jsonnet@bench",
+			KubernetesModule:   "k8s.io/apimachinery@bench",
+		},
+	}
+	return request
 }
 
 func writeBenchmarkApplication(tb testing.TB, root string, name string) {

--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -87,7 +87,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 		Inclusions: result.Settings.ResourceInclusions,
 	}
 
-	provider, cleanup, err := newLocalProvider(session.orchestrator, session.root, result.Settings, session.request, session.cacheRecorder, "drydock-cache-snapshots-*")
+	provider, cleanup, err := newLocalProvider(ctx, session.orchestrator, session.root, result.Settings, session.request, session.cacheRecorder, "drydock-cache-snapshots-*")
 	if err != nil {
 		return result, err
 	}
@@ -95,6 +95,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 
 	rendered, renderErr := renderApplications(ctx, renderApplicationsRequest{
 		applications:      result.Applications,
+		applicationInputs: applicationInputPathsByKey(result.ApplicationInputs),
 		provider:          provider,
 		renderCache:       result.renderCache,
 		settingsSignature: result.renderSettingsSignature,

--- a/internal/app/build_session_validation.go
+++ b/internal/app/build_session_validation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/pathsafety"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -25,7 +26,35 @@ func validateBuildNetworkOptions(request BuildRequest) error {
 	if _, err := remote.ResolveCacheDir(request.RemoteResourceCacheDir, forbiddenRoots); err != nil {
 		return err
 	}
+	if err := validateBuildRenderCacheRoot(request); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateBuildRenderCacheRoot(request BuildRequest) error {
+	if !request.RenderCacheEnabled {
+		return nil
+	}
+	root := request.Path
+	if root == "" {
+		root = "."
+	}
+	forbiddenRoots := requestForbiddenRoots(root, request.AcquisitionOptions)
+	dir, err := rendercache.ResolveDir(request.RenderCacheDir, forbiddenRoots)
+	if err != nil {
+		return err
+	}
+	if !request.EngineFingerprint.Known() {
+		// Dev builds never open the store (persistence is disabled with
+		// reason "dev-build"), so don't create or probe it here either.
+		return nil
+	}
+	// Opening here makes an unwritable cache dir a hard configuration error,
+	// consistent with the git and chart cache dirs, instead of a silent
+	// cache-disabled run.
+	_, err = rendercache.Open(dir, request.RenderCacheMaxBytes)
+	return err
 }
 
 func validateGitCacheDir(configured string, forbiddenRoots []string) error {

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sholdee/drydock/internal/gitref"
 	"github.com/sholdee/drydock/internal/manifest"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -37,12 +38,16 @@ type DiffRequest struct {
 	StripAttrs              []string
 	ShowIgnoredFields       bool
 	AcquisitionOptions
+	RenderCacheOptions
 	PluginOptions
 	ExecutionOptions
 	FilterOptions
 	ApplicationSetOptions
 
-	changedPaths []string
+	changedPaths          []string
+	persistentRenderCache *persistentRenderCache
+	leftPathRevision      string
+	rightPathRevision     string
 }
 
 type DiffAppRequest struct {
@@ -64,7 +69,7 @@ type ImageDiffResult struct {
 	CacheEvents []cacheevent.Event
 }
 
-func (o Orchestrator) DiffApps(ctx context.Context, request DiffRequest) (DiffResult, error) {
+func (o Orchestrator) DiffApps(ctx context.Context, request DiffRequest) (result DiffResult, err error) {
 	request, cleanup, err := resolveDiffRequestPaths(ctx, request, true)
 	if err != nil {
 		return DiffResult{}, err
@@ -81,12 +86,19 @@ func (o Orchestrator) DiffApps(ctx context.Context, request DiffRequest) (DiffRe
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return DiffResult{}, err
 	}
+	if err := validateDiffRenderCacheRoot(request); err != nil {
+		return DiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request)
 	defer policyCleanup()
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
 	request = loadedRequest
+	request, releaseRenderCache := ensureDiffPersistentRenderCache(request)
+	defer func() {
+		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
+	}()
 
 	leftBuild, rightBuild, diagnostics, err := o.buildDiffSides(ctx, request)
 	diagnostics = request.filterProjectDiagnostics(append(policyDiags, diagnostics...))
@@ -107,7 +119,7 @@ func (o Orchestrator) DiffApps(ctx context.Context, request DiffRequest) (DiffRe
 	return DiffResult{Results: results, Diagnostics: diagnostics, CacheEvents: cacheEvents}, nil
 }
 
-func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (DiffResult, error) {
+func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (result DiffResult, err error) {
 	name := strings.TrimSpace(request.Name)
 	if name == "" {
 		return DiffResult{}, fmt.Errorf("application name is required")
@@ -129,12 +141,19 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return DiffResult{}, err
 	}
+	if err := validateDiffRenderCacheRoot(request.DiffRequest); err != nil {
+		return DiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request.DiffRequest)
 	defer policyCleanup()
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
-	request.DiffRequest = loadedRequest
+	preparedDiffRequest, releaseRenderCache := ensureDiffPersistentRenderCache(loadedRequest)
+	request.DiffRequest = preparedDiffRequest
+	defer func() {
+		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
+	}()
 
 	forbiddenRoots := diffForbiddenRoots(request.DiffRequest)
 	if err := validateDiffCacheRoots(request.DiffRequest, forbiddenRoots); err != nil {
@@ -143,6 +162,8 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 
 	leftBuildRequest := request.buildRequest(request.LeftPath, forbiddenRoots)
 	rightBuildRequest := request.buildRequest(request.RightPath, forbiddenRoots)
+	leftBuildRequest.rootRevision = request.leftPathRevision
+	rightBuildRequest.rootRevision = request.rightPathRevision
 	parallelism, err := normalizeParallelism(request.Parallelism)
 	if err != nil {
 		return DiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
@@ -203,7 +224,7 @@ func (o Orchestrator) DiffApp(ctx context.Context, request DiffAppRequest) (Diff
 	return DiffResult{Results: results, Diagnostics: request.filterProjectDiagnostics(diagnostics), CacheEvents: cacheEvents}, nil
 }
 
-func (o Orchestrator) DiffImages(ctx context.Context, request DiffRequest) (ImageDiffResult, error) {
+func (o Orchestrator) DiffImages(ctx context.Context, request DiffRequest) (result ImageDiffResult, err error) {
 	request, cleanup, err := resolveDiffRequestPaths(ctx, request, true)
 	if err != nil {
 		return ImageDiffResult{}, err
@@ -220,12 +241,19 @@ func (o Orchestrator) DiffImages(ctx context.Context, request DiffRequest) (Imag
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return ImageDiffResult{}, err
 	}
+	if err := validateDiffRenderCacheRoot(request); err != nil {
+		return ImageDiffResult{}, err
+	}
 	loadedRequest, policyDiags, policyCleanup, err := ensureDiffPluginPolicy(ctx, request)
 	defer policyCleanup()
 	if err != nil {
 		return ImageDiffResult{Diagnostics: request.filterProjectDiagnostics(policyDiags)}, err
 	}
 	request = loadedRequest
+	request, releaseRenderCache := ensureDiffPersistentRenderCache(request)
+	defer func() {
+		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
+	}()
 
 	leftBuild, rightBuild, diagnostics, err := o.buildDiffSides(ctx, request)
 	diagnostics = request.filterProjectDiagnostics(append(policyDiags, diagnostics...))
@@ -327,6 +355,7 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 			return request, cleanup, err
 		}
 		request.LeftPath = result.Path
+		request.leftPathRevision = result.Revision
 		cleanups = append(cleanups, result.Cleanup)
 		forbiddenRoots = append(forbiddenRoots, result.Path)
 	}
@@ -340,6 +369,7 @@ func resolveDiffRequestPaths(ctx context.Context, request DiffRequest, computeCh
 			return request, cleanup, errors.Join(err, cleanup())
 		}
 		request.RightPath = result.Path
+		request.rightPathRevision = result.Revision
 		cleanups = append(cleanups, result.Cleanup)
 	}
 	return request, cleanup, nil
@@ -423,10 +453,12 @@ func (request DiffRequest) buildRequest(path string, forbiddenRoots []string) Bu
 		ProjectDiagnosticsMode: request.ProjectDiagnosticsMode,
 		DiscoveryOptions:       cloneDiscoveryOptions(request.DiscoveryOptions),
 		AcquisitionOptions:     request.buildAcquisitionOptions(forbiddenRoots),
+		RenderCacheOptions:     request.RenderCacheOptions,
 		PluginOptions:          request.PluginOptions,
 		ExecutionOptions:       request.ExecutionOptions,
 		FilterOptions:          cloneFilterOptions(request.FilterOptions),
 		ApplicationSetOptions:  cloneApplicationSetOptions(request.ApplicationSetOptions),
+		persistentRenderCache:  request.persistentRenderCache,
 	}
 }
 
@@ -479,7 +511,25 @@ func validateDiffCacheRoots(request DiffRequest, forbiddenRoots []string) error 
 	if _, err := remote.ResolveCacheDir(request.RemoteResourceCacheDir, forbiddenRoots); err != nil {
 		return err
 	}
+	if err := validateDiffRenderCacheRoot(request); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateDiffRenderCacheRoot(request DiffRequest) error {
+	if !request.RenderCacheEnabled {
+		return nil
+	}
+	dir, err := rendercache.ResolveDir(request.RenderCacheDir, diffForbiddenRoots(request))
+	if err != nil {
+		return err
+	}
+	if !request.EngineFingerprint.Known() {
+		return nil
+	}
+	_, err = rendercache.Open(dir, request.RenderCacheMaxBytes)
+	return err
 }
 
 func diffForbiddenRoots(request DiffRequest) []string {

--- a/internal/app/diff_side.go
+++ b/internal/app/diff_side.go
@@ -20,6 +20,8 @@ func (o Orchestrator) buildDiffSides(ctx context.Context, request DiffRequest) (
 
 	leftBuildRequest := request.buildRequest(request.LeftPath, forbiddenRoots)
 	rightBuildRequest := request.buildRequest(request.RightPath, forbiddenRoots)
+	leftBuildRequest.rootRevision = request.leftPathRevision
+	rightBuildRequest.rootRevision = request.rightPathRevision
 	parallelism, err := normalizeParallelism(request.Parallelism)
 	if err != nil {
 		return BuildResult{}, BuildResult{}, nil, err

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/diff"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -980,6 +981,32 @@ func TestDiffAppsRejectsChartCacheInsideEitherRoot(t *testing.T) {
 	}
 }
 
+func TestDiffAppsRejectsRenderCacheInsideEitherRoot(t *testing.T) {
+	left := t.TempDir()
+	right := t.TempDir()
+
+	for _, root := range []string{left, right} {
+		cacheDir := filepath.Join(root, ".drydock", "render")
+		_, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+			LeftPath:  left,
+			RightPath: right,
+			RenderCacheOptions: RenderCacheOptions{
+				RenderCacheEnabled: true,
+				RenderCacheDir:     cacheDir,
+			},
+		})
+		if err == nil {
+			t.Fatal("DiffApps() error = nil, want render cache containment error")
+		}
+		if !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+			t.Fatalf("DiffApps() error = %v, want render cache containment error", err)
+		}
+		if _, statErr := os.Stat(cacheDir); !os.IsNotExist(statErr) {
+			t.Fatalf("render cache dir stat error = %v, want not created", statErr)
+		}
+	}
+}
+
 func TestDiffAppsPassesChartForbiddenRootsToBuilds(t *testing.T) {
 	left := t.TempDir()
 	right := t.TempDir()
@@ -1115,6 +1142,34 @@ func TestDiffAppsRefRejectsRemoteCacheInsideOriginalRepo(t *testing.T) {
 				t.Fatalf("DiffApps() error = %v, want original repo remote cache containment error", err)
 			}
 		})
+	}
+}
+
+func TestDiffAppsRefRejectsRenderCacheInsideOriginalRepo(t *testing.T) {
+	root := t.TempDir()
+	repo, wt := initDiffGitRepo(t, root)
+	writeDeploymentAppWithDataValue(t, root, "baseline")
+	commitDiffGitRepo(t, repo, wt, "baseline")
+	cacheDir := filepath.Join(root, ".drydock", "render")
+
+	_, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		Repo:        root,
+		RefOrig:     "HEAD",
+		Ref:         "HEAD",
+		ChangedOnly: false,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+		},
+	})
+	if err == nil {
+		t.Fatal("DiffApps() error = nil, want render cache containment error")
+	}
+	if !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+		t.Fatalf("DiffApps() error = %v, want original repo render cache containment error", err)
+	}
+	if _, statErr := os.Stat(cacheDir); !os.IsNotExist(statErr) {
+		t.Fatalf("render cache dir stat error = %v, want not created", statErr)
 	}
 }
 
@@ -1613,6 +1668,13 @@ func TestDiffRequestCarriesProviderFixtureConfig(t *testing.T) {
 		},
 		PluginOptions:    PluginOptions{PluginTimeout: time.Second},
 		ExecutionOptions: ExecutionOptions{Parallelism: 3},
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled:  true,
+			RenderCacheDir:      "render-cache",
+			RenderCacheMaxBytes: 1234,
+			RefreshRenders:      true,
+			EngineFingerprint:   rendercache.EngineFingerprint{Version: "1.2.3", Commit: "abc123"},
+		},
 		FilterOptions: FilterOptions{
 			SkipKinds:   []string{"Secret"},
 			SkipCRDs:    true,
@@ -1639,6 +1701,9 @@ func TestDiffRequestCarriesProviderFixtureConfig(t *testing.T) {
 		}
 		if !reflect.DeepEqual(buildRequest.ExecutionOptions, request.ExecutionOptions) {
 			t.Fatalf("%s ExecutionOptions = %#v, want %#v", side, buildRequest.ExecutionOptions, request.ExecutionOptions)
+		}
+		if !reflect.DeepEqual(buildRequest.RenderCacheOptions, request.RenderCacheOptions) {
+			t.Fatalf("%s RenderCacheOptions = %#v, want %#v", side, buildRequest.RenderCacheOptions, request.RenderCacheOptions)
 		}
 		if !reflect.DeepEqual(buildRequest.FilterOptions, request.FilterOptions) {
 			t.Fatalf("%s FilterOptions = %#v, want %#v", side, buildRequest.FilterOptions, request.FilterOptions)
@@ -1701,6 +1766,35 @@ func TestDiffAppRejectsChartCacheInsideEitherRoot(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "chart cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
 			t.Fatalf("DiffApp() error = %v, want chart cache containment error", err)
+		}
+	}
+}
+
+func TestDiffAppRejectsRenderCacheInsideEitherRoot(t *testing.T) {
+	left := t.TempDir()
+	right := t.TempDir()
+
+	for _, root := range []string{left, right} {
+		cacheDir := filepath.Join(root, ".drydock", "render")
+		_, err := Orchestrator{}.DiffApp(context.Background(), DiffAppRequest{
+			Name: "demo",
+			DiffRequest: DiffRequest{
+				LeftPath:  left,
+				RightPath: right,
+				RenderCacheOptions: RenderCacheOptions{
+					RenderCacheEnabled: true,
+					RenderCacheDir:     cacheDir,
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("DiffApp() error = nil, want render cache containment error")
+		}
+		if !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+			t.Fatalf("DiffApp() error = %v, want render cache containment error", err)
+		}
+		if _, statErr := os.Stat(cacheDir); !os.IsNotExist(statErr) {
+			t.Fatalf("render cache dir stat error = %v, want not created", statErr)
 		}
 	}
 }
@@ -2274,4 +2368,24 @@ metadata:
 data:
   value: `+value+`
 `)
+}
+
+func TestDiffImagesValidatesRenderCacheRootBeforeOpeningStore(t *testing.T) {
+	left := t.TempDir()
+	right := t.TempDir()
+	cacheDir := filepath.Join(right, "renders")
+	request := DiffRequest{LeftPath: left, RightPath: right}
+	request.RenderCacheOptions = RenderCacheOptions{
+		RenderCacheEnabled: true,
+		RenderCacheDir:     cacheDir,
+		EngineFingerprint:  testEngineFingerprint(),
+	}
+
+	_, err := Orchestrator{}.DiffImages(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "must not be inside") {
+		t.Fatalf("DiffImages() error = %v, want render cache root rejection", err)
+	}
+	if _, statErr := os.Stat(cacheDir); !os.IsNotExist(statErr) {
+		t.Fatalf("render cache dir %q was created inside the diff tree before validation", cacheDir)
+	}
 }

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -111,7 +111,7 @@ func (o Orchestrator) applyExplicitKustomizeDiscovery(ctx context.Context, root 
 
 func (o Orchestrator) discoverRenderedKustomize(ctx context.Context, root string, settings config.ArgoSettings, request BuildRequest) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
 	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
-	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	provider, cleanup, err := o.discoveryProvider(ctx, root, settings, request, recorder)
 	if err != nil {
 		return discovery.Result{}, nil, recorder.Events(), err
 	}
@@ -223,6 +223,6 @@ func (o Orchestrator) discoverRenderedFleet(ctx context.Context, root string, re
 	return current, settingsSig, renderSig, allDiags, allEvents, nil
 }
 
-func (o Orchestrator) discoveryProvider(root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder) (localProvider, func(), error) {
-	return newLocalProvider(o, root, settings, request, recorder, "drydock-discovery-cache-snapshots-*")
+func (o Orchestrator) discoveryProvider(ctx context.Context, root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder) (localProvider, func(), error) {
+	return newLocalProvider(ctx, o, root, settings, request, recorder, "drydock-discovery-cache-snapshots-*")
 }

--- a/internal/app/discovery_bootstrap.go
+++ b/internal/app/discovery_bootstrap.go
@@ -35,13 +35,13 @@ func (o Orchestrator) applyPolicyBootstrapDiscovery(ctx context.Context, root st
 	if err != nil {
 		return discovered, nil, nil, err
 	}
-	settingsSig, err := settingsSignature(settings)
+	renderSig, err := renderSettingsSignature(settings)
 	if err != nil {
 		return discovered, nil, nil, err
 	}
 
 	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
-	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	provider, cleanup, err := o.discoveryProvider(ctx, root, settings, request, recorder)
 	if err != nil {
 		return discovered, nil, recorder.Events(), err
 	}
@@ -50,7 +50,7 @@ func (o Orchestrator) applyPolicyBootstrapDiscovery(ctx context.Context, root st
 	var rendered discovery.Result
 	var allDiags []diagnostic.Diagnostic
 	for _, entrypoint := range request.pluginPolicy.Bootstrap.Entrypoints {
-		next, diags, err := renderPolicyBootstrapEntrypoint(ctx, root, request, provider, settingsSig, renderCache, entrypoint)
+		next, diags, err := renderPolicyBootstrapEntrypoint(ctx, root, request, provider, renderSig, renderCache, entrypoint)
 		allDiags = append(allDiags, diags...)
 		if err != nil {
 			return discovered, allDiags, recorder.Events(), err

--- a/internal/app/discovery_frontier.go
+++ b/internal/app/discovery_frontier.go
@@ -16,7 +16,7 @@ import (
 
 func (o Orchestrator) renderDiscoveryFrontier(ctx context.Context, root string, request BuildRequest, discovered discovery.Result, settings config.ArgoSettings, settingsSig string, renderCache *applicationRenderCache) (discovery.Result, []diagnostic.Diagnostic, []cacheevent.Event, error) {
 	recorder := cacheevent.NewRecorder(request.RecordCacheEvents)
-	provider, cleanup, err := o.discoveryProvider(root, settings, request, recorder)
+	provider, cleanup, err := o.discoveryProvider(ctx, root, settings, request, recorder)
 	if err != nil {
 		return discovery.Result{}, nil, recorder.Events(), err
 	}
@@ -92,17 +92,19 @@ func renderDiscoveryApplication(ctx context.Context, root string, request BuildR
 	if !applicationMayRenderDiscoveryObjects(root, request, discovered, application) {
 		return discovery.Result{}, nil, nil
 	}
+	parentInputs := inputs[applicationDiscoveryKey(application)]
 	rendered, err := renderApplicationCached(renderContext{
-		context:           ctx,
-		provider:          provider,
-		cache:             renderCache,
-		settingsSignature: settingsSig,
-		request:           request,
+		context:                ctx,
+		provider:               provider,
+		cache:                  renderCache,
+		settingsSignature:      settingsSig,
+		request:                request,
+		applicationInputPaths:  parentInputs,
+		applicationInputsKnown: inputs != nil,
 	}, application)
 	if err != nil {
 		return skippedRenderedDiscovery()
 	}
-	parentInputs := inputs[applicationDiscoveryKey(application)]
 	return scanRenderedApplicationObjects(application, parentInputs, rendered.Manifests)
 }
 
@@ -175,10 +177,21 @@ func renderedInputPaths(parentInputs []string, renderedManifest render.Manifest)
 
 func applicationInputsByKey(discovered discovery.Result) map[string][]string {
 	out := make(map[string][]string, len(discovered.Applications))
+	seen := make(map[string]bool, len(discovered.Applications))
 	for _, appFile := range discovered.Applications {
+		key := applicationDiscoveryKey(appFile.Application)
+		if seen[key] {
+			// Two discovered Applications share namespace/name; neither input
+			// set is authoritative for the render, so nil paths make the
+			// persistent key collection reject the app (input-graph reason)
+			// instead of digesting the wrong file.
+			out[key] = nil
+			continue
+		}
+		seen[key] = true
 		inputs := discoveredApplicationInputPaths(appFile)
 		inputs = applicationSelectionPaths(ApplicationSelectionInput{Application: appFile.Application, Paths: inputs})
-		out[applicationDiscoveryKey(appFile.Application)] = uniqueStrings(inputs)
+		out[key] = uniqueStrings(inputs)
 	}
 	return out
 }

--- a/internal/app/discovery_signature.go
+++ b/internal/app/discovery_signature.go
@@ -32,23 +32,23 @@ func renderSettingsSignature(settings config.ArgoSettings) (string, error) {
 		}
 	}
 	input := struct {
-		KustomizeBuildOptions    []config.Value[string]                 `json:"kustomizeBuildOptions,omitempty"`
-		HelmRepositories         map[string]config.RepositorySettings   `json:"helmRepositories,omitempty"`
-		HelmValuesFileSchemes    []config.Value[string]                 `json:"helmValuesFileSchemes,omitempty"`
+		KustomizeBuildOptions    []string                               `json:"kustomizeBuildOptions,omitempty"`
+		HelmRepositories         map[string]renderSettingsRepository    `json:"helmRepositories,omitempty"`
+		HelmValuesFileSchemes    []string                               `json:"helmValuesFileSchemes,omitempty"`
 		HelmValuesFileSchemesSet bool                                   `json:"helmValuesFileSchemesSet,omitempty"`
-		TrackingMethod           config.Value[string]                   `json:"trackingMethod,omitempty"`
-		InstanceLabelKey         config.Value[string]                   `json:"instanceLabelKey,omitempty"`
-		InstallationID           config.Value[string]                   `json:"installationID,omitempty"`
+		TrackingMethod           string                                 `json:"trackingMethod,omitempty"`
+		InstanceLabelKey         string                                 `json:"instanceLabelKey,omitempty"`
+		InstallationID           string                                 `json:"installationID,omitempty"`
 		ConfigManagementPlugins  map[string]renderSettingsPlugin        `json:"configManagementPlugins,omitempty"`
 		ResourceCustomizations   map[string]renderSettingsCustomization `json:"resourceCustomizations,omitempty"`
 	}{
-		KustomizeBuildOptions:    settings.KustomizeBuildOptions,
-		HelmRepositories:         settings.HelmRepositories,
-		HelmValuesFileSchemes:    settings.HelmValuesFileSchemes,
+		KustomizeBuildOptions:    renderSettingsValues(settings.KustomizeBuildOptions),
+		HelmRepositories:         renderSettingsRepositories(settings.HelmRepositories),
+		HelmValuesFileSchemes:    renderSettingsValues(settings.HelmValuesFileSchemes),
 		HelmValuesFileSchemesSet: settings.HelmValuesFileSchemesSet,
-		TrackingMethod:           settings.TrackingMethod,
-		InstanceLabelKey:         settings.InstanceLabelKey,
-		InstallationID:           settings.InstallationID,
+		TrackingMethod:           settings.TrackingMethod.Value,
+		InstanceLabelKey:         settings.InstanceLabelKey.Value,
+		InstallationID:           settings.InstallationID.Value,
 		ConfigManagementPlugins:  plugins,
 		ResourceCustomizations:   renderSettingsCustomizations(settings.ResourceCustomizations),
 	}
@@ -68,11 +68,47 @@ type renderSettingsPlugin struct {
 	HasInit         bool     `json:"hasInit,omitempty"`
 }
 
+type renderSettingsRepository struct {
+	Name      string `json:"name,omitempty"`
+	Type      string `json:"type,omitempty"`
+	URL       string `json:"url,omitempty"`
+	EnableOCI bool   `json:"enableOCI,omitempty"`
+	Project   string `json:"project,omitempty"`
+}
+
 type renderSettingsCustomization struct {
 	HasHealthLua    bool   `json:"hasHealthLua,omitempty"`
 	HealthLuaSHA256 string `json:"healthLuaSHA256,omitempty"`
 	HasUseOpenLibs  bool   `json:"hasUseOpenLibs,omitempty"`
 	UseOpenLibs     bool   `json:"useOpenLibs,omitempty"`
+}
+
+func renderSettingsValues[T comparable](input []config.Value[T]) []T {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]T, 0, len(input))
+	for _, value := range input {
+		out = append(out, value.Value)
+	}
+	return out
+}
+
+func renderSettingsRepositories(input map[string]config.RepositorySettings) map[string]renderSettingsRepository {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make(map[string]renderSettingsRepository, len(input))
+	for key, repository := range input {
+		out[key] = renderSettingsRepository{
+			Name:      repository.Name,
+			Type:      repository.Type,
+			URL:       repository.URL,
+			EnableOCI: repository.EnableOCI,
+			Project:   repository.Project,
+		}
+	}
+	return out
 }
 
 func renderSettingsCustomizations(input map[string]config.ResourceCustomization) map[string]renderSettingsCustomization {

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -51,8 +51,23 @@ type localProvider struct {
 	kustomizeBuildOptions        []string
 	configManagementPlugins      map[string]config.ConfigManagementPlugin
 	cacheEvents                  *cacheevent.Recorder
-	pluginExecutions             *[]PluginExecution
-	acquisition                  acquisition.Session
+	acquisitions                 *cacheevent.AcquisitionCollector
+	// inputVerifier accumulates the digest path sets behind one application's
+	// persistent key so store() can re-check them after the render. nil for
+	// renders without the persistent tier.
+	inputVerifier *renderInputVerifier
+	rootIdentity  SourceIdentity
+	rootInputMode rootInputMode
+	// rootDirtyPaths is the sorted complete dirty-path enumeration for the
+	// repo root when rootInputMode is dirty; empty otherwise. Per-path-set
+	// keying uses it to keep committed keys for untouched applications. An
+	// empty list in dirty mode disables the committed shortcut (fail-safe
+	// for hand-built providers). Aliases the run-scoped handle memo — treat
+	// as read-only; never sort, append to, or mutate it in place.
+	rootDirtyPaths   []string
+	renderObserver   func(render.ResolvedSource)
+	pluginExecutions *[]PluginExecution
+	acquisition      acquisition.Session
 }
 
 var processCacheTargetLocks = acquisition.NewTargetLocks()
@@ -89,6 +104,7 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 		opts.HelmValueFileSchemesSet = p.helmValueFileSchemesSet
 	}
 	opts.CacheEventRecorder = p.cacheEvents
+	opts.AcquisitionCollector = p.acquisitions
 	anchoredRefRoots, err := anchorLocalRefRoots(sourceRoot, opts.RefRoots)
 	if err != nil {
 		return nil, nil, err
@@ -108,6 +124,9 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 			return nil, nil, err
 		}
 		guardrailDiags := p.cmpAutoDiscoveryDeferredDiagnostics(source, opts)
+		if p.renderObserver != nil {
+			p.renderObserver(source)
+		}
 		manifests, diags, err := renderer.Render(ctx, source, opts)
 		diags = append(guardrailDiags, diags...)
 		return manifests, diags, err

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -1,19 +1,22 @@
 package app
 
 import (
+	"context"
 	"os"
+	"strings"
 
 	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/gitref"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
-func newLocalProvider(orchestrator Orchestrator, root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder, snapshotPrefix string) (localProvider, func(), error) {
+func newLocalProvider(ctx context.Context, orchestrator Orchestrator, root string, settings config.ArgoSettings, request BuildRequest, recorder *cacheevent.Recorder, snapshotPrefix string) (localProvider, func(), error) {
 	acquirer := orchestrator.ChartAcquirer
 	if acquirer == nil {
 		acquirer = chart.DefaultAcquirer{}
@@ -66,6 +69,8 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		configManagementPlugins:      settings.ConfigManagementPlugins,
 		cacheEvents:                  recorder,
 	}
+	provider.rootIdentity, provider.rootInputMode, provider.rootDirtyPaths = rootIdentityForRequest(ctx, root, request)
+	provider.renderObserver = orchestrator.renderObserver
 	if request.snapshotSession != nil {
 		provider.acquisition = acquisition.Session{
 			Locks:                     processCacheTargetLocks,
@@ -88,4 +93,32 @@ func newLocalProvider(orchestrator Orchestrator, root string, settings config.Ar
 		PreserveGitDirInSnapshots: request.EnablePlugins,
 	}
 	return provider, func() { _ = os.RemoveAll(snapshotRoot) }, nil
+}
+
+// rootIdentityForRequest computes the provider root's SourceIdentity, input
+// mode, and (for dirty roots) the complete dirty-path enumeration. A
+// gitref-snapshot root keys on its resolved snapshot revision; a clean
+// worktree root uses HEAD before local input digesting; a dirty worktree
+// root uses filesystem input digests for touched path sets and committed
+// digests for untouched ones; unknown roots (non-git directories) remain
+// ineligible.
+func rootIdentityForRequest(ctx context.Context, root string, request BuildRequest) (SourceIdentity, rootInputMode, []string) {
+	if revision := strings.TrimSpace(request.rootRevision); revision != "" {
+		return SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision}, rootInputModeSnapshot, nil
+	}
+	handle := request.persistentRenderCache
+	if !handle.active() {
+		return SourceIdentity{Kind: sourceIdentityKindRoot}, rootInputModeUnknown, nil
+	}
+	changeSet := handle.worktreeChangeSet(ctx, root)
+	switch changeSet.State {
+	case gitref.WorktreeStateClean:
+		return SourceIdentity{Kind: sourceIdentityKindRoot, Revision: changeSet.Revision}, rootInputModeClean, nil
+	case gitref.WorktreeStateDirty:
+		return SourceIdentity{Kind: sourceIdentityKindRoot, Revision: changeSet.Revision}, rootInputModeDirty, changeSet.DirtyPaths
+	case gitref.WorktreeStateUnknown:
+		return SourceIdentity{Kind: sourceIdentityKindRoot}, rootInputModeUnknown, nil
+	default:
+		return SourceIdentity{Kind: sourceIdentityKindRoot}, rootInputModeUnknown, nil
+	}
 }

--- a/internal/app/local_provider_chart.go
+++ b/internal/app/local_provider_chart.go
@@ -59,7 +59,15 @@ func (p localProvider) renderChartOnlySource(ctx context.Context, source render.
 		Offline:           p.offline,
 		Refresh:           p.refreshCharts,
 	}))
+	p.recordAcquisition(cacheevent.AcquisitionRecord{
+		Kind:              cacheevent.AcquisitionChart,
+		RequestedRevision: source.TargetRevision,
+		ResolvedRevision:  acquired.Version,
+	})
 
+	if p.renderObserver != nil {
+		p.renderObserver(source)
+	}
 	return (render.HelmRenderer{}).Render(ctx, render.ResolvedSource{
 		RepoRoot:       acquired.ChartDir,
 		Path:           ".",

--- a/internal/app/local_provider_helpers.go
+++ b/internal/app/local_provider_helpers.go
@@ -42,3 +42,9 @@ func (p localProvider) recordCacheEvent(event cacheevent.Event) {
 		p.cacheEvents.Record(event)
 	}
 }
+
+func (p localProvider) recordAcquisition(record cacheevent.AcquisitionRecord) {
+	if p.acquisitions != nil {
+		p.acquisitions.Record(record)
+	}
+}

--- a/internal/app/local_provider_paths.go
+++ b/internal/app/local_provider_paths.go
@@ -54,7 +54,7 @@ func selectLocalRenderer(source render.ResolvedSource) (render.Renderer, error) 
 		return nil, fmt.Errorf("unsupported explicit source type %q", source.ExplicitType)
 	}
 
-	for _, name := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+	for _, name := range render.KustomizationFileNames {
 		if exists, err := localPathExists(filepath.Join(root, name)); err != nil {
 			return nil, err
 		} else if exists {

--- a/internal/app/local_provider_sources.go
+++ b/internal/app/local_provider_sources.go
@@ -12,31 +12,41 @@ import (
 )
 
 func (p localProvider) resolveSourceRoot(ctx context.Context, source render.ResolvedSource) (string, error) {
+	root, _, err := p.resolveSourceRootIdentity(ctx, source)
+	return root, err
+}
+
+// resolveSourceRootIdentity resolves the source root exactly as
+// resolveSourceRoot always has, and additionally reports the source's resolved
+// SourceIdentity for the persistent render cache key. A zero identity marks
+// the source persistence-ineligible.
+func (p localProvider) resolveSourceRootIdentity(ctx context.Context, source render.ResolvedSource) (string, SourceIdentity, error) {
 	if source.Path == "" && source.Chart != "" {
-		return p.repoRoot, nil
+		return p.repoRoot, chartOnlySourceIdentity(source), nil
 	}
 	if p.sourceResolver != nil {
 		if mappedPath, ok := p.sourceResolver.MappedPath(source.RepoURL); ok {
 			p.recordCacheEvent(cacheevent.Event{Source: cacheevent.SourceGit, Action: cacheevent.ActionMapped, Target: source.RepoURL, Revision: source.TargetRevision})
-			return filepath.Abs(mappedPath)
+			abs, err := filepath.Abs(mappedPath)
+			return abs, SourceIdentity{}, err
 		}
 	}
 	if source.Path != "" {
 		if exists, err := sourcePathExists(p.repoRoot, source.Path); err != nil {
-			return "", err
+			return "", SourceIdentity{}, err
 		} else if exists {
 			p.recordCacheEvent(cacheevent.Event{Source: cacheevent.SourceGit, Action: cacheevent.ActionLocal, Target: source.RepoURL, Revision: source.TargetRevision})
-			return p.repoRoot, nil
+			return p.repoRoot, p.rootIdentity, nil
 		}
 	}
 	if strings.TrimSpace(source.RepoURL) == "" {
-		return p.repoRoot, nil
+		return p.repoRoot, p.rootIdentity, nil
 	}
 	if p.sourceResolver == nil {
-		return p.repoRoot, nil
+		return p.repoRoot, p.rootIdentity, nil
 	}
 	if _, err := p.sourceResolver.Resolve(source.RepoURL, source.TargetRevision); err != nil {
-		return "", fmt.Errorf("source path %q is not present under local repository root and %w", source.Path, err)
+		return "", SourceIdentity{}, fmt.Errorf("source path %q is not present under local repository root and %w", source.Path, err)
 	}
 	acquirer := p.gitAcquirer
 	if acquirer == nil {
@@ -64,7 +74,7 @@ func (p localProvider) resolveSourceRoot(ctx context.Context, source render.Reso
 			SensitiveValues:   sourceGitSensitiveValues(p.gitCredentials),
 		})
 		p.recordCacheEvent(acquireError.Event)
-		return "", fmt.Errorf("%s", acquireError.RedactedError)
+		return "", SourceIdentity{}, fmt.Errorf("%s", acquireError.RedactedError)
 	}
 	p.recordCacheEvent(cacheevent.NewAcquisitionEvent(cacheevent.AcquisitionEventInput{
 		Source:            cacheevent.SourceGit,
@@ -76,7 +86,31 @@ func (p localProvider) resolveSourceRoot(ctx context.Context, source render.Reso
 		Offline:           p.offline,
 		Refresh:           p.refreshGit,
 	}))
-	return acquired.Path, nil
+	p.recordAcquisition(cacheevent.AcquisitionRecord{
+		Kind:              cacheevent.AcquisitionGit,
+		RequestedRevision: source.TargetRevision,
+		ResolvedRevision:  acquired.Revision,
+	})
+	return acquired.Path, SourceIdentity{
+		Kind:     sourceIdentityKindGit,
+		Locator:  sourcepkg.NormalizeURL(source.RepoURL),
+		Revision: acquired.Revision,
+	}, nil
+}
+
+// chartOnlySourceIdentity derives the identity from the spec alone: drydock
+// supports exact chart versions only, so name+version fully determine content
+// per registry contract.
+func chartOnlySourceIdentity(source render.ResolvedSource) SourceIdentity {
+	version := strings.TrimSpace(source.TargetRevision)
+	if version == "" {
+		return SourceIdentity{}
+	}
+	return SourceIdentity{
+		Kind:     sourceIdentityKindChart,
+		Locator:  strings.TrimSpace(source.RepoURL) + "::" + strings.TrimSpace(source.Chart),
+		Revision: version,
+	}
 }
 
 func (p localProvider) resolveRefRoots(ctx context.Context, refSources map[string]render.ResolvedSource) (map[string]string, error) {

--- a/internal/app/named.go
+++ b/internal/app/named.go
@@ -60,3 +60,20 @@ func applicationDisplayName(application argoappv1.Application) string {
 	}
 	return application.Namespace + "/" + application.Name
 }
+
+// renderEventTarget returns the namespace/name label when it is safe to embed
+// in cache events verbatim. Application names come from unvalidated YAML; a
+// URL-shaped (credential-bearing) name is replaced wholesale, because routing
+// render targets through URL redaction would mangle every legitimate label.
+func renderEventTarget(application argoappv1.Application) string {
+	target := applicationDisplayName(application)
+	for _, r := range target {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '.' || r == '_' || r == '/':
+		default:
+			return "[invalid-name]"
+		}
+	}
+	return target
+}

--- a/internal/app/named_test.go
+++ b/internal/app/named_test.go
@@ -93,3 +93,28 @@ func namedApplication(namespace, name string) argoappv1.Application {
 		},
 	}
 }
+
+func TestRenderEventTargetCharset(t *testing.T) {
+	cases := []struct {
+		name      string
+		namespace string
+		appName   string
+		want      string
+	}{
+		{"dns-name", "argocd", "demo-app.v2", "argocd/demo-app.v2"},
+		{"no-namespace", "", "demo", "demo"},
+		{"permissive-extras", "argocd", "My_App", "argocd/My_App"},
+		{"scp-url", "argocd", "git@host:repo", "[invalid-name]"},
+		{"space", "argocd", "demo app", "[invalid-name]"},
+		{"unicode-colon", "argocd", "demo：app", "[invalid-name]"},
+		{"empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			application := argoappv1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: tc.namespace, Name: tc.appName}}
+			if got := renderEventTarget(application); got != tc.want {
+				t.Fatalf("renderEventTarget(%q/%q) = %q, want %q", tc.namespace, tc.appName, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -41,6 +41,7 @@ type BuildRequest struct {
 	DiscoveryOptions
 	ValidateLuaHealth bool
 	AcquisitionOptions
+	RenderCacheOptions
 	PluginOptions
 	ExecutionOptions
 	FilterOptions
@@ -52,6 +53,8 @@ type BuildRequest struct {
 	renderSettingsSignature string
 	discovered              *discovery.Result
 	snapshotSession         *acquisition.SnapshotSession
+	persistentRenderCache   *persistentRenderCache
+	rootRevision            string
 	discoveryPathMemo       *sync.Map
 	appsetGenerationMemo    *sync.Map
 }
@@ -143,6 +146,10 @@ type Orchestrator struct {
 	PluginRenderer         render.PluginRenderer
 	PluginExecRunner       pluginexec.Runner
 	PluginContainerRunner  plugincontainer.Runner
+
+	// renderObserver is a test seam invoked immediately before local
+	// render-engine invocations. It is nil in production.
+	renderObserver func(render.ResolvedSource)
 }
 
 func ensureSnapshotSession(request BuildRequest) (BuildRequest, func(), error) {
@@ -175,12 +182,20 @@ func (o Orchestrator) Diag(ctx context.Context, request DiagRequest) (DiagResult
 	return diagResult, nil
 }
 
-func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest) (BuildResult, error) {
+func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest) (result BuildResult, err error) {
 	request, releaseSnapshots, err := ensureSnapshotSession(request)
 	if err != nil {
 		return BuildResult{}, err
 	}
 	defer releaseSnapshots()
+
+	if err := validateBuildRenderCacheRoot(request); err != nil {
+		return BuildResult{}, err
+	}
+	request, releaseRenderCache := ensurePersistentRenderCache(request)
+	defer func() {
+		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
+	}()
 
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return BuildResult{}, err
@@ -190,7 +205,6 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 		root = "."
 	}
 
-	var result BuildResult
 	loadedRequest, policyDiags, cleanup, err := ensureBuildPluginPolicy(ctx, request, root)
 	defer cleanup()
 	policyDiags = request.filterProjectDiagnostics(policyDiags)
@@ -231,6 +245,17 @@ func appendDiscoveredApplications(discovered discovery.Result, result *BuildResu
 		})
 	}
 	return nil
+}
+
+func discoveredApplicationSelectionInputs(discovered discovery.Result) []ApplicationSelectionInput {
+	inputs := make([]ApplicationSelectionInput, 0, len(discovered.Applications))
+	for _, appFile := range discovered.Applications {
+		inputs = append(inputs, ApplicationSelectionInput{
+			Application: appFile.Application,
+			Paths:       discoveredApplicationInputPaths(appFile),
+		})
+	}
+	return inputs
 }
 
 func discoveredApplicationInputPaths(appFile discovery.ApplicationFile) []string {
@@ -282,18 +307,27 @@ func applicationSetOptionsForRequest(request BuildRequest) (appset.Options, []di
 	}, diags, nil
 }
 
-func (o Orchestrator) Build(ctx context.Context, request BuildRequest) (BuildResult, error) {
+func (o Orchestrator) Build(ctx context.Context, request BuildRequest) (result BuildResult, err error) {
 	request, releaseSnapshots, err := ensureSnapshotSession(request)
 	if err != nil {
 		return BuildResult{}, err
 	}
 	defer releaseSnapshots()
 
+	if err := validateBuildRenderCacheRoot(request); err != nil {
+		return BuildResult{}, err
+	}
+	request, releaseRenderCache := ensurePersistentRenderCache(request)
+	defer func() {
+		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
+	}()
+
 	session, err := newBuildSession(o, request)
 	if err != nil {
 		return BuildResult{}, err
 	}
-	return session.Build(ctx)
+	result, err = session.Build(ctx)
+	return result, err
 }
 
 func normalizeParallelism(value int) (int, error) {
@@ -331,6 +365,7 @@ func normalizeMaxDiscoveryDepth(value int, explicitlySet bool) (int, error) {
 
 type renderApplicationsRequest struct {
 	applications      []argoappv1.Application
+	applicationInputs map[string][]string
 	provider          localProvider
 	renderCache       *applicationRenderCache
 	settingsSignature string
@@ -453,6 +488,11 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 		settingsSignature: request.settingsSignature,
 		trackingOptions:   request.trackingOptions,
 		request:           request.request,
+		applicationInputPaths: applicationInputPathsForRender(
+			request.applicationInputs,
+			application,
+		),
+		applicationInputsKnown: request.applicationInputs != nil,
 	}, application)
 	if err != nil {
 		out.pluginExecutions = append(out.pluginExecutions, pluginExecutions...)
@@ -562,6 +602,7 @@ func (o Orchestrator) prepareBuildResult(ctx context.Context, request BuildReque
 		result.discovered = request.discovered
 		result.pluginOptions = request.PluginOptions
 		result.Projects = appendDiscoveredProjects(result.Projects, discovered)
+		result.ApplicationInputs = selectApplicationInputsForApplications(discoveredApplicationSelectionInputs(discovered), result.Applications)
 		diags, err := loadBuildSideSettings(root, request, discovered, &result)
 		if err != nil {
 			result.Statuses = skippedApplicationStatuses(result.Applications, err)
@@ -635,14 +676,21 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	}
 	defer releaseSnapshots()
 
+	if err := validateBuildRenderCacheRoot(buildRequest); err != nil {
+		return BuildResult{}, err
+	}
+	buildRequest, releaseRenderCache := ensurePersistentRenderCache(buildRequest)
+
 	listResult, err := o.ListApplications(ctx, buildRequest)
 	if err != nil {
 		listResult.Statuses = skippedStatusesForRequestedApplication(listResult.Applications, name, err)
+		listResult.CacheEvents = append(listResult.CacheEvents, releaseRenderCache()...)
 		return listResult, err
 	}
 
 	selected, err := SelectApplicationByName(listResult.Applications, name)
 	if err != nil {
+		listResult.CacheEvents = append(listResult.CacheEvents, releaseRenderCache()...)
 		return listResult, err
 	}
 
@@ -656,6 +704,7 @@ func (o Orchestrator) BuildApp(ctx context.Context, request BuildAppRequest) (Bu
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
 	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
 	buildResult.CacheEvents = append(append([]cacheevent.Event(nil), listResult.CacheEvents...), buildResult.CacheEvents...)
+	buildResult.CacheEvents = append(buildResult.CacheEvents, releaseRenderCache()...)
 	return buildResult, err
 }
 
@@ -668,9 +717,15 @@ func (o Orchestrator) BuildSelection(ctx context.Context, request BuildRequest, 
 	}
 	defer releaseSnapshots()
 
+	if err := validateBuildRenderCacheRoot(request); err != nil {
+		return BuildResult{}, err
+	}
+	request, releaseRenderCache := ensurePersistentRenderCache(request)
+
 	listResult, err := o.ListApplications(ctx, request)
 	if err != nil {
 		listResult.Statuses = skippedApplicationStatuses(listResult.Applications, err)
+		listResult.CacheEvents = append(listResult.CacheEvents, releaseRenderCache()...)
 		return listResult, err
 	}
 
@@ -692,6 +747,7 @@ func (o Orchestrator) BuildSelection(ctx context.Context, request BuildRequest, 
 	buildResult.Diagnostics = append(append([]diagnostic.Diagnostic(nil), listResult.Diagnostics...), buildResult.Diagnostics...)
 	buildResult.Diagnostics = buildRequest.filterProjectDiagnostics(dedupeDiagnostics(buildResult.Diagnostics))
 	buildResult.CacheEvents = append(append([]cacheevent.Event(nil), listResult.CacheEvents...), buildResult.CacheEvents...)
+	buildResult.CacheEvents = append(buildResult.CacheEvents, releaseRenderCache()...)
 	return buildResult, err
 }
 
@@ -787,6 +843,35 @@ func selectApplicationInputsForApplications(inputs []ApplicationSelectionInput, 
 		}
 	}
 	return out
+}
+
+func applicationInputPathsByKey(inputs []ApplicationSelectionInput) map[string][]string {
+	if len(inputs) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(inputs))
+	seen := make(map[string]bool, len(inputs))
+	for _, input := range inputs {
+		key := applicationKey(input.Application)
+		if seen[key] {
+			// Two discovered Applications share namespace/name; neither input
+			// set is authoritative for the render, so nil paths make the
+			// persistent key collection reject the app (input-graph reason)
+			// instead of digesting the wrong file.
+			out[key] = nil
+			continue
+		}
+		seen[key] = true
+		out[key] = append([]string(nil), input.Paths...)
+	}
+	return out
+}
+
+func applicationInputPathsForRender(inputs map[string][]string, application argoappv1.Application) []string {
+	if inputs == nil {
+		return nil
+	}
+	return append([]string(nil), inputs[applicationKey(application)]...)
 }
 
 func applicationKey(application argoappv1.Application) string {

--- a/internal/app/orchestrator_sources_test.go
+++ b/internal/app/orchestrator_sources_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -271,6 +272,55 @@ func TestOrchestratorBuildRejectsRemoteCacheInsideRepoRoot(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "remote resource cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
 		t.Fatalf("Build() error = %q, want remote cache location error", err.Error())
+	}
+}
+
+func TestOrchestratorBuildRejectsRenderCacheInsideRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	writeBuildApplication(t, root, "plain", "plain")
+	cacheDir := filepath.Join(root, ".drydock", "render")
+
+	_, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path: root,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want render cache location error")
+	}
+	if !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+		t.Fatalf("Build() error = %q, want render cache location error", err.Error())
+	}
+	if _, statErr := os.Stat(cacheDir); !os.IsNotExist(statErr) {
+		t.Fatalf("render cache dir stat error = %v, want not created", statErr)
+	}
+}
+
+func TestOrchestratorBuildRejectsRenderCacheInsideRepoMapRoot(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	writeBuildApplication(t, root, "plain", "plain")
+
+	_, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path: root,
+		AcquisitionOptions: AcquisitionOptions{
+			RepoMaps: []sourcepkg.RepoMap{{
+				URL:  "https://github.com/example/external.git",
+				Path: external,
+			}},
+		},
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     filepath.Join(external, ".drydock", "render"),
+		},
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want render cache location error")
+	}
+	if !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+		t.Fatalf("Build() error = %q, want render cache location error", err.Error())
 	}
 }
 func TestOrchestratorBuildUsesRepoMappedHelmValueRef(t *testing.T) {

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/acquisition"
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/discovery"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -94,7 +98,7 @@ func TestNewLocalProviderCarriesHelmValuesFileSchemes(t *testing.T) {
 	}
 	settings.HelmValuesFileSchemesSet = true
 
-	provider, cleanup, err := newLocalProvider(Orchestrator{}, t.TempDir(), settings, BuildRequest{}, nil, "drydock-test-*")
+	provider, cleanup, err := newLocalProvider(context.Background(), Orchestrator{}, t.TempDir(), settings, BuildRequest{}, nil, "drydock-test-*")
 	defer cleanup()
 	if err != nil {
 		t.Fatalf("newLocalProvider() error = %v", err)
@@ -108,7 +112,7 @@ func TestNewLocalProviderCarriesHelmValuesFileSchemes(t *testing.T) {
 }
 
 func TestNewLocalProviderPreservesGitDirInSnapshotsWhenPluginsEnabled(t *testing.T) {
-	provider, cleanup, err := newLocalProvider(Orchestrator{}, t.TempDir(), config.DefaultSettings(), BuildRequest{
+	provider, cleanup, err := newLocalProvider(context.Background(), Orchestrator{}, t.TempDir(), config.DefaultSettings(), BuildRequest{
 		PluginOptions: PluginOptions{EnablePlugins: true},
 	}, nil, "drydock-test-*")
 	defer cleanup()
@@ -129,7 +133,7 @@ func TestNewLocalProviderReusesRequestSnapshotSession(t *testing.T) {
 	request := BuildRequest{}
 	request.snapshotSession = session
 
-	provider, cleanup, err := newLocalProvider(Orchestrator{}, t.TempDir(), config.DefaultSettings(), request, cacheevent.NewRecorder(false), "unused-*")
+	provider, cleanup, err := newLocalProvider(context.Background(), Orchestrator{}, t.TempDir(), config.DefaultSettings(), request, cacheevent.NewRecorder(false), "unused-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1062,4 +1066,57 @@ func indentLua(lua string) string {
 		out.WriteByte('\n')
 	}
 	return out.String()
+}
+
+func TestApplicationInputPathsByKeyDuplicateAppsAreCacheIneligible(t *testing.T) {
+	app := func(name string) argoappv1.Application {
+		return argoappv1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "argocd", Name: name}}
+	}
+	inputs := []ApplicationSelectionInput{
+		{Application: app("web"), Paths: []string{"apps/web/app.yaml"}},
+		{Application: app("api"), Paths: []string{"apps/api/app.yaml"}},
+		{Application: app("web"), Paths: []string{"overlays/prod/web.yaml"}},
+	}
+
+	byKey := applicationInputPathsByKey(inputs)
+
+	if got := byKey[applicationKey(app("api"))]; !reflect.DeepEqual(got, []string{"apps/api/app.yaml"}) {
+		t.Fatalf("unique app paths = %#v, want preserved", got)
+	}
+	if got := byKey[applicationKey(app("web"))]; got != nil {
+		t.Fatalf("duplicate app paths = %#v, want nil (cache-ineligible)", got)
+	}
+	if got := applicationInputPathsForRender(byKey, app("web")); got != nil {
+		t.Fatalf("applicationInputPathsForRender for duplicate = %#v, want nil", got)
+	}
+}
+
+func TestApplicationInputsByKeyDuplicateAppsAreCacheIneligible(t *testing.T) {
+	app := func(name string) argoappv1.Application {
+		return argoappv1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "argocd", Name: name}}
+	}
+	appFile := func(application argoappv1.Application, paths []string) discovery.ApplicationFile {
+		return discovery.ApplicationFile{
+			Path:          "test.yaml",
+			DocumentIndex: 0,
+			Application:   application,
+			InputPaths:    paths,
+		}
+	}
+	discovered := discovery.Result{
+		Applications: []discovery.ApplicationFile{
+			appFile(app("web"), []string{"apps/web/app.yaml"}),
+			appFile(app("api"), []string{"apps/api/app.yaml"}),
+			appFile(app("web"), []string{"overlays/prod/web.yaml"}),
+		},
+	}
+
+	byKey := applicationInputsByKey(discovered)
+
+	if got := byKey[applicationDiscoveryKey(app("api"))]; !reflect.DeepEqual(got, []string{"apps/api/app.yaml"}) {
+		t.Fatalf("unique app paths = %#v, want preserved", got)
+	}
+	if got := byKey[applicationDiscoveryKey(app("web"))]; got != nil {
+		t.Fatalf("duplicate app paths = %#v, want nil (cache-ineligible)", got)
+	}
 }

--- a/internal/app/persistent_cache_integration_test.go
+++ b/internal/app/persistent_cache_integration_test.go
@@ -1,0 +1,1949 @@
+package app
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const persistentCacheTestSHA = "0123456789abcdef0123456789abcdef01234567"
+
+func gitCommitAll(t *testing.T, root, message string) string {
+	t.Helper()
+	repo, err := git.PlainOpenWithOptions(root, &git.PlainOpenOptions{})
+	if err != nil {
+		repo, err = git.PlainInit(root, false)
+		if err != nil {
+			t.Fatalf("PlainInit() error = %v", err)
+		}
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree() error = %v", err)
+	}
+	if err := worktree.AddWithOptions(&git.AddOptions{All: true}); err != nil {
+		t.Fatalf("AddWithOptions() error = %v", err)
+	}
+	signature := &object.Signature{
+		Name:  "Test",
+		Email: "test@example.invalid",
+		When:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	hash, err := worktree.Commit(message, &git.CommitOptions{Author: signature, Committer: signature})
+	if err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return hash.String()
+}
+
+func writePersistentCacheApp(t *testing.T, root, name string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: charts/`+name+`
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "Chart.yaml"), `apiVersion: v2
+name: `+name+`
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "values.yaml"), `value: persistent-cache
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: {{ .Values.value | quote }}
+`)
+}
+
+func writePersistentDirectoryCacheApp(t *testing.T, root, name string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+name+`
+    targetRevision: main
+    directory: {}
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", name, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: initial
+`)
+}
+
+func writePersistentDirectorySource(t *testing.T, root, name, value string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "manifests", name, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: `+value+`
+`)
+}
+
+func writePersistentCacheAppSetFileGenerator(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "appset.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: generated
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        files:
+          - path: clusters/*.yaml
+  template:
+    metadata:
+      name: "{{.name}}"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: main
+        path: "manifests/{{.name}}"
+        directory: {}
+      destination:
+        name: in-cluster
+        namespace: default
+`)
+}
+
+func writePersistentRenderedFleetCacheFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "root.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: bootstrap-chart
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "Chart.yaml"), `apiVersion: v2
+name: bootstrap
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "child.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: child
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/child
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writePersistentDirectorySource(t, root, "child", "initial-child")
+}
+
+func writePersistentJsonnetCacheApp(t *testing.T, root, name string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+name+`
+    targetRevision: main
+    directory:
+      jsonnet:
+        libs:
+          - lib
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", name, "cm.jsonnet"), `local helper = import 'helper.libsonnet';
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: { name: '`+name+`' },
+  data: { value: helper.value + '-source-a' },
+}
+`)
+	writeTestFile(t, filepath.Join(root, "lib", "helper.libsonnet"), `{
+  value: 'lib-a',
+}
+`)
+}
+
+func writePersistentCacheSameRepoValuesHelmApp(t *testing.T, root, name, valueFile string, ignoreMissing bool) {
+	t.Helper()
+	ignoreMissingBlock := ""
+	if ignoreMissing {
+		ignoreMissingBlock = "        ignoreMissingValueFiles: true\n"
+	}
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/example/repo
+      targetRevision: main
+      ref: values
+    - repoURL: https://github.com/example/repo
+      path: charts/`+name+`
+      targetRevision: main
+      helm:
+`+ignoreMissingBlock+`        valueFiles:
+          - `+valueFile+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "Chart.yaml"), `apiVersion: v2
+name: `+name+`
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "values.yaml"), `value: default
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: {{ .Values.value | quote }}
+`)
+}
+
+func persistentBuildRequest(root, cacheDir string) BuildRequest {
+	return BuildRequest{
+		Path: root,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+}
+
+func countingOrchestrator(counter *atomic.Int64) Orchestrator {
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(render.ResolvedSource) { counter.Add(1) }
+	return orchestrator
+}
+
+func countRenderCacheEntries(t *testing.T, cacheDir string) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(cacheDir, func(_ string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json.gz") {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s) error = %v", cacheDir, err)
+	}
+	return count
+}
+
+func readRenderCachePayloads(t *testing.T, cacheDir string) map[string][]byte {
+	t.Helper()
+	payloads := map[string][]byte{}
+	err := filepath.WalkDir(cacheDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json.gz") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		gz, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			return err
+		}
+		data, err := io.ReadAll(gz)
+		if err != nil {
+			return err
+		}
+		if err := gz.Close(); err != nil {
+			return err
+		}
+		var envelope struct {
+			Key    string          `json:"key"`
+			Result json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return err
+		}
+		payloads[envelope.Key] = []byte(envelope.Result)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read payloads: %v", err)
+	}
+	return payloads
+}
+
+func TestPersistentCacheColdThenWarmBuildSkipsRenderEngines(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	writePersistentCacheApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+
+	var coldRenders atomic.Int64
+	coldResult, err := countingOrchestrator(&coldRenders).Build(context.Background(), persistentBuildRequest(root, cacheDir))
+	if err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if coldRenders.Load() == 0 {
+		t.Fatalf("cold run performed zero render-engine invocations")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got < 2 {
+		t.Fatalf("entries after cold run = %d, want at least 2", got)
+	}
+
+	var warmRenders atomic.Int64
+	warmResult, err := countingOrchestrator(&warmRenders).Build(context.Background(), persistentBuildRequest(root, cacheDir))
+	if err != nil {
+		t.Fatalf("warm Build() error = %v", err)
+	}
+	if got := warmRenders.Load(); got != 0 {
+		t.Fatalf("warm run render-engine invocations = %d, want 0", got)
+	}
+	if len(warmResult.ApplicationManifests) != len(coldResult.ApplicationManifests) {
+		t.Fatalf("warm manifests = %d, cold = %d", len(warmResult.ApplicationManifests), len(coldResult.ApplicationManifests))
+	}
+	for i := range coldResult.ApplicationManifests {
+		coldManifest := coldResult.ApplicationManifests[i]
+		warmManifest := warmResult.ApplicationManifests[i]
+		if !reflect.DeepEqual(coldManifest.Manifest.Object, warmManifest.Manifest.Object) {
+			t.Fatalf("manifest %d differs between cold and warm runs", i)
+		}
+	}
+}
+
+func TestPersistentCacheLocalInputsReuseUnchangedAppAcrossCleanCommits(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	writePersistentCacheApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 2 {
+		t.Fatalf("entries after cold run = %d, want 2", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: changed
+`)
+	gitCommitAll(t, root, "change alpha")
+
+	var renderedMu sync.Mutex
+	renderedPaths := map[string]int{}
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderedMu.Lock()
+		defer renderedMu.Unlock()
+		renderedPaths[filepath.ToSlash(source.Path)]++
+	}
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["charts/alpha"]; got != 1 {
+		t.Fatalf("second build alpha renders = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["charts/beta"]; got != 0 {
+		t.Fatalf("second build beta renders = %d, want 0 persistent hit; all renders = %#v", got, renderedPaths)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 3 {
+		t.Fatalf("entries after second run = %d, want old alpha + beta + new alpha", got)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionStore, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent store", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheUnchangedLocalAppHitsAcrossHeadChange(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	writePersistentCacheApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+
+	var coldRenders atomic.Int64
+	if _, err := countingOrchestrator(&coldRenders).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := coldRenders.Load(); got != 2 {
+		t.Fatalf("cold render-engine invocations = %d, want 2", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: changed-alpha
+`)
+	gitCommitAll(t, root, "change alpha")
+
+	var renderedMu sync.Mutex
+	renderedPaths := map[string]int{}
+	warmOrchestrator := Orchestrator{}
+	warmOrchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderedMu.Lock()
+		defer renderedMu.Unlock()
+		renderedPaths[filepath.ToSlash(source.Path)]++
+	}
+	warmResult, err := warmOrchestrator.Build(context.Background(), persistentBuildRequest(root, cacheDir))
+	if err != nil {
+		t.Fatalf("warm Build() error = %v", err)
+	}
+	if got := renderedPaths["charts/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after alpha commit = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["charts/beta"]; got != 0 {
+		t.Fatalf("beta renders after alpha commit = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+	if len(warmResult.ApplicationManifests) != 2 {
+		t.Fatalf("warm manifests = %d, want 2", len(warmResult.ApplicationManifests))
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 3 {
+		t.Fatalf("entries after app-scoped miss = %d, want 3", got)
+	}
+}
+
+func TestPersistentCacheStaticApplicationYAMLChangeInvalidatesOnlyThatApp(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	writePersistentCacheApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	alphaAppPath := filepath.Join(root, "apps", "alpha.yaml")
+	raw, err := os.ReadFile(alphaAppPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", alphaAppPath, err)
+	}
+	writeTestFile(t, alphaAppPath, string(raw)+"# discovery input changed without changing the Application spec\n")
+	gitCommitAll(t, root, "change alpha application yaml comment")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["charts/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after app yaml change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["charts/beta"]; got != 0 {
+		t.Fatalf("beta renders after alpha app yaml change = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheApplicationSetGeneratorFileChangeInvalidatesOnlyGeneratedApp(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheAppSetFileGenerator(t, root)
+	writePersistentDirectorySource(t, root, "alpha", "initial-alpha")
+	writePersistentDirectorySource(t, root, "beta", "initial-beta")
+	writeTestFile(t, filepath.Join(root, "clusters", "alpha.yaml"), "name: alpha\nunused: one\n")
+	writeTestFile(t, filepath.Join(root, "clusters", "beta.yaml"), "name: beta\nunused: one\n")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(root, "clusters", "alpha.yaml"), "name: alpha\nunused: two\n")
+	gitCommitAll(t, root, "change alpha generator file")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after generator file change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/beta"]; got != 0 {
+		t.Fatalf("beta renders after alpha generator file change = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheRenderedFleetParentInputChangeInvalidatesChild(t *testing.T) {
+	root := t.TempDir()
+	writePersistentRenderedFleetCacheFixture(t, root)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	childTemplatePath := filepath.Join(root, "bootstrap-chart", "templates", "child.yaml")
+	raw, err := os.ReadFile(childTemplatePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", childTemplatePath, err)
+	}
+	writeTestFile(t, childTemplatePath, string(raw)+"# rendered fleet parent input changed\n")
+	gitCommitAll(t, root, "change rendered child template comment")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["bootstrap-chart"]; got != 1 {
+		t.Fatalf("root renders after bootstrap template change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/child"]; got != 1 {
+		t.Fatalf("child renders after rendered parent input change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/child", "") {
+		t.Fatalf("CacheEvents = %#v, want child persistent miss", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheRenderedFleetApplicationYAMLChangeInvalidatesDiscoveryRender(t *testing.T) {
+	root := t.TempDir()
+	writePersistentRenderedFleetCacheFixture(t, root)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	rootAppPath := filepath.Join(root, "apps", "root.yaml")
+	raw, err := os.ReadFile(rootAppPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", rootAppPath, err)
+	}
+	writeTestFile(t, rootAppPath, string(raw)+"# discovery input changed without changing rendered output\n")
+	gitCommitAll(t, root, "change rendered parent application yaml comment")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["bootstrap-chart"]; got != 1 {
+		t.Fatalf("root discovery render after app yaml change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/child"]; got != 1 {
+		t.Fatalf("child render after parent app yaml change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/root", "") {
+		t.Fatalf("CacheEvents = %#v, want root persistent miss", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/child", "") {
+		t.Fatalf("CacheEvents = %#v, want child persistent miss", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheSameRepoHelmValuesChangeInvalidatesOnlyThatApp(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheSameRepoValuesHelmApp(t, root, "alpha", "$values/shared/alpha.yaml", false)
+	writePersistentCacheSameRepoValuesHelmApp(t, root, "beta", "$values/shared/beta.yaml", false)
+	writeTestFile(t, filepath.Join(root, "shared", "alpha.yaml"), "value: alpha-one\n")
+	writeTestFile(t, filepath.Join(root, "shared", "beta.yaml"), "value: beta-one\n")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 2 {
+		t.Fatalf("entries after cold run = %d, want 2", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "shared", "alpha.yaml"), "value: alpha-two\n")
+	gitCommitAll(t, root, "change alpha shared values")
+
+	var renderedMu sync.Mutex
+	renderedPaths := map[string]int{}
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderedMu.Lock()
+		defer renderedMu.Unlock()
+		renderedPaths[filepath.ToSlash(source.Path)]++
+	}
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["charts/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after same-repo values change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["charts/beta"]; got != 0 {
+		t.Fatalf("beta renders after alpha values change = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 3 {
+		t.Fatalf("entries after second run = %d, want old alpha + beta + new alpha", got)
+	}
+}
+
+func TestPersistentCacheOptionalMissingSameRepoHelmValueAddInvalidates(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheSameRepoValuesHelmApp(t, root, "alpha", "$values/optional/alpha.yaml", true)
+	writePersistentCacheSameRepoValuesHelmApp(t, root, "beta", "$values/optional/beta.yaml", true)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 2 {
+		t.Fatalf("entries after cold run = %d, want 2", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "optional", "alpha.yaml"), "value: alpha-added\n")
+	gitCommitAll(t, root, "add optional alpha values")
+
+	var renderedMu sync.Mutex
+	renderedPaths := map[string]int{}
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderedMu.Lock()
+		defer renderedMu.Unlock()
+		renderedPaths[filepath.ToSlash(source.Path)]++
+	}
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["charts/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after optional values add = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["charts/beta"]; got != 0 {
+		t.Fatalf("beta renders after optional values add = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 3 {
+		t.Fatalf("entries after optional add = %d, want old alpha + beta + new alpha", got)
+	}
+}
+
+func writePersistentCacheKustomizeApp(t *testing.T, root, name string, kustomization string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+name+`
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", name, "kustomization.yaml"), kustomization)
+}
+
+func writePersistentCachePlainKustomizeApp(t *testing.T, root, name string) {
+	t.Helper()
+	writePersistentCacheKustomizeApp(t, root, name, `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", name, "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: initial
+`)
+}
+
+func renderedSourceCounts(orchestrator *Orchestrator) map[string]int {
+	renderedMu := sync.Mutex{}
+	renderedPaths := map[string]int{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderedMu.Lock()
+		defer renderedMu.Unlock()
+		renderedPaths[filepath.ToSlash(source.Path)]++
+	}
+	return renderedPaths
+}
+
+func TestPersistentCacheKustomizeSharedBaseInvalidatesAllUsers(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheKustomizeApp(t, root, "alpha", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../bases/shared
+`)
+	writePersistentCacheKustomizeApp(t, root, "beta", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../bases/shared
+`)
+	writeTestFile(t, filepath.Join(root, "bases", "shared", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "bases", "shared", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+data:
+  value: initial
+`)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(root, "bases", "shared", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+data:
+  value: changed
+`)
+	gitCommitAll(t, root, "change shared base")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	if _, err := orchestrator.Build(context.Background(), request); err != nil {
+		t.Fatalf("warm Build() error = %v", err)
+	}
+	if got := renderedPaths["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after shared base change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/beta"]; got != 1 {
+		t.Fatalf("beta renders after shared base change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+}
+
+func TestPersistentCacheKustomizeOverlayChangeInvalidatesOnlyThatApp(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCachePlainKustomizeApp(t, root, "alpha")
+	writePersistentCachePlainKustomizeApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alpha
+data:
+  value: changed
+`)
+	gitCommitAll(t, root, "change alpha overlay")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	if _, err := orchestrator.Build(context.Background(), request); err != nil {
+		t.Fatalf("warm Build() error = %v", err)
+	}
+	if got := renderedPaths["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after alpha overlay change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/beta"]; got != 0 {
+		t.Fatalf("beta renders after alpha overlay change = %d, want 0; all renders = %#v", got, renderedPaths)
+	}
+}
+
+func TestPersistentCacheKustomizeHelmValuesAndLocalChartInvalidate(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheKustomizeApp(t, root, "alpha", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: demo
+    releaseName: demo
+    valuesFile: values.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "values.yaml"), "value: initial\n")
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "charts", "demo", "Chart.yaml"), `apiVersion: v2
+name: demo
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "charts", "demo", "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  value: {{ .Values.value | quote }}
+`)
+	writePersistentCachePlainKustomizeApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "values.yaml"), "value: changed-values\n")
+	gitCommitAll(t, root, "change kustomize helm values")
+	valuesOrchestrator := Orchestrator{}
+	valuesRendered := renderedSourceCounts(&valuesOrchestrator)
+	if _, err := valuesOrchestrator.Build(context.Background(), request); err != nil {
+		t.Fatalf("values warm Build() error = %v", err)
+	}
+	if got := valuesRendered["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after values change = %d, want 1; all renders = %#v", got, valuesRendered)
+	}
+	if got := valuesRendered["manifests/beta"]; got != 0 {
+		t.Fatalf("beta renders after values change = %d, want 0; all renders = %#v", got, valuesRendered)
+	}
+
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "charts", "demo", "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  value: {{ .Values.value | quote }}
+  template: changed
+`)
+	gitCommitAll(t, root, "change kustomize local chart template")
+	templateOrchestrator := Orchestrator{}
+	templateRendered := renderedSourceCounts(&templateOrchestrator)
+	if _, err := templateOrchestrator.Build(context.Background(), request); err != nil {
+		t.Fatalf("template warm Build() error = %v", err)
+	}
+	if got := templateRendered["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after template change = %d, want 1; all renders = %#v", got, templateRendered)
+	}
+	if got := templateRendered["manifests/beta"]; got != 0 {
+		t.Fatalf("beta renders after template change = %d, want 0; all renders = %#v", got, templateRendered)
+	}
+}
+
+func TestPersistentCacheEntriesByteIdenticalAcrossCheckoutLocations(t *testing.T) {
+	cacheDirA := t.TempDir()
+	cacheDirB := t.TempDir()
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	for _, root := range []string{rootA, rootB} {
+		writePersistentCacheApp(t, root, "alpha")
+		gitCommitAll(t, root, "initial")
+	}
+
+	if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(rootA, cacheDirA)); err != nil {
+		t.Fatalf("Build(rootA) error = %v", err)
+	}
+	if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(rootB, cacheDirB)); err != nil {
+		t.Fatalf("Build(rootB) error = %v", err)
+	}
+
+	payloadsA := readRenderCachePayloads(t, cacheDirA)
+	payloadsB := readRenderCachePayloads(t, cacheDirB)
+	if len(payloadsA) != 1 || len(payloadsB) != 1 {
+		t.Fatalf("payload counts = %d/%d, want 1/1", len(payloadsA), len(payloadsB))
+	}
+	for key, payloadA := range payloadsA {
+		payloadB, ok := payloadsB[key]
+		if !ok {
+			t.Fatalf("key %s missing from second checkout's cache", key[:12])
+		}
+		if !bytes.Equal(payloadA, payloadB) {
+			t.Fatalf("payloads differ between checkout locations")
+		}
+	}
+}
+
+func hasRenderCacheEvent(events []cacheevent.Event, action cacheevent.Action, target, reason string) bool {
+	for _, event := range events {
+		if event.Source != cacheevent.SourceRender || event.Action != action || event.Target != target {
+			continue
+		}
+		if reason != "" && event.Reason != reason {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func persistentConfigMapDataValue(t *testing.T, result BuildResult, appName, cmName, key string) string {
+	t.Helper()
+	for _, item := range result.ApplicationManifests {
+		if item.Application.Name != appName || item.Manifest.Object == nil || item.Manifest.Object.GetName() != cmName {
+			continue
+		}
+		data, ok := item.Manifest.Object.Object["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("manifest %s/%s data = %#v, want object", appName, cmName, item.Manifest.Object.Object["data"])
+		}
+		value, ok := data[key].(string)
+		if !ok {
+			t.Fatalf("manifest %s/%s data[%q] = %#v, want string", appName, cmName, key, data[key])
+		}
+		return value
+	}
+	t.Fatalf("ApplicationManifests = %#v, missing %s/%s", result.ApplicationManifests, appName, cmName)
+	return ""
+}
+
+func TestPersistentCacheDirectoryInputsReuseUnchangedSiblingAcrossCleanCommits(t *testing.T) {
+	root := t.TempDir()
+	writePersistentDirectoryCacheApp(t, root, "alpha")
+	writePersistentDirectoryCacheApp(t, root, "beta")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 2 {
+		t.Fatalf("entries after cold run = %d, want 2", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "manifests", "alpha", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alpha
+data:
+  value: changed
+`)
+	gitCommitAll(t, root, "change alpha directory")
+
+	orchestrator := Orchestrator{}
+	renderedPaths := renderedSourceCounts(&orchestrator)
+	result, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := renderedPaths["manifests/alpha"]; got != 1 {
+		t.Fatalf("alpha renders after source change = %d, want 1; all renders = %#v", got, renderedPaths)
+	}
+	if got := renderedPaths["manifests/beta"]; got != 0 {
+		t.Fatalf("beta renders after sibling change = %d, want 0 persistent hit; all renders = %#v", got, renderedPaths)
+	}
+	if got := persistentConfigMapDataValue(t, result, "alpha", "alpha", "value"); got != "changed" {
+		t.Fatalf("alpha value = %q, want changed", got)
+	}
+	if got := persistentConfigMapDataValue(t, result, "beta", "beta", "value"); got != "initial" {
+		t.Fatalf("beta value = %q, want initial", got)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionHit, "argocd/beta", "") {
+		t.Fatalf("CacheEvents = %#v, want beta persistent hit", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionMiss, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent miss", result.CacheEvents)
+	}
+	if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionStore, "argocd/alpha", "") {
+		t.Fatalf("CacheEvents = %#v, want alpha persistent store", result.CacheEvents)
+	}
+}
+
+func TestPersistentCacheJsonnetInputsRotateOnSourceAndDeclaredLibChanges(t *testing.T) {
+	root := t.TempDir()
+	writePersistentJsonnetCacheApp(t, root, "jsonnet")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	coldResult, err := (Orchestrator{}).Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := persistentConfigMapDataValue(t, coldResult, "jsonnet", "jsonnet", "value"); got != "lib-a-source-a" {
+		t.Fatalf("cold jsonnet value = %q, want lib-a-source-a", got)
+	}
+
+	writeTestFile(t, filepath.Join(root, "manifests", "jsonnet", "cm.jsonnet"), `local helper = import 'helper.libsonnet';
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: { name: 'jsonnet' },
+  data: { value: helper.value + '-source-b' },
+}
+`)
+	gitCommitAll(t, root, "change jsonnet source")
+	sourceOrchestrator := Orchestrator{}
+	sourceRenders := renderedSourceCounts(&sourceOrchestrator)
+	sourceResult, err := sourceOrchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("source-change Build() error = %v", err)
+	}
+	if got := sourceRenders["manifests/jsonnet"]; got != 1 {
+		t.Fatalf("jsonnet renders after source change = %d, want 1; all renders = %#v", got, sourceRenders)
+	}
+	if got := persistentConfigMapDataValue(t, sourceResult, "jsonnet", "jsonnet", "value"); got != "lib-a-source-b" {
+		t.Fatalf("source-change jsonnet value = %q, want lib-a-source-b", got)
+	}
+	if !hasRenderCacheEvent(sourceResult.CacheEvents, cacheevent.ActionMiss, "argocd/jsonnet", "") {
+		t.Fatalf("CacheEvents = %#v, want jsonnet miss after source change", sourceResult.CacheEvents)
+	}
+
+	writeTestFile(t, filepath.Join(root, "lib", "helper.libsonnet"), `{
+  value: 'lib-b',
+}
+`)
+	gitCommitAll(t, root, "change jsonnet lib")
+	libOrchestrator := Orchestrator{}
+	libRenders := renderedSourceCounts(&libOrchestrator)
+	libResult, err := libOrchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("lib-change Build() error = %v", err)
+	}
+	if got := libRenders["manifests/jsonnet"]; got != 1 {
+		t.Fatalf("jsonnet renders after declared lib change = %d, want 1; all renders = %#v", got, libRenders)
+	}
+	if got := persistentConfigMapDataValue(t, libResult, "jsonnet", "jsonnet", "value"); got != "lib-b-source-b" {
+		t.Fatalf("lib-change jsonnet value = %q, want lib-b-source-b", got)
+	}
+	if !hasRenderCacheEvent(libResult.CacheEvents, cacheevent.ActionMiss, "argocd/jsonnet", "") {
+		t.Fatalf("CacheEvents = %#v, want jsonnet miss after declared lib change", libResult.CacheEvents)
+	}
+}
+
+func TestPersistentCacheJsonnetUnprovableLibSkipsPersistence(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "jsonnet-skip.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jsonnet-skip
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/jsonnet-skip
+    targetRevision: main
+    directory:
+      jsonnet:
+        libs:
+          - ../outside
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "jsonnet-skip", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jsonnet-skip
+data:
+  value: rendered
+`)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+
+	for run := range 2 {
+		var renders atomic.Int64
+		result, err := countingOrchestrator(&renders).Build(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Build() run %d error = %v", run, err)
+		}
+		if got := renders.Load(); got != 1 {
+			t.Fatalf("run %d renders = %d, want 1 because persistence is skipped", run, got)
+		}
+		if got := persistentConfigMapDataValue(t, result, "jsonnet-skip", "jsonnet-skip", "value"); got != "rendered" {
+			t.Fatalf("run %d value = %q, want rendered", run, got)
+		}
+		if !hasRenderCacheEvent(result.CacheEvents, cacheevent.ActionSkipped, "argocd/jsonnet-skip", renderCacheReasonInputGraph) {
+			t.Fatalf("run %d CacheEvents = %#v, want input graph skip", run, result.CacheEvents)
+		}
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 0 {
+		t.Fatalf("entries for unprovable jsonnet graph = %d, want 0", got)
+	}
+}
+
+func TestPersistentCacheWarmDiffRefBothSidesHit(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	writeTestFile(t, filepath.Join(root, "settings", "argocd-cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+data:
+  kustomize.buildOptions: --enable-helm
+`)
+	baseline := gitCommitAll(t, root, "initial")
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: changed
+`)
+	gitCommitAll(t, root, "change alpha")
+	cacheDir := t.TempDir()
+	diffRequest := DiffRequest{
+		RightPath: root,
+		Repo:      root,
+		Ref:       "HEAD",
+		RefOrig:   baseline,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+
+	var coldRenders atomic.Int64
+	if _, err := countingOrchestrator(&coldRenders).DiffApps(context.Background(), diffRequest); err != nil {
+		t.Fatalf("cold DiffApps() error = %v", err)
+	}
+	if coldRenders.Load() == 0 {
+		t.Fatalf("cold diff performed zero renders")
+	}
+	entriesAfterCold := countRenderCacheEntries(t, cacheDir)
+	if entriesAfterCold == 0 {
+		t.Fatalf("cold diff stored no render cache entries")
+	}
+
+	var warmRenders atomic.Int64
+	warmResult, err := countingOrchestrator(&warmRenders).DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("warm DiffApps() error = %v", err)
+	}
+	if got := warmRenders.Load(); got != 0 {
+		t.Fatalf("warm diff render-engine invocations = %d, want 0", got)
+	}
+	if len(warmResult.Results) == 0 {
+		t.Fatalf("warm diff returned no results; expected the cm change diff")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != entriesAfterCold {
+		t.Fatalf("warm diff changed entry count: %d -> %d", entriesAfterCold, got)
+	}
+}
+
+func TestPersistentCacheDirtyRepositoryDiffRefsUseSnapshotIdentities(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	baseline := gitCommitAll(t, root, "initial")
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: changed
+`)
+	gitCommitAll(t, root, "change alpha")
+	cacheDir := t.TempDir()
+	diffRequest := DiffRequest{
+		Repo:    root,
+		Ref:     "HEAD",
+		RefOrig: baseline,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+
+	var coldRenders atomic.Int64
+	coldResult, err := countingOrchestrator(&coldRenders).DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("cold DiffApps() error = %v", err)
+	}
+	if coldRenders.Load() == 0 {
+		t.Fatalf("cold diff performed zero renders")
+	}
+	if len(coldResult.Results) == 0 {
+		t.Fatalf("cold diff returned no results; expected the cm change diff")
+	}
+	entriesAfterCold := countRenderCacheEntries(t, cacheDir)
+	if entriesAfterCold == 0 {
+		t.Fatalf("cold diff stored no render cache entries")
+	}
+
+	writeTestFile(t, filepath.Join(root, "scratch.txt"), "dirty real worktree\n")
+	var dirtyRepoRenders atomic.Int64
+	dirtyRepoResult, err := countingOrchestrator(&dirtyRepoRenders).DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("dirty repo DiffApps() error = %v", err)
+	}
+	if got := dirtyRepoRenders.Load(); got != 0 {
+		t.Fatalf("dirty repo ref diff render-engine invocations = %d, want 0 snapshot cache hits", got)
+	}
+	if len(dirtyRepoResult.Results) == 0 {
+		t.Fatalf("dirty repo ref diff returned no results; expected the cached cm change diff")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != entriesAfterCold {
+		t.Fatalf("dirty repo ref diff changed entry count: %d -> %d", entriesAfterCold, got)
+	}
+}
+
+func TestPersistentCacheDirtyWorktreeDiffPathSidesHit(t *testing.T) {
+	left := t.TempDir()
+	right := t.TempDir()
+	for _, side := range []struct {
+		root  string
+		value string
+	}{
+		{root: left, value: "left-dirty"},
+		{root: right, value: "right-dirty"},
+	} {
+		writePersistentCacheApp(t, side.root, "alpha")
+		gitCommitAll(t, side.root, "initial")
+		writeTestFile(t, filepath.Join(side.root, "charts", "alpha", "values.yaml"), "value: "+side.value+"\n")
+	}
+	cacheDir := t.TempDir()
+	diffRequest := DiffRequest{
+		LeftPath:  left,
+		RightPath: right,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+
+	var coldRenders atomic.Int64
+	coldResult, err := countingOrchestrator(&coldRenders).DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("cold DiffApps() error = %v", err)
+	}
+	if coldRenders.Load() == 0 {
+		t.Fatalf("cold dirty worktree diff performed zero renders")
+	}
+	if len(coldResult.Results) == 0 {
+		t.Fatalf("cold dirty worktree diff returned no results; expected the cm change diff")
+	}
+	entriesAfterCold := countRenderCacheEntries(t, cacheDir)
+	if entriesAfterCold == 0 {
+		t.Fatalf("cold dirty worktree diff stored no render cache entries")
+	}
+
+	var warmRenders atomic.Int64
+	warmResult, err := countingOrchestrator(&warmRenders).DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("warm DiffApps() error = %v", err)
+	}
+	if got := warmRenders.Load(); got != 0 {
+		t.Fatalf("warm dirty worktree diff render-engine invocations = %d, want 0", got)
+	}
+	if len(warmResult.Results) == 0 {
+		t.Fatalf("warm dirty worktree diff returned no results; expected the cached cm change diff")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != entriesAfterCold {
+		t.Fatalf("warm dirty worktree diff changed entry count: %d -> %d", entriesAfterCold, got)
+	}
+}
+
+func TestPersistentCacheDirtyWorktreeStoresInputScopedEntries(t *testing.T) {
+	// Each dirty file lives inside the app's digested input subtree
+	// (charts/alpha) so the per-path-set intersection forces the
+	// worktree-inputs flow. Dirt outside the app's inputs no longer re-keys
+	// it — that committed-shortcut behavior is pinned by
+	// TestDirtyModeUntouchedSourceKeepsCommittedIdentity and
+	// TestDirtyWorktreeServesCommittedHitsForUntouchedApps.
+	cases := []struct {
+		name  string
+		dirty func(t *testing.T, root string)
+	}{
+		{name: "modified tracked file", dirty: func(t *testing.T, root string) {
+			writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), "value: edited-locally\n")
+		}},
+		{name: "untracked file", dirty: func(t *testing.T, root string) {
+			writeTestFile(t, filepath.Join(root, "charts", "alpha", "scratch.txt"), "untracked\n")
+		}},
+		{name: "ignored file", dirty: func(t *testing.T, root string) {
+			writeTestFile(t, filepath.Join(root, "charts", "alpha", "ignored", "values.yaml"), "a: 1\n")
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePersistentCacheApp(t, root, "alpha")
+			writeTestFile(t, filepath.Join(root, "README.md"), "readme\n")
+			writeTestFile(t, filepath.Join(root, ".gitignore"), "ignored/\n")
+			gitCommitAll(t, root, "initial")
+			cacheDir := t.TempDir()
+
+			if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+				t.Fatalf("clean Build() error = %v", err)
+			}
+			entriesAfterClean := countRenderCacheEntries(t, cacheDir)
+			if entriesAfterClean == 0 {
+				t.Fatalf("clean run stored nothing")
+			}
+
+			testCase.dirty(t, root)
+			var dirtyRenders atomic.Int64
+			if _, err := countingOrchestrator(&dirtyRenders).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+				t.Fatalf("dirty Build() error = %v", err)
+			}
+			if dirtyRenders.Load() == 0 {
+				t.Fatalf("dirty worktree run rendered nothing; want initial worktree-inputs cache population")
+			}
+			entriesAfterDirty := countRenderCacheEntries(t, cacheDir)
+			if entriesAfterDirty <= entriesAfterClean {
+				t.Fatalf("dirty run entry count = %d, want more than clean count %d", entriesAfterDirty, entriesAfterClean)
+			}
+
+			var warmDirtyRenders atomic.Int64
+			if _, err := countingOrchestrator(&warmDirtyRenders).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+				t.Fatalf("warm dirty Build() error = %v", err)
+			}
+			if got := warmDirtyRenders.Load(); got != 0 {
+				t.Fatalf("warm dirty renders = %d, want persistent cache hit", got)
+			}
+			if got := countRenderCacheEntries(t, cacheDir); got != entriesAfterDirty {
+				t.Fatalf("warm dirty run changed entry count: %d -> %d", entriesAfterDirty, got)
+			}
+		})
+	}
+}
+
+func TestPersistentCacheKeyMutationsMiss(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, root string, request *BuildRequest)
+	}{
+		{name: "app spec change", mutate: func(t *testing.T, root string, _ *BuildRequest) {
+			writeTestFile(t, filepath.Join(root, "apps", "alpha.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alpha
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: charts/alpha
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: other
+`)
+			gitCommitAll(t, root, "spec change")
+		}},
+		{name: "revision change", mutate: func(t *testing.T, root string, _ *BuildRequest) {
+			writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: rotated
+`)
+			gitCommitAll(t, root, "content change")
+		}},
+		{name: "settings change", mutate: func(t *testing.T, root string, _ *BuildRequest) {
+			writeTestFile(t, filepath.Join(root, "argocd", "argocd-cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+data:
+  application.instanceLabelKey: app.kubernetes.io/cache-test
+`)
+			gitCommitAll(t, root, "settings change")
+		}},
+		{name: "engine fingerprint change", mutate: func(_ *testing.T, _ string, request *BuildRequest) {
+			request.EngineFingerprint.Commit = "fedcba9876543210fedcba9876543210fedcba98"
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePersistentCacheApp(t, root, "alpha")
+			gitCommitAll(t, root, "initial")
+			cacheDir := t.TempDir()
+
+			if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+				t.Fatalf("cold Build() error = %v", err)
+			}
+
+			request := persistentBuildRequest(root, cacheDir)
+			testCase.mutate(t, root, &request)
+			var renders atomic.Int64
+			if _, err := countingOrchestrator(&renders).Build(context.Background(), request); err != nil {
+				t.Fatalf("mutated Build() error = %v", err)
+			}
+			if renders.Load() == 0 {
+				t.Fatalf("%s did not rotate the key (warm hit observed)", testCase.name)
+			}
+		})
+	}
+}
+
+func TestPersistentCacheFailedRenderLeavesNoEntry(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "broken.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: broken
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/broken
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "broken", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - missing.yaml
+`)
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+
+	if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err == nil {
+		t.Fatalf("Build() error = nil, want render failure")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 0 {
+		t.Fatalf("entries after failed render = %d, want 0", got)
+	}
+}
+
+func TestPersistentCachePluginSourceNeverPersists(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "plugged.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugged
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/plugged
+    targetRevision: main
+    plugin:
+      name: example
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "plugged", "placeholder.yaml"), "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: placeholder\n")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+
+	request := persistentBuildRequest(root, cacheDir)
+	request.PluginRenderer = internalPluginRendererFunc(func(_ context.Context, _ render.PluginRequest) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		return []render.Manifest{{Object: &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "from-plugin"},
+		}}}}, nil, nil
+	})
+
+	for run := range 2 {
+		if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+			t.Fatalf("Build() run %d error = %v", run, err)
+		}
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 0 {
+		t.Fatalf("entries for plugin-source app = %d, want 0", got)
+	}
+}
+
+type fixedRemoteAcquirer struct {
+	path     string
+	revision string
+}
+
+func (acquirer fixedRemoteAcquirer) Acquire(_ context.Context, _ remote.Request, _ remote.Options) (remote.Result, error) {
+	return remote.Result{Path: acquirer.path, Revision: acquirer.revision, FromCache: false}, nil
+}
+
+func writeRemoteBaseApp(t *testing.T, root, name, ref string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+name+`
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", name, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/example/base//demo?ref=`+ref+`
+`)
+}
+
+func TestPersistentCachePinStabilityGate(t *testing.T) {
+	for _, recordEvents := range []bool{false, true} {
+		name := "cache-events off"
+		if recordEvents {
+			name = "cache-events on"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeRemoteBaseApp(t, root, "floating", "main")
+			writeRemoteBaseApp(t, root, "pinned", persistentCacheTestSHA)
+			writePersistentCacheApp(t, root, "plain")
+			gitCommitAll(t, root, "initial")
+
+			remoteRoot := t.TempDir()
+			writeTestFile(t, filepath.Join(remoteRoot, "demo", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+			writeTestFile(t, filepath.Join(remoteRoot, "demo", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remote-base
+`)
+			cacheDir := t.TempDir()
+			request := persistentBuildRequest(root, cacheDir)
+			request.RecordCacheEvents = recordEvents
+			request.RemoteResourceCacheDir = t.TempDir()
+			orchestrator := Orchestrator{RemoteResourceAcquirer: fixedRemoteAcquirer{path: remoteRoot, revision: persistentCacheTestSHA}}
+
+			coldResult, err := orchestrator.Build(context.Background(), request)
+			if err != nil {
+				t.Fatalf("cold Build() error = %v", err)
+			}
+			if got := countRenderCacheEntries(t, cacheDir); got != 2 {
+				t.Fatalf("entries after cold run = %d, want 2", got)
+			}
+			if recordEvents && !hasRenderCacheEvent(coldResult.CacheEvents, cacheevent.ActionSkipped, "argocd/floating", renderCacheReasonInputGraph) {
+				t.Fatalf("CacheEvents = %#v, want floating Kustomize input graph skip", coldResult.CacheEvents)
+			}
+
+			var renderedMu sync.Mutex
+			renderedPaths := map[string]int{}
+			warmOrchestrator := Orchestrator{RemoteResourceAcquirer: fixedRemoteAcquirer{path: remoteRoot, revision: persistentCacheTestSHA}}
+			warmOrchestrator.renderObserver = func(source render.ResolvedSource) {
+				renderedMu.Lock()
+				defer renderedMu.Unlock()
+				renderedPaths[filepath.ToSlash(source.Path)]++
+			}
+			if _, err := warmOrchestrator.Build(context.Background(), request); err != nil {
+				t.Fatalf("warm Build() error = %v", err)
+			}
+			if got := renderedPaths["manifests/floating"]; got != 1 {
+				t.Fatalf("warm renders for floating app = %d, want 1; all renders = %#v", got, renderedPaths)
+			}
+			if got := renderedPaths["manifests/pinned"]; got != 0 {
+				t.Fatalf("warm renders for pinned app = %d, want 0; all renders = %#v", got, renderedPaths)
+			}
+			if got := renderedPaths["charts/plain"]; got != 0 {
+				t.Fatalf("warm renders for plain app = %d, want 0; all renders = %#v", got, renderedPaths)
+			}
+		})
+	}
+}
+
+func TestPersistentCacheRepoMappedSourceNeverPersists(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "mapped.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mapped
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.test/mapped/repo.git
+    path: manifests/demo
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	gitCommitAll(t, root, "initial")
+	mappedDir := t.TempDir()
+	writeTestFile(t, filepath.Join(mappedDir, "manifests", "demo", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, filepath.Join(mappedDir, "manifests", "demo", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mapped
+`)
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RepoMaps = []sourcepkg.RepoMap{{URL: "https://git.example.test/mapped/repo.git", Path: mappedDir}}
+
+	for run := range 2 {
+		var renders atomic.Int64
+		if _, err := countingOrchestrator(&renders).Build(context.Background(), request); err != nil {
+			t.Fatalf("Build() run %d error = %v", run, err)
+		}
+		if renders.Load() == 0 {
+			t.Fatalf("run %d rendered nothing; repo-mapped app must render every run", run)
+		}
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 0 {
+		t.Fatalf("entries for repo-mapped app = %d, want 0", got)
+	}
+}
+
+func TestPersistentCacheDisabledTouchesNothing(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	gitCommitAll(t, root, "initial")
+	cacheDir := filepath.Join(t.TempDir(), "render-cache")
+	request := persistentBuildRequest(root, cacheDir)
+	request.RenderCacheEnabled = false
+
+	if _, err := (Orchestrator{}).Build(context.Background(), request); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("disabled run touched the cache dir: stat err = %v", err)
+	}
+}
+
+func TestPersistentCacheRefreshRendersForcesMissAndOverwrites(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	gitCommitAll(t, root, "initial")
+	cacheDir := t.TempDir()
+
+	if _, err := (Orchestrator{}).Build(context.Background(), persistentBuildRequest(root, cacheDir)); err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	entriesBefore := countRenderCacheEntries(t, cacheDir)
+
+	request := persistentBuildRequest(root, cacheDir)
+	request.RefreshRenders = true
+	var renders atomic.Int64
+	if _, err := countingOrchestrator(&renders).Build(context.Background(), request); err != nil {
+		t.Fatalf("refresh Build() error = %v", err)
+	}
+	if renders.Load() == 0 {
+		t.Fatalf("--refresh-renders run hit the cache; want forced miss")
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != entriesBefore {
+		t.Fatalf("entries after refresh = %d, want %d", got, entriesBefore)
+	}
+}
+
+func TestPersistentCachePermissionFailureFailsFastAtValidation(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	gitCommitAll(t, root, "initial")
+	occupied := filepath.Join(t.TempDir(), "occupied")
+	writeTestFile(t, occupied, "not a directory")
+
+	request := persistentBuildRequest(root, occupied)
+	request.RecordCacheEvents = true
+	_, err := (Orchestrator{}).Build(context.Background(), request)
+	if err == nil {
+		t.Fatalf("Build() error = nil, want validation failure for unopenable cache dir")
+	}
+}
+
+func writeRemoteValuesHelmApp(t *testing.T, root, name, valuesURL string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", name+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+name+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: charts/`+name+`
+    targetRevision: main
+    helm:
+      valueFiles:
+        - `+valuesURL+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "Chart.yaml"), `apiVersion: v2
+name: `+name+`
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "charts", name, "values.yaml"), "value: default\n")
+	writeTestFile(t, filepath.Join(root, "charts", name, "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: `+name+`
+data:
+  value: {{ .Values.value | quote }}
+`)
+}
+
+func TestPersistentCacheRemoteHTTPValueFileNeverPersists(t *testing.T) {
+	root := t.TempDir()
+	writeRemoteValuesHelmApp(t, root, "urlvalues", "https://values.example.invalid/prod/values.yaml")
+	writePersistentCacheApp(t, root, "plain")
+	gitCommitAll(t, root, "initial")
+
+	remoteValues := filepath.Join(t.TempDir(), "remote-values.yaml")
+	writeTestFile(t, remoteValues, "value: from-remote-url\n")
+	cacheDir := t.TempDir()
+	request := persistentBuildRequest(root, cacheDir)
+	request.RecordCacheEvents = true
+	request.RemoteResourceCacheDir = t.TempDir()
+	acquirer := fixedRemoteAcquirer{path: remoteValues, revision: persistentCacheTestSHA}
+
+	coldResult, err := (Orchestrator{RemoteResourceAcquirer: acquirer}).Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("cold Build() error = %v", err)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 1 {
+		t.Fatalf("entries after cold run = %d, want 1", got)
+	}
+	skipped := false
+	for _, event := range coldResult.CacheEvents {
+		if event.Source == cacheevent.SourceRender && event.Action == cacheevent.ActionSkipped &&
+			event.Target == "argocd/urlvalues" && event.Reason == renderCacheReasonInputGraph {
+			skipped = true
+		}
+	}
+	if !skipped {
+		t.Fatalf("no render/skipped event with reason %q for argocd/urlvalues; events = %#v",
+			renderCacheReasonInputGraph, coldResult.CacheEvents)
+	}
+
+	var warmRenders atomic.Int64
+	warmOrchestrator := Orchestrator{RemoteResourceAcquirer: acquirer}
+	warmOrchestrator.renderObserver = func(render.ResolvedSource) { warmRenders.Add(1) }
+	if _, err := warmOrchestrator.Build(context.Background(), request); err != nil {
+		t.Fatalf("warm Build() error = %v", err)
+	}
+	if got := warmRenders.Load(); got == 0 {
+		t.Fatalf("warm renders = %d, want the remote-URL value file app to re-render", got)
+	}
+	if got := countRenderCacheEntries(t, cacheDir); got != 1 {
+		t.Fatalf("entries after warm run = %d, want 1", got)
+	}
+}
+
+func TestPersistentCacheDirtyWorktreeRefSideStillHits(t *testing.T) {
+	root := t.TempDir()
+	writePersistentCacheApp(t, root, "alpha")
+	baseline := gitCommitAll(t, root, "initial")
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "values.yaml"), `value: changed
+`)
+	gitCommitAll(t, root, "change alpha")
+	cacheDir := t.TempDir()
+	diffRequest := DiffRequest{
+		RightPath: root,
+		Repo:      root,
+		RefOrig:   baseline,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     cacheDir,
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+
+	var coldRenders atomic.Int64
+	if _, err := countingOrchestrator(&coldRenders).DiffApps(context.Background(), diffRequest); err != nil {
+		t.Fatalf("cold DiffApps() error = %v", err)
+	}
+	if coldRenders.Load() == 0 {
+		t.Fatalf("cold diff performed zero renders")
+	}
+	entriesAfterCold := countRenderCacheEntries(t, cacheDir)
+	if entriesAfterCold == 0 {
+		t.Fatalf("cold diff stored nothing")
+	}
+
+	// The untracked file sits inside the app's digested input subtree so the
+	// worktree side takes the worktree-inputs flow; dirt outside the app's
+	// inputs would now hit the committed-key entry via the per-path-set
+	// shortcut instead.
+	writeTestFile(t, filepath.Join(root, "charts", "alpha", "scratch.txt"), "untracked\n")
+	dirtyOrchestrator, worktreeRenders, refRenders := dirtyDiffCountingOrchestrator(t, root)
+	dirtyResult, err := dirtyOrchestrator.DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("dirty DiffApps() error = %v", err)
+	}
+	assertDirtyDiffInitialRender(t, dirtyResult, worktreeRenders, refRenders)
+	entriesAfterDirty := countRenderCacheEntries(t, cacheDir)
+	if entriesAfterDirty <= entriesAfterCold {
+		t.Fatalf("dirty diff entry count = %d, want more than cold count %d", entriesAfterDirty, entriesAfterCold)
+	}
+
+	worktreeRenders.Store(0)
+	refRenders.Store(0)
+	warmDirtyResult, err := dirtyOrchestrator.DiffApps(context.Background(), diffRequest)
+	if err != nil {
+		t.Fatalf("warm dirty DiffApps() error = %v", err)
+	}
+	assertDirtyDiffWarmHit(t, warmDirtyResult, worktreeRenders, refRenders)
+	if got := countRenderCacheEntries(t, cacheDir); got != entriesAfterDirty {
+		t.Fatalf("warm dirty diff changed entry count: %d -> %d", entriesAfterDirty, got)
+	}
+}
+
+func dirtyDiffCountingOrchestrator(t *testing.T, root string) (Orchestrator, *atomic.Int64, *atomic.Int64) {
+	t.Helper()
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s) error = %v", root, err)
+	}
+	worktreeRenders := &atomic.Int64{}
+	refRenders := &atomic.Int64{}
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		rendered := source.RepoRoot
+		if resolved, err := filepath.EvalSymlinks(rendered); err == nil {
+			rendered = resolved
+		}
+		if rendered == realRoot || strings.HasPrefix(rendered, realRoot+string(filepath.Separator)) {
+			worktreeRenders.Add(1)
+			return
+		}
+		refRenders.Add(1)
+	}
+	return orchestrator, worktreeRenders, refRenders
+}
+
+func assertDirtyDiffInitialRender(t *testing.T, result DiffResult, worktreeRenders, refRenders *atomic.Int64) {
+	t.Helper()
+	if got := refRenders.Load(); got != 0 {
+		t.Fatalf("ref-side renders = %d, want 0", got)
+	}
+	if worktreeRenders.Load() == 0 {
+		t.Fatalf("worktree side rendered nothing; want initial worktree-inputs cache population")
+	}
+	if len(result.Results) == 0 {
+		t.Fatalf("dirty diff returned no results; expected the cm change diff")
+	}
+}
+
+func assertDirtyDiffWarmHit(t *testing.T, result DiffResult, worktreeRenders, refRenders *atomic.Int64) {
+	t.Helper()
+	if got := refRenders.Load(); got != 0 {
+		t.Fatalf("warm dirty ref-side renders = %d, want 0", got)
+	}
+	if got := worktreeRenders.Load(); got != 0 {
+		t.Fatalf("warm dirty worktree renders = %d, want 0", got)
+	}
+	if len(result.Results) == 0 {
+		t.Fatalf("warm dirty diff returned no results; expected cached cm change diff")
+	}
+}

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -45,84 +46,145 @@ func RenderApplicationWithOptions(ctx context.Context, application argoappv1.App
 		return RenderResult{}, err
 	}
 
+	plan, prepareFailedAt, prepareErr := preparePlanSourcesForRender(ctx, application, provider, plan)
+
+	var persist persistentRenderState
+	if prepareErr == nil {
+		persist = preparePersistentRender(ctx, application, plan, provider, options)
+		if cached, ok := persist.lookup(); ok {
+			return cached, nil
+		}
+	}
+
 	pluginOpts := options.PluginOptions
 	trackingOpts := normalizeTrackingOptions(options.TrackingOptions)
 	byID := map[manifest.Identity]int{}
 	var result RenderResult
-	for _, sourcePlan := range plan.Sources {
+	for i, sourcePlan := range plan.Sources {
+		if prepareErr != nil && i == prepareFailedAt {
+			// Render the prepared prefix, then surface the prepare failure
+			// with the partial diagnostics, matching the historical
+			// lazy-prepare behavior.
+			return result, prepareErr
+		}
 		if sourcePlan.RefOnly {
 			continue
 		}
-		if preparer, ok := provider.(sourcePreparer); ok {
-			prepared, err := preparer.PrepareSource(ctx, application, sourcePlan)
-			if err != nil {
-				return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
-			}
-			sourcePlan = prepared
+		if sourcePlan.Source.Plugin != nil {
+			persist.skip(renderCacheReasonIneligibleSource)
 		}
 
-		opts, err := renderOptions(application, sourcePlan.Source)
-		if err != nil {
-			return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
-		}
-		opts.EnableAVPCompat = pluginOpts.EnableAVPCompat
-		opts.EnablePlugins = pluginOpts.EnablePlugins
-		opts.SourceIndex = sourcePlan.Index
-		opts.SourceName = sourcePlan.Name
-		refRoots, refSources, err := renderRefsForSource(plan, sourcePlan, helmRefInputPaths(opts))
-		if err != nil {
-			return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
-		}
-		opts.RefRoots = mergeRefRoots(opts.RefRoots, refRoots)
-		opts.RefSources = refSources
-		manifests, diags, err := provider.RenderSource(ctx, render.ResolvedSource{
-			RepoRoot:       sourcePlan.SourceRoot,
-			Path:           sourcePlan.Source.Path,
-			Chart:          sourcePlan.Source.Chart,
-			RepoURL:        sourcePlan.Source.RepoURL,
-			TargetRevision: sourcePlan.Source.TargetRevision,
-			ExplicitType:   sourcePlan.ExplicitType,
-		}, opts)
-		result.Diagnostics = append(result.Diagnostics, sourceDiagnostics(application, sourcePlan, diags)...)
-		if err != nil {
-			return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
-		}
-		avpCompatSubstituted := false
-
-		for _, rendered := range manifests {
-			if rendered.Object != nil {
-				rendered.Object = rendered.Object.DeepCopy()
-			}
-			if applyAVPCompatToManifest(&rendered, opts) {
-				avpCompatSubstituted = true
-			}
-			rendered.SourceIndex = sourcePlan.Index
-			rendered.SourceName = sourcePlan.Name
-			recordNamespaceBeforeNormalization(&rendered)
-			ApplyDestinationNamespace(application, rendered.Object)
-			if err := applyTrackingMetadata(application, rendered.Object, trackingOpts); err != nil {
-				return result, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
-			}
-
-			id := manifest.IdentityOf(rendered.Object)
-			if existing, ok := byID[id]; ok {
-				result.Manifests[existing] = rendered
-				result.Diagnostics = append(result.Diagnostics, diagnostic.Diagnostic{
-					Severity: diagnostic.SeverityWarning,
-					Category: "repeated-resource",
-					Message:  fmt.Sprintf("resource %s repeated in Application %s; later source wins", id.String(), application.Name),
-				})
-				continue
-			}
-
-			byID[id] = len(result.Manifests)
-			result.Manifests = append(result.Manifests, rendered)
-		}
-		if avpCompatSubstituted {
-			result.Diagnostics = append(result.Diagnostics, sourceDiagnostics(application, sourcePlan, []diagnostic.Diagnostic{avpCompatDiagnostic()})...)
+		if err := renderSourcePlan(ctx, application, provider, plan, sourcePlan, pluginOpts, trackingOpts, byID, &result); err != nil {
+			return result, err
 		}
 	}
+	persist.store(ctx, result)
 	return result, nil
+}
+
+func renderSourcePlan(ctx context.Context, application argoappv1.Application, provider render.Provider, plan PlanResult, sourcePlan SourcePlan, pluginOpts PluginOptions, trackingOpts TrackingOptions, byID map[manifest.Identity]int, result *RenderResult) error {
+	opts, err := renderOptions(application, sourcePlan.Source)
+	if err != nil {
+		return fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
+	}
+	opts.EnableAVPCompat = pluginOpts.EnableAVPCompat
+	opts.EnablePlugins = pluginOpts.EnablePlugins
+	opts.SourceIndex = sourcePlan.Index
+	opts.SourceName = sourcePlan.Name
+	refRoots, refSources, err := renderRefsForSource(plan, sourcePlan, helmRefInputPaths(opts))
+	if err != nil {
+		return fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
+	}
+	opts.RefRoots = mergeRefRoots(opts.RefRoots, refRoots)
+	opts.RefSources = refSources
+
+	manifests, diags, err := provider.RenderSource(ctx, resolvedSourceForPlan(sourcePlan), opts)
+	result.Diagnostics = append(result.Diagnostics, sourceDiagnostics(application, sourcePlan, diags)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
+	}
+	avpCompatSubstituted, err := appendRenderedManifests(application, sourcePlan, opts, trackingOpts, manifests, byID, result)
+	if err != nil {
+		return err
+	}
+	if avpCompatSubstituted {
+		result.Diagnostics = append(result.Diagnostics, sourceDiagnostics(application, sourcePlan, []diagnostic.Diagnostic{avpCompatDiagnostic()})...)
+	}
+	return nil
+}
+
+func resolvedSourceForPlan(sourcePlan SourcePlan) render.ResolvedSource {
+	return render.ResolvedSource{
+		RepoRoot:       sourcePlan.SourceRoot,
+		Path:           sourcePlan.Source.Path,
+		Chart:          sourcePlan.Source.Chart,
+		RepoURL:        sourcePlan.Source.RepoURL,
+		TargetRevision: sourcePlan.Source.TargetRevision,
+		ExplicitType:   sourcePlan.ExplicitType,
+	}
+}
+
+func appendRenderedManifests(application argoappv1.Application, sourcePlan SourcePlan, opts render.RenderOptions, trackingOpts TrackingOptions, manifests []render.Manifest, byID map[manifest.Identity]int, result *RenderResult) (bool, error) {
+	avpCompatSubstituted := false
+	for _, rendered := range manifests {
+		if rendered.Object != nil {
+			rendered.Object = rendered.Object.DeepCopy()
+		}
+		if applyAVPCompatToManifest(&rendered, opts) {
+			avpCompatSubstituted = true
+		}
+		rendered.SourceIndex = sourcePlan.Index
+		rendered.SourceName = sourcePlan.Name
+		recordNamespaceBeforeNormalization(&rendered)
+		ApplyDestinationNamespace(application, rendered.Object)
+		if err := applyTrackingMetadata(application, rendered.Object, trackingOpts); err != nil {
+			return false, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
+		}
+
+		id := manifest.IdentityOf(rendered.Object)
+		if existing, ok := byID[id]; ok {
+			result.Manifests[existing] = rendered
+			result.Diagnostics = append(result.Diagnostics, diagnostic.Diagnostic{
+				Severity: diagnostic.SeverityWarning,
+				Category: "repeated-resource",
+				Message:  fmt.Sprintf("resource %s repeated in Application %s; later source wins", id.String(), application.Name),
+			})
+			continue
+		}
+
+		byID[id] = len(result.Manifests)
+		result.Manifests = append(result.Manifests, rendered)
+	}
+	return avpCompatSubstituted, nil
+}
+
+// preparePlanSourcesForRender prepares every render source up front. On a
+// prepare failure it returns the plan with all earlier sources prepared, the
+// failing source's position, and the error; the caller renders the prepared
+// prefix first so partial diagnostics match the historical lazy-prepare path.
+func preparePlanSourcesForRender(ctx context.Context, application argoappv1.Application, provider render.Provider, plan PlanResult) (PlanResult, int, error) {
+	preparer, ok := provider.(sourcePreparer)
+	if !ok {
+		return plan, -1, nil
+	}
+	preparedPlan := plan
+	preparedPlan.Sources = append([]SourcePlan(nil), plan.Sources...)
+	preparedPlan.Refs = make(map[string]SourcePlan, len(plan.Refs))
+	maps.Copy(preparedPlan.Refs, plan.Refs)
+	for i, sourcePlan := range preparedPlan.Sources {
+		if sourcePlan.RefOnly {
+			continue
+		}
+		prepared, err := preparer.PrepareSource(ctx, application, sourcePlan)
+		if err != nil {
+			return preparedPlan, i, fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
+		}
+		preparedPlan.Sources[i] = prepared
+		if prepared.RefKey != "" {
+			preparedPlan.Refs[prepared.RefKey] = prepared
+		}
+	}
+	return preparedPlan, -1, nil
 }
 
 func recordNamespaceBeforeNormalization(rendered *render.Manifest) {

--- a/internal/app/render_cache.go
+++ b/internal/app/render_cache.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
@@ -112,10 +113,22 @@ func renderApplicationCached(ctx renderContext, application argoappv1.Applicatio
 			return result, err
 		}
 	}
-	result, err := RenderApplicationWithOptions(ctx.context, application, ctx.provider, ApplicationRenderOptions{
+	provider := ctx.provider
+	provider.acquisitions = cacheevent.NewAcquisitionCollector()
+	options := ApplicationRenderOptions{
 		PluginOptions:   ctx.request.PluginOptions,
 		TrackingOptions: ctx.trackingOptions,
-	})
+	}
+	if key != "" {
+		options.persistent = persistentRenderOptions{
+			cache:                   ctx.request.persistentRenderCache,
+			settingsSignature:       ctx.settingsSignature,
+			hasInjectedPluginRender: ctx.request.PluginRenderer != nil,
+			applicationInputPaths:   append([]string(nil), ctx.applicationInputPaths...),
+			applicationInputsKnown:  ctx.applicationInputsKnown,
+		}
+	}
+	result, err := RenderApplicationWithOptions(ctx.context, application, provider, options)
 	if ctx.context.Err() == nil {
 		ctx.cache.set(key, result, err)
 	}
@@ -150,12 +163,14 @@ func applicationUsesPluginSource(application argoappv1.Application) bool {
 }
 
 type renderContext struct {
-	context           context.Context
-	provider          localProvider
-	cache             *applicationRenderCache
-	settingsSignature string
-	trackingOptions   TrackingOptions
-	request           BuildRequest
+	context                context.Context
+	provider               localProvider
+	cache                  *applicationRenderCache
+	settingsSignature      string
+	trackingOptions        TrackingOptions
+	request                BuildRequest
+	applicationInputPaths  []string
+	applicationInputsKnown bool
 }
 
 func applicationRenderCacheKey(ctx renderContext, application argoappv1.Application) (string, error) {

--- a/internal/app/render_cache_payload.go
+++ b/internal/app/render_cache_payload.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// renderCachePayload is the persistent-cache serialization of a successful
+// RenderResult. render.Manifest carries no JSON tags, so the app layer owns
+// explicit DTOs; internal/rendercache stores these bytes opaquely.
+type renderCachePayload struct {
+	Manifests        []renderCacheManifest   `json:"manifests"`
+	Diagnostics      []diagnostic.Diagnostic `json:"diagnostics,omitempty"`
+	PluginExecutions []PluginExecution       `json:"pluginExecutions,omitempty"`
+}
+
+type renderCacheManifest struct {
+	SourceIndex                  int                        `json:"sourceIndex"`
+	SourceName                   string                     `json:"sourceName,omitempty"`
+	Path                         string                     `json:"path,omitempty"`
+	NamespaceBeforeNormalization string                     `json:"namespaceBeforeNormalization,omitempty"`
+	Object                       *unstructured.Unstructured `json:"object,omitempty"`
+}
+
+func marshalRenderResultPayload(result RenderResult) ([]byte, error) {
+	payload := renderCachePayload{
+		Diagnostics:      result.Diagnostics,
+		PluginExecutions: result.PluginExecutions,
+	}
+	if result.Manifests != nil {
+		payload.Manifests = make([]renderCacheManifest, 0, len(result.Manifests))
+		for _, item := range result.Manifests {
+			payload.Manifests = append(payload.Manifests, renderCacheManifest{
+				SourceIndex:                  item.SourceIndex,
+				SourceName:                   item.SourceName,
+				Path:                         item.Path,
+				NamespaceBeforeNormalization: item.NamespaceBeforeNormalization,
+				Object:                       item.Object,
+			})
+		}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode render cache payload: %w", err)
+	}
+	return data, nil
+}
+
+func unmarshalRenderResultPayload(data []byte) (RenderResult, error) {
+	var payload renderCachePayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return RenderResult{}, fmt.Errorf("decode render cache payload: %w", err)
+	}
+	result := RenderResult{
+		Diagnostics:      payload.Diagnostics,
+		PluginExecutions: payload.PluginExecutions,
+	}
+	if payload.Manifests != nil {
+		result.Manifests = make([]render.Manifest, 0, len(payload.Manifests))
+		for _, item := range payload.Manifests {
+			result.Manifests = append(result.Manifests, render.Manifest{
+				SourceIndex:                  item.SourceIndex,
+				SourceName:                   item.SourceName,
+				Path:                         item.Path,
+				NamespaceBeforeNormalization: item.NamespaceBeforeNormalization,
+				Object:                       item.Object,
+			})
+		}
+	}
+	return result, nil
+}

--- a/internal/app/render_cache_payload_test.go
+++ b/internal/app/render_cache_payload_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func payloadFixtureResult() RenderResult {
+	return RenderResult{
+		Manifests: []render.Manifest{
+			{
+				SourceIndex:                  0,
+				SourceName:                   "primary",
+				Path:                         "manifests/demo",
+				NamespaceBeforeNormalization: "demo-ns",
+				Object: &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"name":      "demo",
+						"namespace": "demo-ns",
+						"labels":    map[string]any{"app": "demo"},
+					},
+					"spec": map[string]any{
+						"replicas": int64(3),
+						"template": map[string]any{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{"name": "main", "image": "registry.example.test/demo:1.2.3"},
+								},
+							},
+						},
+					},
+				}},
+			},
+			{
+				SourceIndex: 1,
+				Path:        "manifests/extra",
+				Object: &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": "extra"},
+					"data":       map[string]any{"key": "value"},
+				}},
+			},
+		},
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:       "plugin.avp-compat-substituted",
+				Severity:   diagnostic.SeverityWarning,
+				Category:   "plugin",
+				Message:    "placeholders replaced",
+				Provenance: diagnostic.Provenance{Path: "manifests/demo/values.yaml", Pointer: "/spec"},
+			},
+		},
+		PluginExecutions: []PluginExecution{
+			{
+				AppNamespace: "argocd",
+				AppName:      "demo",
+				SourceIndex:  0,
+				PluginName:   "example",
+				Engine:       "native",
+				Phase:        "render",
+				Command:      "internal",
+				Duration:     "10ms",
+			},
+		},
+	}
+}
+
+func TestRenderResultPayloadRoundTrip(t *testing.T) {
+	original := payloadFixtureResult()
+
+	payload, err := marshalRenderResultPayload(original)
+	if err != nil {
+		t.Fatalf("marshalRenderResultPayload() error = %v", err)
+	}
+	restored, err := unmarshalRenderResultPayload(payload)
+	if err != nil {
+		t.Fatalf("unmarshalRenderResultPayload() error = %v", err)
+	}
+	if !reflect.DeepEqual(original, restored) {
+		t.Fatalf("round trip mismatch:\noriginal: %#v\nrestored: %#v", original, restored)
+	}
+}
+
+func TestRenderResultPayloadRoundTripEmptyResult(t *testing.T) {
+	payload, err := marshalRenderResultPayload(RenderResult{})
+	if err != nil {
+		t.Fatalf("marshalRenderResultPayload() error = %v", err)
+	}
+	restored, err := unmarshalRenderResultPayload(payload)
+	if err != nil {
+		t.Fatalf("unmarshalRenderResultPayload() error = %v", err)
+	}
+	if !reflect.DeepEqual(RenderResult{}, restored) {
+		t.Fatalf("empty round trip mismatch: %#v", restored)
+	}
+}
+
+func TestRenderResultPayloadDeterministicBytes(t *testing.T) {
+	// Two marshals of the same logical result must be byte-identical: the
+	// foundation of the no-absolute-paths invariant test.
+	first, err := marshalRenderResultPayload(payloadFixtureResult())
+	if err != nil {
+		t.Fatalf("marshalRenderResultPayload() error = %v", err)
+	}
+	second, err := marshalRenderResultPayload(payloadFixtureResult())
+	if err != nil {
+		t.Fatalf("marshalRenderResultPayload() error = %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("payload bytes are not deterministic")
+	}
+}
+
+func TestUnmarshalRenderResultPayloadRejectsGarbage(t *testing.T) {
+	if _, err := unmarshalRenderResultPayload([]byte("not-json")); err == nil {
+		t.Fatalf("unmarshalRenderResultPayload() error = nil, want decode error")
+	}
+}

--- a/internal/app/render_cache_persistent.go
+++ b/internal/app/render_cache_persistent.go
@@ -1,0 +1,1293 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/digestpath"
+	"github.com/sholdee/drydock/internal/filedigest"
+	"github.com/sholdee/drydock/internal/gitref"
+	"github.com/sholdee/drydock/internal/pathsafety"
+	"github.com/sholdee/drydock/internal/render"
+	"github.com/sholdee/drydock/internal/rendercache"
+)
+
+// SourceIdentity is one source's resolved identity in the persistent render
+// cache key. Locator is a repository URL or chart repo+name, never a
+// filesystem path. The provider root uses Kind "root" with an empty Locator.
+type SourceIdentity struct {
+	Kind     string `json:"kind"`
+	Locator  string `json:"locator,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	Digest   string `json:"digest,omitempty"`
+}
+
+const (
+	sourceIdentityKindRoot           = "root"
+	sourceIdentityKindGit            = "git"
+	sourceIdentityKindChart          = "chart"
+	sourceIdentityKindLocalInputs    = "local-inputs"
+	sourceIdentityKindWorktreeInputs = "worktree-inputs"
+)
+
+type rootInputMode string
+
+const (
+	rootInputModeSnapshot rootInputMode = "snapshot"
+	rootInputModeClean    rootInputMode = "clean"
+	rootInputModeDirty    rootInputMode = "dirty"
+	rootInputModeUnknown  rootInputMode = "unknown"
+)
+
+// persistentRenderCache is the run-scoped handle threaded through requests.
+// Exactly one creator opens the store and owns the post-run eviction sweep.
+type persistentRenderCache struct {
+	store        *rendercache.Store
+	fingerprint  rendercache.EngineFingerprint
+	refresh      bool
+	recordEvents bool
+
+	mu                sync.Mutex
+	pending           []cacheevent.Event
+	changeSets        map[string]gitref.WorktreeChangeSetResult
+	digests           map[string]gitref.PathDigestResult
+	filesystemDigests map[string]filedigest.PathDigestResult
+	contentDigests    *filedigest.ContentDigestCache
+}
+
+func (handle *persistentRenderCache) active() bool {
+	return handle != nil && handle.store != nil
+}
+
+func (handle *persistentRenderCache) appendEvent(event cacheevent.Event) {
+	if handle == nil || !handle.recordEvents {
+		return
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	handle.pending = append(handle.pending, event)
+}
+
+// worktreeChangeSet returns the explicit Git worktree state and complete
+// dirty-path enumeration for root. It is computed once per run per root;
+// like the digest memos, the run-stability contract applies (mid-run edits
+// after the first call are caught by store-time verification, not here).
+func (handle *persistentRenderCache) worktreeChangeSet(ctx context.Context, root string) gitref.WorktreeChangeSetResult {
+	if handle == nil {
+		return gitref.WorktreeChangeSetResult{State: gitref.WorktreeStateUnknown}
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return gitref.WorktreeChangeSetResult{State: gitref.WorktreeStateUnknown}
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if handle.changeSets == nil {
+		handle.changeSets = map[string]gitref.WorktreeChangeSetResult{}
+	}
+	if cached, ok := handle.changeSets[abs]; ok {
+		return cached
+	}
+	result, err := gitref.WorktreeChangeSet(ctx, abs)
+	if err != nil {
+		result = gitref.WorktreeChangeSetResult{State: gitref.WorktreeStateUnknown}
+	}
+	if result.State == "" {
+		result.State = gitref.WorktreeStateUnknown
+	}
+	handle.changeSets[abs] = result
+	return result
+}
+
+func (handle *persistentRenderCache) committedPathDigest(ctx context.Context, repoPath, revision string, paths []gitref.PathDigestPath) (gitref.PathDigestResult, error) {
+	if handle == nil {
+		return gitref.PathDigestResult{}, fmt.Errorf("persistent render cache handle is nil")
+	}
+	key, normalized, err := committedPathDigestMemoKey(repoPath, revision, paths)
+	if err != nil {
+		return gitref.PathDigestResult{}, err
+	}
+	handle.mu.Lock()
+	if result, ok := handle.digests[key]; ok {
+		handle.mu.Unlock()
+		return result, nil
+	}
+	handle.mu.Unlock()
+
+	result, err := gitref.CommittedPathDigest(ctx, gitref.PathDigestInput{
+		RepoPath: repoPath,
+		Revision: revision,
+		Paths:    normalized,
+	})
+	if err != nil {
+		return gitref.PathDigestResult{}, err
+	}
+
+	handle.mu.Lock()
+	if cached, ok := handle.digests[key]; ok {
+		handle.mu.Unlock()
+		return cached, nil
+	}
+	if handle.digests == nil {
+		handle.digests = map[string]gitref.PathDigestResult{}
+	}
+	handle.digests[key] = result
+	handle.mu.Unlock()
+	return result, nil
+}
+
+func committedPathDigestMemoKey(repoPath, revision string, paths []gitref.PathDigestPath) (string, []gitref.PathDigestPath, error) {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", nil, err
+	}
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "HEAD"
+	}
+	byPath := make(map[string]bool, len(paths))
+	for _, item := range paths {
+		clean, err := digestpath.CanonicalGitPath(item.Path)
+		if err != nil {
+			return "", nil, err
+		}
+		if optional, ok := byPath[clean]; ok {
+			byPath[clean] = optional && item.Optional
+			continue
+		}
+		byPath[clean] = item.Optional
+	}
+	normalized := make([]gitref.PathDigestPath, 0, len(byPath))
+	for clean, optional := range byPath {
+		normalized = append(normalized, gitref.PathDigestPath{Path: clean, Optional: optional})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Path == normalized[j].Path {
+			return !normalized[i].Optional && normalized[j].Optional
+		}
+		return normalized[i].Path < normalized[j].Path
+	})
+	var builder strings.Builder
+	builder.WriteString(abs)
+	builder.WriteByte(0)
+	builder.WriteString(revision)
+	for _, item := range normalized {
+		builder.WriteByte(0)
+		builder.WriteString(item.Path)
+		if item.Optional {
+			builder.WriteString(":optional")
+		} else {
+			builder.WriteString(":required")
+		}
+	}
+	return builder.String(), normalized, nil
+}
+
+func (handle *persistentRenderCache) filesystemPathDigest(ctx context.Context, repoRoot string, paths []filedigest.PathDigestPath, forbiddenRoots []string) (filedigest.PathDigestResult, error) {
+	if handle == nil {
+		return filedigest.PathDigestResult{}, fmt.Errorf("persistent render cache handle is nil")
+	}
+	key, normalizedPaths, normalizedForbiddenRoots, err := filesystemPathDigestMemoKey(repoRoot, paths, forbiddenRoots)
+	if err != nil {
+		return filedigest.PathDigestResult{}, err
+	}
+	handle.mu.Lock()
+	if result, ok := handle.filesystemDigests[key]; ok {
+		handle.mu.Unlock()
+		return result, nil
+	}
+	handle.mu.Unlock()
+
+	result, err := filedigest.PathDigest(ctx, filedigest.PathDigestInput{
+		RepoRoot:       repoRoot,
+		Paths:          normalizedPaths,
+		ForbiddenRoots: normalizedForbiddenRoots,
+		ContentCache:   handle.contentDigests,
+	})
+	if err != nil {
+		return filedigest.PathDigestResult{}, err
+	}
+
+	handle.mu.Lock()
+	if cached, ok := handle.filesystemDigests[key]; ok {
+		handle.mu.Unlock()
+		return cached, nil
+	}
+	if handle.filesystemDigests == nil {
+		handle.filesystemDigests = map[string]filedigest.PathDigestResult{}
+	}
+	handle.filesystemDigests[key] = result
+	handle.mu.Unlock()
+	return result, nil
+}
+
+func filesystemPathDigestMemoKey(repoRoot string, paths []filedigest.PathDigestPath, forbiddenRoots []string) (string, []filedigest.PathDigestPath, []string, error) {
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	normalizedPaths, err := normalizeFilesystemPathDigestPaths(paths)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	normalizedForbiddenRoots, err := normalizeFilesystemDigestForbiddenRoots(forbiddenRoots)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	keyInput := struct {
+		Version        string                      `json:"version"`
+		RepoRoot       string                      `json:"repoRoot"`
+		ForbiddenRoots []string                    `json:"forbiddenRoots,omitempty"`
+		Paths          []filedigest.PathDigestPath `json:"paths,omitempty"`
+	}{
+		Version:        "drydock.app.filesystem-path-digest-memo-key.v1",
+		RepoRoot:       filepath.Clean(absRoot),
+		ForbiddenRoots: normalizedForbiddenRoots,
+		Paths:          normalizedPaths,
+	}
+	data, err := json.Marshal(keyInput)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return string(data), normalizedPaths, normalizedForbiddenRoots, nil
+}
+
+func normalizeFilesystemPathDigestPaths(paths []filedigest.PathDigestPath) ([]filedigest.PathDigestPath, error) {
+	type pathKey struct {
+		path       string
+		markerKind string
+	}
+	byPath := make(map[pathKey]bool, len(paths))
+	for _, item := range paths {
+		clean, err := canonicalFilesystemDigestPath(item.Path)
+		if err != nil {
+			return nil, err
+		}
+		if strings.Contains(item.MarkerKind, "\x00") {
+			return nil, fmt.Errorf("marker kind contains nul")
+		}
+		key := pathKey{path: clean, markerKind: item.MarkerKind}
+		if optional, ok := byPath[key]; ok {
+			byPath[key] = optional && item.Optional
+			continue
+		}
+		byPath[key] = item.Optional
+	}
+	normalized := make([]filedigest.PathDigestPath, 0, len(byPath))
+	for key, optional := range byPath {
+		normalized = append(normalized, filedigest.PathDigestPath{Path: key.path, Optional: optional, MarkerKind: key.markerKind})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Path == normalized[j].Path {
+			if normalized[i].MarkerKind == normalized[j].MarkerKind {
+				return !normalized[i].Optional && normalized[j].Optional
+			}
+			return normalized[i].MarkerKind < normalized[j].MarkerKind
+		}
+		return normalized[i].Path < normalized[j].Path
+	})
+	return normalized, nil
+}
+
+func canonicalFilesystemDigestPath(value string) (string, error) {
+	return digestpath.CanonicalFilesystemPath(value)
+}
+
+func normalizeFilesystemDigestForbiddenRoots(forbiddenRoots []string) ([]string, error) {
+	normalized := make([]string, 0, len(forbiddenRoots))
+	for _, root := range forbiddenRoots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			return nil, err
+		}
+		normalized = append(normalized, filepath.Clean(abs))
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+// release runs the post-run eviction sweep only when this run wrote at least
+// one entry, then returns deferred observability events.
+func (handle *persistentRenderCache) release() []cacheevent.Event {
+	if handle == nil {
+		return nil
+	}
+	handle.mu.Lock()
+	events := append([]cacheevent.Event(nil), handle.pending...)
+	handle.pending = nil
+	handle.mu.Unlock()
+	if !handle.active() || handle.store.Writes() == 0 {
+		return events
+	}
+	result, err := handle.store.Sweep()
+	if err != nil {
+		if handle.recordEvents {
+			events = append(events, cacheevent.Event{Source: cacheevent.SourceRender, Action: cacheevent.ActionError, Error: err.Error()})
+		}
+		return events
+	}
+	if handle.recordEvents {
+		for _, key := range result.EvictedKeys {
+			events = append(events, cacheevent.Event{Source: cacheevent.SourceRender, Action: cacheevent.ActionEvict, Revision: renderCacheKeyPrefix(key)})
+		}
+	}
+	return events
+}
+
+func renderCacheKeyPrefix(key string) string {
+	if len(key) <= 12 {
+		return key
+	}
+	return key[:12]
+}
+
+// newPersistentRenderCache opens or initializes the run-scoped persistent render
+// cache handle. Callers must pre-fold the acquisition refresh flags via
+// renderCacheRefreshOptions; go through the ensure functions rather than calling
+// this directly.
+func newPersistentRenderCache(options RenderCacheOptions, recordEvents bool) *persistentRenderCache {
+	if !options.RenderCacheEnabled {
+		return nil
+	}
+	handle := &persistentRenderCache{
+		fingerprint:       options.EngineFingerprint,
+		refresh:           options.RefreshRenders,
+		recordEvents:      recordEvents,
+		changeSets:        map[string]gitref.WorktreeChangeSetResult{},
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+		contentDigests:    filedigest.NewContentDigestCache(),
+	}
+	if !options.EngineFingerprint.Known() {
+		handle.appendEvent(cacheevent.Event{Source: cacheevent.SourceRender, Action: cacheevent.ActionDisabled, Reason: "dev-build"})
+		return handle
+	}
+	store, err := rendercache.Open(options.RenderCacheDir, options.RenderCacheMaxBytes)
+	if err != nil {
+		handle.appendEvent(cacheevent.Event{Source: cacheevent.SourceRender, Action: cacheevent.ActionError, Error: err.Error()})
+		return handle
+	}
+	handle.store = store
+	return handle
+}
+
+func noRenderCacheEvents() []cacheevent.Event { return nil }
+
+// renderCacheRefreshOptions folds the acquisition refresh flags into the
+// persistent tier's refresh bit. The in-memory key already varies on these
+// flags; the persistent tier instead bypasses lookup and overwrites the entry,
+// so an explicitly refreshed chart, git ref, or remote resource is always
+// re-rendered. Offline is excluded: offline runs want cache hits.
+func renderCacheRefreshOptions(options RenderCacheOptions, acquisition AcquisitionOptions) RenderCacheOptions {
+	options.RefreshRenders = options.RefreshRenders ||
+		acquisition.RefreshCharts ||
+		acquisition.RefreshGit ||
+		acquisition.RefreshRemoteResources
+	return options
+}
+
+// ensurePersistentRenderCache opens or reuses the run-scoped persistent render
+// cache handle. Only the creator's release sweeps and surfaces events.
+func ensurePersistentRenderCache(request BuildRequest) (BuildRequest, func() []cacheevent.Event) {
+	if request.persistentRenderCache != nil {
+		return request, noRenderCacheEvents
+	}
+	handle := newPersistentRenderCache(renderCacheRefreshOptions(request.RenderCacheOptions, request.AcquisitionOptions), request.RecordCacheEvents)
+	if handle == nil {
+		return request, noRenderCacheEvents
+	}
+	request.persistentRenderCache = handle
+	return request, handle.release
+}
+
+// ensureDiffPersistentRenderCache is the DiffRequest twin; buildRequest copies
+// the handle into both side BuildRequests.
+func ensureDiffPersistentRenderCache(request DiffRequest) (DiffRequest, func() []cacheevent.Event) {
+	if request.persistentRenderCache != nil {
+		return request, noRenderCacheEvents
+	}
+	handle := newPersistentRenderCache(renderCacheRefreshOptions(request.RenderCacheOptions, request.AcquisitionOptions), request.RecordCacheEvents)
+	if handle == nil {
+		return request, noRenderCacheEvents
+	}
+	request.persistentRenderCache = handle
+	return request, handle.release
+}
+
+const (
+	renderCacheReasonIneligibleSource = "ineligible-source"
+	renderCacheReasonDirtyWorktree    = "dirty-worktree"
+	renderCacheReasonInputGraph       = "input-graph-unsupported"
+	renderCacheReasonInputDigest      = "input-digest-error"
+	renderCacheReasonPinUnstable      = "pin-unstable"
+	renderCacheReasonRecordsInactive  = "records-inactive"
+	renderCacheReasonRefresh          = "refresh"
+	renderCacheReasonInputsChanged    = "inputs-changed"
+)
+
+// collectSourceIdentities is the prepare phase: resolve every source and
+// ref-only source through the real acquisition path and build the ordered
+// identity vector: all plan.Sources by index, then plan.Refs sorted by ref key.
+// A failure or empty identity makes the application persistence-ineligible;
+// it never fails the render.
+func collectSourceIdentities(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult) ([]SourceIdentity, string, bool) {
+	byIndex := make(map[int]SourceIdentity, len(plan.Sources))
+	var resolve func(SourcePlan) (SourceIdentity, string, bool)
+	resolve = func(sourcePlan SourcePlan) (SourceIdentity, string, bool) {
+		if identity, ok := byIndex[sourcePlan.Index]; ok {
+			return identity, "", true
+		}
+		identity, reason, ok := sourceIdentityForPlan(ctx, handle, provider, plan, sourcePlan, resolve)
+		if ok {
+			byIndex[sourcePlan.Index] = identity
+		}
+		return identity, reason, ok
+	}
+	for _, sourcePlan := range plan.Sources {
+		identity, reason, ok := resolve(sourcePlan)
+		if !ok {
+			if reason != "" {
+				return nil, reason, false
+			}
+			if identity.Kind == sourceIdentityKindRoot {
+				return nil, renderCacheReasonDirtyWorktree, false
+			}
+			return nil, renderCacheReasonIneligibleSource, false
+		}
+	}
+	vector := make([]SourceIdentity, 0, len(plan.Sources)+len(plan.Refs))
+	for _, sourcePlan := range plan.Sources {
+		vector = append(vector, byIndex[sourcePlan.Index])
+	}
+	refKeys := make([]string, 0, len(plan.Refs))
+	for refKey := range plan.Refs {
+		refKeys = append(refKeys, refKey)
+	}
+	sort.Strings(refKeys)
+	for _, refKey := range refKeys {
+		vector = append(vector, byIndex[plan.Refs[refKey].Index])
+	}
+	return vector, "", true
+}
+
+func sourceIdentityForPlan(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult, sourcePlan SourcePlan, resolve func(SourcePlan) (SourceIdentity, string, bool)) (SourceIdentity, string, bool) {
+	if sourcePlan.RefOnly {
+		if candidate, ok := planSameRevisionRenderSource(plan, sourcePlan); ok {
+			return resolve(candidate)
+		}
+	}
+	_, identity, err := provider.resolveSourceRootIdentity(ctx, render.ResolvedSource{
+		Path:           sourcePlan.Source.Path,
+		Chart:          sourcePlan.Source.Chart,
+		RepoURL:        sourcePlan.Source.RepoURL,
+		TargetRevision: sourcePlan.Source.TargetRevision,
+		ExplicitType:   sourcePlan.ExplicitType,
+	})
+	if err != nil {
+		return identity, "", false
+	}
+	if identity.Kind != sourceIdentityKindRoot {
+		if strings.TrimSpace(identity.Revision) == "" {
+			return identity, "", false
+		}
+		return identity, "", true
+	}
+	return rootSourceIdentityForPlan(ctx, handle, provider, plan, sourcePlan, identity)
+}
+
+func rootSourceIdentityForPlan(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult, sourcePlan SourcePlan, identity SourceIdentity) (SourceIdentity, string, bool) {
+	switch provider.rootInputMode {
+	case rootInputModeSnapshot:
+		if strings.TrimSpace(identity.Revision) == "" {
+			return identity, renderCacheReasonIneligibleSource, false
+		}
+		return identity, "", true
+	case rootInputModeClean:
+		if strings.TrimSpace(identity.Revision) == "" {
+			return identity, renderCacheReasonDirtyWorktree, false
+		}
+		localIdentity, reason, ok := localInputSourceIdentity(ctx, handle, provider, plan, sourcePlan, identity.Revision)
+		return localIdentity, reason, ok
+	case rootInputModeDirty:
+		localIdentity, reason, ok := worktreeInputSourceIdentity(ctx, handle, provider, plan, sourcePlan)
+		return localIdentity, reason, ok
+	case rootInputModeUnknown:
+		return identity, renderCacheReasonIneligibleSource, false
+	default:
+		return identity, renderCacheReasonIneligibleSource, false
+	}
+}
+
+func localInputSourceIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult, sourcePlan SourcePlan, revision string) (SourceIdentity, string, bool) {
+	// Clean mode: globs are safe because Helm expansion happens against
+	// committed-equal content and any expansion change rotates the path set
+	// (and therefore the cache key) via the committed digest.
+	paths, _, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider.repoRoot)
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputGraph, false
+	}
+	return committedSourceIdentityForPaths(ctx, handle, provider, revision, paths)
+}
+
+// committedSourceIdentityForPaths digests paths at revision and records the
+// committed store-time verification. Shared by clean mode and by dirty
+// mode's untouched-path-set shortcut.
+func committedSourceIdentityForPaths(ctx context.Context, handle *persistentRenderCache, provider localProvider, revision string, paths []gitref.PathDigestPath) (SourceIdentity, string, bool) {
+	result, err := handle.committedPathDigest(ctx, provider.repoRoot, revision, paths)
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	if strings.TrimSpace(result.Digest) == "" {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	provider.inputVerifier.addCommitted(provider, revision, paths)
+	return SourceIdentity{
+		Kind:   sourceIdentityKindLocalInputs,
+		Digest: result.Digest,
+	}, "", true
+}
+
+func worktreeInputSourceIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult, sourcePlan SourcePlan) (SourceIdentity, string, bool) {
+	paths, helmGlobs, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider.repoRoot)
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputGraph, false
+	}
+	if !helmGlobs && dirtyWorktreeCommittedShortcut(provider, paths) {
+		// No dirty path touches this source's digested inputs, so its
+		// worktree content provably matches the commit: reuse the committed
+		// key (identical to clean mode after Revision normalization) and the
+		// committed store-time verification.
+		return committedSourceIdentityForPaths(ctx, handle, provider, provider.rootIdentity.Revision, paths)
+	}
+	if helmGlobs {
+		// Dirty mode: globs are rejected because the expansion set depends on
+		// the current worktree and is not provable from committed content
+		// alone — a new untracked file matching the glob would be invisible
+		// to the path-set intersection above.
+		return SourceIdentity{}, renderCacheReasonInputGraph, false
+	}
+	result, err := handle.filesystemPathDigest(ctx, provider.repoRoot, filesystemInputDigestPaths(paths), filesystemDigestForbiddenRoots(provider))
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	if strings.TrimSpace(result.Digest) == "" {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	provider.inputVerifier.addFilesystem(provider, paths, result.Digest)
+	return SourceIdentity{
+		Kind:   sourceIdentityKindWorktreeInputs,
+		Digest: result.Digest,
+	}, "", true
+}
+
+func helmDigestInputsHaveGlob(valueFiles []string, fileParameters []argoappv1.HelmFileParameter) bool {
+	if slices.ContainsFunc(valueFiles, helmInputPathHasGlob) {
+		return true
+	}
+	for _, parameter := range fileParameters {
+		if helmInputPathHasGlob(parameter.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func helmInputPathHasGlob(inputPath string) bool {
+	return strings.ContainsAny(inputPath, "*?[")
+}
+
+func filesystemInputDigestPaths(paths []gitref.PathDigestPath) []filedigest.PathDigestPath {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]filedigest.PathDigestPath, 0, len(paths))
+	for _, item := range paths {
+		out = append(out, filedigest.PathDigestPath{Path: item.Path, Optional: item.Optional})
+	}
+	return out
+}
+
+// dirtyPathsTouch reports whether any dirty repository-relative path equals
+// or falls under any digested path. Digested directory paths cover their
+// subtree; dirty entries are file paths (plus nested-.git directory
+// markers). sortedDirtyPaths must be sorted. Canonicalization failures and
+// "." fail closed (touched). If the enumeration is ever optimized to record
+// untracked DIRECTORIES as single markers, this helper must additionally
+// match ancestors of each digested path — today only nested .git uses a
+// directory marker and digest paths cannot live under .git.
+// Note: on case-insensitive filesystems a case-only rename yields a dirty
+// set containing only the on-disk casing; committed-name intersection may
+// not match. This is correct today (content is byte-identical on such
+// filesystems) and consistent with the committed-digest behavior.
+func dirtyPathsTouch(sortedDirtyPaths []string, paths []gitref.PathDigestPath) bool {
+	if len(sortedDirtyPaths) == 0 {
+		return false
+	}
+	for _, item := range paths {
+		clean, err := digestpath.CanonicalGitPath(item.Path)
+		if err != nil {
+			return true
+		}
+		if clean == "." {
+			return true
+		}
+		i := sort.SearchStrings(sortedDirtyPaths, clean)
+		if i < len(sortedDirtyPaths) && sortedDirtyPaths[i] == clean {
+			return true
+		}
+		j := sort.SearchStrings(sortedDirtyPaths, clean+"/")
+		if j < len(sortedDirtyPaths) && strings.HasPrefix(sortedDirtyPaths[j], clean+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// dirtyWorktreeCommittedShortcut reports whether a dirty-mode path set may
+// use the committed-digest flow: the dirty enumeration must be present
+// (empty means a hand-built provider without enumeration — fail safe), the
+// root revision known, and no dirty path touching the set.
+func dirtyWorktreeCommittedShortcut(provider localProvider, paths []gitref.PathDigestPath) bool {
+	if len(provider.rootDirtyPaths) == 0 {
+		return false
+	}
+	if strings.TrimSpace(provider.rootIdentity.Revision) == "" {
+		return false
+	}
+	return !dirtyPathsTouch(provider.rootDirtyPaths, paths)
+}
+
+func filesystemDigestForbiddenRoots(provider localProvider) []string {
+	candidates := append([]string(nil), provider.chartForbiddenRoots...)
+	candidates = append(candidates, provider.remoteResourceForbiddenRoots...)
+	roots := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strictPathInsideRoot(provider.repoRoot, candidate) {
+			roots = appendUniqueString(roots, candidate)
+		}
+	}
+	return roots
+}
+
+// renderInputVerification re-checks one digest path set after the render.
+// Dirty mode records the filesystem baseline digest behind the key; clean
+// mode records the committed revision and path set so store() can prove the
+// worktree still matches the commit the key was derived from.
+type renderInputVerification struct {
+	repoRoot       string
+	revision       string
+	committedPaths []gitref.PathDigestPath
+	paths          []filedigest.PathDigestPath
+	forbiddenRoots []string
+	digest         string
+}
+
+type renderInputVerifier struct {
+	entries []renderInputVerification
+}
+
+func (v *renderInputVerifier) addFilesystem(provider localProvider, paths []gitref.PathDigestPath, digest string) {
+	if v == nil {
+		return
+	}
+	v.entries = append(v.entries, renderInputVerification{
+		repoRoot:       provider.repoRoot,
+		paths:          filesystemInputDigestPaths(paths),
+		forbiddenRoots: filesystemDigestForbiddenRoots(provider),
+		digest:         digest,
+	})
+}
+
+func (v *renderInputVerifier) addCommitted(provider localProvider, revision string, paths []gitref.PathDigestPath) {
+	if v == nil {
+		return
+	}
+	v.entries = append(v.entries, renderInputVerification{
+		repoRoot:       provider.repoRoot,
+		revision:       revision,
+		committedPaths: append([]gitref.PathDigestPath(nil), paths...),
+	})
+}
+
+func strictPathInsideRoot(root, candidate string) bool {
+	root = strings.TrimSpace(root)
+	candidate = strings.TrimSpace(candidate)
+	if root == "" || candidate == "" {
+		return false
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	absCandidate, err := filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(absRoot), filepath.Clean(absCandidate))
+	if err != nil {
+		return false
+	}
+	return rel != "." && !pathsafety.RelEscapes(rel) && !filepath.IsAbs(rel)
+}
+
+func localInputDigestPathsForSource(ctx context.Context, plan PlanResult, sourcePlan SourcePlan, repoRoot string) ([]gitref.PathDigestPath, bool, error) {
+	sourcePath := strings.TrimSpace(sourcePlan.Source.Path)
+	if sourcePath == "" {
+		return nil, false, fmt.Errorf("local source path is empty")
+	}
+	clean, err := cleanLocalSourcePath(sourcePath)
+	if err != nil {
+		return nil, false, err
+	}
+	paths, helmGlobs, err := localToolInputDigestPaths(ctx, plan, sourcePlan, repoRoot, clean)
+	if err != nil {
+		return nil, false, err
+	}
+	// PrepareSource merges these override files into the source spec before
+	// rendering, so their content is a render input for every tool. Optional:
+	// absence is itself a digest record, so adding or deleting one rotates
+	// the key.
+	return append(paths, argocdSourceOverrideDigestPaths(clean, plan.Application.Name)...), helmGlobs, nil
+}
+
+func argocdSourceOverrideDigestPaths(sourcePath, appName string) []gitref.PathDigestPath {
+	sourcePath = filepath.ToSlash(sourcePath)
+	paths := []gitref.PathDigestPath{{Path: path.Join(sourcePath, repoSourceFile), Optional: true}}
+	if strings.TrimSpace(appName) != "" {
+		paths = append(paths, gitref.PathDigestPath{Path: path.Join(sourcePath, fmt.Sprintf(appSourceFile, appName)), Optional: true})
+	}
+	return paths
+}
+
+// localToolInputDigestPaths picks the per-tool input enumerator using the
+// same classification the render path uses (selectLocalRenderer), so the
+// digested inputs cannot diverge from the files the render actually reads.
+// The returned bool reports whether any Helm input path contains glob
+// metacharacters.
+func localToolInputDigestPaths(ctx context.Context, plan PlanResult, sourcePlan SourcePlan, repoRoot, clean string) ([]gitref.PathDigestPath, bool, error) {
+	switch sourcePlan.ExplicitType {
+	case argoappv1.ApplicationSourceTypeDirectory, argoappv1.ApplicationSourceTypeHelm, argoappv1.ApplicationSourceTypeKustomize, "":
+	case argoappv1.ApplicationSourceTypePlugin:
+		return nil, false, fmt.Errorf("source type %q is not persistent-cache eligible", sourcePlan.ExplicitType)
+	default:
+		return nil, false, fmt.Errorf("source type %q is not persistent-cache eligible", sourcePlan.ExplicitType)
+	}
+	renderer, err := selectLocalRenderer(render.ResolvedSource{
+		RepoRoot:     repoRoot,
+		Path:         clean,
+		ExplicitType: sourcePlan.ExplicitType,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	switch renderer.(type) {
+	case render.DirectoryRenderer:
+		paths, err := localDirectoryInputDigestPaths(plan, sourcePlan, repoRoot)
+		return paths, false, err
+	case render.HelmRenderer:
+		return localHelmInputDigestPaths(plan, sourcePlan, repoRoot)
+	case render.KustomizeRenderer:
+		paths, err := localKustomizeInputDigestPaths(ctx, plan, sourcePlan, repoRoot)
+		return paths, false, err
+	default:
+		return nil, false, fmt.Errorf("renderer %T is not persistent-cache eligible", renderer)
+	}
+}
+
+func localKustomizeInputDigestPaths(ctx context.Context, plan PlanResult, sourcePlan SourcePlan, repoRoot string) ([]gitref.PathDigestPath, error) {
+	opts, err := renderOptions(plan.Application, sourcePlan.Source)
+	if err != nil {
+		return nil, err
+	}
+	source := resolvedSourceForPlan(sourcePlan)
+	if source.RepoRoot == "" {
+		source.RepoRoot = repoRoot
+	}
+	return render.KustomizeInputDigestPaths(ctx, source, opts)
+}
+
+func localDirectoryInputDigestPaths(plan PlanResult, sourcePlan SourcePlan, repoRoot string) ([]gitref.PathDigestPath, error) {
+	opts, err := renderOptions(plan.Application, sourcePlan.Source)
+	if err != nil {
+		return nil, err
+	}
+	source := resolvedSourceForPlan(sourcePlan)
+	if source.RepoRoot == "" {
+		source.RepoRoot = repoRoot
+	}
+	return render.DirectoryInputDigestPaths(source, opts)
+}
+
+func localHelmInputDigestPaths(plan PlanResult, sourcePlan SourcePlan, repoRoot string) ([]gitref.PathDigestPath, bool, error) {
+	opts, err := renderOptions(plan.Application, sourcePlan.Source)
+	if err != nil {
+		return nil, false, err
+	}
+	valueFiles, fileParameters, err := localHelmDigestInputPaths(plan, sourcePlan, opts)
+	if err != nil {
+		return nil, false, err
+	}
+	helmGlobs := helmDigestInputsHaveGlob(valueFiles, fileParameters)
+	opts.ValueFiles = valueFiles
+	opts.HelmFileParameters = fileParameters
+	refRoots, _, err := renderRefsForSource(plan, sourcePlan, helmRefInputPaths(opts))
+	if err != nil {
+		return nil, helmGlobs, err
+	}
+	opts.RefRoots = mergeRefRoots(opts.RefRoots, refRoots)
+	collected, err := render.CollectHelmLocalInputPaths(render.HelmLocalInputOptions{
+		RepoRoot: repoRoot,
+		Source:   resolvedSourceForPlan(sourcePlan),
+		Options:  opts,
+	})
+	if err != nil {
+		return nil, helmGlobs, err
+	}
+	paths := make([]gitref.PathDigestPath, 0, len(collected))
+	for _, item := range collected {
+		paths = append(paths, gitref.PathDigestPath{Path: item.Path, Optional: item.Optional})
+	}
+	return paths, helmGlobs, nil
+}
+
+func localHelmDigestInputPaths(plan PlanResult, sourcePlan SourcePlan, opts render.RenderOptions) ([]string, []argoappv1.HelmFileParameter, error) {
+	valueFiles := make([]string, 0, len(opts.ValueFiles))
+	for _, valueFile := range opts.ValueFiles {
+		keep, err := localHelmDigestShouldCollectPath(plan, sourcePlan, valueFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		if keep {
+			valueFiles = append(valueFiles, valueFile)
+		}
+	}
+	fileParameters := make([]argoappv1.HelmFileParameter, 0, len(opts.HelmFileParameters))
+	for _, parameter := range opts.HelmFileParameters {
+		keep, err := localHelmDigestShouldCollectPath(plan, sourcePlan, parameter.Path)
+		if err != nil {
+			return nil, nil, err
+		}
+		if keep {
+			fileParameters = append(fileParameters, parameter)
+		}
+	}
+	return valueFiles, fileParameters, nil
+}
+
+func localHelmDigestShouldCollectPath(plan PlanResult, sourcePlan SourcePlan, inputPath string) (bool, error) {
+	trimmed := strings.TrimSpace(inputPath)
+	if trimmed == "" {
+		return true, nil
+	}
+	if !strings.HasPrefix(trimmed, "$") {
+		return true, nil
+	}
+	refKey, ok, err := helmValueFileRefKey(trimmed)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("unprovable Helm ref path %q", inputPath)
+	}
+	refSource, ok := plan.Refs[refKey]
+	if !ok {
+		return false, fmt.Errorf("unknown Helm ref path %q", inputPath)
+	}
+	return isSameSourceRevision(refSource.Source, sourcePlan.Source), nil
+}
+
+func planSameRevisionRenderSource(plan PlanResult, refPlan SourcePlan) (SourcePlan, bool) {
+	for _, candidate := range plan.Sources {
+		if candidate.RefOnly || candidate.Index == refPlan.Index {
+			continue
+		}
+		if isSameSourceRevision(candidate.Source, refPlan.Source) {
+			return candidate, true
+		}
+	}
+	return SourcePlan{}, false
+}
+
+// persistentRenderKeyInput mirrors applicationRenderCacheKey's input with
+// path-typed and run-ephemeral fields replaced by resolved source identities.
+type persistentRenderKeyInput struct {
+	FormatVersion           int                           `json:"formatVersion"`
+	Application             applicationRenderCacheInput   `json:"application"`
+	ApplicationInputs       SourceIdentity                `json:"applicationInputs,omitempty"`
+	SettingsSignature       string                        `json:"settingsSignature"`
+	PluginTimeout           string                        `json:"pluginTimeout,omitempty"`
+	EnableAVPCompat         bool                          `json:"enableAVPCompat"`
+	EnablePlugins           bool                          `json:"enablePlugins"`
+	PluginPolicyFingerprint string                        `json:"pluginPolicyFingerprint,omitempty"`
+	HasInjectedPluginRender bool                          `json:"hasInjectedPluginRender"`
+	TrackingOptions         TrackingOptions               `json:"trackingOptions"`
+	Sources                 []SourceIdentity              `json:"sources"`
+	Engine                  rendercache.EngineFingerprint `json:"engine"`
+}
+
+func persistentRenderCacheKey(input persistentRenderKeyInput) (string, error) {
+	input.FormatVersion = rendercache.FormatVersion
+	input.Sources = normalizePersistentSourceIdentities(input.Sources)
+	input.ApplicationInputs = normalizePersistentSourceIdentity(input.ApplicationInputs)
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint persistent render cache key: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func normalizePersistentSourceIdentities(input []SourceIdentity) []SourceIdentity {
+	if len(input) == 0 {
+		return nil
+	}
+	out := append([]SourceIdentity(nil), input...)
+	for i := range out {
+		out[i] = normalizePersistentSourceIdentity(out[i])
+	}
+	return out
+}
+
+func normalizePersistentSourceIdentity(input SourceIdentity) SourceIdentity {
+	if input.Kind == sourceIdentityKindLocalInputs || input.Kind == sourceIdentityKindWorktreeInputs {
+		input.Revision = ""
+	}
+	return input
+}
+
+// persistentRenderOptions are the unexported persistent-tier inputs threaded
+// into RenderApplicationWithOptions. Exported direct callers leave them zero,
+// which keeps persistence off.
+type persistentRenderOptions struct {
+	cache                   *persistentRenderCache
+	settingsSignature       string
+	hasInjectedPluginRender bool
+	applicationInputPaths   []string
+	applicationInputsKnown  bool
+}
+
+// persistentRenderState carries one application render's persistent-tier
+// decision through prepare, lookup, render, and store phases.
+type persistentRenderState struct {
+	enabled       bool
+	key           string
+	handle        *persistentRenderCache
+	refresh       bool
+	recorder      *cacheevent.Recorder
+	acquisitions  *cacheevent.AcquisitionCollector
+	appName       string
+	verifications []renderInputVerification
+}
+
+func (state *persistentRenderState) event(action cacheevent.Action, reason string, errorText string) {
+	if state.recorder == nil {
+		return
+	}
+	state.recorder.Record(cacheevent.Event{
+		Source:   cacheevent.SourceRender,
+		Action:   action,
+		Target:   state.appName,
+		Revision: renderCacheKeyPrefix(state.key),
+		Reason:   reason,
+		Error:    errorText,
+	})
+}
+
+func (state *persistentRenderState) skip(reason string) {
+	if !state.enabled {
+		return
+	}
+	state.event(cacheevent.ActionSkipped, reason, "")
+	state.enabled = false
+}
+
+// preparePersistentRender is the prepare + eligibility phase. It never fails
+// the render: every problem degrades to "not enabled".
+func preparePersistentRender(ctx context.Context, application argoappv1.Application, plan PlanResult, provider render.Provider, options ApplicationRenderOptions) persistentRenderState {
+	state := persistentRenderState{appName: renderEventTarget(application)}
+	handle := options.persistent.cache
+	if !handle.active() {
+		return state
+	}
+	local, ok := provider.(localProvider)
+	if !ok {
+		return state
+	}
+	state.handle = handle
+	state.refresh = handle.refresh
+	state.recorder = local.cacheEvents
+	state.acquisitions = local.acquisitions
+	verifier := &renderInputVerifier{}
+	local.inputVerifier = verifier
+	if applicationUsesPluginSource(application) || planUsesPluginSource(plan) {
+		state.event(cacheevent.ActionSkipped, renderCacheReasonIneligibleSource, "")
+		return state
+	}
+	identities, reason, ok := collectSourceIdentities(ctx, handle, local, plan)
+	if !ok {
+		state.event(cacheevent.ActionSkipped, reason, "")
+		return state
+	}
+	inputIdentity, reason, ok := collectApplicationInputIdentity(ctx, handle, local, options.persistent.applicationInputPaths, options.persistent.applicationInputsKnown)
+	if !ok {
+		state.event(cacheevent.ActionSkipped, reason, "")
+		return state
+	}
+	key, err := persistentRenderCacheKey(persistentRenderKeyInput{
+		Application:             newApplicationRenderCacheInput(application),
+		ApplicationInputs:       inputIdentity,
+		SettingsSignature:       options.persistent.settingsSignature,
+		PluginTimeout:           options.PluginOptions.PluginTimeout.String(),
+		EnableAVPCompat:         options.PluginOptions.EnableAVPCompat,
+		EnablePlugins:           options.PluginOptions.EnablePlugins,
+		PluginPolicyFingerprint: options.PluginOptions.pluginPolicyFingerprint,
+		HasInjectedPluginRender: options.persistent.hasInjectedPluginRender,
+		TrackingOptions:         normalizeTrackingOptions(options.TrackingOptions),
+		Sources:                 identities,
+		Engine:                  handle.fingerprint,
+	})
+	if err != nil {
+		state.event(cacheevent.ActionError, "", err.Error())
+		return state
+	}
+	state.key = key
+	state.verifications = verifier.entries
+	state.enabled = true
+	return state
+}
+
+func collectApplicationInputIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, inputPaths []string, known bool) (SourceIdentity, string, bool) {
+	if !known {
+		return SourceIdentity{}, "", true
+	}
+	switch provider.rootInputMode {
+	case rootInputModeSnapshot:
+		return SourceIdentity{}, "", true
+	case rootInputModeUnknown:
+		return SourceIdentity{}, renderCacheReasonIneligibleSource, false
+	case rootInputModeClean, rootInputModeDirty:
+	default:
+		return SourceIdentity{}, renderCacheReasonIneligibleSource, false
+	}
+	paths, err := applicationInputDigestPaths(inputPaths)
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputGraph, false
+	}
+	if len(paths) == 0 {
+		return SourceIdentity{}, renderCacheReasonInputGraph, false
+	}
+	switch provider.rootInputMode {
+	case rootInputModeClean:
+		return committedApplicationInputIdentity(ctx, handle, provider, paths)
+	case rootInputModeDirty:
+		if dirtyWorktreeCommittedShortcut(provider, paths) {
+			return committedApplicationInputIdentity(ctx, handle, provider, paths)
+		}
+		return filesystemApplicationInputIdentity(ctx, handle, provider, paths)
+	case rootInputModeSnapshot:
+		return SourceIdentity{}, "", true
+	case rootInputModeUnknown:
+		return SourceIdentity{}, renderCacheReasonIneligibleSource, false
+	default:
+		return SourceIdentity{}, renderCacheReasonIneligibleSource, false
+	}
+}
+
+func committedApplicationInputIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, paths []gitref.PathDigestPath) (SourceIdentity, string, bool) {
+	if provider.rootIdentity.Kind != sourceIdentityKindRoot || strings.TrimSpace(provider.rootIdentity.Revision) == "" {
+		return SourceIdentity{}, renderCacheReasonDirtyWorktree, false
+	}
+	result, err := handle.committedPathDigest(ctx, provider.repoRoot, provider.rootIdentity.Revision, paths)
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	if strings.TrimSpace(result.Digest) == "" {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	provider.inputVerifier.addCommitted(provider, provider.rootIdentity.Revision, paths)
+	return SourceIdentity{
+		Kind:   sourceIdentityKindLocalInputs,
+		Digest: result.Digest,
+	}, "", true
+}
+
+func filesystemApplicationInputIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, paths []gitref.PathDigestPath) (SourceIdentity, string, bool) {
+	result, err := handle.filesystemPathDigest(ctx, provider.repoRoot, filesystemInputDigestPaths(paths), filesystemDigestForbiddenRoots(provider))
+	if err != nil {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	if strings.TrimSpace(result.Digest) == "" {
+		return SourceIdentity{}, renderCacheReasonInputDigest, false
+	}
+	provider.inputVerifier.addFilesystem(provider, paths, result.Digest)
+	return SourceIdentity{
+		Kind:   sourceIdentityKindWorktreeInputs,
+		Digest: result.Digest,
+	}, "", true
+}
+
+func applicationInputDigestPaths(inputPaths []string) ([]gitref.PathDigestPath, error) {
+	unique := uniqueStrings(inputPaths)
+	paths := make([]gitref.PathDigestPath, 0, len(unique))
+	for _, inputPath := range unique {
+		clean, err := cleanLocalSourcePath(inputPath)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, gitref.PathDigestPath{Path: clean})
+	}
+	return paths, nil
+}
+
+func planUsesPluginSource(plan PlanResult) bool {
+	for _, sourcePlan := range plan.Sources {
+		if sourcePlan.Source.Plugin != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *persistentRenderState) lookup() (RenderResult, bool) {
+	if !state.enabled {
+		return RenderResult{}, false
+	}
+	if state.refresh {
+		state.event(cacheevent.ActionMiss, renderCacheReasonRefresh, "")
+		return RenderResult{}, false
+	}
+	payload, hit, err := state.handle.store.Get(state.key)
+	if err != nil {
+		state.event(cacheevent.ActionError, "", err.Error())
+		return RenderResult{}, false
+	}
+	if !hit {
+		state.event(cacheevent.ActionMiss, "", "")
+		return RenderResult{}, false
+	}
+	result, err := unmarshalRenderResultPayload(payload)
+	if err != nil {
+		_ = state.handle.store.Delete(state.key)
+		state.event(cacheevent.ActionError, "", err.Error())
+		return RenderResult{}, false
+	}
+	state.event(cacheevent.ActionHit, "", "")
+	return result, true
+}
+
+func (state *persistentRenderState) store(ctx context.Context, result RenderResult) {
+	if !state.enabled || ctx.Err() != nil {
+		return
+	}
+	if state.acquisitions == nil {
+		state.event(cacheevent.ActionSkipped, renderCacheReasonRecordsInactive, "")
+		return
+	}
+	if !acquisitionsPinStable(state.acquisitions.Records()) {
+		state.event(cacheevent.ActionSkipped, renderCacheReasonPinUnstable, "")
+		return
+	}
+	if unchanged, detail := state.renderInputsUnchanged(ctx); !unchanged {
+		state.event(cacheevent.ActionSkipped, renderCacheReasonInputsChanged, detail)
+		return
+	}
+	payload, err := marshalRenderResultPayload(result)
+	if err != nil {
+		state.event(cacheevent.ActionError, "", err.Error())
+		return
+	}
+	if err := state.handle.store.Put(state.key, payload, rendercache.EntryMeta{
+		Version: state.handle.fingerprint.Version,
+		Commit:  state.handle.fingerprint.Commit,
+	}); err != nil {
+		state.event(cacheevent.ActionError, "", err.Error())
+		return
+	}
+	state.event(cacheevent.ActionStore, "", "")
+}
+
+// renderInputsUnchanged re-checks every input path set after the render.
+// Dirty sets are re-digested via a direct filedigest call (bypassing the
+// run-scoped memo); clean sets are compared against the committed content at
+// the key's revision. Any error fails closed (skip the store, never the
+// render).
+func (state *persistentRenderState) renderInputsUnchanged(ctx context.Context) (bool, string) {
+	for _, verification := range state.verifications {
+		if verification.revision != "" {
+			match, err := gitref.WorktreePathsMatchRevision(ctx, gitref.PathDigestInput{
+				RepoPath: verification.repoRoot,
+				Revision: verification.revision,
+				Paths:    verification.committedPaths,
+			})
+			if err != nil {
+				return false, err.Error()
+			}
+			if !match {
+				return false, ""
+			}
+			continue
+		}
+		result, err := filedigest.PathDigest(ctx, filedigest.PathDigestInput{
+			RepoRoot:       verification.repoRoot,
+			Paths:          verification.paths,
+			ForbiddenRoots: verification.forbiddenRoots,
+		})
+		if err != nil {
+			return false, err.Error()
+		}
+		if result.Digest != verification.digest {
+			return false, ""
+		}
+	}
+	return true, ""
+}
+
+func acquisitionsPinStable(records []cacheevent.AcquisitionRecord) bool {
+	for _, record := range records {
+		switch record.Kind {
+		case cacheevent.AcquisitionGit:
+			// Git source revisions are already key inputs.
+		case cacheevent.AcquisitionChart:
+			if strings.TrimSpace(record.RequestedRevision) == "" {
+				return false
+			}
+		case cacheevent.AcquisitionRemoteGit:
+			if !isFullCommitSHA(record.RequestedRevision) {
+				return false
+			}
+		case cacheevent.AcquisitionRemoteHTTP:
+			return false
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isFullCommitSHA(revision string) bool {
+	if len(revision) != 40 {
+		return false
+	}
+	for _, r := range revision {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/render_cache_persistent_test.go
+++ b/internal/app/render_cache_persistent_test.go
@@ -1,0 +1,1961 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/filedigest"
+	"github.com/sholdee/drydock/internal/gitref"
+	"github.com/sholdee/drydock/internal/render"
+	"github.com/sholdee/drydock/internal/rendercache"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testEngineFingerprint() rendercache.EngineFingerprint {
+	return rendercache.EngineFingerprint{
+		Version:            "test",
+		Commit:             "0123456789abcdef0123456789abcdef01234567",
+		ArgoCDModule:       "github.com/argoproj/argo-cd/v3@v3.0.0-test",
+		GitOpsEngineModule: "github.com/argoproj/argo-cd/gitops-engine@v0.0.0-test",
+		HelmModule:         "helm.sh/helm/v4@v4.0.0-test",
+		KustomizeModule:    "sigs.k8s.io/kustomize/api@v0.0.0-test",
+		JsonnetModule:      "github.com/google/go-jsonnet@v0.0.0-test",
+		KubernetesModule:   "k8s.io/apimachinery@v0.0.0-test",
+	}
+}
+
+func testRenderCacheOptions(t *testing.T) RenderCacheOptions {
+	t.Helper()
+	return RenderCacheOptions{
+		RenderCacheEnabled: true,
+		RenderCacheDir:     t.TempDir(),
+		EngineFingerprint:  testEngineFingerprint(),
+	}
+}
+
+func TestEnsurePersistentRenderCacheDisabledByDefault(t *testing.T) {
+	request, release := ensurePersistentRenderCache(BuildRequest{})
+	if request.persistentRenderCache != nil {
+		t.Fatalf("persistentRenderCache = %v, want nil when disabled", request.persistentRenderCache)
+	}
+	if events := release(); len(events) != 0 {
+		t.Fatalf("release() = %v, want no events", events)
+	}
+}
+
+func TestEnsurePersistentRenderCacheOpensStoreAndReusesHandle(t *testing.T) {
+	request := BuildRequest{RenderCacheOptions: testRenderCacheOptions(t)}
+	prepared, release := ensurePersistentRenderCache(request)
+	if prepared.persistentRenderCache == nil || !prepared.persistentRenderCache.active() {
+		t.Fatalf("persistentRenderCache not active after ensure")
+	}
+	again, releaseAgain := ensurePersistentRenderCache(prepared)
+	if again.persistentRenderCache != prepared.persistentRenderCache {
+		t.Fatalf("ensure created a second handle instead of reusing")
+	}
+	if events := releaseAgain(); len(events) != 0 {
+		t.Fatalf("inner release() = %v, want no events (creator owns the sweep)", events)
+	}
+	_ = release()
+}
+
+func TestEnsurePersistentRenderCacheDevBuildGuard(t *testing.T) {
+	options := testRenderCacheOptions(t)
+	options.EngineFingerprint = rendercache.EngineFingerprint{Version: "dev", Commit: "none"}
+	request, release := ensurePersistentRenderCache(BuildRequest{RenderCacheOptions: options})
+	if request.persistentRenderCache.active() {
+		t.Fatalf("persistent cache active for unknown fingerprint")
+	}
+	_ = release()
+}
+
+func TestEnsurePersistentRenderCacheOpenFailureDegrades(t *testing.T) {
+	dir := t.TempDir()
+	blocking := dir + "/occupied"
+	writeTestFile(t, blocking, "not a directory")
+	options := testRenderCacheOptions(t)
+	options.RenderCacheDir = blocking
+	options.RenderCacheEnabled = true
+	request, release := ensurePersistentRenderCache(BuildRequest{
+		RenderCacheOptions: options,
+		AcquisitionOptions: AcquisitionOptions{RecordCacheEvents: true},
+	})
+	if request.persistentRenderCache.active() {
+		t.Fatalf("persistent cache active after open failure")
+	}
+	events := release()
+	if len(events) != 1 || events[0].Action != "error" || events[0].Source != "render" {
+		t.Fatalf("release() = %#v, want one render/error event", events)
+	}
+}
+
+func TestHandleWorktreeChangeSetMemoizesPerRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "a: 1\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, repoRoot+"/apps/alpha/untracked.yaml", "u: 1\n")
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+
+	first := handle.worktreeChangeSet(context.Background(), repoRoot)
+	if first.State != gitref.WorktreeStateDirty || first.Revision != revision {
+		t.Fatalf("changeSet = %+v, want dirty/%s", first, revision)
+	}
+	if len(first.DirtyPaths) != 1 || first.DirtyPaths[0] != "apps/alpha/untracked.yaml" {
+		t.Fatalf("DirtyPaths = %#v, want the untracked file", first.DirtyPaths)
+	}
+
+	// Memoized: a second dirty file added after the first call is invisible
+	// within the run (same contract as the old worktreeStatus memo).
+	writeTestFile(t, repoRoot+"/apps/alpha/second.yaml", "s: 1\n")
+	again := handle.worktreeChangeSet(context.Background(), repoRoot)
+	if len(again.DirtyPaths) != 1 {
+		t.Fatalf("memoized DirtyPaths = %#v, want the first result", again.DirtyPaths)
+	}
+}
+
+func TestPersistentRenderCacheRootIdentityForRequestModes(t *testing.T) {
+	snapshotRevision := "1111111111111111111111111111111111111111"
+	snapshotIdentity, snapshotMode, _ := rootIdentityForRequest(context.Background(), t.TempDir(), BuildRequest{rootRevision: snapshotRevision})
+	if snapshotIdentity != (SourceIdentity{Kind: sourceIdentityKindRoot, Revision: snapshotRevision}) || snapshotMode != rootInputModeSnapshot {
+		t.Fatalf("snapshot root identity = %#v/%s, want revision snapshot", snapshotIdentity, snapshotMode)
+	}
+
+	disabledIdentity, disabledMode, _ := rootIdentityForRequest(context.Background(), t.TempDir(), BuildRequest{})
+	if disabledIdentity != (SourceIdentity{Kind: sourceIdentityKindRoot}) || disabledMode != rootInputModeUnknown {
+		t.Fatalf("cache-disabled root identity = %#v/%s, want unknown root", disabledIdentity, disabledMode)
+	}
+
+	cleanRoot := t.TempDir()
+	writeTestFile(t, cleanRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	cleanRevision := gitCommitAll(t, cleanRoot, "initial")
+	cleanHandle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+	cleanIdentity, cleanMode, _ := rootIdentityForRequest(context.Background(), cleanRoot, BuildRequest{persistentRenderCache: cleanHandle})
+	if cleanIdentity != (SourceIdentity{Kind: sourceIdentityKindRoot, Revision: cleanRevision}) || cleanMode != rootInputModeClean {
+		t.Fatalf("clean root identity = %#v/%s, want clean HEAD %s", cleanIdentity, cleanMode, cleanRevision)
+	}
+
+	dirtyRoot := t.TempDir()
+	writeTestFile(t, dirtyRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	dirtyRevision := gitCommitAll(t, dirtyRoot, "initial")
+	writeTestFile(t, dirtyRoot+"/scratch.yaml", "kind: ConfigMap\n")
+	dirtyHandle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+	dirtyIdentity, dirtyMode, dirtyPaths := rootIdentityForRequest(context.Background(), dirtyRoot, BuildRequest{persistentRenderCache: dirtyHandle})
+	if dirtyIdentity != (SourceIdentity{Kind: sourceIdentityKindRoot, Revision: dirtyRevision}) || dirtyMode != rootInputModeDirty {
+		t.Fatalf("dirty root identity = %#v/%s, want dirty HEAD %s", dirtyIdentity, dirtyMode, dirtyRevision)
+	}
+	if len(dirtyPaths) != 1 || dirtyPaths[0] != "scratch.yaml" {
+		t.Fatalf("dirty paths = %#v, want [scratch.yaml]", dirtyPaths)
+	}
+
+	unknownHandle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+	unknownIdentity, unknownMode, _ := rootIdentityForRequest(context.Background(), t.TempDir(), BuildRequest{persistentRenderCache: unknownHandle})
+	if unknownIdentity != (SourceIdentity{Kind: sourceIdentityKindRoot}) || unknownMode != rootInputModeUnknown {
+		t.Fatalf("non-git root identity = %#v/%s, want unknown", unknownIdentity, unknownMode)
+	}
+}
+
+func TestResolveSourceRootIdentityVariants(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	mappedDir := t.TempDir()
+	acquiredDir := t.TempDir()
+	rootIdentity := SourceIdentity{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"}
+
+	provider := localProvider{
+		repoRoot: repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{
+			RepoMaps: []sourcepkg.RepoMap{{URL: "https://git.example.test/mapped/repo.git", Path: mappedDir}},
+		}),
+		gitAcquirer: &recordingGitAcquirer{
+			path:     acquiredDir,
+			revision: "2222222222222222222222222222222222222222",
+		},
+		rootIdentity: rootIdentity,
+	}
+
+	cases := []struct {
+		name         string
+		source       render.ResolvedSource
+		wantIdentity SourceIdentity
+	}{
+		{
+			name:         "chart-only source keys on spec version",
+			source:       render.ResolvedSource{Chart: "demo", RepoURL: "https://charts.example.test", TargetRevision: "1.2.3"},
+			wantIdentity: SourceIdentity{Kind: sourceIdentityKindChart, Locator: "https://charts.example.test::demo", Revision: "1.2.3"},
+		},
+		{
+			name:         "chart-only without version yields no identity",
+			source:       render.ResolvedSource{Chart: "demo", RepoURL: "https://charts.example.test"},
+			wantIdentity: SourceIdentity{},
+		},
+		{
+			name:         "repo-mapped source yields no identity",
+			source:       render.ResolvedSource{RepoURL: "https://git.example.test/mapped/repo.git", Path: "manifests/demo", TargetRevision: "main"},
+			wantIdentity: SourceIdentity{},
+		},
+		{
+			name:         "local path uses provider root identity",
+			source:       render.ResolvedSource{RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main"},
+			wantIdentity: rootIdentity,
+		},
+		{
+			name:         "external git uses acquired revision",
+			source:       render.ResolvedSource{RepoURL: "https://git.example.test/other/repo.git", Path: "elsewhere", TargetRevision: "main"},
+			wantIdentity: SourceIdentity{Kind: sourceIdentityKindGit, Locator: sourcepkg.NormalizeURL("https://git.example.test/other/repo.git"), Revision: "2222222222222222222222222222222222222222"},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, identity, err := provider.resolveSourceRootIdentity(context.Background(), testCase.source)
+			if err != nil {
+				t.Fatalf("resolveSourceRootIdentity() error = %v", err)
+			}
+			if identity != testCase.wantIdentity {
+				t.Fatalf("identity = %#v, want %#v", identity, testCase.wantIdentity)
+			}
+		})
+	}
+}
+
+func mustPlan(t *testing.T, application argoappv1.Application) PlanResult {
+	t.Helper()
+	plan, err := Plan(application)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	return plan
+}
+
+func mustCollectSingleSourceIdentity(t *testing.T, provider localProvider, plan PlanResult) SourceIdentity {
+	t.Helper()
+	identities := mustCollectSourceIdentities(t, provider, plan)
+	if len(identities) != 1 {
+		t.Fatalf("identities = %#v, want one identity", identities)
+	}
+	return identities[0]
+}
+
+func mustCollectSourceIdentities(t *testing.T, provider localProvider, plan PlanResult) []SourceIdentity {
+	t.Helper()
+	handle := &persistentRenderCache{
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+	identities, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	return identities
+}
+
+func TestCollectSourceIdentitiesOrdersSourcesThenRefs(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	rootIdentity := SourceIdentity{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		gitAcquirer: &recordingGitAcquirer{
+			path:     t.TempDir(),
+			revision: "3333333333333333333333333333333333333333",
+		},
+		rootIdentity:  rootIdentity,
+		rootInputMode: rootInputModeSnapshot,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main"},
+		{RepoURL: "https://git.example.test/org/values.git", TargetRevision: "main", Ref: "values"},
+	}}}
+	plan := mustPlan(t, application)
+
+	identities, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	valuesIdentity := SourceIdentity{Kind: sourceIdentityKindGit, Locator: sourcepkg.NormalizeURL("https://git.example.test/org/values.git"), Revision: "3333333333333333333333333333333333333333"}
+	want := []SourceIdentity{rootIdentity, valuesIdentity, valuesIdentity}
+	if !reflect.DeepEqual(identities, want) {
+		t.Fatalf("identities = %#v, want %#v", identities, want)
+	}
+}
+
+func TestCollectSourceIdentitiesSameRepoRefReusesSourceIdentity(t *testing.T) {
+	// A ref-only source sharing repo+revision with a render source must not be
+	// acquired externally; the real render path roots it at the render source.
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	rootIdentity := SourceIdentity{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"}
+	failingAcquirer := &recordingGitAcquirer{err: fmt.Errorf("must not acquire same-repo ref")}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		gitAcquirer:    failingAcquirer,
+		rootIdentity:   rootIdentity,
+		rootInputMode:  rootInputModeSnapshot,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main"},
+		{RepoURL: "https://git.example.test/org/repo.git", TargetRevision: "main", Ref: "self"},
+	}}}
+	plan := mustPlan(t, application)
+
+	identities, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	want := []SourceIdentity{rootIdentity, rootIdentity, rootIdentity}
+	if !reflect.DeepEqual(identities, want) {
+		t.Fatalf("identities = %#v, want %#v", identities, want)
+	}
+	if len(failingAcquirer.requests) != 0 {
+		t.Fatalf("same-repo ref was acquired externally: %v", failingAcquirer.requests)
+	}
+}
+
+func TestCollectSourceIdentitiesExternalSameRepoRefDoesNotAcquireTwice(t *testing.T) {
+	acquirer := &recordingGitAcquirer{
+		path:     t.TempDir(),
+		revision: "2222222222222222222222222222222222222222",
+	}
+	provider := localProvider{
+		repoRoot:       t.TempDir(),
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		gitAcquirer:    acquirer,
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot},
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "remote-path", TargetRevision: "main"},
+		{RepoURL: "https://git.example.test/org/repo.git", TargetRevision: "main", Ref: "values"},
+	}}}
+	plan := mustPlan(t, application)
+
+	identities, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	wantIdentity := SourceIdentity{Kind: sourceIdentityKindGit, Locator: sourcepkg.NormalizeURL("https://git.example.test/org/repo.git"), Revision: "2222222222222222222222222222222222222222"}
+	want := []SourceIdentity{wantIdentity, wantIdentity, wantIdentity}
+	if !reflect.DeepEqual(identities, want) {
+		t.Fatalf("identities = %#v, want %#v", identities, want)
+	}
+	if len(acquirer.requests) != 1 {
+		t.Fatalf("git acquisitions = %d, want exactly one for external same-repo source+ref: %v", len(acquirer.requests), acquirer.requests)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyDirectoryUsesWorktreeInputs(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, repoRoot+"/manifests/demo/dirty.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dirty\n")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	identities, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	if len(identities) != 1 {
+		t.Fatalf("identities = %#v, want one identity", identities)
+	}
+	if identities[0].Kind != sourceIdentityKindWorktreeInputs || identities[0].Digest == "" || identities[0].Revision != "" {
+		t.Fatalf("identity = %#v, want worktree-inputs digest without revision", identities[0])
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyHelmDigestTracksSourceGraph(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	writeTestFile(t, repoRoot+"/charts/demo/values.yaml", "name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "charts/demo",
+		TargetRevision: "main",
+		Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values.yaml"}},
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSingleSourceIdentity(t, provider, plan)
+	if first.Kind != sourceIdentityKindWorktreeInputs || first.Digest == "" {
+		t.Fatalf("identity = %#v, want worktree-inputs digest", first)
+	}
+	again := mustCollectSingleSourceIdentity(t, provider, plan)
+	if again != first {
+		t.Fatalf("identity changed without source content changes:\nfirst=%#v\nagain=%#v", first, again)
+	}
+
+	writeTestFile(t, repoRoot+"/README.md", "unrelated dirty file\n")
+	unrelated := mustCollectSingleSourceIdentity(t, provider, plan)
+	if unrelated != first {
+		t.Fatalf("identity changed for dirty file outside source graph:\nfirst=%#v\nunrelated=%#v", first, unrelated)
+	}
+
+	writeTestFile(t, repoRoot+"/charts/demo/values.yaml", "name: changed\n")
+	changed := mustCollectSingleSourceIdentity(t, provider, plan)
+	if changed.Kind != sourceIdentityKindWorktreeInputs || changed.Digest == "" {
+		t.Fatalf("changed identity = %#v, want worktree-inputs digest", changed)
+	}
+	if changed == first {
+		t.Fatalf("identity did not change after dirty source file mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyKustomizeBaseTracksGraph(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../bases/shared
+`)
+	writeTestFile(t, repoRoot+"/bases/shared/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeTestFile(t, repoRoot+"/bases/shared/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+data:
+  value: initial
+`)
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "manifests/demo",
+		TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSingleSourceIdentity(t, provider, plan)
+	if first.Kind != sourceIdentityKindWorktreeInputs || first.Digest == "" {
+		t.Fatalf("identity = %#v, want worktree-inputs digest", first)
+	}
+
+	writeTestFile(t, repoRoot+"/README.md", "unrelated dirty file\n")
+	unrelated := mustCollectSingleSourceIdentity(t, provider, plan)
+	if unrelated != first {
+		t.Fatalf("identity changed for dirty file outside Kustomize graph:\nfirst=%#v\nunrelated=%#v", first, unrelated)
+	}
+
+	writeTestFile(t, repoRoot+"/bases/shared/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+data:
+  value: changed
+`)
+	changed := mustCollectSingleSourceIdentity(t, provider, plan)
+	if changed.Kind != sourceIdentityKindWorktreeInputs || changed.Digest == "" {
+		t.Fatalf("changed identity = %#v, want worktree-inputs digest", changed)
+	}
+	if changed == first {
+		t.Fatalf("identity did not change after dirty Kustomize base mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtySameRepoValuesDigestTracksRefFile(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	writeTestFile(t, repoRoot+"/shared/values.yaml", "name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", TargetRevision: "main", Ref: "values"},
+		{
+			RepoURL:        "https://git.example.test/org/repo.git",
+			Path:           "charts/demo",
+			TargetRevision: "main",
+			Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"$values/shared/values.yaml"}},
+		},
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSourceIdentities(t, provider, plan)
+	if len(first) != 3 {
+		t.Fatalf("identities = %#v, want render source, ref source, and ref vector identity", first)
+	}
+	for _, identity := range first {
+		if identity.Kind != sourceIdentityKindWorktreeInputs || identity.Digest == "" {
+			t.Fatalf("identity = %#v, want worktree-inputs digest", identity)
+		}
+	}
+
+	writeTestFile(t, repoRoot+"/unrelated.yaml", "kind: ConfigMap\n")
+	unrelated := mustCollectSourceIdentities(t, provider, plan)
+	if !reflect.DeepEqual(unrelated, first) {
+		t.Fatalf("identities changed for dirty file outside source graph:\nfirst=%#v\nunrelated=%#v", first, unrelated)
+	}
+
+	writeTestFile(t, repoRoot+"/shared/values.yaml", "name: changed\n")
+	changed := mustCollectSourceIdentities(t, provider, plan)
+	if reflect.DeepEqual(changed, first) {
+		t.Fatalf("identities did not change after same-repo values mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyKustomizeDigestTracksGraph(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSingleSourceIdentity(t, provider, plan)
+	writeTestFile(t, repoRoot+"/README.md", "unrelated\n")
+	unrelated := mustCollectSingleSourceIdentity(t, provider, plan)
+	if unrelated != first {
+		t.Fatalf("identity changed for dirty file outside kustomize graph:\nfirst=%#v\nunrelated=%#v", first, unrelated)
+	}
+
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n")
+	changed := mustCollectSingleSourceIdentity(t, provider, plan)
+	if changed == first {
+		t.Fatalf("identity did not change after kustomize graph mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyDirectoryDigestIncludesUntrackedFiles(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main", Directory: &argoappv1.ApplicationSourceDirectory{},
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSingleSourceIdentity(t, provider, plan)
+	writeTestFile(t, repoRoot+"/manifests/other/untracked.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: other\n")
+	outside := mustCollectSingleSourceIdentity(t, provider, plan)
+	if outside != first {
+		t.Fatalf("identity changed for untracked file outside directory source:\nfirst=%#v\noutside=%#v", first, outside)
+	}
+
+	writeTestFile(t, repoRoot+"/manifests/demo/untracked.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: untracked\n")
+	inside := mustCollectSingleSourceIdentity(t, provider, plan)
+	if inside == first {
+		t.Fatalf("identity did not change after untracked file inside directory source: %#v", inside)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyJsonnetDigestTracksDeclaredLib(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.jsonnet", "local helper = import 'helper.libsonnet'; { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: helper.name } }\n")
+	writeTestFile(t, repoRoot+"/lib/helper.libsonnet", "{ name: 'demo' }\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+		Directory: &argoappv1.ApplicationSourceDirectory{Jsonnet: argoappv1.ApplicationSourceJsonnet{Libs: []string{"lib"}}},
+	}}}
+	plan := mustPlan(t, application)
+
+	first := mustCollectSingleSourceIdentity(t, provider, plan)
+	writeTestFile(t, repoRoot+"/lib/helper.libsonnet", "{ name: 'changed' }\n")
+	changed := mustCollectSingleSourceIdentity(t, provider, plan)
+	if changed == first {
+		t.Fatalf("identity did not change after declared jsonnet lib mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyHelmGlobSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	writeTestFile(t, repoRoot+"/charts/demo/values/one.yaml", "name: one\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "charts/demo",
+		TargetRevision: "main",
+		Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values/*.yaml"}},
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want dirty Helm glob to skip persistence")
+	}
+	if reason != renderCacheReasonInputGraph {
+		t.Fatalf("reason = %q, want input graph", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyMissingRequiredInputSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL:        "https://git.example.test/org/repo.git",
+		Path:           "charts/demo",
+		TargetRevision: "main",
+		Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"missing-required.yaml"}},
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want required missing input to skip persistence")
+	}
+	if reason != renderCacheReasonInputGraph && reason != renderCacheReasonInputDigest {
+		t.Fatalf("reason = %q, want input graph or digest reason", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesDirtyUnsafeGraphSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - ../../../outside/cm.yaml\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want unsafe graph to skip persistence")
+	}
+	if reason != renderCacheReasonInputGraph {
+		t.Fatalf("reason = %q, want input graph", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesUnknownRootReason(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot},
+		rootInputMode:  rootInputModeUnknown,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want ineligible for unknown root")
+	}
+	if reason != "ineligible-source" {
+		t.Fatalf("reason = %q, want ineligible-source", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesRepoMappedReason(t *testing.T) {
+	mappedDir := t.TempDir()
+	writeTestFile(t, mappedDir+"/manifests/demo/kustomization.yaml", "kind: Kustomization\n")
+	provider := localProvider{
+		repoRoot: t.TempDir(),
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{
+			RepoMaps: []sourcepkg.RepoMap{{URL: "https://git.example.test/mapped/repo.git", Path: mappedDir}},
+		}),
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"},
+		rootInputMode: rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/mapped/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want ineligible for repo-mapped source")
+	}
+	if reason != "ineligible-source" {
+		t.Fatalf("reason = %q, want ineligible-source", reason)
+	}
+}
+
+func TestPersistentRenderCachePrepareDirtyPluginSourceIneligible(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/plugin-input.yaml", "kind: ConfigMap\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	recorder := cacheevent.NewRecorder(true)
+	handle := &persistentRenderCache{
+		store:             &rendercache.Store{},
+		fingerprint:       testEngineFingerprint(),
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+		cacheEvents:    recorder,
+	}
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "plugin-app", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+			RepoURL:        "https://git.example.test/org/repo.git",
+			Path:           "manifests/demo",
+			TargetRevision: "main",
+			Plugin:         &argoappv1.ApplicationSourcePlugin{Name: "example"},
+		}},
+	}
+	plan := mustPlan(t, application)
+
+	state := preparePersistentRender(context.Background(), application, plan, provider, ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: handle},
+	})
+	if state.enabled {
+		t.Fatalf("preparePersistentRender() enabled plugin source persistence")
+	}
+	events := recorder.Events()
+	if len(events) != 1 || events[0].Reason != renderCacheReasonIneligibleSource {
+		t.Fatalf("events = %#v, want one ineligible-source skipped event", events)
+	}
+}
+
+func TestCollectSourceIdentitiesAcquireErrorIsIneligibleNotFatal(t *testing.T) {
+	// Identity resolution must never fail the render: the real error surfaces
+	// from the render itself.
+	provider := localProvider{
+		repoRoot:       t.TempDir(),
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		gitAcquirer:    &recordingGitAcquirer{err: fmt.Errorf("network down")},
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"},
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), nil, provider, plan)
+	if ok {
+		t.Fatalf("collectSourceIdentities() ok = true, want ineligible on acquire error")
+	}
+	if reason != "ineligible-source" {
+		t.Fatalf("reason = %q, want ineligible-source", reason)
+	}
+}
+
+func persistentKeyFixtureInput() persistentRenderKeyInput {
+	return persistentRenderKeyInput{
+		Application: applicationRenderCacheInput{
+			Name:      "demo",
+			Namespace: "argocd",
+			Spec: argoappv1.ApplicationSpec{
+				Project: "default",
+				Source: &argoappv1.ApplicationSource{
+					RepoURL:        "https://git.example.test/org/repo.git",
+					Path:           "manifests/demo",
+					TargetRevision: "main",
+				},
+				Destination: argoappv1.ApplicationDestination{Name: "in-cluster", Namespace: "default"},
+			},
+		},
+		SettingsSignature: "settings-sig",
+		PluginTimeout:     "1m0s",
+		TrackingOptions:   normalizeTrackingOptions(TrackingOptions{}),
+		Sources: []SourceIdentity{
+			{Kind: sourceIdentityKindRoot, Revision: "1111111111111111111111111111111111111111"},
+			{Kind: sourceIdentityKindGit, Locator: "https://git.example.test/org/values.git", Revision: "2222222222222222222222222222222222222222"},
+		},
+		Engine: testEngineFingerprint(),
+	}
+}
+
+func TestPersistentRenderCacheKeyStableAcrossCalls(t *testing.T) {
+	first, err := persistentRenderCacheKey(persistentKeyFixtureInput())
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	second, err := persistentRenderCacheKey(persistentKeyFixtureInput())
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("key not stable: %s != %s", first, second)
+	}
+	if len(first) != 64 {
+		t.Fatalf("key length = %d, want 64 hex chars", len(first))
+	}
+}
+
+func TestPersistentRenderCacheKeyIgnoresLocalInputRevision(t *testing.T) {
+	input := persistentKeyFixtureInput()
+	input.Sources = []SourceIdentity{{
+		Kind:     sourceIdentityKindLocalInputs,
+		Revision: "1111111111111111111111111111111111111111",
+		Digest:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}}
+	first, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	input.Sources[0].Revision = "2222222222222222222222222222222222222222"
+	second, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("local-inputs revision changed persistent key: %s != %s", first, second)
+	}
+	input.Sources[0].Digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	third, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if third == first {
+		t.Fatalf("local-inputs digest mutation did not rotate persistent key")
+	}
+
+	input = persistentKeyFixtureInput()
+	input.ApplicationInputs = SourceIdentity{
+		Kind:     sourceIdentityKindLocalInputs,
+		Revision: "1111111111111111111111111111111111111111",
+		Digest:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	first, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	input.ApplicationInputs.Revision = "2222222222222222222222222222222222222222"
+	second, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("application input revision changed persistent key: %s != %s", first, second)
+	}
+	input.ApplicationInputs.Digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	third, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if third == first {
+		t.Fatalf("application input digest mutation did not rotate persistent key")
+	}
+}
+
+func TestPersistentRenderCacheKeyIgnoresWorktreeInputRevision(t *testing.T) {
+	input := persistentKeyFixtureInput()
+	input.Sources = []SourceIdentity{{
+		Kind:     sourceIdentityKindWorktreeInputs,
+		Revision: "1111111111111111111111111111111111111111",
+		Digest:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}}
+	first, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	input.Sources[0].Revision = "2222222222222222222222222222222222222222"
+	second, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("worktree-inputs revision changed persistent key: %s != %s", first, second)
+	}
+	input.Sources[0].Digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	third, err := persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if third == first {
+		t.Fatalf("worktree-inputs digest mutation did not rotate persistent key")
+	}
+
+	input = persistentKeyFixtureInput()
+	input.ApplicationInputs = SourceIdentity{
+		Kind:     sourceIdentityKindWorktreeInputs,
+		Revision: "1111111111111111111111111111111111111111",
+		Digest:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	first, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	input.ApplicationInputs.Revision = "2222222222222222222222222222222222222222"
+	second, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("worktree application input revision changed persistent key: %s != %s", first, second)
+	}
+	input.ApplicationInputs.Digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	third, err = persistentRenderCacheKey(input)
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	if third == first {
+		t.Fatalf("worktree application input digest mutation did not rotate persistent key")
+	}
+}
+
+func TestPersistentRenderCacheKeyRotatesOnEveryInput(t *testing.T) {
+	base, err := persistentRenderCacheKey(persistentKeyFixtureInput())
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	mutations := []struct {
+		name   string
+		mutate func(*persistentRenderKeyInput)
+	}{
+		{"app spec", func(input *persistentRenderKeyInput) { input.Application.Spec.Project = "other" }},
+		{"app name", func(input *persistentRenderKeyInput) { input.Application.Name = "other" }},
+		{"application input digest", func(input *persistentRenderKeyInput) {
+			input.ApplicationInputs = SourceIdentity{Kind: sourceIdentityKindLocalInputs, Digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+		}},
+		{"settings signature", func(input *persistentRenderKeyInput) { input.SettingsSignature = "other" }},
+		{"plugin timeout", func(input *persistentRenderKeyInput) { input.PluginTimeout = "2m0s" }},
+		{"avp compat", func(input *persistentRenderKeyInput) { input.EnableAVPCompat = true }},
+		{"enable plugins", func(input *persistentRenderKeyInput) { input.EnablePlugins = true }},
+		{"policy fingerprint", func(input *persistentRenderKeyInput) { input.PluginPolicyFingerprint = "policy" }},
+		{"injected plugin render", func(input *persistentRenderKeyInput) { input.HasInjectedPluginRender = true }},
+		{"tracking options", func(input *persistentRenderKeyInput) { input.TrackingOptions.InstanceLabelKey = "custom" }},
+		{"source revision", func(input *persistentRenderKeyInput) {
+			input.Sources[0].Revision = "9999999999999999999999999999999999999999"
+		}},
+		{"ref-only source revision", func(input *persistentRenderKeyInput) {
+			input.Sources[1].Revision = "9999999999999999999999999999999999999999"
+		}},
+		{"source order", func(input *persistentRenderKeyInput) {
+			input.Sources[0], input.Sources[1] = input.Sources[1], input.Sources[0]
+		}},
+		{"drydock version", func(input *persistentRenderKeyInput) { input.Engine.Version = "other" }},
+		{"drydock commit", func(input *persistentRenderKeyInput) {
+			input.Engine.Commit = "fedcba9876543210fedcba9876543210fedcba98"
+		}},
+		{"argo module", func(input *persistentRenderKeyInput) { input.Engine.ArgoCDModule = "other" }},
+		{"gitops engine module", func(input *persistentRenderKeyInput) { input.Engine.GitOpsEngineModule = "other" }},
+		{"helm module", func(input *persistentRenderKeyInput) { input.Engine.HelmModule = "other" }},
+		{"kustomize module", func(input *persistentRenderKeyInput) { input.Engine.KustomizeModule = "other" }},
+		{"jsonnet module", func(input *persistentRenderKeyInput) { input.Engine.JsonnetModule = "other" }},
+		{"kubernetes module", func(input *persistentRenderKeyInput) { input.Engine.KubernetesModule = "other" }},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			input := persistentKeyFixtureInput()
+			mutation.mutate(&input)
+			key, err := persistentRenderCacheKey(input)
+			if err != nil {
+				t.Fatalf("persistentRenderCacheKey() error = %v", err)
+			}
+			if key == base {
+				t.Fatalf("mutating %s did not rotate the key", mutation.name)
+			}
+		})
+	}
+}
+
+func TestPersistentRenderCacheFilesystemDigestMemoizesByInputs(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root+"/apps/demo/values.yaml", "value: one\n")
+	handle := &persistentRenderCache{}
+	paths := []filedigest.PathDigestPath{{Path: "apps/demo/values.yaml"}}
+
+	first, err := handle.filesystemPathDigest(context.Background(), root, paths, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigest() error = %v", err)
+	}
+	writeTestFile(t, root+"/apps/demo/values.yaml", "value: two\n")
+	memoized, err := handle.filesystemPathDigest(context.Background(), root, paths, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigest() memoized error = %v", err)
+	}
+	if memoized != first {
+		t.Fatalf("filesystemPathDigest() = %#v after file change, want memoized %#v", memoized, first)
+	}
+
+	pathChanged, err := handle.filesystemPathDigest(context.Background(), root, []filedigest.PathDigestPath{
+		{Path: "apps/demo/values.yaml"},
+		{Path: "apps/demo/missing.yaml", Optional: true},
+	}, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigest() with changed paths error = %v", err)
+	}
+	if pathChanged == first {
+		t.Fatalf("filesystemPathDigest() did not recompute after path list changed")
+	}
+
+	writeTestFile(t, root+"/apps/demo/values.yaml", "value: three\n")
+	forbiddenChanged, err := handle.filesystemPathDigest(context.Background(), root, paths, []string{t.TempDir()})
+	if err != nil {
+		t.Fatalf("filesystemPathDigest() with changed forbidden roots error = %v", err)
+	}
+	if forbiddenChanged == first || forbiddenChanged == pathChanged {
+		t.Fatalf("filesystemPathDigest() did not recompute after forbidden roots changed: first=%#v pathChanged=%#v forbiddenChanged=%#v", first, pathChanged, forbiddenChanged)
+	}
+}
+
+func TestPersistentRenderCacheFilesystemPathDigestMemoKeyNormalizesPathsAndForbiddenRoots(t *testing.T) {
+	root := t.TempDir()
+	forbidden := t.TempDir()
+	firstKey, firstPaths, firstForbidden, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "apps/demo/missing.yaml", Optional: true},
+		{Path: "apps/demo/../demo/values.yaml", MarkerKind: "marker"},
+		{Path: "apps/demo/values.yaml", MarkerKind: "marker", Optional: true},
+	}, []string{forbidden})
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() error = %v", err)
+	}
+	secondKey, secondPaths, secondForbidden, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "apps/demo/values.yaml", MarkerKind: "marker", Optional: true},
+		{Path: "apps/demo/missing.yaml", Optional: true},
+		{Path: "apps/demo/values.yaml", MarkerKind: "marker"},
+	}, []string{forbidden})
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() second error = %v", err)
+	}
+	if firstKey != secondKey {
+		t.Fatalf("memo key did not normalize equivalent paths:\nfirst=%q\nsecond=%q", firstKey, secondKey)
+	}
+	if !reflect.DeepEqual(firstPaths, secondPaths) {
+		t.Fatalf("normalized paths differ: %#v != %#v", firstPaths, secondPaths)
+	}
+	if !reflect.DeepEqual(firstForbidden, secondForbidden) {
+		t.Fatalf("normalized forbidden roots differ: %#v != %#v", firstForbidden, secondForbidden)
+	}
+
+	markerChangedKey, _, _, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "apps/demo/values.yaml", MarkerKind: "other-marker"},
+		{Path: "apps/demo/missing.yaml", Optional: true},
+	}, []string{forbidden})
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() marker change error = %v", err)
+	}
+	if markerChangedKey == firstKey {
+		t.Fatalf("memo key did not include marker kind")
+	}
+
+	forbiddenChangedKey, _, _, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "apps/demo/values.yaml", MarkerKind: "marker"},
+		{Path: "apps/demo/missing.yaml", Optional: true},
+	}, []string{t.TempDir()})
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() forbidden change error = %v", err)
+	}
+	if forbiddenChangedKey == firstKey {
+		t.Fatalf("memo key did not include forbidden roots")
+	}
+}
+
+func TestPersistentRenderCacheFilesystemPathDigestMemoKeyDoesNotCollideOnDelimiters(t *testing.T) {
+	root := t.TempDir()
+	firstKey, firstPaths, _, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "aa", MarkerKind: "b:optional:c"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() error = %v", err)
+	}
+	secondKey, secondPaths, _, err := filesystemPathDigestMemoKey(root, []filedigest.PathDigestPath{
+		{Path: "aa:required:b", Optional: true, MarkerKind: "c"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigestMemoKey() second error = %v", err)
+	}
+	if reflect.DeepEqual(firstPaths, secondPaths) {
+		t.Fatalf("test inputs unexpectedly normalized to same paths: %#v", firstPaths)
+	}
+	if firstKey == secondKey {
+		t.Fatalf("memo keys collided for distinct path/optional/marker inputs:\nfirst=%#v\nsecond=%#v\nkey=%q", firstPaths, secondPaths, firstKey)
+	}
+}
+
+func TestPersistentRenderCacheCollectApplicationInputIdentityRootModes(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/demo.yaml", "kind: Application\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+
+	cleanIdentity, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode: rootInputModeClean,
+	}, []string{"apps/demo.yaml"}, true)
+	if !ok {
+		t.Fatalf("clean collectApplicationInputIdentity() ok = false, reason = %s", reason)
+	}
+	if cleanIdentity.Kind != sourceIdentityKindLocalInputs || cleanIdentity.Digest == "" {
+		t.Fatalf("clean identity = %#v, want local-inputs digest", cleanIdentity)
+	}
+
+	snapshotIdentity, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode: rootInputModeSnapshot,
+	}, []string{"apps/demo.yaml"}, true)
+	if !ok || reason != "" || snapshotIdentity != (SourceIdentity{}) {
+		t.Fatalf("snapshot collectApplicationInputIdentity() = %#v/%q/%t, want empty ok", snapshotIdentity, reason, ok)
+	}
+
+	dirtyIdentity, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode: rootInputModeDirty,
+	}, []string{"apps/demo.yaml"}, true)
+	if !ok {
+		t.Fatalf("dirty collectApplicationInputIdentity() ok = false, reason = %s", reason)
+	}
+	if dirtyIdentity.Kind != sourceIdentityKindWorktreeInputs || dirtyIdentity.Digest == "" {
+		t.Fatalf("dirty identity = %#v, want worktree-inputs digest", dirtyIdentity)
+	}
+
+	_, reason, ok = collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot},
+		rootInputMode: rootInputModeUnknown,
+	}, []string{"apps/demo.yaml"}, true)
+	if ok || reason != renderCacheReasonIneligibleSource {
+		t.Fatalf("unknown collectApplicationInputIdentity() ok=%t reason=%q, want ineligible skip", ok, reason)
+	}
+}
+
+func mustCollectApplicationInputIdentity(t *testing.T, provider localProvider, inputPaths []string) SourceIdentity {
+	t.Helper()
+	handle := &persistentRenderCache{
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+	identity, reason, ok := collectApplicationInputIdentity(context.Background(), handle, provider, inputPaths, true)
+	if !ok {
+		t.Fatalf("collectApplicationInputIdentity() ok = false, reason = %s", reason)
+	}
+	return identity
+}
+
+func TestPersistentRenderCacheCollectApplicationInputIdentityDirtyDigestTracksAppInputs(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/demo.yaml", "kind: Application\n# comment one\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode: rootInputModeDirty,
+	}
+
+	first := mustCollectApplicationInputIdentity(t, provider, []string{"apps/demo.yaml"})
+	if first.Kind != sourceIdentityKindWorktreeInputs || first.Digest == "" {
+		t.Fatalf("identity = %#v, want worktree-inputs digest", first)
+	}
+
+	writeTestFile(t, repoRoot+"/README.md", "unrelated dirty file\n")
+	unrelated := mustCollectApplicationInputIdentity(t, provider, []string{"apps/demo.yaml"})
+	if unrelated != first {
+		t.Fatalf("identity changed for dirty file outside app inputs:\nfirst=%#v\nunrelated=%#v", first, unrelated)
+	}
+
+	writeTestFile(t, repoRoot+"/apps/demo.yaml", "kind: Application\n# comment two\n")
+	changed := mustCollectApplicationInputIdentity(t, provider, []string{"apps/demo.yaml"})
+	if changed.Kind != sourceIdentityKindWorktreeInputs || changed.Digest == "" {
+		t.Fatalf("changed identity = %#v, want worktree-inputs digest", changed)
+	}
+	if changed == first {
+		t.Fatalf("identity did not change after dirty application input mutation: %#v", changed)
+	}
+}
+
+func TestPersistentRenderCacheCollectApplicationInputIdentityDirtyMissingRequiredInputSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/demo.yaml", "kind: Application\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	_, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode: rootInputModeDirty,
+	}, []string{"apps/missing.yaml"}, true)
+	if ok {
+		t.Fatalf("collectApplicationInputIdentity() ok = true, want missing required app input to skip persistence")
+	}
+	if reason != renderCacheReasonInputDigest {
+		t.Fatalf("reason = %q, want input digest", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectApplicationInputIdentityEmptyKnownInputSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/demo.yaml", "kind: Application\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	_, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode: rootInputModeDirty,
+	}, nil, true)
+	if ok {
+		t.Fatalf("collectApplicationInputIdentity() ok = true, want empty known app inputs to skip persistence")
+	}
+	if reason != renderCacheReasonInputGraph {
+		t.Fatalf("reason = %q, want input graph", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectApplicationInputIdentityDirtySymlinkSkips(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/target.yaml", "kind: Application\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	if err := os.Symlink("target.yaml", repoRoot+"/apps/link.yaml"); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	_, reason, ok := collectApplicationInputIdentity(context.Background(), handle, localProvider{
+		repoRoot:      repoRoot,
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode: rootInputModeDirty,
+	}, []string{"apps/link.yaml"}, true)
+	if ok {
+		t.Fatalf("collectApplicationInputIdentity() ok = true, want symlink app input to skip persistence")
+	}
+	if reason != renderCacheReasonInputDigest && reason != renderCacheReasonInputGraph {
+		t.Fatalf("reason = %q, want input digest or graph", reason)
+	}
+}
+
+func TestPersistentRenderCacheCollectSourceIdentitiesLocalInputDigestStableAcrossHeadChange(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	firstRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{digests: map[string]gitref.PathDigestResult{}}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: firstRevision},
+		rootInputMode:  rootInputModeClean,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "charts/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	first, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	writeTestFile(t, repoRoot+"/README.md", "unrelated\n")
+	secondRevision := gitCommitAll(t, repoRoot, "unrelated")
+	provider.rootIdentity.Revision = secondRevision
+	second, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() after unrelated commit ok = false, reason = %s", reason)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("identity counts = %d/%d, want 1/1", len(first), len(second))
+	}
+	if first[0].Kind != sourceIdentityKindLocalInputs {
+		t.Fatalf("identity kind = %q, want %q", first[0].Kind, sourceIdentityKindLocalInputs)
+	}
+	if first[0].Revision != "" || second[0].Revision != "" {
+		t.Fatalf("local input identities carried revisions: %#v %#v", first[0], second[0])
+	}
+	if first[0].Digest == "" {
+		t.Fatalf("local input digest is empty: %#v", first[0])
+	}
+	if first[0] != second[0] {
+		t.Fatalf("local input identity changed across unrelated HEAD commit:\nfirst=%#v\nsecond=%#v", first[0], second[0])
+	}
+}
+
+func TestAcquisitionsPinStable(t *testing.T) {
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	cases := []struct {
+		name    string
+		records []cacheevent.AcquisitionRecord
+		want    bool
+	}{
+		{name: "no records", records: nil, want: true},
+		{name: "git always passes even floating", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionGit, RequestedRevision: "main", ResolvedRevision: sha},
+		}, want: true},
+		{name: "exact chart version passes", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionChart, RequestedRevision: "1.2.3", ResolvedRevision: "1.2.3"},
+		}, want: true},
+		{name: "empty chart version blocks", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionChart, RequestedRevision: " ", ResolvedRevision: "1.2.3"},
+		}, want: false},
+		{name: "sha-pinned remote git passes", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionRemoteGit, RequestedRevision: sha, ResolvedRevision: sha},
+		}, want: true},
+		{name: "floating remote git blocks", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionRemoteGit, RequestedRevision: "main", ResolvedRevision: sha},
+		}, want: false},
+		{name: "short-sha remote git blocks", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionRemoteGit, RequestedRevision: sha[:12], ResolvedRevision: sha},
+		}, want: false},
+		{name: "remote http always blocks", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionRemoteHTTP, RequestedRevision: "", ResolvedRevision: "etag"},
+		}, want: false},
+		{name: "unknown kind blocks", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionKind("future"), RequestedRevision: sha, ResolvedRevision: sha},
+		}, want: false},
+		{name: "one unstable blocks the set", records: []cacheevent.AcquisitionRecord{
+			{Kind: cacheevent.AcquisitionGit, RequestedRevision: "main", ResolvedRevision: sha},
+			{Kind: cacheevent.AcquisitionRemoteGit, RequestedRevision: "main", ResolvedRevision: sha},
+		}, want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := acquisitionsPinStable(testCase.records); got != testCase.want {
+				t.Fatalf("acquisitionsPinStable() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestIsFullCommitSHA(t *testing.T) {
+	cases := []struct {
+		revision string
+		want     bool
+	}{
+		{"0123456789abcdef0123456789abcdef01234567", true},
+		{"0123456789ABCDEF0123456789ABCDEF01234567", false},
+		{"main", false},
+		{"", false},
+		{"0123456789abcdef0123456789abcdef0123456", false},
+		{"0123456789abcdef0123456789abcdef012345678", false},
+		{"012345678zabcdef0123456789abcdef01234567", false},
+	}
+	for _, testCase := range cases {
+		if got := isFullCommitSHA(testCase.revision); got != testCase.want {
+			t.Fatalf("isFullCommitSHA(%q) = %t, want %t", testCase.revision, got, testCase.want)
+		}
+	}
+}
+
+func TestPersistentLookupSkippedWhenSourceOverrideIntroducesPlugin(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: live
+`)
+	writeTestFile(t, repoRoot+"/manifests/demo/.argocd-source.yaml", `plugin:
+  name: cue
+`)
+	rootRevision := "1111111111111111111111111111111111111111"
+	cacheOptions := testRenderCacheOptions(t)
+	handle := newPersistentRenderCache(cacheOptions, true)
+	if !handle.active() {
+		t.Fatalf("persistent cache did not open")
+	}
+	provider := localProvider{
+		repoRoot:      repoRoot,
+		cacheEvents:   cacheevent.NewRecorder(true),
+		acquisitions:  cacheevent.NewAcquisitionCollector(),
+		rootIdentity:  SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode: rootInputModeSnapshot,
+	}
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "https://git.example.test/org/repo.git",
+				Path:           "manifests/demo",
+				TargetRevision: "main",
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+	key, err := persistentRenderCacheKey(persistentRenderKeyInput{
+		Application:       newApplicationRenderCacheInput(application),
+		SettingsSignature: "settings",
+		PluginTimeout:     "0s",
+		TrackingOptions:   normalizeTrackingOptions(TrackingOptions{}),
+		Sources:           []SourceIdentity{{Kind: sourceIdentityKindRoot, Revision: rootRevision}},
+		Engine:            cacheOptions.EngineFingerprint,
+	})
+	if err != nil {
+		t.Fatalf("persistentRenderCacheKey() error = %v", err)
+	}
+	payload, err := marshalRenderResultPayload(RenderResult{
+		Manifests: []render.Manifest{{Object: cm("cached", "value")}},
+	})
+	if err != nil {
+		t.Fatalf("marshalRenderResultPayload() error = %v", err)
+	}
+	if err := handle.store.Put(key, payload, rendercache.EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	result, err := RenderApplicationWithOptions(context.Background(), application, provider, ApplicationRenderOptions{
+		TrackingOptions: TrackingOptions{},
+		persistent: persistentRenderOptions{
+			cache:             handle,
+			settingsSignature: "settings",
+		},
+	})
+	if err == nil {
+		t.Fatalf("RenderApplicationWithOptions() error = nil, want plugin override to bypass cached result; manifests = %#v", result.Manifests)
+	}
+	for _, rendered := range result.Manifests {
+		if rendered.Object != nil && rendered.Object.GetName() == "cached" {
+			t.Fatalf("returned stale persistent cached manifest despite plugin override: %#v", result.Manifests)
+		}
+	}
+}
+
+func TestValidateRenderCacheRootRejectsUnopenableStore(t *testing.T) {
+	// A regular file where the cache dir should be makes MkdirAll fail
+	// deterministically on every platform.
+	blocker := t.TempDir() + "/not-a-dir"
+	writeTestFile(t, blocker, "blocker")
+
+	options := RenderCacheOptions{
+		RenderCacheEnabled: true,
+		RenderCacheDir:     blocker,
+		EngineFingerprint:  testEngineFingerprint(),
+	}
+
+	buildErr := validateBuildRenderCacheRoot(BuildRequest{Path: t.TempDir(), RenderCacheOptions: options})
+	if buildErr == nil {
+		t.Fatalf("validateBuildRenderCacheRoot() = nil, want store open failure")
+	}
+
+	diffRequest := DiffRequest{LeftPath: t.TempDir(), RightPath: t.TempDir()}
+	diffRequest.RenderCacheOptions = options
+	if err := validateDiffRenderCacheRoot(diffRequest); err == nil {
+		t.Fatalf("validateDiffRenderCacheRoot() = nil, want store open failure")
+	}
+}
+
+func TestEnsurePersistentRenderCacheAcquisitionRefreshFlagsBypassLookup(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*BuildRequest)
+		refresh bool
+	}{
+		{"refresh-charts", func(r *BuildRequest) { r.RefreshCharts = true }, true},
+		{"refresh-git", func(r *BuildRequest) { r.RefreshGit = true }, true},
+		{"refresh-remote-resources", func(r *BuildRequest) { r.RefreshRemoteResources = true }, true},
+		{"offline-does-not-refresh", func(r *BuildRequest) { r.Offline = true }, false},
+		{"no-flags", func(r *BuildRequest) {}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := BuildRequest{RenderCacheOptions: testRenderCacheOptions(t)}
+			tc.mutate(&request)
+			prepared, _ := ensurePersistentRenderCache(request)
+			if prepared.persistentRenderCache.refresh != tc.refresh {
+				t.Fatalf("handle.refresh = %v, want %v", prepared.persistentRenderCache.refresh, tc.refresh)
+			}
+		})
+	}
+}
+
+func TestEnsureDiffPersistentRenderCacheAcquisitionRefreshFlagsBypassLookup(t *testing.T) {
+	request := DiffRequest{}
+	request.RenderCacheOptions = testRenderCacheOptions(t)
+	request.RefreshCharts = true
+	prepared, _ := ensureDiffPersistentRenderCache(request)
+	if !prepared.persistentRenderCache.refresh {
+		t.Fatalf("handle.refresh = false, want true with --refresh-charts")
+	}
+}
+
+func TestLocalInputDigestPathsIncludeArgocdSourceOverrides(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-app"},
+		Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+			RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+		}},
+	}
+	plan := mustPlan(t, application)
+
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	if err != nil {
+		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
+	}
+	want := map[string]bool{
+		"manifests/demo/.argocd-source.yaml":          true,
+		"manifests/demo/.argocd-source-demo-app.yaml": true,
+	}
+	for _, item := range paths {
+		if _, ok := want[item.Path]; ok {
+			if !item.Optional {
+				t.Fatalf("override path %q must be optional", item.Path)
+			}
+			delete(want, item.Path)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("digest paths missing override files %v; got %#v", want, paths)
+	}
+}
+
+func TestPersistentRenderCacheDirtyKustomizeDigestTracksSourceOverrides(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-app"},
+		Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+			RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+		}},
+	}
+	plan := mustPlan(t, application)
+
+	before := mustCollectSingleSourceIdentity(t, provider, plan)
+	writeTestFile(t, repoRoot+"/manifests/demo/.argocd-source.yaml", "kustomize:\n  namePrefix: prod-\n")
+	after := mustCollectSingleSourceIdentity(t, provider, plan)
+	if after == before {
+		t.Fatalf("identity did not change after adding .argocd-source.yaml override: %#v", after)
+	}
+}
+
+func TestLocalToolInputDigestPathsMatchSelectLocalRendererPrecedence(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Both Chart.yaml and kustomization.yaml: the renderer picks Kustomize,
+	// so the digest must track the kustomization graph (including ../base).
+	writeTestFile(t, repoRoot+"/base/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: base\n")
+	writeTestFile(t, repoRoot+"/base/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/kustomization.yaml", "resources:\n  - ../../base\n")
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	if err != nil {
+		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
+	}
+	foundBase := false
+	for _, item := range paths {
+		if item.Path == "base" || strings.HasPrefix(item.Path, "base/") {
+			foundBase = true
+		}
+	}
+	if !foundBase {
+		t.Fatalf("digest paths %#v do not track the kustomize base; helm classification won over the renderer's kustomize choice", paths)
+	}
+}
+
+func TestCollectSourceIdentitiesDirtyModePopulatesInputVerifier(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{filesystemDigests: map[string]filedigest.PathDigestResult{}}
+	verifier := &renderInputVerifier{}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeDirty,
+		inputVerifier:  verifier,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	identities, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	if len(verifier.entries) != 1 {
+		t.Fatalf("verifier entries = %#v, want one entry per digested source", verifier.entries)
+	}
+	if verifier.entries[0].digest != identities[0].Digest {
+		t.Fatalf("verifier baseline %q != source identity digest %q", verifier.entries[0].digest, identities[0].Digest)
+	}
+}
+
+func TestCollectSourceIdentitiesCleanModePopulatesCommittedVerification(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	rootRevision := gitCommitAll(t, repoRoot, "initial")
+	handle := &persistentRenderCache{
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+	verifier := &renderInputVerifier{}
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rootRevision},
+		rootInputMode:  rootInputModeClean,
+		inputVerifier:  verifier,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	_, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if !ok {
+		t.Fatalf("collectSourceIdentities() ok = false, reason = %s", reason)
+	}
+	if len(verifier.entries) != 1 {
+		t.Fatalf("verifier entries = %#v, want one committed verification", verifier.entries)
+	}
+	entry := verifier.entries[0]
+	if entry.revision != rootRevision || len(entry.committedPaths) == 0 || entry.digest != "" || len(entry.paths) != 0 {
+		t.Fatalf("entry = %#v, want committed verification (revision + paths, no filesystem baseline)", entry)
+	}
+}
+
+func TestCommittedPathDigestMemoKeyDedupesEquivalentPaths(t *testing.T) {
+	_, normalized, err := committedPathDigestMemoKey(t.TempDir(), "HEAD", []gitref.PathDigestPath{
+		{Path: `a\b`, Optional: true},
+		{Path: "a/./b", Optional: false},
+	})
+	if err != nil {
+		t.Fatalf("committedPathDigestMemoKey() error = %v", err)
+	}
+	if len(normalized) != 1 || normalized[0].Path != "a/b" || normalized[0].Optional {
+		t.Fatalf("normalized = %#v, want single required a/b entry", normalized)
+	}
+}
+
+func TestHandleFilesystemPathDigestSharesPerFileCache(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 1\n")
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+
+	pathsA := []filedigest.PathDigestPath{{Path: "manifests/demo"}}
+	if _, err := handle.filesystemPathDigest(context.Background(), repoRoot, pathsA, nil); err != nil {
+		t.Fatalf("warm digest error = %v", err)
+	}
+
+	// Edit the file, then digest a DIFFERENT path set (different memo key)
+	// covering the same file: with a shared per-file cache the stale content
+	// hash is reused, so the result matches a pre-edit computation.
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 2\n")
+	pathsB := []filedigest.PathDigestPath{{Path: "manifests/demo"}, {Path: "manifests/missing.yaml", Optional: true}}
+	viaHandle, err := handle.filesystemPathDigest(context.Background(), repoRoot, pathsB, nil)
+	if err != nil {
+		t.Fatalf("handle digest error = %v", err)
+	}
+	fresh, err := filedigest.PathDigest(context.Background(), filedigest.PathDigestInput{RepoRoot: repoRoot, Paths: pathsB})
+	if err != nil {
+		t.Fatalf("direct digest error = %v", err)
+	}
+	if viaHandle.Digest == fresh.Digest {
+		t.Fatalf("handle digest saw the edit; the per-file cache is not wired into filesystemPathDigest")
+	}
+}
+
+func TestKustomizeDigestPathsIncludeFilenameVariants(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\n")
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "apps/alpha", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	if err != nil {
+		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
+	}
+	want := map[string]bool{
+		"apps/alpha/kustomization.yml": false,
+		"apps/alpha/Kustomization":     false,
+	}
+	for _, item := range paths {
+		if _, ok := want[item.Path]; ok && item.Optional {
+			want[item.Path] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("digest paths missing optional kustomization variant %q: %#v", name, paths)
+		}
+	}
+	// required-wins dedup pin: the committed kustomization.yaml must appear as
+	// required (Optional=false) even though the optional-variant loop also emits
+	// it. The normalizer deduplicates optional-AND-required to required.
+	foundRequired := false
+	for _, item := range paths {
+		if item.Path == "apps/alpha/kustomization.yaml" && !item.Optional {
+			foundRequired = true
+			break
+		}
+	}
+	if !foundRequired {
+		t.Fatalf("apps/alpha/kustomization.yaml must appear as required (Optional=false) — required-wins dedup broken: %#v", paths)
+	}
+}
+
+func TestDirtyPathsTouch(t *testing.T) {
+	dirty := []string{"apps/alpha/cm.yaml", "apps/beta/.git", "newdir/x.yaml"}
+	cases := []struct {
+		name  string
+		paths []gitref.PathDigestPath
+		want  bool
+	}{
+		{"exact file", []gitref.PathDigestPath{{Path: "apps/alpha/cm.yaml"}}, true},
+		{"dir covering dirty file", []gitref.PathDigestPath{{Path: "apps/alpha"}}, true},
+		{"untouched dir", []gitref.PathDigestPath{{Path: "apps/gamma"}}, false},
+		{"sibling prefix is not a dir match", []gitref.PathDigestPath{{Path: "apps/alph"}}, false},
+		{"optional path appearing dirty", []gitref.PathDigestPath{{Path: "newdir/x.yaml", Optional: true}}, true},
+		{"dot covers everything", []gitref.PathDigestPath{{Path: "."}}, true},
+		{"backslash path canonicalized", []gitref.PathDigestPath{{Path: `apps\alpha`}}, true},
+		{"invalid path fails closed", []gitref.PathDigestPath{{Path: "../escape"}}, true},
+		{"no paths", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dirtyPathsTouch(dirty, tc.paths); got != tc.want {
+				t.Fatalf("dirtyPathsTouch(%v) = %v, want %v", tc.paths, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRootIdentityForRequestReturnsDirtyPaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "a: 1\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, repoRoot+"/apps/alpha/edit.yaml", "e: 1\n")
+	request := BuildRequest{RenderCacheOptions: testRenderCacheOptions(t)}
+	prepared, _ := ensurePersistentRenderCache(request)
+
+	identity, mode, dirtyPaths := rootIdentityForRequest(context.Background(), repoRoot, prepared)
+	if mode != rootInputModeDirty || identity.Revision != revision {
+		t.Fatalf("identity/mode = %+v/%s, want dirty with revision", identity, mode)
+	}
+	if len(dirtyPaths) != 1 || dirtyPaths[0] != "apps/alpha/edit.yaml" {
+		t.Fatalf("dirtyPaths = %#v, want the edit", dirtyPaths)
+	}
+
+	cleanRoot := t.TempDir()
+	writeTestFile(t, cleanRoot+"/apps/alpha/cm.yaml", "a: 1\n")
+	gitCommitAll(t, cleanRoot, "initial")
+	_, cleanMode, cleanDirty := rootIdentityForRequest(context.Background(), cleanRoot, prepared)
+	if cleanMode != rootInputModeClean || cleanDirty != nil {
+		t.Fatalf("clean root = %s/%v, want clean with nil dirty paths", cleanMode, cleanDirty)
+	}
+}
+
+func TestDirtyModeUntouchedSourceKeepsCommittedIdentity(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\n")
+	writeTestFile(t, repoRoot+"/apps/beta/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: beta\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	application := func(name string) argoappv1.Application {
+		return argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+			RepoURL: "https://git.example.test/org/repo.git", Path: "apps/" + name, TargetRevision: "main",
+		}}}
+	}
+	provider := func(mode rootInputMode, dirtyPaths []string) localProvider {
+		return localProvider{
+			repoRoot:       repoRoot,
+			sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+			rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+			rootInputMode:  mode,
+			rootDirtyPaths: dirtyPaths,
+		}
+	}
+
+	cleanAlpha := mustCollectSingleSourceIdentity(t, provider(rootInputModeClean, nil), mustPlan(t, application("alpha")))
+	if cleanAlpha.Kind != sourceIdentityKindLocalInputs {
+		t.Fatalf("clean identity = %+v, want local-inputs", cleanAlpha)
+	}
+
+	// Dirty worktree: beta touched, alpha untouched.
+	writeTestFile(t, repoRoot+"/apps/beta/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: beta2\n")
+	dirty := provider(rootInputModeDirty, []string{"apps/beta/cm.yaml"})
+
+	dirtyAlpha := mustCollectSingleSourceIdentity(t, dirty, mustPlan(t, application("alpha")))
+	if dirtyAlpha != cleanAlpha {
+		t.Fatalf("untouched app identity changed across modes:\nclean = %+v\ndirty = %+v", cleanAlpha, dirtyAlpha)
+	}
+
+	dirtyBeta := mustCollectSingleSourceIdentity(t, dirty, mustPlan(t, application("beta")))
+	if dirtyBeta.Kind != sourceIdentityKindWorktreeInputs {
+		t.Fatalf("touched app identity = %+v, want worktree-inputs", dirtyBeta)
+	}
+}
+
+func TestDirtyModeEmptyDirtySetDisablesCommittedShortcut(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	// Dirty mode with NO dirty-path enumeration (hand-built provider):
+	// fail-safe to filesystem keys, preserving pre-feature behavior.
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode:  rootInputModeDirty,
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "apps/alpha", TargetRevision: "main",
+	}}}
+	identity := mustCollectSingleSourceIdentity(t, provider, mustPlan(t, application))
+	if identity.Kind != sourceIdentityKindWorktreeInputs {
+		t.Fatalf("identity = %+v, want worktree-inputs when the dirty set is empty", identity)
+	}
+}
+
+func TestDirtyModeUntrackedFileUnderAppForcesWorktreeKey(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, repoRoot+"/apps/alpha/untracked.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: extra\n")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode:  rootInputModeDirty,
+		rootDirtyPaths: []string{"apps/alpha/untracked.yaml"},
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "apps/alpha", TargetRevision: "main",
+	}}}
+	identity := mustCollectSingleSourceIdentity(t, provider, mustPlan(t, application))
+	if identity.Kind != sourceIdentityKindWorktreeInputs {
+		t.Fatalf("identity = %+v, want worktree-inputs (untracked file is a render input)", identity)
+	}
+}
+
+func TestDirtyModeUntouchedHelmGlobSourceStaysIneligible(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/values.yaml", "name: demo\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	writeTestFile(t, repoRoot+"/unrelated.txt", "dirt\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, repoRoot+"/unrelated.txt", "dirt2\n")
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+		rootInputMode:  rootInputModeDirty,
+		rootDirtyPaths: []string{"unrelated.txt"},
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "charts/demo", TargetRevision: "main",
+		Helm: &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values*.yaml"}},
+	}}}
+	plan := mustPlan(t, application)
+	handle := &persistentRenderCache{
+		digests:           map[string]gitref.PathDigestResult{},
+		filesystemDigests: map[string]filedigest.PathDigestResult{},
+	}
+	_, reason, ok := collectSourceIdentities(context.Background(), handle, provider, plan)
+	if ok || reason != renderCacheReasonInputGraph {
+		t.Fatalf("ok/reason = %v/%s, want glob-bearing dirty source ineligible even when untouched (a new file matching the glob is invisible to the path-set intersection)", ok, reason)
+	}
+}
+
+func TestDirtyModeKustomizeUntrackedVariantForcesWorktreeKey(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/apps/alpha/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/apps/alpha/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\n")
+	revision := gitCommitAll(t, repoRoot, "initial")
+	provider := func(dirtyPaths []string) localProvider {
+		return localProvider{
+			repoRoot:       repoRoot,
+			sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+			rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: revision},
+			rootInputMode:  rootInputModeDirty,
+			rootDirtyPaths: dirtyPaths,
+		}
+	}
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+		RepoURL: "https://git.example.test/org/repo.git", Path: "apps/alpha", TargetRevision: "main",
+	}}}
+	plan := mustPlan(t, application)
+
+	// Untouched kustomize source takes the committed shortcut.
+	untouched := mustCollectSingleSourceIdentity(t, provider([]string{"unrelated.txt"}), plan)
+	if untouched.Kind != sourceIdentityKindLocalInputs {
+		t.Fatalf("untouched kustomize identity = %+v, want local-inputs", untouched)
+	}
+
+	// An untracked lower-precedence variant beside the committed file is a
+	// render input (kustomize errors on multiple variants) and must force
+	// the filesystem key via the Task 2 optional-variant digest paths.
+	writeTestFile(t, repoRoot+"/apps/alpha/kustomization.yml", "resources:\n  - cm.yaml\n")
+	variant := mustCollectSingleSourceIdentity(t, provider([]string{"apps/alpha/kustomization.yml"}), plan)
+	if variant.Kind != sourceIdentityKindWorktreeInputs {
+		t.Fatalf("identity with untracked variant = %+v, want worktree-inputs (variant must intersect the digest path set)", variant)
+	}
+}

--- a/internal/app/render_cache_verify_test.go
+++ b/internal/app/render_cache_verify_test.go
@@ -1,0 +1,485 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/filedigest"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testRenderCacheStoreKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
+}
+
+func mustFilesystemDigest(t *testing.T, repoRoot string, paths []filedigest.PathDigestPath) string {
+	t.Helper()
+	result, err := filedigest.PathDigest(context.Background(), filedigest.PathDigestInput{RepoRoot: repoRoot, Paths: paths})
+	if err != nil {
+		t.Fatalf("PathDigest() error = %v", err)
+	}
+	return result.Digest
+}
+
+func TestPersistentRenderStateStoreSkipsWhenInputsChangedAfterDigest(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 1\n")
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	paths := []filedigest.PathDigestPath{{Path: "manifests/demo"}}
+	state := persistentRenderState{
+		enabled:      true,
+		key:          testRenderCacheStoreKey("store-verify"),
+		handle:       handle,
+		recorder:     cacheevent.NewRecorder(true),
+		acquisitions: cacheevent.NewAcquisitionCollector(),
+		verifications: []renderInputVerification{{
+			repoRoot: repoRoot,
+			paths:    paths,
+			digest:   mustFilesystemDigest(t, repoRoot, paths),
+		}},
+	}
+
+	// The render "happened"; an editor save lands before store().
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 2\n")
+	state.store(context.Background(), RenderResult{})
+	if got := handle.store.Writes(); got != 0 {
+		t.Fatalf("store wrote %d entries under a stale input digest, want 0", got)
+	}
+
+	// With a current baseline the store proceeds.
+	state.verifications[0].digest = mustFilesystemDigest(t, repoRoot, paths)
+	state.store(context.Background(), RenderResult{})
+	if got := handle.store.Writes(); got != 1 {
+		t.Fatalf("store writes = %d after verified store, want 1", got)
+	}
+}
+
+// TestRenderInputsUnchangedBypassesRunScopedMemo pins that renderInputsUnchanged
+// calls filedigest.PathDigest directly and NOT the run-scoped memo on
+// state.handle.filesystemPathDigest.
+//
+// Setup: the memo is deliberately warmed with the pre-edit digest (exactly what
+// the production path does), then the file is edited.  If renderInputsUnchanged
+// were using the memo it would see the stale cached value == baseline → store
+// would proceed → Writes() == 1 → test fails.  With the direct call the
+// recomputed digest diverges → store is skipped → Writes() == 0.
+func TestRenderInputsUnchangedBypassesRunScopedMemo(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 1\n")
+
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	if !handle.active() {
+		t.Fatal("persistent cache did not open")
+	}
+
+	paths := []filedigest.PathDigestPath{{Path: "manifests/demo"}}
+
+	// Warm the run-scoped memo through handle.filesystemPathDigest — exactly
+	// what worktreeInputSourceIdentity / localInputSourceIdentity does during
+	// preparePersistentRender.  This records the digest of the CURRENT file
+	// content in the memo map keyed on (repoRoot, paths, forbiddenRoots).
+	memoResult, err := handle.filesystemPathDigest(context.Background(), repoRoot, paths, nil)
+	if err != nil {
+		t.Fatalf("filesystemPathDigest() error = %v", err)
+	}
+	baseline := memoResult.Digest
+
+	state := persistentRenderState{
+		enabled:      true,
+		key:          testRenderCacheStoreKey("memo-bypass"),
+		handle:       handle,
+		recorder:     cacheevent.NewRecorder(true),
+		acquisitions: cacheevent.NewAcquisitionCollector(),
+		verifications: []renderInputVerification{{
+			repoRoot: repoRoot,
+			paths:    paths,
+			digest:   baseline,
+		}},
+	}
+
+	// Edit the file AFTER the memo was warmed.  The memo still holds the
+	// pre-edit digest; a direct PathDigest call will see the new content.
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "a: 2\n")
+
+	state.store(context.Background(), RenderResult{})
+
+	if got := handle.store.Writes(); got != 0 {
+		t.Fatalf("store wrote %d entries; renderInputsUnchanged used the memoized digest instead of re-reading disk (want 0 — guard must bypass the memo)", got)
+	}
+
+	// Sanity: confirm the skip event carried the expected reason so a
+	// records-inactive false-positive cannot silently pass this test.
+	events := state.recorder.Events()
+	var found bool
+	for _, ev := range events {
+		if ev.Action == cacheevent.ActionSkipped && ev.Reason == renderCacheReasonInputsChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected skipped/inputs-changed event, got %#v", events)
+	}
+}
+
+// TestRenderApplicationStoreSkipsOnMidRenderEdit pins the end-to-end wiring of
+// preparePersistentRender: specifically that local.inputVerifier is set and
+// state.verifications is populated, so that a mid-render file mutation causes
+// store() to skip.
+//
+// It runs two phases in sequence on the same cache handle:
+//  1. Control — no mutation → store must write exactly one entry.
+//  2. Dirty — renderObserver mutates the source file mid-render → store must
+//     skip with reason "inputs-changed".
+//
+// The control phase proves the wiring produces stores at all, making the skip
+// assertion in the dirty phase meaningful.
+func TestRenderApplicationStoreSkipsOnMidRenderEdit(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	// Plain YAML directory source — renders with zero external tooling.
+	writeTestFile(t, filepath.Join(repoRoot, "manifests", "demo", "cm.yaml"),
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  value: initial\n")
+	rev := gitCommitAll(t, repoRoot, "initial")
+
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "https://git.example.test/org/repo.git",
+				Path:           "manifests/demo",
+				TargetRevision: "main",
+				Directory:      &argoappv1.ApplicationSourceDirectory{},
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+
+	cacheOptions := testRenderCacheOptions(t)
+
+	// ── Phase 1: control — no mid-render mutation ────────────────────────────
+	controlHandle := newPersistentRenderCache(cacheOptions, true)
+	if !controlHandle.active() {
+		t.Fatal("control persistent cache did not open")
+	}
+
+	controlProvider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rev},
+		rootInputMode:  rootInputModeDirty,
+		cacheEvents:    cacheevent.NewRecorder(true),
+		acquisitions:   cacheevent.NewAcquisitionCollector(),
+		// renderObserver intentionally nil — no mutation
+	}
+
+	_, err := RenderApplicationWithOptions(context.Background(), application, controlProvider, ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: controlHandle},
+	})
+	if err != nil {
+		t.Fatalf("control RenderApplicationWithOptions() error = %v", err)
+	}
+	if got := controlHandle.store.Writes(); got != 1 {
+		t.Fatalf("control phase: store.Writes() = %d, want 1 (wiring must produce a store when inputs are unchanged)", got)
+	}
+
+	// ── Phase 2: dirty — mutate a source file mid-render ────────────────────
+	// Use a fresh cache handle (different cacheDir) so the miss→render→store
+	// path is exercised rather than returning a hit from phase 1.
+	dirtyHandle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	if !dirtyHandle.active() {
+		t.Fatal("dirty persistent cache did not open")
+	}
+
+	mutatedOnce := false
+	dirtyProvider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rev},
+		rootInputMode:  rootInputModeDirty,
+		cacheEvents:    cacheevent.NewRecorder(true),
+		acquisitions:   cacheevent.NewAcquisitionCollector(),
+		renderObserver: func(_ render.ResolvedSource) {
+			// Guard: mutate only on first call so concurrency does not
+			// interfere.  A single overwrite is sufficient to change
+			// the directory digest.
+			if mutatedOnce {
+				return
+			}
+			mutatedOnce = true
+			writeTestFile(t, filepath.Join(repoRoot, "manifests", "demo", "cm.yaml"),
+				"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  value: mutated\n")
+		},
+	}
+
+	_, err = RenderApplicationWithOptions(context.Background(), application, dirtyProvider, ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: dirtyHandle},
+	})
+	if err != nil {
+		t.Fatalf("dirty RenderApplicationWithOptions() error = %v", err)
+	}
+
+	if got := dirtyHandle.store.Writes(); got != 0 {
+		t.Fatalf("dirty phase: store.Writes() = %d, want 0 — mid-render mutation must prevent the store", got)
+	}
+
+	// Confirm the skip reason is inputs-changed, not records-inactive or
+	// any other false-positive reason.
+	events := dirtyProvider.cacheEvents.Events()
+	var foundSkip bool
+	for _, ev := range events {
+		if ev.Action == cacheevent.ActionSkipped && ev.Reason == renderCacheReasonInputsChanged {
+			foundSkip = true
+		}
+	}
+	if !foundSkip {
+		t.Fatalf("expected skipped/inputs-changed event in dirty phase, got %#v", events)
+	}
+}
+
+func TestRenderApplicationCleanModeStoreSkipsOnMidRenderEdit(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "manifests", "demo", "cm.yaml")
+	writeTestFile(t, sourceFile,
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  value: initial\n")
+	rev := gitCommitAll(t, repoRoot, "initial")
+
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "https://git.example.test/org/repo.git",
+				Path:           "manifests/demo",
+				TargetRevision: "main",
+				Directory:      &argoappv1.ApplicationSourceDirectory{},
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+
+	cleanProvider := func(observer func(render.ResolvedSource)) localProvider {
+		return localProvider{
+			repoRoot:       repoRoot,
+			sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+			rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rev},
+			rootInputMode:  rootInputModeClean,
+			cacheEvents:    cacheevent.NewRecorder(true),
+			acquisitions:   cacheevent.NewAcquisitionCollector(),
+			renderObserver: observer,
+		}
+	}
+
+	controlHandle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	_, err := RenderApplicationWithOptions(context.Background(), application, cleanProvider(nil), ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: controlHandle},
+	})
+	if err != nil {
+		t.Fatalf("control render error = %v", err)
+	}
+	if got := controlHandle.store.Writes(); got != 1 {
+		t.Fatalf("control phase: store.Writes() = %d, want 1", got)
+	}
+
+	dirtyHandle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	mutated := false
+	provider := cleanProvider(func(_ render.ResolvedSource) {
+		if mutated {
+			return
+		}
+		mutated = true
+		writeTestFile(t, sourceFile,
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  value: mutated\n")
+	})
+	_, err = RenderApplicationWithOptions(context.Background(), application, provider, ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: dirtyHandle},
+	})
+	if err != nil {
+		t.Fatalf("mutating render error = %v", err)
+	}
+	if got := dirtyHandle.store.Writes(); got != 0 {
+		t.Fatalf("clean-mode mid-render edit: store.Writes() = %d, want 0", got)
+	}
+	events := provider.cacheEvents.Events()
+	found := false
+	for _, ev := range events {
+		if ev.Action == cacheevent.ActionSkipped && ev.Reason == renderCacheReasonInputsChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected skipped/inputs-changed event, got %#v", events)
+	}
+}
+
+func TestStoreInputsChangedEventCarriesErrorDetail(t *testing.T) {
+	state := persistentRenderState{
+		enabled:      true,
+		key:          testRenderCacheStoreKey("inputs-changed-detail"),
+		handle:       newPersistentRenderCache(testRenderCacheOptions(t), true),
+		recorder:     cacheevent.NewRecorder(true),
+		acquisitions: cacheevent.NewAcquisitionCollector(),
+		verifications: []renderInputVerification{{
+			repoRoot: t.TempDir(),
+			paths:    []filedigest.PathDigestPath{{Path: "missing-required.yaml"}},
+			digest:   "stale",
+		}},
+	}
+	state.store(context.Background(), RenderResult{})
+
+	events := state.recorder.Events()
+	for _, ev := range events {
+		if ev.Action == cacheevent.ActionSkipped && ev.Reason == renderCacheReasonInputsChanged {
+			if ev.Error == "" {
+				t.Fatalf("inputs-changed skip from a digest ERROR must carry the error text, got %#v", ev)
+			}
+			return
+		}
+	}
+	t.Fatalf("no skipped/inputs-changed event, got %#v", events)
+}
+
+func TestDirtyWorktreeServesCommittedHitsForUntouchedApps(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, filepath.Join(repoRoot, "apps", "alpha", "cm.yaml"),
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\ndata:\n  value: one\n")
+	writeTestFile(t, filepath.Join(repoRoot, "apps", "beta", "cm.yaml"),
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: beta\ndata:\n  value: one\n")
+	rev := gitCommitAll(t, repoRoot, "initial")
+	cacheOptions := testRenderCacheOptions(t) // ONE options value: both runs share the store
+
+	application := func(name string) argoappv1.Application {
+		return argoappv1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argocd"},
+			Spec: argoappv1.ApplicationSpec{
+				Source: &argoappv1.ApplicationSource{
+					RepoURL:        "https://git.example.test/org/repo.git",
+					Path:           "apps/" + name,
+					TargetRevision: "main",
+					Directory:      &argoappv1.ApplicationSourceDirectory{},
+				},
+				Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+			},
+		}
+	}
+	renderApp := func(handle *persistentRenderCache, mode rootInputMode, dirtyPaths []string, name string) []cacheevent.Event {
+		provider := localProvider{
+			repoRoot:       repoRoot,
+			sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+			rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rev},
+			rootInputMode:  mode,
+			rootDirtyPaths: dirtyPaths,
+			cacheEvents:    cacheevent.NewRecorder(true),
+			acquisitions:   cacheevent.NewAcquisitionCollector(),
+		}
+		_, err := RenderApplicationWithOptions(context.Background(), application(name), provider, ApplicationRenderOptions{
+			persistent: persistentRenderOptions{cache: handle},
+		})
+		if err != nil {
+			t.Fatalf("render %s: %v", name, err)
+		}
+		return provider.cacheEvents.Events()
+	}
+	hasAction := func(events []cacheevent.Event, action cacheevent.Action) bool {
+		for _, ev := range events {
+			if ev.Action == action {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Run 1: clean worktree — both apps render and store under committed keys.
+	cleanHandle := newPersistentRenderCache(cacheOptions, true)
+	renderApp(cleanHandle, rootInputModeClean, nil, "alpha")
+	renderApp(cleanHandle, rootInputModeClean, nil, "beta")
+	if got := cleanHandle.store.Writes(); got != 2 {
+		t.Fatalf("clean run stores = %d, want 2", got)
+	}
+
+	// Edit beta only; run 2 in dirty mode with the enumerated dirty set.
+	writeTestFile(t, filepath.Join(repoRoot, "apps", "beta", "cm.yaml"),
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: beta\ndata:\n  value: two\n")
+	dirtyHandle := newPersistentRenderCache(cacheOptions, true)
+	dirtyPaths := []string{"apps/beta/cm.yaml"}
+
+	alphaEvents := renderApp(dirtyHandle, rootInputModeDirty, dirtyPaths, "alpha")
+	if !hasAction(alphaEvents, cacheevent.ActionHit) {
+		t.Fatalf("untouched app must HIT its committed-key entry across the mode transition, got %#v", alphaEvents)
+	}
+	betaEvents := renderApp(dirtyHandle, rootInputModeDirty, dirtyPaths, "beta")
+	if !hasAction(betaEvents, cacheevent.ActionStore) || hasAction(betaEvents, cacheevent.ActionHit) {
+		t.Fatalf("touched app must miss and store under a worktree key, got %#v", betaEvents)
+	}
+	if got := dirtyHandle.store.Writes(); got != 1 {
+		t.Fatalf("dirty run stores = %d, want exactly 1 (the touched app)", got)
+	}
+}
+
+func TestRenderApplicationDirtyShortcutStoreSkipsOnMidRenderEdit(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "apps", "alpha", "cm.yaml")
+	writeTestFile(t, sourceFile,
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\ndata:\n  value: initial\n")
+	writeTestFile(t, filepath.Join(repoRoot, "unrelated.txt"), "dirt\n")
+	rev := gitCommitAll(t, repoRoot, "initial")
+	writeTestFile(t, filepath.Join(repoRoot, "unrelated.txt"), "dirt2\n")
+
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "https://git.example.test/org/repo.git",
+				Path:           "apps/alpha",
+				TargetRevision: "main",
+				Directory:      &argoappv1.ApplicationSourceDirectory{},
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), true)
+	mutated := false
+	provider := localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot, Revision: rev},
+		rootInputMode:  rootInputModeDirty,
+		rootDirtyPaths: []string{"unrelated.txt"}, // alpha untouched → committed shortcut
+		cacheEvents:    cacheevent.NewRecorder(true),
+		acquisitions:   cacheevent.NewAcquisitionCollector(),
+		renderObserver: func(_ render.ResolvedSource) {
+			if mutated {
+				return
+			}
+			mutated = true
+			writeTestFile(t, sourceFile,
+				"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: alpha\ndata:\n  value: mutated\n")
+		},
+	}
+	_, err := RenderApplicationWithOptions(context.Background(), application, provider, ApplicationRenderOptions{
+		persistent: persistentRenderOptions{cache: handle},
+	})
+	if err != nil {
+		t.Fatalf("render error = %v", err)
+	}
+	if got := handle.store.Writes(); got != 0 {
+		t.Fatalf("store.Writes() = %d, want 0 — a mid-render edit under a committed-shortcut key must skip the store", got)
+	}
+	events := provider.cacheEvents.Events()
+	found := false
+	for _, ev := range events {
+		if ev.Action == cacheevent.ActionSkipped && ev.Reason == renderCacheReasonInputsChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected skipped/inputs-changed event, got %#v", events)
+	}
+}

--- a/internal/app/render_input_coverage_test.go
+++ b/internal/app/render_input_coverage_test.go
@@ -1,0 +1,204 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/gitref"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// renderOutcomeSignature reduces a render to a comparable string: an error
+// (any error) is one outcome class; otherwise the JSON of the manifest objects
+// and diagnostics in order. Diagnostics are included so that diagnostic-only
+// changes (e.g. a new warning emitted by a mutated file) count as outcome
+// changes and trigger the coverage check.
+func renderOutcomeSignature(t *testing.T, result RenderResult, err error) string {
+	t.Helper()
+	if err != nil {
+		return "error"
+	}
+	objects := make([]map[string]any, 0, len(result.Manifests))
+	for _, manifest := range result.Manifests {
+		if manifest.Object != nil {
+			objects = append(objects, manifest.Object.Object)
+		}
+	}
+	type outcomePayload struct {
+		Objects     []map[string]any `json:"objects"`
+		Diagnostics any              `json:"diagnostics"`
+	}
+	data, marshalErr := json.Marshal(outcomePayload{
+		Objects:     objects,
+		Diagnostics: result.Diagnostics,
+	})
+	if marshalErr != nil {
+		t.Fatalf("marshal render outcome: %v", marshalErr)
+	}
+	return string(data)
+}
+
+func digestPathsCover(paths []gitref.PathDigestPath, rel string) bool {
+	for _, item := range paths {
+		if item.Path == "." || item.Path == rel || strings.HasPrefix(rel, item.Path+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func renderCoverageFixtureProvider(repoRoot string) localProvider {
+	return localProvider{
+		repoRoot:       repoRoot,
+		sourceResolver: sourcepkg.NewResolver(sourcepkg.Options{}),
+		rootIdentity:   SourceIdentity{Kind: sourceIdentityKindRoot},
+		rootInputMode:  rootInputModeDirty,
+		cacheEvents:    cacheevent.NewRecorder(false),
+		acquisitions:   cacheevent.NewAcquisitionCollector(),
+	}
+}
+
+// assertRenderInputCoverage mutates every file under repoRoot (except .git)
+// to garbage, one at a time, and asserts that any file whose mutation changes
+// the render outcome is covered by the digest path set computed from the
+// pristine tree. Files whose mutation does not change the outcome did not
+// change the outcome under this probe and are legitimately uncovered.
+//
+// Fixture constraint: files under the source path must contribute to the
+// baseline output for the probe to be potent. The garbage payload has no
+// apiVersion/kind, and the directory renderer silently skips non-manifest
+// decode failures — a file that only produces decode errors when corrupted
+// will not register as an outcome change.
+func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoappv1.Application) {
+	t.Helper()
+	provider := renderCoverageFixtureProvider(repoRoot)
+	plan := mustPlan(t, application)
+
+	// Use the prepared plan to mirror production: PrepareSource merges
+	// .argocd-source.yaml into the source spec before rendering, so digestPaths
+	// must be computed from the same prepared state.
+	preparedPlan, _, prepErr := preparePlanSourcesForRender(context.Background(), application, provider, plan)
+	if prepErr != nil {
+		t.Fatalf("preparePlanSourcesForRender() error = %v", prepErr)
+	}
+
+	digestPaths, _, err := localInputDigestPathsForSource(context.Background(), preparedPlan, preparedPlan.Sources[0], repoRoot)
+	if err != nil {
+		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
+	}
+
+	baselineResult, baselineErr := RenderApplication(context.Background(), application, provider)
+	if baselineErr != nil {
+		t.Fatalf("baseline render must succeed, got %v", baselineErr)
+	}
+	baseline := renderOutcomeSignature(t, baselineResult, baselineErr)
+
+	var files []string
+	walkErr := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk fixture: %v", walkErr)
+	}
+
+	for _, file := range files {
+		rel, err := filepath.Rel(repoRoot, file)
+		if err != nil {
+			t.Fatalf("rel %q: %v", file, err)
+		}
+		rel = filepath.ToSlash(rel)
+
+		original, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %q: %v", file, err)
+		}
+		if err := os.WriteFile(file, []byte("}{ tripwire-garbage: ["), 0o600); err != nil {
+			t.Fatalf("mutate %q: %v", file, err)
+		}
+
+		result, renderErr := RenderApplication(context.Background(), application, renderCoverageFixtureProvider(repoRoot))
+		mutated := renderOutcomeSignature(t, result, renderErr)
+
+		if err := os.WriteFile(file, original, 0o600); err != nil {
+			t.Fatalf("restore %q: %v", file, err)
+		}
+
+		if mutated != baseline && !digestPathsCover(digestPaths, rel) {
+			t.Errorf("file %q changes the render outcome when corrupted but is NOT covered by the digest path set %#v — a cache entry would stay valid while the render changed", rel, digestPaths)
+		}
+	}
+}
+
+func TestRenderInputCoverageDirectorySource(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  value: one\n")
+	writeTestFile(t, repoRoot+"/manifests/demo/extra.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: extra\n")
+	writeTestFile(t, repoRoot+"/unrelated/README.md", "not a render input\n")
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+				Directory: &argoappv1.ApplicationSourceDirectory{},
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+	assertRenderInputCoverage(t, repoRoot, application)
+}
+
+func TestRenderInputCoverageKustomizeSourceWithBaseAndOverride(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/base/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	writeTestFile(t, repoRoot+"/base/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: base\ndata:\n  value: one\n")
+	writeTestFile(t, repoRoot+"/manifests/app/kustomization.yaml", "resources:\n  - ../../base\n")
+	writeTestFile(t, repoRoot+"/manifests/app/.argocd-source.yaml", "kustomize:\n  namePrefix: prod-\n")
+	writeTestFile(t, repoRoot+"/unrelated/README.md", "not a render input\n")
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/app", TargetRevision: "main",
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+	assertRenderInputCoverage(t, repoRoot, application)
+}
+
+func TestRenderInputCoverageHelmSource(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeTestFile(t, repoRoot+"/charts/demo/values.yaml", "value: one\n")
+	writeTestFile(t, repoRoot+"/charts/demo/templates/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Chart.Name }}\ndata:\n  value: {{ .Values.value }}\n")
+	writeTestFile(t, repoRoot+"/unrelated/README.md", "not a render input\n")
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://git.example.test/org/repo.git", Path: "charts/demo", TargetRevision: "main",
+				Helm: &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values.yaml"}},
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+	assertRenderInputCoverage(t, repoRoot, application)
+}

--- a/internal/app/render_prepare_test.go
+++ b/internal/app/render_prepare_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+type renderAndPrepareFailingProvider struct{}
+
+func (renderAndPrepareFailingProvider) RenderSource(_ context.Context, source render.ResolvedSource, _ render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+	if source.Path == "first" {
+		return nil, nil, fmt.Errorf("render boom")
+	}
+	return nil, nil, nil
+}
+
+func (renderAndPrepareFailingProvider) PrepareSource(_ context.Context, _ argoappv1.Application, sourcePlan SourcePlan) (SourcePlan, error) {
+	if sourcePlan.Source.Path == "second" {
+		return sourcePlan, fmt.Errorf("prepare boom")
+	}
+	return sourcePlan, nil
+}
+
+// An earlier source's render failure must surface instead of a later
+// source's prepare failure — the prepared prefix renders first.
+func TestRenderApplicationEarlierRenderFailureWinsOverLaterPrepareFailure(t *testing.T) {
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "first", TargetRevision: "main"},
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "second", TargetRevision: "main"},
+	}}}
+
+	_, err := RenderApplicationWithOptions(context.Background(), application, renderAndPrepareFailingProvider{}, ApplicationRenderOptions{TrackingOptions: defaultTrackingOptions()})
+	if err == nil || !strings.Contains(err.Error(), "render boom") || strings.Contains(err.Error(), "prepare boom") {
+		t.Fatalf("err = %v, want source[0] render failure to win over source[1] prepare failure", err)
+	}
+}
+
+type prepareFailingProvider struct{}
+
+func (prepareFailingProvider) RenderSource(_ context.Context, source render.ResolvedSource, _ render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+	return nil, []diagnostic.Diagnostic{{
+		Severity: diagnostic.SeverityWarning,
+		Category: "test",
+		Message:  "warning from " + source.Path,
+	}}, nil
+}
+
+func (prepareFailingProvider) PrepareSource(_ context.Context, _ argoappv1.Application, sourcePlan SourcePlan) (SourcePlan, error) {
+	if sourcePlan.Source.Path == "second" {
+		return sourcePlan, fmt.Errorf("prepare boom")
+	}
+	return sourcePlan, nil
+}
+
+func TestRenderApplicationPrepareFailurePreservesEarlierSourceDiagnostics(t *testing.T) {
+	application := argoappv1.Application{Spec: argoappv1.ApplicationSpec{Sources: argoappv1.ApplicationSources{
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "first", TargetRevision: "main"},
+		{RepoURL: "https://git.example.test/org/repo.git", Path: "second", TargetRevision: "main"},
+	}}}
+	handle := newPersistentRenderCache(testRenderCacheOptions(t), false)
+	options := ApplicationRenderOptions{TrackingOptions: defaultTrackingOptions()}
+	options.persistent = persistentRenderOptions{cache: handle}
+
+	result, err := RenderApplicationWithOptions(context.Background(), application, prepareFailingProvider{}, options)
+	if err == nil || !strings.Contains(err.Error(), "prepare boom") {
+		t.Fatalf("err = %v, want prepare failure", err)
+	}
+	found := false
+	for _, diag := range result.Diagnostics {
+		if strings.Contains(diag.Message, "warning from first") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostics = %#v, want source[0] warning preserved on source[1] prepare failure", result.Diagnostics)
+	}
+}

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -32,6 +33,16 @@ type AcquisitionOptions struct {
 	RemoteResourceCredentials    remote.Credentials
 	RemoteResourceGitCredentials remote.GitCredentials
 	RecordCacheEvents            bool
+}
+
+// RenderCacheOptions controls the persistent render-output cache. The zero
+// value leaves the persistent tier off; CLI and pkg/drydock default it on.
+type RenderCacheOptions struct {
+	RenderCacheEnabled  bool
+	RenderCacheDir      string
+	RenderCacheMaxBytes int64
+	RefreshRenders      bool
+	EngineFingerprint   rendercache.EngineFingerprint
 }
 
 type FilterOptions struct {
@@ -72,6 +83,8 @@ type TrackingOptions struct {
 type ApplicationRenderOptions struct {
 	PluginOptions   PluginOptions
 	TrackingOptions TrackingOptions
+
+	persistent persistentRenderOptions
 }
 
 type ExecutionOptions struct {

--- a/internal/app/tracking_test.go
+++ b/internal/app/tracking_test.go
@@ -178,6 +178,62 @@ func TestRenderSettingsSignatureIgnoresCommandParameters(t *testing.T) {
 	}
 }
 
+func TestRenderSettingsSignatureIgnoresProvenance(t *testing.T) {
+	base := config.DefaultSettings()
+	base.KustomizeBuildOptions = []config.Value[string]{{Value: "--enable-helm", Provenance: config.Provenance{Path: "/tmp/left/argocd-cm.yaml"}}}
+	base.HelmValuesFileSchemes = []config.Value[string]{{Value: "https", Provenance: config.Provenance{Path: "/tmp/left/argocd-cm.yaml"}}}
+	base.TrackingMethod = config.Value[string]{Value: string(argoappv1.TrackingMethodAnnotation), Provenance: config.Provenance{Path: "/tmp/left/argocd-cm.yaml"}}
+	base.InstanceLabelKey = config.Value[string]{Value: "app.kubernetes.io/instance", Provenance: config.Provenance{Path: "/tmp/left/argocd-cm.yaml"}}
+	base.InstallationID = config.Value[string]{Value: "cluster-one", Provenance: config.Provenance{Path: "/tmp/left/argocd-cm.yaml"}}
+	base.HelmRepositories = map[string]config.RepositorySettings{
+		"https://charts.example.test": {
+			Name:       "example",
+			URL:        "https://charts.example.test",
+			Provenance: config.Provenance{Path: "/tmp/left/repositories.yaml"},
+		},
+	}
+	base.ResourceCustomizations = map[string]config.ResourceCustomization{
+		"apps/Deployment": {
+			HasHealthLua:    true,
+			HealthLuaSHA256: "abc123",
+			Provenance:      config.Provenance{Path: "/tmp/left/argocd-cm.yaml"},
+		},
+	}
+
+	next := config.DefaultSettings()
+	next.KustomizeBuildOptions = []config.Value[string]{{Value: "--enable-helm", Provenance: config.Provenance{Path: "/tmp/right/argocd-cm.yaml"}}}
+	next.HelmValuesFileSchemes = []config.Value[string]{{Value: "https", Provenance: config.Provenance{Path: "/tmp/right/argocd-cm.yaml"}}}
+	next.TrackingMethod = config.Value[string]{Value: string(argoappv1.TrackingMethodAnnotation), Provenance: config.Provenance{Path: "/tmp/right/argocd-cm.yaml"}}
+	next.InstanceLabelKey = config.Value[string]{Value: "app.kubernetes.io/instance", Provenance: config.Provenance{Path: "/tmp/right/argocd-cm.yaml"}}
+	next.InstallationID = config.Value[string]{Value: "cluster-one", Provenance: config.Provenance{Path: "/tmp/right/argocd-cm.yaml"}}
+	next.HelmRepositories = map[string]config.RepositorySettings{
+		"https://charts.example.test": {
+			Name:       "example",
+			URL:        "https://charts.example.test",
+			Provenance: config.Provenance{Path: "/tmp/right/repositories.yaml"},
+		},
+	}
+	next.ResourceCustomizations = map[string]config.ResourceCustomization{
+		"apps/Deployment": {
+			HasHealthLua:    true,
+			HealthLuaSHA256: "abc123",
+			Provenance:      config.Provenance{Path: "/tmp/right/argocd-cm.yaml"},
+		},
+	}
+
+	baseSig, err := renderSettingsSignature(base)
+	if err != nil {
+		t.Fatalf("renderSettingsSignature(base) error = %v", err)
+	}
+	nextSig, err := renderSettingsSignature(next)
+	if err != nil {
+		t.Fatalf("renderSettingsSignature(next) error = %v", err)
+	}
+	if nextSig != baseSig {
+		t.Fatalf("render settings signature changed for provenance-only metadata")
+	}
+}
+
 func trackingTestApplication(namespace, name string) argoappv1.Application {
 	return argoappv1.Application{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/internal/cacheevent/acquisition.go
+++ b/internal/cacheevent/acquisition.go
@@ -1,0 +1,58 @@
+package cacheevent
+
+import "sync"
+
+// AcquisitionKind classifies a mid-render acquisition for the persistent
+// render cache pin-stability gate. Unlike Event.Source, it distinguishes
+// remote git bases from remote HTTP files.
+type AcquisitionKind string
+
+const (
+	AcquisitionGit        AcquisitionKind = "git"
+	AcquisitionChart      AcquisitionKind = "chart"
+	AcquisitionRemoteGit  AcquisitionKind = "remote-git"
+	AcquisitionRemoteHTTP AcquisitionKind = "remote-http"
+)
+
+// AcquisitionRecord retains the pre-collapse requested and resolved revisions
+// of one successful acquisition. The user-facing Event collapses these into a
+// single Revision field, so the pin-stability gate cannot consume Events.
+type AcquisitionRecord struct {
+	Kind              AcquisitionKind
+	RequestedRevision string
+	ResolvedRevision  string
+}
+
+// AcquisitionCollector gathers records for one application render. It records
+// unconditionally, independent of the --cache-events Recorder gating.
+type AcquisitionCollector struct {
+	mu      sync.Mutex
+	records []AcquisitionRecord
+}
+
+func NewAcquisitionCollector() *AcquisitionCollector {
+	return &AcquisitionCollector{}
+}
+
+func (c *AcquisitionCollector) Record(record AcquisitionRecord) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, record)
+}
+
+func (c *AcquisitionCollector) Records() []AcquisitionRecord {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.records == nil {
+		return nil
+	}
+	out := make([]AcquisitionRecord, len(c.records))
+	copy(out, c.records)
+	return out
+}

--- a/internal/cacheevent/acquisition_test.go
+++ b/internal/cacheevent/acquisition_test.go
@@ -1,0 +1,48 @@
+package cacheevent
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestAcquisitionCollectorRecordsIndependentlyOfRecorder(t *testing.T) {
+	// The collector must work with the user-facing recorder disabled: the
+	// pin-stability gate depends on unconditional collection.
+	collector := NewAcquisitionCollector()
+	collector.Record(AcquisitionRecord{Kind: AcquisitionRemoteGit, RequestedRevision: "main", ResolvedRevision: "0123456789abcdef0123456789abcdef01234567"})
+	collector.Record(AcquisitionRecord{Kind: AcquisitionChart, RequestedRevision: "1.2.3", ResolvedRevision: "1.2.3"})
+
+	got := collector.Records()
+	want := []AcquisitionRecord{
+		{Kind: AcquisitionRemoteGit, RequestedRevision: "main", ResolvedRevision: "0123456789abcdef0123456789abcdef01234567"},
+		{Kind: AcquisitionChart, RequestedRevision: "1.2.3", ResolvedRevision: "1.2.3"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Records() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAcquisitionCollectorNilSafe(t *testing.T) {
+	var collector *AcquisitionCollector
+	collector.Record(AcquisitionRecord{Kind: AcquisitionGit})
+	if got := collector.Records(); got != nil {
+		t.Fatalf("nil collector Records() = %#v, want nil", got)
+	}
+}
+
+func TestAcquisitionCollectorConcurrentRecords(t *testing.T) {
+	collector := NewAcquisitionCollector()
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
+				collector.Record(AcquisitionRecord{Kind: AcquisitionGit, RequestedRevision: "main", ResolvedRevision: "abc"})
+			}
+		})
+	}
+	wg.Wait()
+	if got := len(collector.Records()); got != 400 {
+		t.Fatalf("Records() length = %d, want 400", got)
+	}
+}

--- a/internal/cacheevent/cacheevent.go
+++ b/internal/cacheevent/cacheevent.go
@@ -15,6 +15,7 @@ const (
 	SourceGit    Source = "git"
 	SourceChart  Source = "chart"
 	SourceRemote Source = "remote"
+	SourceRender Source = "render"
 )
 
 type Action string
@@ -28,6 +29,9 @@ const (
 	ActionMiss     Action = "miss"
 	ActionError    Action = "error"
 	ActionDisabled Action = "disabled"
+	ActionStore    Action = "store"
+	ActionEvict    Action = "evict"
+	ActionSkipped  Action = "skipped"
 )
 
 type Event struct {
@@ -39,6 +43,7 @@ type Event struct {
 	Offline         bool     `json:"offline,omitempty" yaml:"offline,omitempty"`
 	Refresh         bool     `json:"refresh,omitempty" yaml:"refresh,omitempty"`
 	Error           string   `json:"error,omitempty" yaml:"error,omitempty"`
+	Reason          string   `json:"reason,omitempty" yaml:"reason,omitempty"`
 	RawTargets      []string `json:"-" yaml:"-"`
 	SensitiveValues []string `json:"-" yaml:"-"`
 }
@@ -81,8 +86,15 @@ func (r *Recorder) Record(event Event) {
 	if !r.Enabled() {
 		return
 	}
-	rawTargets := append([]string{event.Target}, event.RawTargets...)
-	event.Target = RedactTarget(event.Target)
+	rawTargets := append([]string(nil), event.RawTargets...)
+	// Render event targets are namespace/name labels, not URLs; URL redaction
+	// would mangle them, so they are sanitized at creation instead (see
+	// renderEventTarget in internal/app) and excluded from error-text
+	// substitution for the same reason.
+	if event.Source != SourceRender {
+		rawTargets = append([]string{event.Target}, rawTargets...)
+		event.Target = RedactTarget(event.Target)
+	}
 	event.Error = RedactEventError(event.Error, event.Target, rawTargets, event.SensitiveValues...)
 	event.RawTargets = nil
 	event.SensitiveValues = nil

--- a/internal/cacheevent/cacheevent_test.go
+++ b/internal/cacheevent/cacheevent_test.go
@@ -46,6 +46,23 @@ func TestRecorderRedactsTargetsAndCopiesEvents(t *testing.T) {
 	}
 }
 
+func TestRecorderPassesRenderTargetThroughVerbatim(t *testing.T) {
+	recorder := NewRecorder(true)
+	recorder.Record(Event{Source: SourceRender, Action: ActionSkipped, Target: "argocd/urlvalues", Reason: "pin-unstable"})
+	recorder.Record(Event{Source: SourceGit, Action: ActionFetch, Target: "https://user:secret@example.test/repo.git"})
+
+	events := recorder.Events()
+	if len(events) != 2 {
+		t.Fatalf("Events = %#v, want two events", events)
+	}
+	if got := events[0].Target; got != "argocd/urlvalues" {
+		t.Fatalf("render Target = %q, want application name passed through verbatim", got)
+	}
+	if got := events[1].Target; got != "https://example.test/repo.git" {
+		t.Fatalf("git Target = %q, want redacted URL", got)
+	}
+}
+
 func TestRecorderRedactsErrorTargetVariants(t *testing.T) {
 	recorder := NewRecorder(true)
 	recorder.Record(Event{
@@ -263,6 +280,15 @@ func TestNewAcquisitionErrorRedactsEventAndReturnedMessage(t *testing.T) {
 	}
 	if strings.Contains(events[0].Error, "secret") || strings.Contains(events[0].Error, "abc") {
 		t.Fatalf("Event error = %q leaked credentials", events[0].Error)
+	}
+}
+
+func TestRecordRenderEventErrorKeepsApplicationLabel(t *testing.T) {
+	recorder := NewRecorder(true)
+	recorder.Record(Event{Source: SourceRender, Action: ActionError, Target: "argocd/demo", Error: "render argocd/demo failed"})
+	events := recorder.Events()
+	if len(events) != 1 || events[0].Error != "render argocd/demo failed" {
+		t.Fatalf("render event = %#v, want the namespace/name label preserved in Error", events)
 	}
 }
 

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -9,7 +9,7 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-func newBuildCommand(deps Dependencies) *cobra.Command {
+func newBuildCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Render Applications",
@@ -21,6 +21,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 
 	appsFlags := defaultCommonFlags()
 	appsFlags.parallelism = defaultRenderAppsParallelism()
+	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Render all Applications",
@@ -44,6 +45,7 @@ func newBuildCommand(deps Dependencies) *cobra.Command {
 
 	appFlags := defaultCommonFlags()
 	appFlags.parallelism = defaultRenderAppsParallelism()
+	appFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Render one Application",

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	"github.com/sholdee/drydock/internal/requestopts"
 	"github.com/sholdee/drydock/internal/source"
 	"github.com/spf13/cobra"
@@ -71,6 +72,11 @@ type commonFlags struct {
 	limitBytes               int
 	cacheEvents              bool
 	parallelism              int
+	renderCache              bool
+	renderCacheDir           string
+	renderCacheMaxSize       quantityFlag
+	refreshRenders           bool
+	engineFingerprint        rendercache.EngineFingerprint
 }
 
 func defaultCommonFlags() commonFlags {
@@ -82,6 +88,8 @@ func defaultCommonFlags() commonFlags {
 		unified:            3,
 		limitBytes:         65536,
 		parallelism:        1,
+		renderCache:        true,
+		renderCacheMaxSize: defaultRenderCacheMaxSize(),
 		discoveryMode:      "fleet",
 		maxDiscoveryDepth:  4,
 		projectDiagnostics: string(diagnostic.ProjectDiagnosticsModeActionable),
@@ -101,6 +109,7 @@ func bindCommonFlags(cmd *cobra.Command, flags *commonFlags) {
 	bindOutputFlags(cmd, flags)
 	bindDiagnosticsCacheEventFlags(cmd, flags)
 	bindParallelismFlags(cmd, flags)
+	bindRenderCacheFlags(cmd, flags)
 }
 
 func bindPathDiscoveryFlags(cmd *cobra.Command, flags *commonFlags) {
@@ -305,6 +314,11 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		SkipCRDs:                       flags.skipCRDs,
 		SkipSecrets:                    flags.skipSecrets,
 		RecordCacheEvents:              flags.cacheEvents,
+		RenderCacheEnabled:             flags.renderCache,
+		RenderCacheDir:                 flags.renderCacheDir,
+		RenderCacheMaxBytes:            flags.renderCacheMaxSize.bytes,
+		RefreshRenders:                 flags.refreshRenders,
+		EngineFingerprint:              flags.engineFingerprint,
 	}
 }
 

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -57,9 +57,10 @@ type diagResourceActions struct {
 	MergeBuiltinActions bool                           `json:"mergeBuiltinActions,omitempty" yaml:"mergeBuiltinActions,omitempty"`
 }
 
-func newDiagCommand(deps Dependencies) *cobra.Command {
+func newDiagCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	flags := defaultCommonFlags()
 	flags.parallelism = defaultRenderAppsParallelism()
+	flags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	options := diagCommandOptions{}
 	cmd := &cobra.Command{
 		Use:   "diag",

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -21,7 +21,7 @@ const (
 	diffColorNever  = "never"
 )
 
-func newDiffCommand(deps Dependencies) *cobra.Command {
+func newDiffCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Diff rendered desired manifests",
@@ -31,13 +31,14 @@ func newDiffCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newDiffAppsCommand(deps), newDiffAppCommand(deps), newDiffImagesCommand(deps))
+	cmd.AddCommand(newDiffAppsCommand(info, deps), newDiffAppCommand(info, deps), newDiffImagesCommand(info, deps))
 	return cmd
 }
 
-func newDiffAppsCommand(deps Dependencies) *cobra.Command {
+func newDiffAppsCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	appsFlags := defaultCommonFlags()
 	appsFlags.parallelism = defaultRenderAppsParallelism()
+	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appsColor := diffColorAuto
 	appsMarkdownMaxBytes := report.DefaultMaxBytes
 	appsRawOutputFile := ""
@@ -88,9 +89,10 @@ func newDiffAppsCommand(deps Dependencies) *cobra.Command {
 	return apps
 }
 
-func newDiffAppCommand(deps Dependencies) *cobra.Command {
+func newDiffAppCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	appFlags := defaultCommonFlags()
 	appFlags.parallelism = defaultRenderAppsParallelism()
+	appFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appColor := diffColorAuto
 	appMarkdownMaxBytes := report.DefaultMaxBytes
 	appRawOutputFile := ""
@@ -143,9 +145,10 @@ func newDiffAppCommand(deps Dependencies) *cobra.Command {
 	return appCmd
 }
 
-func newDiffImagesCommand(deps Dependencies) *cobra.Command {
+func newDiffImagesCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	imagesFlags := defaultCommonFlags()
 	imagesFlags.parallelism = defaultRenderAppsParallelism()
+	imagesFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	imagesColor := diffColorAuto
 	imagesMarkdownMaxBytes := report.DefaultMaxBytes
 	images := &cobra.Command{

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func newGetCommand(deps Dependencies) *cobra.Command {
+func newGetCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "List discovered Argo CD objects",
@@ -28,6 +28,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 	appsFlags := defaultCommonFlags()
 	appsFlags.output = string(cliformat.OutputTable)
 	appsFlags.parallelism = defaultRenderAppsParallelism()
+	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "List Applications",
@@ -63,6 +64,7 @@ func newGetCommand(deps Dependencies) *cobra.Command {
 	imagesFlags := defaultCommonFlags()
 	imagesFlags.output = string(cliformat.OutputTable)
 	imagesFlags.parallelism = defaultRenderAppsParallelism()
+	imagesFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "List rendered image references",

--- a/internal/cli/render_cache.go
+++ b/internal/cli/render_cache.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/sholdee/drydock/internal/rendercache"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// quantityFlag parses Kubernetes resource quantities into bytes at flag-parse
+// time so invalid cache caps fail before any render work runs.
+type quantityFlag struct {
+	raw   string
+	bytes int64
+}
+
+func defaultRenderCacheMaxSize() quantityFlag {
+	return quantityFlag{raw: "512Mi", bytes: rendercache.DefaultMaxSizeBytes}
+}
+
+func (q *quantityFlag) Set(value string) error {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return fmt.Errorf("invalid quantity %q: %w", value, err)
+	}
+	bytes := quantity.Value()
+	if bytes <= 0 {
+		return fmt.Errorf("quantity %q must be positive", value)
+	}
+	q.raw = value
+	q.bytes = bytes
+	return nil
+}
+
+func (q *quantityFlag) String() string { return q.raw }
+func (q *quantityFlag) Type() string   { return "quantity" }
+
+func bindRenderCacheFlags(cmd *cobra.Command, flags *commonFlags) {
+	cmd.Flags().BoolVar(&flags.renderCache, "render-cache", flags.renderCache, "reuse persisted Application render outputs across runs")
+	cmd.Flags().StringVar(&flags.renderCacheDir, "render-cache-dir", flags.renderCacheDir, "directory for persisted Application render outputs")
+	cmd.Flags().Var(&flags.renderCacheMaxSize, "render-cache-max-size", "size cap for the persistent render cache before LRU eviction (Kubernetes quantity, e.g. 512Mi)")
+	cmd.Flags().BoolVar(&flags.refreshRenders, "refresh-renders", flags.refreshRenders, "ignore persisted render outputs and overwrite them after rendering")
+}
+
+// engineFingerprintFromVersionInfo derives the module list from build info -
+// the same source main.go used to populate VersionInfo - and overrides only
+// the ldflags-stamped Version and Commit.
+func engineFingerprintFromVersionInfo(info VersionInfo) rendercache.EngineFingerprint {
+	fingerprint := rendercache.FingerprintFromBuildInfo()
+	fingerprint.Version = info.Version
+	fingerprint.Commit = info.Commit
+	if !fingerprint.Known() {
+		if commit, ok := rendercache.VCSCommitFromBuildInfo(); ok {
+			fingerprint.Commit = commit
+		}
+	}
+	return fingerprint
+}

--- a/internal/cli/render_cache_test.go
+++ b/internal/cli/render_cache_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/rendercache"
+)
+
+func executeVersionedCommand(t *testing.T, info VersionInfo, recorder *recordingCLIOrchestrator, args ...string) {
+	t.Helper()
+	cmd := NewRootCommandWithDependencies(info, Dependencies{Orchestrator: recorder})
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, err, stdout.String(), stderr.String())
+	}
+}
+
+func releaseVersionInfo() VersionInfo {
+	return VersionInfo{
+		Version:            "1.2.3",
+		Commit:             "0123456789abcdef0123456789abcdef01234567",
+		ArgoCDModule:       "github.com/argoproj/argo-cd/v3@v3.0.0",
+		GitOpsEngineModule: "github.com/argoproj/argo-cd/gitops-engine@v0.7.0",
+		HelmModule:         "helm.sh/helm/v4@v4.0.0",
+		KustomizeModule:    "sigs.k8s.io/kustomize/api@v0.20.0",
+		JsonnetModule:      "github.com/google/go-jsonnet@v0.21.0",
+		KubernetesModule:   "k8s.io/apimachinery@v0.34.0",
+	}
+}
+
+func TestBuildAppsRenderCacheDefaults(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeVersionedCommand(t, releaseVersionInfo(), recorder, "build", "apps")
+
+	request := recorder.buildRequests[0]
+	if !request.RenderCacheEnabled {
+		t.Fatalf("RenderCacheEnabled = false, want true by default")
+	}
+	if request.RenderCacheDir != "" {
+		t.Fatalf("RenderCacheDir = %q, want empty (store resolves the default)", request.RenderCacheDir)
+	}
+	if request.RenderCacheMaxBytes != rendercache.DefaultMaxSizeBytes {
+		t.Fatalf("RenderCacheMaxBytes = %d, want %d", request.RenderCacheMaxBytes, rendercache.DefaultMaxSizeBytes)
+	}
+	if request.RefreshRenders {
+		t.Fatalf("RefreshRenders = true, want false by default")
+	}
+}
+
+func TestBuildAppsRenderCacheFlags(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeVersionedCommand(t, releaseVersionInfo(), recorder, "build", "apps",
+		"--render-cache=false", "--render-cache-dir", "/tmp/render-cache",
+		"--render-cache-max-size", "1Gi", "--refresh-renders")
+
+	request := recorder.buildRequests[0]
+	if request.RenderCacheEnabled {
+		t.Fatalf("RenderCacheEnabled = true, want false")
+	}
+	if request.RenderCacheDir != "/tmp/render-cache" {
+		t.Fatalf("RenderCacheDir = %q, want /tmp/render-cache", request.RenderCacheDir)
+	}
+	if request.RenderCacheMaxBytes != 1024*1024*1024 {
+		t.Fatalf("RenderCacheMaxBytes = %d, want 1Gi", request.RenderCacheMaxBytes)
+	}
+	if !request.RefreshRenders {
+		t.Fatalf("RefreshRenders = false, want true")
+	}
+}
+
+func TestRenderCacheFlagsOnEveryRenderPathCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		get  func(recorder *recordingCLIOrchestrator) bool
+	}{
+		{"build app", []string{"build", "app", "demo", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.buildAppRequests[0].RefreshRenders }},
+		{"test apps", []string{"test", "apps", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.buildRequests[0].RefreshRenders }},
+		{"test app", []string{"test", "app", "demo", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.buildAppRequests[0].RefreshRenders }},
+		{"diff apps", []string{"diff", "apps", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.diffAppsRequests[0].RefreshRenders }},
+		{"diff app", []string{"diff", "app", "demo", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.diffAppRequests[0].RefreshRenders }},
+		{"diff images", []string{"diff", "images", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.diffImagesRequests[0].RefreshRenders }},
+		{"get apps", []string{"get", "apps", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.listRequests[0].RefreshRenders }},
+		{"get images", []string{"get", "images", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.buildSelectionRequests[0].RefreshRenders }},
+		{"diag", []string{"diag", "--render", "--refresh-renders"}, func(r *recordingCLIOrchestrator) bool { return r.diagRequests[0].RefreshRenders }},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			recorder := &recordingCLIOrchestrator{}
+			executeVersionedCommand(t, releaseVersionInfo(), recorder, testCase.args...)
+			if !testCase.get(recorder) {
+				t.Fatalf("RefreshRenders not threaded for %s", testCase.name)
+			}
+		})
+	}
+}
+
+func TestRenderCacheMaxSizeRejectsInvalidQuantity(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(releaseVersionInfo(), Dependencies{Orchestrator: recorder})
+	cmd.SetArgs([]string{"build", "apps", "--render-cache-max-size", "not-a-quantity"})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want quantity parse error")
+	}
+}
+
+func TestEngineFingerprintFromVersionInfoOverridesVersionAndCommit(t *testing.T) {
+	fingerprint := engineFingerprintFromVersionInfo(VersionInfo{Version: "v9.9.9", Commit: "abc123"})
+	if fingerprint.Version != "v9.9.9" || fingerprint.Commit != "abc123" {
+		t.Fatalf("fingerprint = %#v, want ldflags version/commit override", fingerprint)
+	}
+	buildInfo := rendercache.FingerprintFromBuildInfo()
+	if fingerprint.ArgoCDModule != buildInfo.ArgoCDModule || fingerprint.KustomizeModule != buildInfo.KustomizeModule {
+		t.Fatalf("module labels diverge from FingerprintFromBuildInfo: %#v vs %#v", fingerprint, buildInfo)
+	}
+}
+
+func TestEngineFingerprintFromVersionInfoDevBuild(t *testing.T) {
+	fingerprint := engineFingerprintFromVersionInfo(VersionInfo{Version: "dev", Commit: "none"})
+	if vcs, ok := rendercache.VCSCommitFromBuildInfo(); ok {
+		if fingerprint.Commit != vcs {
+			t.Fatalf("Commit = %q, want VCS fallback %q", fingerprint.Commit, vcs)
+		}
+		return
+	}
+	if fingerprint.Known() {
+		t.Fatalf("Known() = true for dev build without VCS buildinfo")
+	}
+}
+
+func TestBuildAppsThreadsEngineFingerprint(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	executeVersionedCommand(t, releaseVersionInfo(), recorder, "build", "apps")
+
+	fingerprint := recorder.buildRequests[0].EngineFingerprint
+	if fingerprint.Version != "1.2.3" || fingerprint.Commit != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("EngineFingerprint = %#v, want VersionInfo-derived fingerprint", fingerprint)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,12 +56,12 @@ func NewRootCommandWithDependencies(info VersionInfo, deps Dependencies) *cobra.
 		SilenceErrors: true,
 	}
 	bindProfileFlags(cmd, &profileFlags)
-	cmd.AddCommand(newGetCommand(deps))
-	cmd.AddCommand(newBuildCommand(deps))
-	cmd.AddCommand(newTestCommand(deps))
-	cmd.AddCommand(newDiffCommand(deps))
+	cmd.AddCommand(newGetCommand(info, deps))
+	cmd.AddCommand(newBuildCommand(info, deps))
+	cmd.AddCommand(newTestCommand(info, deps))
+	cmd.AddCommand(newDiffCommand(info, deps))
 	cmd.AddCommand(newCacheCommand())
-	cmd.AddCommand(newDiagCommand(deps))
+	cmd.AddCommand(newDiagCommand(info, deps))
 	cmd.AddCommand(newPluginPolicyCommand(deps))
 	cmd.AddCommand(newCompletionCommand())
 	cmd.AddCommand(newVersionCommand(info))

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -16,7 +16,7 @@ import (
 )
 
 //nolint:gocyclo // CLI flag binding and output-mode branching stay together for command readability.
-func newTestCommand(deps Dependencies) *cobra.Command {
+func newTestCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Test whether Applications render",
@@ -29,6 +29,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 	appsFlags := defaultCommonFlags()
 	appsFlags.output = testOutputText
 	appsFlags.parallelism = defaultRenderAppsParallelism()
+	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	apps := &cobra.Command{
 		Use:   "apps",
 		Short: "Test all Applications",
@@ -95,6 +96,7 @@ func newTestCommand(deps Dependencies) *cobra.Command {
 	appFlags := defaultCommonFlags()
 	appFlags.output = testOutputText
 	appFlags.parallelism = defaultRenderAppsParallelism()
+	appFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appCmd := &cobra.Command{
 		Use:   "app NAME",
 		Short: "Test one Application",

--- a/internal/digestpath/digestpath.go
+++ b/internal/digestpath/digestpath.go
@@ -1,0 +1,64 @@
+// Package digestpath holds the canonical path rules shared by the committed
+// (gitref) and filesystem (filedigest) digest schemes. The two schemes are two
+// halves of one persistent render-cache key space: their canonicalization and
+// record framing must stay byte-identical, so both packages call this one.
+package digestpath
+
+import (
+	"fmt"
+	"hash"
+	"path"
+	"strings"
+)
+
+// canonical returns the canonical repository-relative form of value. label
+// names the path family in error text ("git path", "filesystem path").
+// allowEmpty preserves gitref's historical acceptance of "" (which cleans to
+// "."); filedigest rejects empty input.
+func canonical(value, label string, allowEmpty bool) (string, error) {
+	if value == "" && !allowEmpty {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	if strings.Contains(value, "\x00") {
+		return "", fmt.Errorf("%s contains nul", label)
+	}
+	clean := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if clean == "." {
+		return clean, nil
+	}
+	if strings.HasPrefix(clean, "/") || IsWindowsDrivePath(clean) || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("%s %q must be repository-relative", label, value)
+	}
+	return clean, nil
+}
+
+// CanonicalGitPath canonicalizes a committed-digest (gitref) path. Empty
+// input is allowed and cleans to "." (historical gitref behavior).
+func CanonicalGitPath(value string) (string, error) {
+	return canonical(value, "git path", true)
+}
+
+// CanonicalFilesystemPath canonicalizes a filesystem-digest (filedigest)
+// path. Empty input is rejected.
+func CanonicalFilesystemPath(value string) (string, error) {
+	return canonical(value, "filesystem path", false)
+}
+
+// IsWindowsDrivePath reports whether value begins with a drive designator.
+func IsWindowsDrivePath(value string) bool {
+	if len(value) < 2 || value[1] != ':' {
+		return false
+	}
+	drive := value[0]
+	return (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
+}
+
+// WriteRecord frames one digest record: each field NUL-terminated, the record
+// newline-terminated. Both digest schemes use this exact framing.
+func WriteRecord(digest hash.Hash, fields ...string) {
+	for _, field := range fields {
+		_, _ = digest.Write([]byte(field))
+		_, _ = digest.Write([]byte{0})
+	}
+	_, _ = digest.Write([]byte{'\n'})
+}

--- a/internal/digestpath/digestpath_test.go
+++ b/internal/digestpath/digestpath_test.go
@@ -1,0 +1,61 @@
+package digestpath
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestCanonicalVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		git     bool
+		want    string
+		wantErr bool
+	}{
+		{name: "plain", value: "a/b", want: "a/b"},
+		{name: "backslashes", value: `a\b`, want: "a/b"},
+		{name: "redundant", value: "a/./b/../c", want: "a/c"},
+		{name: "dot", value: ".", want: "."},
+		{name: "empty-git-allowed", value: "", git: true, want: "."},
+		{name: "empty-filesystem-rejected", value: "", wantErr: true},
+		{name: "nul", value: "a\x00b", wantErr: true},
+		{name: "absolute", value: "/etc", wantErr: true},
+		{name: "parent", value: "../x", wantErr: true},
+		{name: "parent-exact", value: "..", wantErr: true},
+		{name: "drive", value: `C:\x`, wantErr: true},
+		{name: "lowercase-drive", value: `c:\x`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			canonicalize := CanonicalFilesystemPath
+			if tc.git {
+				canonicalize = CanonicalGitPath
+			}
+			got, err := canonicalize(tc.value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("canonicalize(%q) = %q, want error", tc.value, got)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("canonicalize(%q) = %q, %v, want %q", tc.value, got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteRecordFraming(t *testing.T) {
+	digest := sha256.New()
+	WriteRecord(digest, "path", "a/b", "present")
+	got := hex.EncodeToString(digest.Sum(nil))
+
+	manual := sha256.New()
+	manual.Write([]byte("path\x00a/b\x00present\x00\n"))
+	want := hex.EncodeToString(manual.Sum(nil))
+	if got != want {
+		t.Fatalf("WriteRecord framing = %s, want %s", got, want)
+	}
+}

--- a/internal/filedigest/path_digest.go
+++ b/internal/filedigest/path_digest.go
@@ -1,0 +1,422 @@
+package filedigest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/sholdee/drydock/internal/digestpath"
+	"github.com/sholdee/drydock/internal/pathsafety"
+)
+
+// ContentDigestCache memoizes per-file content digests for one run. It is
+// safe for concurrent use. Callers own staleness: a run-scoped cache assumes
+// worktree content is stable for the run — the same contract as the path-set
+// memoization layered above it. Verification recomputes MUST pass a nil
+// cache so they re-read disk.
+type ContentDigestCache struct {
+	mu      sync.Mutex
+	digests map[string]string
+}
+
+func NewContentDigestCache() *ContentDigestCache {
+	return &ContentDigestCache{digests: map[string]string{}}
+}
+
+func (c *ContentDigestCache) lookup(path string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	digest, ok := c.digests[path]
+	return digest, ok
+}
+
+func (c *ContentDigestCache) record(path, digest string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.digests[path] = digest
+}
+
+type PathDigestInput struct {
+	RepoRoot       string
+	Paths          []PathDigestPath
+	ForbiddenRoots []string
+	ContentCache   *ContentDigestCache
+}
+
+type PathDigestPath struct {
+	Path       string
+	Optional   bool
+	MarkerKind string
+}
+
+type PathDigestResult struct {
+	Digest string
+}
+
+const pathDigestVersion = "drydock.filedigest.path-digest.v1"
+
+// PathDigest returns a stable digest for repository-relative filesystem inputs.
+// It reads the working tree as drydock renderers see it: untracked and ignored
+// files under requested directories are included, while symlinks and special
+// files are rejected so callers can fail closed.
+func PathDigest(ctx context.Context, input PathDigestInput) (PathDigestResult, error) {
+	if err := ctx.Err(); err != nil {
+		return PathDigestResult{}, err
+	}
+	root, forbiddenRoots, err := normalizeDigestRoot(input.RepoRoot, input.ForbiddenRoots)
+	if err != nil {
+		return PathDigestResult{}, err
+	}
+	paths, err := normalizePathDigestInputs(ctx, input.Paths)
+	if err != nil {
+		return PathDigestResult{}, err
+	}
+
+	digest := sha256.New()
+	writePathDigestRecord(digest, "version", pathDigestVersion)
+	for _, requested := range paths {
+		if err := ctx.Err(); err != nil {
+			return PathDigestResult{}, err
+		}
+		if requested.markerKind != "" {
+			writePathDigestRecord(digest, "marker", requested.path, requested.markerKind, optionalRecordValue(requested.optional))
+			continue
+		}
+		if err := writeFilesystemPathDigestEntry(ctx, digest, root, forbiddenRoots, requested, input.ContentCache); err != nil {
+			return PathDigestResult{}, fmt.Errorf("digest filesystem path %q: %w", requested.path, err)
+		}
+	}
+
+	return PathDigestResult{Digest: hex.EncodeToString(digest.Sum(nil))}, nil
+}
+
+type normalizedPathDigestPath struct {
+	path       string
+	optional   bool
+	markerKind string
+}
+
+func normalizePathDigestInputs(ctx context.Context, requested []PathDigestPath) ([]normalizedPathDigestPath, error) {
+	type pathKey struct {
+		path       string
+		markerKind string
+	}
+	byPath := make(map[pathKey]bool, len(requested))
+	for _, item := range requested {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		clean, err := canonicalPathDigestPath(item.Path)
+		if err != nil {
+			return nil, err
+		}
+		if strings.Contains(item.MarkerKind, "\x00") {
+			return nil, fmt.Errorf("marker kind contains nul")
+		}
+		key := pathKey{path: clean, markerKind: item.MarkerKind}
+		if optional, ok := byPath[key]; ok {
+			byPath[key] = optional && item.Optional
+			continue
+		}
+		byPath[key] = item.Optional
+	}
+
+	paths := make([]normalizedPathDigestPath, 0, len(byPath))
+	for key, optional := range byPath {
+		paths = append(paths, normalizedPathDigestPath{
+			path:       key.path,
+			optional:   optional,
+			markerKind: key.markerKind,
+		})
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].path == paths[j].path {
+			return paths[i].markerKind < paths[j].markerKind
+		}
+		return paths[i].path < paths[j].path
+	})
+	return paths, nil
+}
+
+func canonicalPathDigestPath(value string) (string, error) {
+	return digestpath.CanonicalFilesystemPath(value)
+}
+
+func normalizeDigestRoot(repoRoot string, forbiddenRoots []string) (string, []string, error) {
+	if strings.TrimSpace(repoRoot) == "" {
+		return "", nil, fmt.Errorf("repository root must not be empty")
+	}
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	resolvedRoot, err := pathsafety.ResolveForContainment(absRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve repository root containment: %w", err)
+	}
+	info, err := os.Stat(resolvedRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("stat repository root: %w", err)
+	}
+	if !info.IsDir() {
+		return "", nil, fmt.Errorf("repository root is not a directory")
+	}
+
+	normalizedForbidden := make([]string, 0, len(forbiddenRoots))
+	for _, root := range forbiddenRoots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		absForbidden, err := filepath.Abs(root)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve forbidden root %q: %w", root, err)
+		}
+		resolvedForbidden, err := pathsafety.ResolveForContainment(absForbidden)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve forbidden root %q containment: %w", root, err)
+		}
+		forbiddenInsideRoot, err := pathInsideRoot(resolvedForbidden, resolvedRoot)
+		if err != nil {
+			return "", nil, err
+		}
+		rootInsideForbidden, err := pathInsideRoot(resolvedRoot, resolvedForbidden)
+		if err != nil {
+			return "", nil, err
+		}
+		if forbiddenInsideRoot || rootInsideForbidden {
+			normalizedForbidden = append(normalizedForbidden, resolvedForbidden)
+		}
+	}
+	sort.Strings(normalizedForbidden)
+	return resolvedRoot, normalizedForbidden, nil
+}
+
+func writeFilesystemPathDigestEntry(ctx context.Context, digest hash.Hash, repoRoot string, forbiddenRoots []string, requested normalizedPathDigestPath, cache *ContentDigestCache) error {
+	fullPath, info, missing, err := resolveRequestedPath(repoRoot, forbiddenRoots, requested.path, requested.optional)
+	if err != nil {
+		return err
+	}
+	if missing {
+		writePathDigestRecord(digest, "path", requested.path, "missing", "optional")
+		return nil
+	}
+	return writeExistingFilesystemEntry(ctx, digest, requested.path, fullPath, info, forbiddenRoots, cache)
+}
+
+func resolveRequestedPath(repoRoot string, forbiddenRoots []string, relPath string, optional bool) (string, os.FileInfo, bool, error) {
+	if relPath == "." {
+		if err := rejectForbiddenPath(repoRoot, forbiddenRoots); err != nil {
+			return "", nil, false, err
+		}
+		info, err := os.Lstat(repoRoot)
+		if err != nil {
+			return "", nil, false, fmt.Errorf("stat path: %w", err)
+		}
+		return repoRoot, info, false, nil
+	}
+
+	components := strings.Split(relPath, "/")
+	current := repoRoot
+	for i, component := range components {
+		current = filepath.Join(current, component)
+		if err := rejectForbiddenPath(current, forbiddenRoots); err != nil {
+			return "", nil, false, err
+		}
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if optional {
+					return filesystemPath(repoRoot, relPath), nil, true, nil
+				}
+				return "", nil, false, fmt.Errorf("required path is missing")
+			}
+			return "", nil, false, fmt.Errorf("stat path: %w", err)
+		}
+		if component == ".git" {
+			return "", nil, false, fmt.Errorf("unsupported .git path")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", nil, false, fmt.Errorf("unsupported symlink")
+		}
+		if i < len(components)-1 && !info.IsDir() {
+			return "", nil, false, fmt.Errorf("path component %q is not a directory", path.Join(components[:i+1]...))
+		}
+		if i == len(components)-1 {
+			return current, info, false, nil
+		}
+	}
+	return filesystemPath(repoRoot, relPath), nil, true, nil
+}
+
+func writeExistingFilesystemEntry(ctx context.Context, digest hash.Hash, relPath, fullPath string, info os.FileInfo, forbiddenRoots []string, cache *ContentDigestCache) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if info.Name() == ".git" {
+		return fmt.Errorf("unsupported .git path")
+	}
+	if err := rejectForbiddenPath(fullPath, forbiddenRoots); err != nil {
+		return err
+	}
+	mode := info.Mode()
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return fmt.Errorf("unsupported symlink")
+	case mode.IsDir():
+		return writeDirectoryDigestEntry(ctx, digest, relPath, fullPath, forbiddenRoots, cache)
+	case mode.IsRegular():
+		return writeRegularFileDigestEntry(ctx, digest, relPath, fullPath, mode, cache)
+	default:
+		return fmt.Errorf("unsupported filesystem mode %s", mode.String())
+	}
+}
+
+func writeDirectoryDigestEntry(ctx context.Context, digest hash.Hash, relPath, fullPath string, forbiddenRoots []string, cache *ContentDigestCache) error {
+	writePathDigestRecord(digest, "path", relPath, "present", "directory")
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		return fmt.Errorf("read directory: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		if err := writeDirectoryChildDigestEntry(ctx, digest, relPath, fullPath, entry, forbiddenRoots, cache); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDirectoryChildDigestEntry(ctx context.Context, digest hash.Hash, relPath, fullPath string, entry os.DirEntry, forbiddenRoots []string, cache *ContentDigestCache) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if entry.Name() == ".git" {
+		return fmt.Errorf("unsupported .git path")
+	}
+	childRel := path.Join(relPath, entry.Name())
+	if relPath == "." {
+		childRel = entry.Name()
+	}
+	childPath := filepath.Join(fullPath, entry.Name())
+	if err := rejectForbiddenPath(childPath, forbiddenRoots); err != nil {
+		return err
+	}
+	childInfo, err := entry.Info()
+	if err != nil {
+		return fmt.Errorf("stat child %q: %w", childRel, err)
+	}
+	if err := writeExistingFilesystemEntry(ctx, digest, childRel, childPath, childInfo, forbiddenRoots, cache); err != nil {
+		return fmt.Errorf("%s: %w", childRel, err)
+	}
+	return nil
+}
+
+func writeRegularFileDigestEntry(ctx context.Context, digest hash.Hash, relPath, fullPath string, mode os.FileMode, cache *ContentDigestCache) error {
+	contentDigest, ok := cache.lookup(fullPath)
+	if !ok {
+		computed, err := fileContentDigest(ctx, fullPath)
+		if err != nil {
+			return err
+		}
+		contentDigest = computed
+		cache.record(fullPath, contentDigest)
+	}
+	writePathDigestRecord(digest, "path", relPath, "present", modeClass(mode), "sha256", contentDigest)
+	return nil
+}
+
+func fileContentDigest(ctx context.Context, filename string) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", fmt.Errorf("read file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	digest := sha256.New()
+	buffer := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		n, readErr := file.Read(buffer)
+		if n > 0 {
+			if _, err := digest.Write(buffer[:n]); err != nil {
+				return "", err
+			}
+		}
+		if readErr == nil {
+			continue
+		}
+		if readErr == io.EOF {
+			break
+		}
+		return "", fmt.Errorf("read file: %w", readErr)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func filesystemPath(repoRoot, relPath string) string {
+	if relPath == "." {
+		return repoRoot
+	}
+	return filepath.Join(repoRoot, filepath.FromSlash(relPath))
+}
+
+func rejectForbiddenPath(target string, forbiddenRoots []string) error {
+	if len(forbiddenRoots) == 0 {
+		return nil
+	}
+	cleanTarget := filepath.Clean(target)
+	for _, root := range forbiddenRoots {
+		inside, err := pathInsideRoot(cleanTarget, root)
+		if err != nil {
+			return err
+		}
+		if inside {
+			return fmt.Errorf("path is inside forbidden root %q", root)
+		}
+	}
+	return nil
+}
+
+func pathInsideRoot(target, root string) (bool, error) {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false, err
+	}
+	return !pathsafety.RelEscapes(rel), nil
+}
+
+func modeClass(mode os.FileMode) string {
+	if mode&0o111 != 0 {
+		return "executable"
+	}
+	return "regular"
+}
+
+func optionalRecordValue(optional bool) string {
+	if optional {
+		return "optional"
+	}
+	return "required"
+}
+
+func writePathDigestRecord(digest hash.Hash, fields ...string) {
+	digestpath.WriteRecord(digest, fields...)
+}

--- a/internal/filedigest/path_digest_test.go
+++ b/internal/filedigest/path_digest_test.go
@@ -1,0 +1,409 @@
+package filedigest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPathDigestFileContentChangesRotateDigest(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/values.yaml", "replicas: 1\n")
+
+	first := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/values.yaml"}})
+	writeDigestFile(t, root, "apps/demo/values.yaml", "replicas: 2\n")
+	changed := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/values.yaml"}})
+
+	if changed.Digest == first.Digest {
+		t.Fatalf("PathDigest() digest did not change after file content changed")
+	}
+}
+
+func TestPathDigestDirectoryContentAndMembershipChangesRotateDigest(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/a.yaml", "a: 1\n")
+	writeDigestFile(t, root, "apps/other/a.yaml", "a: 1\n")
+
+	first := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+
+	writeDigestFile(t, root, "apps/other/a.yaml", "a: 2\n")
+	unrelated := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+	if unrelated.Digest != first.Digest {
+		t.Fatalf("PathDigest() digest changed after unrelated directory edit: got %q, want %q", unrelated.Digest, first.Digest)
+	}
+
+	writeDigestFile(t, root, "apps/demo/a.yaml", "a: 2\n")
+	contentChanged := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+	if contentChanged.Digest == first.Digest {
+		t.Fatalf("PathDigest() digest did not change after child file content changed")
+	}
+
+	writeDigestFile(t, root, "apps/demo/b.yaml", "b: 1\n")
+	membershipChanged := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+	if membershipChanged.Digest == contentChanged.Digest {
+		t.Fatalf("PathDigest() digest did not change after directory membership changed")
+	}
+}
+
+func TestPathDigestIncludesUntrackedAndIgnoredLikeFiles(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+	writeDigestFile(t, root, "apps/demo/.gitignore", "*.tmp\n")
+
+	first := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+	writeDigestFile(t, root, "apps/demo/local.tmp", "ignored by convention, still render-visible\n")
+	ignoredLike := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo"}})
+
+	if ignoredLike.Digest == first.Digest {
+		t.Fatalf("PathDigest() digest did not change after ignored-like file was added")
+	}
+}
+
+func TestPathDigestRequiredMissingErrorsAndOptionalMissingRotatesOnAdd(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo/missing.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() error = nil, want required missing error")
+	}
+	if !strings.Contains(err.Error(), "required path is missing") {
+		t.Fatalf("PathDigest() error = %q, want required missing message", err)
+	}
+
+	missing := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/values.yaml", Optional: true}})
+	writeDigestFile(t, root, "apps/demo/values.yaml", "replicas: 1\n")
+	added := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/values.yaml", Optional: true}})
+	if added.Digest == missing.Digest {
+		t.Fatalf("PathDigest() digest did not change when optional missing path became present")
+	}
+
+	if err := os.Remove(filepath.Join(root, "apps", "demo", "values.yaml")); err != nil {
+		t.Fatalf("Remove(values.yaml) error = %v", err)
+	}
+	deleted := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/values.yaml", Optional: true}})
+	if deleted.Digest != missing.Digest {
+		t.Fatalf("PathDigest() optional missing digest after delete = %q, want original %q", deleted.Digest, missing.Digest)
+	}
+}
+
+func TestPathDigestSyntheticMarkerDoesNotStatFilesystem(t *testing.T) {
+	root := t.TempDir()
+
+	first := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/*.values.yaml", MarkerKind: "missing-glob"}})
+	second := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/*.values.yaml", MarkerKind: "missing-glob"}})
+	if second.Digest != first.Digest {
+		t.Fatalf("PathDigest() synthetic marker digest = %q, want stable %q", second.Digest, first.Digest)
+	}
+
+	changed := pathDigestForTest(t, root, []PathDigestPath{{Path: "apps/demo/*.values.yaml", MarkerKind: "missing-optional-glob"}})
+	if changed.Digest == first.Digest {
+		t.Fatalf("PathDigest() digest did not change after marker kind changed")
+	}
+}
+
+func TestPathDigestSortsDeduplicatesAndRequiredWins(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/a.yaml", "a: 1\n")
+	writeDigestFile(t, root, "apps/demo/b.yaml", "b: 1\n")
+
+	normalized := pathDigestForTest(t, root, []PathDigestPath{
+		{Path: "apps/demo/a.yaml"},
+		{Path: "apps/demo/b.yaml"},
+	})
+	unsortedDuplicate := pathDigestForTest(t, root, []PathDigestPath{
+		{Path: `apps\demo\.\b.yaml`},
+		{Path: "apps/demo/a.yaml"},
+		{Path: "apps/demo/b.yaml", Optional: true},
+	})
+	if unsortedDuplicate.Digest != normalized.Digest {
+		t.Fatalf("PathDigest() digest = %q, want normalized digest %q", unsortedDuplicate.Digest, normalized.Digest)
+	}
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths: []PathDigestPath{
+			{Path: "apps/demo/missing.yaml", Optional: true},
+			{Path: "apps/demo/missing.yaml"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() error = nil, want required duplicate to win")
+	}
+}
+
+func TestPathDigestExecutableModeClassRotatesDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not provide a stable executable mode bit")
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, "scripts", "render.sh")
+	writeDigestFile(t, root, "scripts/render.sh", "#!/bin/sh\n")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod(0644) error = %v", err)
+	}
+	regular := pathDigestForTest(t, root, []PathDigestPath{{Path: "scripts/render.sh"}})
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("Chmod(0755) error = %v", err)
+	}
+	executable := pathDigestForTest(t, root, []PathDigestPath{{Path: "scripts/render.sh"}})
+
+	if executable.Digest == regular.Digest {
+		t.Fatalf("PathDigest() digest did not change after executable bit changed")
+	}
+}
+
+func TestPathDigestRejectsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "target.yaml", "kind: ConfigMap\n")
+	if err := os.Symlink("target.yaml", filepath.Join(root, "linked.yaml")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "linked.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() symlink path error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("PathDigest() symlink path error = %q, want symlink rejection", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, "real-dir"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(real-dir) error = %v", err)
+	}
+	writeDigestFile(t, root, "real-dir/cm.yaml", "kind: ConfigMap\n")
+	if err := os.Symlink("real-dir", filepath.Join(root, "linked-dir")); err != nil {
+		t.Fatalf("Symlink(linked-dir) error = %v", err)
+	}
+	_, err = PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "linked-dir/cm.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() symlink component error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("PathDigest() symlink component error = %q, want symlink rejection", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, "apps", "demo"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(apps/demo) error = %v", err)
+	}
+	if err := os.Symlink("../../target.yaml", filepath.Join(root, "apps", "demo", "linked.yaml")); err != nil {
+		t.Fatalf("Symlink(nested) error = %v", err)
+	}
+	_, err = PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() nested symlink error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("PathDigest() nested symlink error = %q, want symlink rejection", err)
+	}
+}
+
+func TestPathDigestRejectsGitDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/.git/config", "[core]\n")
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() .git error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), ".git") {
+		t.Fatalf("PathDigest() .git error = %q, want .git rejection", err)
+	}
+}
+
+func TestPathDigestRejectsForbiddenRoots(t *testing.T) {
+	root := t.TempDir()
+	forbidden := filepath.Join(root, ".drydock-cache")
+	writeDigestFile(t, root, ".drydock-cache/render.db", "cache\n")
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot:       root,
+		ForbiddenRoots: []string{forbidden},
+		Paths:          []PathDigestPath{{Path: ".drydock-cache"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() forbidden root error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "forbidden root") {
+		t.Fatalf("PathDigest() forbidden root error = %q, want forbidden root rejection", err)
+	}
+
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	repoInsideCache := filepath.Join(cacheRoot, "repo")
+	writeDigestFile(t, repoInsideCache, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+	_, err = PathDigest(t.Context(), PathDigestInput{
+		RepoRoot:       repoInsideCache,
+		ForbiddenRoots: []string{cacheRoot},
+		Paths:          []PathDigestPath{{Path: "apps/demo/cm.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() forbidden ancestor error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "forbidden root") {
+		t.Fatalf("PathDigest() forbidden ancestor error = %q, want forbidden root rejection", err)
+	}
+}
+
+func TestPathDigestRejectsInvalidPaths(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	for _, testCase := range []struct {
+		name string
+		path string
+	}{
+		{name: "empty", path: ""},
+		{name: "posix absolute", path: "/apps/demo/cm.yaml"},
+		{name: "windows absolute slash", path: `C:/repo/apps/demo/cm.yaml`},
+		{name: "windows absolute backslash", path: `C:\repo\apps\demo\cm.yaml`},
+		{name: "windows drive relative", path: `C:apps\demo\cm.yaml`},
+		{name: "parent escape", path: "../apps/demo/cm.yaml"},
+		{name: "cleaned parent escape", path: "apps/../../demo/cm.yaml"},
+		{name: "nul", path: "apps/demo/cm.yaml\x00other"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := PathDigest(t.Context(), PathDigestInput{
+				RepoRoot: root,
+				Paths:    []PathDigestPath{{Path: testCase.path, Optional: true}},
+			})
+			if err == nil {
+				t.Fatalf("PathDigest() error = nil, want invalid path error")
+			}
+			if !strings.Contains(err.Error(), "path") {
+				t.Fatalf("PathDigest() error = %q, want path error", err)
+			}
+		})
+	}
+}
+
+func TestPathDigestCanceledContext(t *testing.T) {
+	root := t.TempDir()
+	writeDigestFile(t, root, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := PathDigest(ctx, PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo/cm.yaml"}},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PathDigest() error = %v, want context.Canceled", err)
+	}
+	if result != (PathDigestResult{}) {
+		t.Fatalf("PathDigest() result = %#v, want zero result", result)
+	}
+}
+
+func BenchmarkPathDigestDirectoryTree(b *testing.B) {
+	root := b.TempDir()
+	for dir := range 20 {
+		for file := range 25 {
+			writeDigestFile(b, root, filepath.ToSlash(filepath.Join("apps", "demo", "dir-"+string(rune('a'+dir)), "file-"+string(rune('a'+file))+".yaml")), strings.Repeat("kind: ConfigMap\n", 8))
+		}
+	}
+
+	ctx := context.Background()
+	input := PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo"}},
+	}
+	b.ResetTimer()
+	for range b.N {
+		if _, err := PathDigest(ctx, input); err != nil {
+			b.Fatalf("PathDigest() error = %v", err)
+		}
+	}
+}
+
+func TestPathDigestContentCacheByteIdentityAndReuse(t *testing.T) {
+	repoRoot := t.TempDir()
+	target := filepath.Join(repoRoot, "manifests", "demo", "cm.yaml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("a: 1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	paths := []PathDigestPath{{Path: "manifests/demo"}}
+	cache := NewContentDigestCache()
+
+	cached, err := PathDigest(context.Background(), PathDigestInput{RepoRoot: repoRoot, Paths: paths, ContentCache: cache})
+	if err != nil {
+		t.Fatalf("PathDigest(cache) error = %v", err)
+	}
+	uncached, err := PathDigest(context.Background(), PathDigestInput{RepoRoot: repoRoot, Paths: paths})
+	if err != nil {
+		t.Fatalf("PathDigest(nil) error = %v", err)
+	}
+	if cached.Digest != uncached.Digest {
+		t.Fatalf("cache must not change digest values: %s != %s", cached.Digest, uncached.Digest)
+	}
+
+	// The cache is run-scoped: a content edit is invisible through the same
+	// cache instance (callers own staleness) but visible without it.
+	if err := os.WriteFile(target, []byte("a: 2\n"), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	stale, err := PathDigest(context.Background(), PathDigestInput{RepoRoot: repoRoot, Paths: paths, ContentCache: cache})
+	if err != nil {
+		t.Fatalf("PathDigest(warm cache) error = %v", err)
+	}
+	if stale.Digest != cached.Digest {
+		t.Fatalf("warm cache digest = %s, want the cached value %s (proves the cache is consulted)", stale.Digest, cached.Digest)
+	}
+	fresh, err := PathDigest(context.Background(), PathDigestInput{RepoRoot: repoRoot, Paths: paths})
+	if err != nil {
+		t.Fatalf("PathDigest(nil, post-edit) error = %v", err)
+	}
+	if fresh.Digest == cached.Digest {
+		t.Fatalf("nil-cache digest must see the edit")
+	}
+}
+
+func pathDigestForTest(t *testing.T, root string, paths []PathDigestPath) PathDigestResult {
+	t.Helper()
+	result, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    paths,
+	})
+	if err != nil {
+		t.Fatalf("PathDigest() error = %v", err)
+	}
+	return result
+}
+
+type testingWriter interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+func writeDigestFile(t testingWriter, root, name, content string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(target), err)
+	}
+	if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", target, err)
+	}
+}

--- a/internal/filedigest/path_digest_unix_test.go
+++ b/internal/filedigest/path_digest_unix_test.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux
+
+package filedigest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestPathDigestRejectsSpecialFileModes(t *testing.T) {
+	root := t.TempDir()
+	fifo := filepath.Join(root, "apps", "demo", "fifo")
+	if err := os.MkdirAll(filepath.Dir(fifo), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(fifo), err)
+	}
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	_, err := PathDigest(t.Context(), PathDigestInput{
+		RepoRoot: root,
+		Paths:    []PathDigestPath{{Path: "apps/demo/fifo"}},
+	})
+	if err == nil {
+		t.Fatalf("PathDigest() special file error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "unsupported filesystem mode") {
+		t.Fatalf("PathDigest() special file error = %q, want unsupported mode rejection", err)
+	}
+}

--- a/internal/gitref/changes.go
+++ b/internal/gitref/changes.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/utils/merkletrie"
 	"github.com/sholdee/drydock/internal/source"
-	"github.com/sholdee/drydock/internal/streamcmp"
 )
 
 func ChangedPathsBetweenRefs(ctx context.Context, repoPath, leftRef, rightRef string) ([]string, error) {
@@ -223,6 +226,14 @@ func worktreeFileChanged(root string, file *object.File) (bool, error) {
 	if errors.Is(err, os.ErrNotExist) {
 		return true, nil
 	}
+	// ENOTDIR fires when a path component that was a directory in HEAD has been
+	// replaced by a regular file in the worktree. The tracked file is
+	// unquestionably gone; the replacing file is caught as an extra by the
+	// walk in addWorktreeExtraFiles. Treat it as changed rather than hard-failing
+	// the whole scan (errors.Is(syscall.ENOTDIR, os.ErrNotExist) is false in Go).
+	if errors.Is(err, syscall.ENOTDIR) {
+		return true, nil
+	}
 	if err != nil {
 		return false, err
 	}
@@ -257,24 +268,41 @@ func regularWorktreeFileChanged(path string, file *object.File) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if regularWorktreeModeChanged(info.Mode(), file.Mode) {
+		return true, nil
+	}
 	if info.Size() != file.Size {
 		return true, nil
 	}
-	reader, err := file.Reader()
-	if err != nil {
-		return false, err
-	}
-	defer reader.Close()
+	// Hash the worktree file with git's blob framing and compare against the
+	// known blob hash: exact equality without decompressing the blob.
 	worktreeFile, err := os.Open(path)
 	if err != nil {
 		return false, err
 	}
 	defer worktreeFile.Close()
-	equal, err := streamcmp.Equal(worktreeFile, reader)
-	if err != nil {
+	hasher := plumbing.NewHasher(plumbing.BlobObject, info.Size())
+	if _, err := io.Copy(hasher, worktreeFile); err != nil {
 		return false, err
 	}
-	return !equal, nil
+	return hasher.Sum() != file.Hash, nil
+}
+
+func regularWorktreeModeChanged(worktreeMode os.FileMode, gitMode filemode.FileMode) bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	executable := worktreeMode&0o111 != 0
+	switch comparableGitFileMode(gitMode) {
+	case filemode.Regular, filemode.Deprecated:
+		return executable
+	case filemode.Executable:
+		return !executable
+	case filemode.Empty, filemode.Dir, filemode.Symlink, filemode.Submodule:
+		return true
+	default:
+		return true
+	}
 }
 
 func stringSet(values []string) map[string]struct{} {

--- a/internal/gitref/path_digest.go
+++ b/internal/gitref/path_digest.go
@@ -1,0 +1,199 @@
+package gitref
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/digestpath"
+	"github.com/sholdee/drydock/internal/source"
+)
+
+type PathDigestInput struct {
+	RepoPath string
+	Revision string
+	Paths    []PathDigestPath
+}
+
+type PathDigestPath struct {
+	Path     string
+	Optional bool
+}
+
+type PathDigestResult struct {
+	Digest   string
+	Revision string
+}
+
+const committedPathDigestVersion = "drydock.gitref.committed-path-digest.v1"
+
+// CommittedPathDigest returns a stable digest for repository-relative paths in
+// a committed Git tree. It reads Git object identity only, not worktree files.
+func CommittedPathDigest(ctx context.Context, input PathDigestInput) (PathDigestResult, error) {
+	if err := ctx.Err(); err != nil {
+		return PathDigestResult{}, err
+	}
+	ref := strings.TrimSpace(input.Revision)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	paths, err := normalizePathDigestPaths(ctx, input.Paths)
+	if err != nil {
+		return PathDigestResult{}, err
+	}
+
+	repo, displayRepoPath, err := openLocalRepository(input.RepoPath)
+	if err != nil {
+		return PathDigestResult{}, err
+	}
+	hash, err := source.ResolveGitRevision(repo, ref)
+	if err != nil {
+		return PathDigestResult{}, fmt.Errorf("resolve Git ref %q in %q: %w", ref, displayRepoPath, err)
+	}
+	commit, err := repo.CommitObject(*hash)
+	if err != nil {
+		return PathDigestResult{}, fmt.Errorf("load Git commit %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return PathDigestResult{}, fmt.Errorf("load Git tree for %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return PathDigestResult{}, err
+	}
+
+	digest := sha256.New()
+	writePathDigestRecord(digest, "version", committedPathDigestVersion)
+	for _, requested := range paths {
+		if err := ctx.Err(); err != nil {
+			return PathDigestResult{}, err
+		}
+		if err := writeCommittedPathDigestEntry(ctx, digest, tree, requested); err != nil {
+			return PathDigestResult{}, fmt.Errorf("digest Git path %q at %s: %w", requested.path, hash.String(), err)
+		}
+	}
+
+	return PathDigestResult{
+		Digest:   hex.EncodeToString(digest.Sum(nil)),
+		Revision: hash.String(),
+	}, nil
+}
+
+type normalizedPathDigestPath struct {
+	path     string
+	optional bool
+}
+
+func normalizePathDigestPaths(ctx context.Context, requested []PathDigestPath) ([]normalizedPathDigestPath, error) {
+	byPath := make(map[string]bool, len(requested))
+	for _, item := range requested {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		clean, err := canonicalPathDigestPath(item.Path)
+		if err != nil {
+			return nil, err
+		}
+		if optional, ok := byPath[clean]; ok {
+			byPath[clean] = optional && item.Optional
+			continue
+		}
+		byPath[clean] = item.Optional
+	}
+
+	paths := make([]normalizedPathDigestPath, 0, len(byPath))
+	for clean, optional := range byPath {
+		paths = append(paths, normalizedPathDigestPath{path: clean, optional: optional})
+	}
+	sort.Slice(paths, func(i, j int) bool { return paths[i].path < paths[j].path })
+	return paths, nil
+}
+
+func canonicalPathDigestPath(value string) (string, error) {
+	return digestpath.CanonicalGitPath(value)
+}
+
+func writeCommittedPathDigestEntry(ctx context.Context, digest hash.Hash, tree *object.Tree, requested normalizedPathDigestPath) error {
+	if requested.path == "." {
+		if err := rejectSubmodulesInDigestTree(ctx, requested.path, tree); err != nil {
+			return err
+		}
+		writePathDigestRecord(digest, "path", requested.path, "present", filemode.Dir.String(), "tree", tree.Hash.String())
+		return nil
+	}
+
+	entry, err := tree.FindEntry(requested.path)
+	if err != nil {
+		if !pathDigestEntryMissing(err) {
+			return err
+		}
+		if !requested.optional {
+			return fmt.Errorf("required Git path is missing")
+		}
+		writePathDigestRecord(digest, "path", requested.path, "missing")
+		return nil
+	}
+
+	switch entry.Mode {
+	case filemode.Dir:
+		subtree, err := tree.Tree(requested.path)
+		if err != nil {
+			return err
+		}
+		if err := rejectSubmodulesInDigestTree(ctx, requested.path, subtree); err != nil {
+			return err
+		}
+		writePathDigestRecord(digest, "path", requested.path, "present", entry.Mode.String(), "tree", entry.Hash.String())
+	case filemode.Regular, filemode.Deprecated, filemode.Executable, filemode.Symlink:
+		writePathDigestRecord(digest, "path", requested.path, "present", entry.Mode.String(), "blob", entry.Hash.String())
+	case filemode.Submodule:
+		return fmt.Errorf("unsupported gitlink/submodule")
+	case filemode.Empty:
+		return fmt.Errorf("unsupported empty git tree file mode")
+	default:
+		return fmt.Errorf("unsupported git tree file mode %s", entry.Mode)
+	}
+	return nil
+}
+
+func pathDigestEntryMissing(err error) bool {
+	return errors.Is(err, object.ErrEntryNotFound) || errors.Is(err, object.ErrDirectoryNotFound)
+}
+
+func rejectSubmodulesInDigestTree(ctx context.Context, base string, tree *object.Tree) error {
+	for _, entry := range tree.Entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entryPath := entry.Name
+		if base != "." {
+			entryPath = path.Join(base, entry.Name)
+		}
+		switch entry.Mode {
+		case filemode.Submodule:
+			return fmt.Errorf("unsupported gitlink/submodule at %q", entryPath)
+		case filemode.Dir:
+			subtree, err := tree.Tree(entry.Name)
+			if err != nil {
+				return err
+			}
+			if err := rejectSubmodulesInDigestTree(ctx, entryPath, subtree); err != nil {
+				return err
+			}
+		case filemode.Empty, filemode.Regular, filemode.Deprecated, filemode.Executable, filemode.Symlink:
+		}
+	}
+	return nil
+}
+
+func writePathDigestRecord(digest hash.Hash, fields ...string) {
+	digestpath.WriteRecord(digest, fields...)
+}

--- a/internal/gitref/path_digest_test.go
+++ b/internal/gitref/path_digest_test.go
@@ -1,0 +1,264 @@
+package gitref
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestCommittedPathDigestFileUsesCommittedBlobIdentity(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	head := commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	first := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/cm.yaml"},
+	})
+	if first.Revision != head.String() {
+		t.Fatalf("CommittedPathDigest() revision = %q, want %q", first.Revision, head.String())
+	}
+
+	writeSnapshotFileForTest(t, filepath.Join(root, "apps", "demo", "cm.yaml"), "kind: Secret\n")
+	dirtyWorktree := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/cm.yaml"},
+	})
+	if dirtyWorktree.Digest != first.Digest {
+		t.Fatalf("CommittedPathDigest() changed after uncommitted worktree edit: got %q, want %q", dirtyWorktree.Digest, first.Digest)
+	}
+
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: Secret\n")
+	changed := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/cm.yaml"},
+	})
+	if changed.Digest == first.Digest {
+		t.Fatalf("CommittedPathDigest() digest did not change after committed file edit")
+	}
+}
+
+func TestCommittedPathDigestDirectoryUsesTreeIdentity(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	first := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo"},
+	})
+
+	commitSnapshotFile(t, repo, wt, "apps/other/cm.yaml", "kind: ConfigMap\n")
+	unrelated := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo"},
+	})
+	if unrelated.Digest != first.Digest {
+		t.Fatalf("CommittedPathDigest() changed for unrelated commit: got %q, want %q", unrelated.Digest, first.Digest)
+	}
+
+	commitSnapshotFile(t, repo, wt, "apps/demo/secret.yaml", "kind: Secret\n")
+	changed := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo"},
+	})
+	if changed.Digest == first.Digest {
+		t.Fatalf("CommittedPathDigest() digest did not change after committed directory tree edit")
+	}
+}
+
+func TestCommittedPathDigestOptionalMissingMarkerInvalidatesOnAddAndDelete(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	missing := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/values.yaml", Optional: true},
+	})
+
+	commitSnapshotFile(t, repo, wt, "apps/demo/values.yaml", "replicas: 1\n")
+	added := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/values.yaml", Optional: true},
+	})
+	if added.Digest == missing.Digest {
+		t.Fatalf("CommittedPathDigest() digest did not change when optional missing path was added")
+	}
+
+	removeSnapshotFile(t, wt, "apps/demo/values.yaml")
+	commitAllSnapshotFiles(t, wt, "delete values")
+	deleted := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/values.yaml", Optional: true},
+	})
+	if deleted.Digest != missing.Digest {
+		t.Fatalf("CommittedPathDigest() missing marker = %q after delete, want original %q", deleted.Digest, missing.Digest)
+	}
+}
+
+func TestCommittedPathDigestRequiredMissingPathErrors(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	_, err := CommittedPathDigest(t.Context(), PathDigestInput{
+		RepoPath: root,
+		Revision: "HEAD",
+		Paths: []PathDigestPath{
+			{Path: "apps/demo/missing.yaml"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("CommittedPathDigest() error = nil, want required missing path error")
+	}
+	if !strings.Contains(err.Error(), "required Git path is missing") {
+		t.Fatalf("CommittedPathDigest() error = %q, want required missing path message", err)
+	}
+}
+
+func TestCommittedPathDigestSortsCanonicalizesAndDeduplicatesPaths(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/a.yaml", "a: 1\n")
+	commitSnapshotFile(t, repo, wt, "apps/demo/b.yaml", "b: 1\n")
+
+	normalized := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: "apps/demo/a.yaml"},
+		{Path: "apps/demo/b.yaml"},
+	})
+	unsortedDuplicate := committedPathDigestForTest(t, root, "HEAD", []PathDigestPath{
+		{Path: `apps\demo\.\b.yaml`},
+		{Path: "apps/demo/a.yaml"},
+		{Path: "apps/demo/b.yaml", Optional: true},
+	})
+	if unsortedDuplicate.Digest != normalized.Digest {
+		t.Fatalf("CommittedPathDigest() = %q, want normalized digest %q", unsortedDuplicate.Digest, normalized.Digest)
+	}
+}
+
+func TestCommittedPathDigestRejectsInvalidPaths(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+
+	for _, testCase := range []struct {
+		name string
+		path string
+	}{
+		{name: "posix absolute", path: "/apps/demo/cm.yaml"},
+		{name: "windows absolute slash", path: `C:/repo/apps/demo/cm.yaml`},
+		{name: "windows absolute backslash", path: `C:\repo\apps\demo\cm.yaml`},
+		{name: "windows drive relative", path: `C:apps\demo\cm.yaml`},
+		{name: "parent escape", path: "../apps/demo/cm.yaml"},
+		{name: "cleaned parent escape", path: "apps/../../demo/cm.yaml"},
+		{name: "nul", path: "apps/demo/cm.yaml\x00other"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := CommittedPathDigest(t.Context(), PathDigestInput{
+				RepoPath: root,
+				Revision: "HEAD",
+				Paths: []PathDigestPath{
+					{Path: testCase.path, Optional: true},
+				},
+			})
+			if err == nil {
+				t.Fatalf("CommittedPathDigest() error = nil, want invalid path error")
+			}
+			if !strings.Contains(err.Error(), "git path") {
+				t.Fatalf("CommittedPathDigest() error = %q, want git path error", err)
+			}
+		})
+	}
+}
+
+func TestCommittedPathDigestCanceledContext(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "apps/demo/cm.yaml", "kind: ConfigMap\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := CommittedPathDigest(ctx, PathDigestInput{
+		RepoPath: root,
+		Revision: "HEAD",
+		Paths: []PathDigestPath{
+			{Path: "apps/demo/cm.yaml"},
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CommittedPathDigest() error = %v, want context.Canceled", err)
+	}
+	if result != (PathDigestResult{}) {
+		t.Fatalf("CommittedPathDigest() result = %#v, want zero result", result)
+	}
+}
+
+func TestCommittedPathDigestRejectsGitlinkSubmodule(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSubmoduleEntryForTest(t, repo, wt, "vendor/dep")
+
+	_, err := CommittedPathDigest(t.Context(), PathDigestInput{
+		RepoPath: root,
+		Revision: "HEAD",
+		Paths: []PathDigestPath{
+			{Path: "vendor/dep"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("CommittedPathDigest() error = nil, want submodule rejection")
+	}
+	if !strings.Contains(err.Error(), "gitlink/submodule") {
+		t.Fatalf("CommittedPathDigest() error = %q, want gitlink/submodule rejection", err)
+	}
+
+	_, err = CommittedPathDigest(t.Context(), PathDigestInput{
+		RepoPath: root,
+		Revision: "HEAD",
+		Paths: []PathDigestPath{
+			{Path: "vendor"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("CommittedPathDigest() directory error = nil, want nested submodule rejection")
+	}
+	if !strings.Contains(err.Error(), "gitlink/submodule") {
+		t.Fatalf("CommittedPathDigest() directory error = %q, want gitlink/submodule rejection", err)
+	}
+}
+
+func committedPathDigestForTest(t *testing.T, repoPath, revision string, paths []PathDigestPath) PathDigestResult {
+	t.Helper()
+	result, err := CommittedPathDigest(t.Context(), PathDigestInput{
+		RepoPath: repoPath,
+		Revision: revision,
+		Paths:    paths,
+	})
+	if err != nil {
+		t.Fatalf("CommittedPathDigest() error = %v", err)
+	}
+	return result
+}
+
+func removeSnapshotFile(t *testing.T, wt *git.Worktree, name string) {
+	t.Helper()
+	if err := os.Remove(filepath.Join(wt.Filesystem.Root(), filepath.FromSlash(name))); err != nil {
+		t.Fatalf("Remove(%s) error = %v", name, err)
+	}
+	if _, err := wt.Remove(name); err != nil {
+		t.Fatalf("Remove(%s) from worktree error = %v", name, err)
+	}
+}
+
+func commitSubmoduleEntryForTest(t *testing.T, repo *git.Repository, wt *git.Worktree, name string) plumbing.Hash {
+	t.Helper()
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		t.Fatalf("Index() error = %v", err)
+	}
+	entry := idx.Add(name)
+	entry.Mode = filemode.Submodule
+	entry.Hash = plumbing.NewHash("1111111111111111111111111111111111111111")
+	if err := repo.Storer.SetIndex(idx); err != nil {
+		t.Fatalf("SetIndex() error = %v", err)
+	}
+	hash, err := wt.Commit("add submodule "+name, &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.invalid"},
+	})
+	if err != nil {
+		t.Fatalf("Commit(submodule) error = %v", err)
+	}
+	return hash
+}

--- a/internal/gitref/worktree.go
+++ b/internal/gitref/worktree.go
@@ -1,0 +1,211 @@
+package gitref
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/source"
+)
+
+type WorktreeState string
+
+const (
+	WorktreeStateClean   WorktreeState = "clean"
+	WorktreeStateDirty   WorktreeState = "dirty"
+	WorktreeStateUnknown WorktreeState = "unknown"
+)
+
+type WorktreeStatusResult struct {
+	State    WorktreeState
+	Revision string
+}
+
+// WorktreeStatus reports whether repoPath is a clean Git worktree, a dirty
+// Git worktree, or an unknown/non-Git root. Clean and dirty Git states include
+// the resolved HEAD revision. Non-repository roots report unknown without
+// failing; other resolution problems are returned as errors with unknown state.
+func WorktreeStatus(ctx context.Context, repoPath string) (WorktreeStatusResult, error) {
+	return worktreeStatus(ctx, repoPath, true)
+}
+
+// WorktreeHeadIdentity reports the HEAD commit SHA when the worktree at
+// repoPath matches the HEAD tree exactly: identical file set and content,
+// counting untracked and ignored files as dirt. Any difference yields ("",
+// nil). Errors mean the identity could not be determined; callers treat that
+// the same as dirt. Checked-out submodules read dirty because their files are
+// not in the HEAD tree. No shellouts.
+func WorktreeHeadIdentity(ctx context.Context, repoPath string) (string, error) {
+	status, err := worktreeStatus(ctx, repoPath, false)
+	if err != nil {
+		return "", err
+	}
+	if status.State != WorktreeStateClean {
+		return "", nil
+	}
+	return status.Revision, nil
+}
+
+func worktreeStatus(ctx context.Context, repoPath string, nonRepositoryIsUnknown bool) (WorktreeStatusResult, error) {
+	if err := ctx.Err(); err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, err
+	}
+	repo, displayRepoPath, err := openLocalRepository(repoPath)
+	if err != nil {
+		if nonRepositoryIsUnknown && errors.Is(err, git.ErrRepositoryNotExists) {
+			return WorktreeStatusResult{State: WorktreeStateUnknown}, nil
+		}
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, err
+	}
+	hash, err := source.ResolveGitRevision(repo, "HEAD")
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, fmt.Errorf("resolve Git ref %q in %q: %w", "HEAD", displayRepoPath, err)
+	}
+	commit, err := repo.CommitObject(*hash)
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, fmt.Errorf("load Git commit %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, fmt.Errorf("load Git tree for %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, fmt.Errorf("open Git worktree in %q: %w", displayRepoPath, err)
+	}
+	root := worktree.Filesystem.Root()
+
+	files, err := headTreeFiles(tree)
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, err
+	}
+	dirtyFiles, err := anyWorktreeFileDiffers(ctx, root, files)
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, err
+	}
+	if dirtyFiles {
+		return WorktreeStatusResult{State: WorktreeStateDirty, Revision: hash.String()}, nil
+	}
+	clean, err := worktreeHasOnlyHeadFiles(ctx, root, files)
+	if err != nil {
+		return WorktreeStatusResult{State: WorktreeStateUnknown}, err
+	}
+	if !clean {
+		return WorktreeStatusResult{State: WorktreeStateDirty, Revision: hash.String()}, nil
+	}
+	return WorktreeStatusResult{State: WorktreeStateClean, Revision: hash.String()}, nil
+}
+
+// anyWorktreeFileDiffers reports whether any tracked file differs from its
+// committed blob, stopping all workers at the first detected difference.
+func anyWorktreeFileDiffers(ctx context.Context, root string, files []object.File) (bool, error) {
+	workers := materializeTreeParallelism(len(files))
+	if workers == 0 {
+		return false, nil
+	}
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var dirty atomic.Bool
+	errs := make([]error, len(files))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				worktreeDifferWorker(root, files, i, &dirty, errs, cancel, scanCtx)
+			}
+		}()
+	}
+	for i := range files {
+		if scanCtx.Err() != nil {
+			break
+		}
+		select {
+		case <-scanCtx.Done():
+		case jobs <- i:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	if dirty.Load() {
+		return true, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	for _, err := range errs {
+		if err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+func worktreeDifferWorker(root string, files []object.File, i int, dirty *atomic.Bool, errs []error, cancel context.CancelFunc, scanCtx context.Context) {
+	if dirty.Load() || scanCtx.Err() != nil {
+		return
+	}
+	changed, err := worktreeFileChanged(root, &files[i])
+	if err != nil {
+		errs[i] = err
+		cancel()
+		return
+	}
+	if changed {
+		dirty.Store(true)
+		cancel()
+	}
+}
+
+const gitDirName = ".git"
+
+// worktreeHasOnlyHeadFiles reports false when any file exists that is not in
+// the HEAD tree: untracked, ignored, or a submodule working file. Directories
+// named .git are skipped as repository metadata.
+func worktreeHasOnlyHeadFiles(ctx context.Context, root string, files []object.File) (bool, error) {
+	headSet := make(map[string]struct{}, len(files))
+	for i := range files {
+		headSet[filepath.ToSlash(files[i].Name)] = struct{}{}
+	}
+	extra := false
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == gitDirName {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() == gitDirName && filepath.Dir(path) == root {
+			// A .git file at the root (linked worktree layout) is repository
+			// metadata, not content.
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if _, ok := headSet[filepath.ToSlash(rel)]; !ok {
+			extra = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return !extra, nil
+}

--- a/internal/gitref/worktree_changeset.go
+++ b/internal/gitref/worktree_changeset.go
@@ -1,0 +1,133 @@
+package gitref
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sholdee/drydock/internal/source"
+)
+
+// WorktreeChangeSetResult is WorktreeStatus plus the complete dirty-path
+// enumeration. DirtyPaths lists every repository-relative path whose worktree
+// state differs from HEAD: modified, deleted, mode-flipped, or type-changed
+// tracked files, plus every extra file (untracked, ignored, and files under
+// untracked directories). A nested .git directory is recorded as a single
+// dirty path without descending into it. Sorted, deduplicated, and empty
+// exactly when State is clean. Completeness is load-bearing: per-path-set
+// cache keying serves committed-key hits for path sets that no dirty path
+// touches, so a missed category here would become a stale cache hit.
+type WorktreeChangeSetResult struct {
+	State      WorktreeState
+	Revision   string
+	DirtyPaths []string
+}
+
+// WorktreeChangeSet classifies repoPath like WorktreeStatus and additionally
+// enumerates every dirty path. Unlike WorktreeStatus it cannot short-circuit
+// at the first difference: callers need the full set. Non-repository roots
+// report unknown without failing.
+func WorktreeChangeSet(ctx context.Context, repoPath string) (WorktreeChangeSetResult, error) {
+	if err := ctx.Err(); err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, err
+	}
+	repo, displayRepoPath, err := openLocalRepository(repoPath)
+	if err != nil {
+		if errors.Is(err, git.ErrRepositoryNotExists) {
+			return WorktreeChangeSetResult{State: WorktreeStateUnknown}, nil
+		}
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, err
+	}
+	hash, err := source.ResolveGitRevision(repo, "HEAD")
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, fmt.Errorf("resolve Git ref %q in %q: %w", "HEAD", displayRepoPath, err)
+	}
+	commit, err := repo.CommitObject(*hash)
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, fmt.Errorf("load Git commit %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, fmt.Errorf("load Git tree for %q in %q: %w", hash.String(), displayRepoPath, err)
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, fmt.Errorf("open Git worktree in %q: %w", displayRepoPath, err)
+	}
+	root := worktree.Filesystem.Root()
+
+	files, err := headTreeFiles(tree)
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, err
+	}
+	changed, err := changedWorktreeFiles(root, files)
+	if err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, err
+	}
+	dirtySet := map[string]struct{}{}
+	for i := range files {
+		if changed[i] {
+			dirtySet[filepath.ToSlash(files[i].Name)] = struct{}{}
+		}
+	}
+	if err := addWorktreeExtraFiles(ctx, root, files, dirtySet); err != nil {
+		return WorktreeChangeSetResult{State: WorktreeStateUnknown}, err
+	}
+
+	result := WorktreeChangeSetResult{Revision: hash.String()}
+	if len(dirtySet) == 0 {
+		result.State = WorktreeStateClean
+		return result, nil
+	}
+	result.State = WorktreeStateDirty
+	result.DirtyPaths = sortedStringSet(dirtySet)
+	return result, nil
+}
+
+// addWorktreeExtraFiles records every worktree file that is not in the HEAD
+// tree. Nested .git directories are recorded as a single dirty path and not
+// descended into (their content is repository metadata the cache layers treat
+// fail-closed). This deliberately diverges from worktreeHasOnlyHeadFiles,
+// which silently skips all .git directories: here the fail-closed side is
+// taken so that a nested .git always marks the worktree dirty even when
+// WorktreeStatus considers it clean. The root .git is still skipped.
+func addWorktreeExtraFiles(ctx context.Context, root string, files []object.File, dirtySet map[string]struct{}) error {
+	headSet := make(map[string]struct{}, len(files))
+	for i := range files {
+		headSet[filepath.ToSlash(files[i].Name)] = struct{}{}
+	}
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if entry.IsDir() {
+			if entry.Name() == gitDirName {
+				if filepath.Dir(path) == root {
+					return fs.SkipDir
+				}
+				dirtySet[rel] = struct{}{}
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() == gitDirName && filepath.Dir(path) == root {
+			return nil
+		}
+		if _, ok := headSet[rel]; !ok {
+			dirtySet[rel] = struct{}{}
+		}
+		return nil
+	})
+}

--- a/internal/gitref/worktree_changeset_test.go
+++ b/internal/gitref/worktree_changeset_test.go
@@ -1,0 +1,221 @@
+package gitref
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestWorktreeChangeSetCleanIsEmpty(t *testing.T) {
+	dir, revision := changeSetFixtureRepo(t)
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v", err)
+	}
+	if result.State != WorktreeStateClean || result.Revision != revision || len(result.DirtyPaths) != 0 {
+		t.Fatalf("result = %+v, want clean/%s with no dirty paths", result, revision)
+	}
+}
+
+func TestWorktreeChangeSetEnumeratesEveryDirtCategory(t *testing.T) {
+	dir, revision := changeSetFixtureRepo(t)
+
+	// same-size tracked edit
+	writeChangeSetFile(t, filepath.Join(dir, "apps", "alpha", "cm.yaml"), "a: 2\n")
+	// deleted tracked file
+	if err := os.Remove(filepath.Join(dir, "apps", "beta", "cm.yaml")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// untracked file in a tracked dir
+	writeChangeSetFile(t, filepath.Join(dir, "apps", "alpha", "untracked.yaml"), "u: 1\n")
+	// file under an entirely untracked dir
+	writeChangeSetFile(t, filepath.Join(dir, "newdir", "deep", "x.yaml"), "x: 1\n")
+	// ignored file (fixture commits a .gitignore for *.tmp)
+	writeChangeSetFile(t, filepath.Join(dir, "apps", "alpha", "scratch.tmp"), "t\n")
+	// nested .git directory content
+	writeChangeSetFile(t, filepath.Join(dir, "apps", "beta", ".git", "config"), "g\n")
+
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v", err)
+	}
+	if result.State != WorktreeStateDirty || result.Revision != revision {
+		t.Fatalf("result = %+v, want dirty/%s", result, revision)
+	}
+	want := []string{
+		"apps/alpha/cm.yaml",
+		"apps/alpha/scratch.tmp",
+		"apps/alpha/untracked.yaml",
+		"apps/beta/.git",
+		"apps/beta/cm.yaml",
+		"newdir/deep/x.yaml",
+	}
+	if !reflect.DeepEqual(result.DirtyPaths, want) {
+		t.Fatalf("DirtyPaths = %#v, want %#v (sorted, complete)", result.DirtyPaths, want)
+	}
+}
+
+func TestWorktreeChangeSetDetectsSymlinkTargetChange(t *testing.T) {
+	if isWindowsChangeSetTest() {
+		t.Skip("symlinks are unreliable on windows")
+	}
+	dir, _ := changeSetFixtureRepo(t)
+	link := filepath.Join(dir, "apps", "alpha", "link.yaml")
+	if err := os.Symlink("cm.yaml", link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	commitChangeSetRepo(t, dir) // re-commit so the symlink is tracked
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("remove link: %v", err)
+	}
+	if err := os.Symlink("untracked.yaml", link); err != nil {
+		t.Fatalf("relink: %v", err)
+	}
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v", err)
+	}
+	if result.State != WorktreeStateDirty {
+		t.Fatalf("result = %+v, want dirty (symlink target changed)", result)
+	}
+}
+
+func TestWorktreeChangeSetDetectsTypeChange(t *testing.T) {
+	if isWindowsChangeSetTest() {
+		t.Skip("symlinks are unreliable on windows")
+	}
+	dir, _ := changeSetFixtureRepo(t)
+	target := filepath.Join(dir, "apps", "alpha", "cm.yaml")
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Symlink("../beta/cm.yaml", target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v", err)
+	}
+	if result.State != WorktreeStateDirty || len(result.DirtyPaths) != 1 || result.DirtyPaths[0] != "apps/alpha/cm.yaml" {
+		t.Fatalf("result = %+v, want dirty with exactly apps/alpha/cm.yaml", result)
+	}
+}
+
+func TestWorktreeChangeSetParentDirReplacedByFile(t *testing.T) {
+	dir, _ := changeSetFixtureRepo(t)
+	parent := filepath.Join(dir, "apps", "alpha")
+	if err := os.RemoveAll(parent); err != nil {
+		t.Fatalf("remove parent: %v", err)
+	}
+	if err := os.WriteFile(parent, []byte("now a file\n"), 0o600); err != nil {
+		t.Fatalf("replace with file: %v", err)
+	}
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v, want dirty enumeration (ENOTDIR must read as changed)", err)
+	}
+	if result.State != WorktreeStateDirty {
+		t.Fatalf("result = %+v, want dirty", result)
+	}
+	// The vanished tracked file and the replacing file must both be present.
+	want := map[string]bool{"apps/alpha/cm.yaml": false, "apps/alpha": false}
+	for _, p := range result.DirtyPaths {
+		if _, ok := want[p]; ok {
+			want[p] = true
+		}
+	}
+	for p, found := range want {
+		if !found {
+			t.Fatalf("DirtyPaths = %#v, missing %q", result.DirtyPaths, p)
+		}
+	}
+}
+
+func TestWorktreeChangeSetNestedGitDirIsDirtWhereStatusIsClean(t *testing.T) {
+	dir, _ := changeSetFixtureRepo(t)
+	writeChangeSetFile(t, filepath.Join(dir, "apps", "alpha", ".git", "config"), "g\n")
+	status, err := WorktreeStatus(context.Background(), dir)
+	if err != nil || status.State != WorktreeStateClean {
+		t.Fatalf("WorktreeStatus = %+v, %v — this pin assumes status skips nested .git; if status changed, update the divergence comment", status, err)
+	}
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil || result.State != WorktreeStateDirty {
+		t.Fatalf("WorktreeChangeSet = %+v, %v, want dirty (fail-closed divergence from WorktreeStatus)", result, err)
+	}
+}
+
+func TestWorktreeChangeSetDetectsModeFlip(t *testing.T) {
+	if isWindowsChangeSetTest() {
+		t.Skip("executable bits are not tracked on windows")
+	}
+	dir, _ := changeSetFixtureRepo(t)
+	target := filepath.Join(dir, "apps", "alpha", "cm.yaml")
+	if err := os.Chmod(target, 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	result, err := WorktreeChangeSet(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("WorktreeChangeSet() error = %v", err)
+	}
+	if result.State != WorktreeStateDirty || len(result.DirtyPaths) != 1 || result.DirtyPaths[0] != "apps/alpha/cm.yaml" {
+		t.Fatalf("result = %+v, want exactly the mode-flipped file", result)
+	}
+}
+
+// changeSetFixtureRepo creates a fresh git repository with a baseline commit
+// containing apps/alpha/cm.yaml, apps/beta/cm.yaml, and .gitignore (*.tmp).
+// Returns the repo root directory and the HEAD revision string.
+func changeSetFixtureRepo(t *testing.T) (string, string) {
+	t.Helper()
+	root, _, wt := newSnapshotRepo(t)
+	writeChangeSetFile(t, filepath.Join(root, "apps", "alpha", "cm.yaml"), "a: 1\n")
+	writeChangeSetFile(t, filepath.Join(root, "apps", "beta", "cm.yaml"), "b: 1\n")
+	writeChangeSetFile(t, filepath.Join(root, ".gitignore"), "*.tmp\n")
+	revision := commitAllSnapshotFiles(t, wt, "fixture")
+	return root, revision
+}
+
+// writeChangeSetFile writes body to path, creating parent directories as needed.
+func writeChangeSetFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+// commitChangeSetRepo stages all worktree changes and commits them.
+// Used by the symlink-target-change subtest to make the symlink a tracked file.
+func commitChangeSetRepo(t *testing.T, dir string) {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen(%s) error = %v", dir, err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree() error = %v", err)
+	}
+	if err := wt.AddWithOptions(&git.AddOptions{All: true}); err != nil {
+		t.Fatalf("AddWithOptions() error = %v", err)
+	}
+	if _, err := wt.Commit("re-commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.invalid"},
+	}); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+}
+
+// isWindowsChangeSetTest reports whether the current platform is Windows, used
+// to skip tests that rely on symlinks or executable mode bits.
+func isWindowsChangeSetTest() bool {
+	return runtime.GOOS == "windows"
+}

--- a/internal/gitref/worktree_match.go
+++ b/internal/gitref/worktree_match.go
@@ -1,0 +1,228 @@
+package gitref
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// WorktreePathsMatchRevision reports whether the worktree content of every
+// requested repository-relative path matches the committed content at
+// Revision: identical tracked file content under each path and no extra
+// worktree files inside requested directories. Symlinks, submodules, and
+// other unsupported modes fail closed (false). Errors mean the comparison
+// could not be completed; callers must treat that as a mismatch.
+func WorktreePathsMatchRevision(ctx context.Context, input PathDigestInput) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	ref := strings.TrimSpace(input.Revision)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	paths, err := normalizePathDigestPaths(ctx, input.Paths)
+	if err != nil {
+		return false, err
+	}
+	repo, displayRepoPath, err := openLocalRepository(input.RepoPath)
+	if err != nil {
+		return false, err
+	}
+	tree, err := treeForRef(repo, ref)
+	if err != nil {
+		return false, fmt.Errorf("resolve Git ref %q in %q: %w", ref, displayRepoPath, err)
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return false, fmt.Errorf("open Git worktree in %q: %w", displayRepoPath, err)
+	}
+	root := worktree.Filesystem.Root()
+	for _, requested := range paths {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		match, err := worktreePathMatchesTree(ctx, root, tree, requested.path)
+		if err != nil || !match {
+			return match, err
+		}
+	}
+	return true, nil
+}
+
+func worktreePathMatchesTree(ctx context.Context, root string, tree *object.Tree, relPath string) (bool, error) {
+	if relPath == "." {
+		// Reject any gitlink in the root tree before iterating files.
+		// go-git's FileIter skips filemode.Submodule entries entirely, so the
+		// per-file guard below is unreachable for gitlinks; pre-check here.
+		if err := rejectSubmodulesInDigestTree(ctx, ".", tree); err != nil {
+			return false, err
+		}
+		return worktreeDirMatchesTree(ctx, root, tree, ".")
+	}
+	entry, err := tree.FindEntry(relPath)
+	if err != nil {
+		if !pathDigestEntryMissing(err) {
+			return false, err
+		}
+		// Absent from the commit: the worktree must not have it either.
+		// Optional/required is irrelevant at match time — presence equality
+		// is the contract; an optional path that appears is a mismatch.
+		_, statErr := os.Lstat(filepath.Join(root, filepath.FromSlash(relPath)))
+		if os.IsNotExist(statErr) {
+			return true, nil
+		}
+		if statErr != nil {
+			return false, statErr
+		}
+		return false, nil
+	}
+	switch entry.Mode {
+	case filemode.Dir:
+		subtree, err := tree.Tree(relPath)
+		if err != nil {
+			return false, err
+		}
+		// Reject any gitlink in the subtree before iterating files.
+		// go-git's FileIter skips filemode.Submodule entries entirely, so the
+		// per-file guard in committedTreeFilesMatchWorktree is unreachable for
+		// gitlinks; pre-check here ensures fail-closed behavior.
+		if err := rejectSubmodulesInDigestTree(ctx, relPath, subtree); err != nil {
+			return false, err
+		}
+		return worktreeDirMatchesTree(ctx, root, subtree, relPath)
+	case filemode.Regular, filemode.Deprecated, filemode.Executable:
+		file, err := tree.File(relPath)
+		if err != nil {
+			return false, err
+		}
+		changed, err := worktreeFileChanged(root, file)
+		if err != nil {
+			return false, err
+		}
+		return !changed, nil
+	case filemode.Symlink, filemode.Empty:
+		// Symlink targets are invisible to the committed digest; fail closed.
+		return false, nil
+	case filemode.Submodule:
+		// Load-bearing guard: when a requested path directly names a gitlink
+		// entry, FindEntry returns filemode.Submodule and this arm handles it.
+		// rejectSubmodulesInDigestTree only covers "." and Dir entries; it does
+		// not protect this code path. Fail closed.
+		return false, nil
+	default:
+		return false, nil
+	}
+}
+
+func worktreeDirMatchesTree(ctx context.Context, root string, tree *object.Tree, base string) (bool, error) {
+	committed, match, err := committedTreeFilesMatchWorktree(ctx, root, tree, base)
+	if err != nil || !match {
+		return false, err
+	}
+	extra, err := worktreeDirHasExtraFiles(ctx, root, base, committed)
+	if err != nil {
+		return false, err
+	}
+	return !extra, nil
+}
+
+// committedTreeFilesMatchWorktree compares every committed file under base
+// against the worktree and returns the committed name set for the extra-file
+// sweep. A false match means a committed file changed, was deleted, or has an
+// unverifiable mode (symlink, submodule).
+func committedTreeFilesMatchWorktree(ctx context.Context, root string, tree *object.Tree, base string) (map[string]struct{}, bool, error) {
+	committed := map[string]struct{}{}
+	iter := tree.Files()
+	defer iter.Close()
+	for {
+		file, err := iter.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		name := file.Name
+		if base != "." {
+			name = path.Join(base, file.Name)
+		}
+		committed[name] = struct{}{}
+		if file.Mode == filemode.Symlink {
+			// Symlink targets are invisible to the committed digest; fail closed.
+			// Note: filemode.Submodule (gitlinks) is never yielded by FileIter
+			// (go-git skips them at the iteration layer); gitlinks are rejected
+			// up front by rejectSubmodulesInDigestTree in the caller.
+			return nil, false, nil
+		}
+		full := *file
+		full.Name = name
+		changed, err := worktreeFileChanged(root, &full)
+		if err != nil {
+			return nil, false, err
+		}
+		if changed {
+			return nil, false, nil
+		}
+	}
+	return committed, true, nil
+}
+
+// worktreeDirHasExtraFiles walks the worktree directory at base and reports
+// whether it holds any file absent from the committed set — including nested
+// .git directories, which fail closed as unverifiable content.
+func worktreeDirHasExtraFiles(ctx context.Context, root, base string, committed map[string]struct{}) (bool, error) {
+	dir := root
+	if base != "." {
+		dir = filepath.Join(root, filepath.FromSlash(base))
+	}
+	extra := false
+	err := filepath.WalkDir(dir, func(p string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == gitDirName {
+				if filepath.Dir(p) == root {
+					return fs.SkipDir // repository metadata at the root only
+				}
+				// A nested .git directory is unverifiable content: the
+				// committed tree cannot represent it, but a recursive
+				// directory render reads it. Fail closed.
+				extra = true
+				return fs.SkipAll
+			}
+			return nil
+		}
+		if entry.Name() == gitDirName && filepath.Dir(p) == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		if _, ok := committed[filepath.ToSlash(rel)]; !ok {
+			extra = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return extra, nil
+}

--- a/internal/gitref/worktree_match_test.go
+++ b/internal/gitref/worktree_match_test.go
@@ -1,0 +1,127 @@
+package gitref
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func assertWorktreeMatch(t *testing.T, input PathDigestInput, want bool, why string) {
+	t.Helper()
+	match, err := WorktreePathsMatchRevision(context.Background(), input)
+	if err != nil || match != want {
+		t.Fatalf("match = %v, %v, want %v (%s)", match, err, want, why)
+	}
+}
+
+func TestWorktreePathsMatchRevision(t *testing.T) {
+	dir, _, wt := newSnapshotRepo(t)
+	writeChangedPathFileForTest(t, filepath.Join(dir, "manifests", "demo", "cm.yaml"), "a: 1\n")
+	writeChangedPathFileForTest(t, filepath.Join(dir, "other", "x.yaml"), "x: 1\n")
+	revision := commitAllSnapshotFiles(t, wt, "fixture")
+	paths := []PathDigestPath{{Path: "manifests/demo"}, {Path: "manifests/demo/.argocd-source.yaml", Optional: true}}
+	input := func() PathDigestInput {
+		return PathDigestInput{RepoPath: dir, Revision: revision, Paths: paths}
+	}
+
+	t.Run("clean worktree matches", func(t *testing.T) {
+		assertWorktreeMatch(t, input(), true, "untouched worktree")
+	})
+
+	t.Run("mtime-only touch still matches", func(t *testing.T) {
+		now := time.Now()
+		if err := os.Chtimes(filepath.Join(dir, "manifests", "demo", "cm.yaml"), now, now); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		assertWorktreeMatch(t, input(), true, "content identical")
+	})
+
+	t.Run("edit outside requested paths still matches", func(t *testing.T) {
+		writeChangedPathFileForTest(t, filepath.Join(dir, "other", "x.yaml"), "x: 2\n")
+		defer writeChangedPathFileForTest(t, filepath.Join(dir, "other", "x.yaml"), "x: 1\n")
+		assertWorktreeMatch(t, input(), true, "edit is outside the requested paths")
+	})
+
+	t.Run("same-size content edit mismatches", func(t *testing.T) {
+		writeChangedPathFileForTest(t, filepath.Join(dir, "manifests", "demo", "cm.yaml"), "a: 2\n")
+		defer writeChangedPathFileForTest(t, filepath.Join(dir, "manifests", "demo", "cm.yaml"), "a: 1\n")
+		assertWorktreeMatch(t, input(), false, "content differs at identical size")
+	})
+
+	t.Run("extra untracked file under requested dir mismatches", func(t *testing.T) {
+		extra := filepath.Join(dir, "manifests", "demo", "untracked.yaml")
+		writeChangedPathFileForTest(t, extra, "u: 1\n")
+		defer func() { _ = os.Remove(extra) }()
+		assertWorktreeMatch(t, input(), false, "untracked file inside requested dir")
+	})
+
+	t.Run("optional path appearing in worktree mismatches", func(t *testing.T) {
+		override := filepath.Join(dir, "manifests", "demo", ".argocd-source.yaml")
+		writeChangedPathFileForTest(t, override, "kustomize:\n  namePrefix: p-\n")
+		defer func() { _ = os.Remove(override) }()
+		assertWorktreeMatch(t, input(), false, "optional path absent from commit but present in worktree")
+	})
+
+	t.Run("nested git dir under requested dir mismatches", func(t *testing.T) {
+		nested := filepath.Join(dir, "manifests", "demo", ".git", "extra.yaml")
+		writeChangedPathFileForTest(t, nested, "u: 1\n")
+		defer func() { _ = os.RemoveAll(filepath.Join(dir, "manifests", "demo", ".git")) }()
+		assertWorktreeMatch(t, input(), false, "nested .git content is unverifiable")
+	})
+
+	t.Run("deleted tracked file mismatches", func(t *testing.T) {
+		target := filepath.Join(dir, "manifests", "demo", "cm.yaml")
+		if err := os.Remove(target); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		defer writeChangedPathFileForTest(t, target, "a: 1\n")
+		assertWorktreeMatch(t, input(), false, "tracked file missing from worktree")
+	})
+}
+
+func TestWorktreePathsMatchRevisionSymlinkFailsClosed(t *testing.T) {
+	dir, _, wt := newSnapshotRepo(t)
+	writeChangedPathFileForTest(t, filepath.Join(dir, "manifests", "demo", "cm.yaml"), "a: 1\n")
+	if err := os.Symlink("cm.yaml", filepath.Join(dir, "manifests", "demo", "link.yaml")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	revision := commitAllSnapshotFiles(t, wt, "fixture")
+	assertWorktreeMatch(t, PathDigestInput{
+		RepoPath: dir, Revision: revision,
+		Paths: []PathDigestPath{{Path: "manifests/demo"}},
+	}, false, "symlink targets are invisible to the committed digest")
+}
+
+func TestWorktreePathsMatchRevisionSubmoduleFailsClosed(t *testing.T) {
+	// Fixture: a commit whose tree contains a gitlink (submodule) at
+	// "vendor/dep", with the submodule uninitialized in the worktree (the
+	// "vendor/dep" directory is present but empty — the typical state of an
+	// uninitialized submodule). go-git's FileIter.Next() skips gitlink entries
+	// entirely, so the committed-file iteration guard for filemode.Submodule is
+	// unreachable; without the fix, committedTreeFilesMatchWorktree sees an
+	// empty committed set and match=true, then worktreeDirHasExtraFiles sees no
+	// extra files in the empty dep dir and returns extra=false — overall
+	// match=true, violating the fail-closed contract.
+	//
+	// The fix must intercept gitlinks before iteration via
+	// rejectSubmodulesInDigestTree so the primitive honors its own contract.
+	//
+	// Reuses commitSubmoduleEntryForTest from path_digest_test.go (same package).
+	dir, repo, wt := newSnapshotRepo(t)
+	revision := commitSubmoduleEntryForTest(t, repo, wt, "vendor/dep")
+
+	// Simulate an uninitialized submodule: the directory exists but is empty.
+	if err := os.MkdirAll(filepath.Join(dir, "vendor", "dep"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(vendor/dep) error = %v", err)
+	}
+
+	match, err := WorktreePathsMatchRevision(context.Background(), PathDigestInput{
+		RepoPath: dir, Revision: revision.String(),
+		Paths: []PathDigestPath{{Path: "vendor"}},
+	})
+	if err == nil && match {
+		t.Fatalf("match = true for a tree containing a gitlink; submodule content is invisible to the committed digest and must fail closed")
+	}
+}

--- a/internal/gitref/worktree_test.go
+++ b/internal/gitref/worktree_test.go
@@ -1,0 +1,251 @@
+package gitref
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWorktreeHeadIdentityCleanCheckout(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	hash := commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+
+	revision, err := WorktreeHeadIdentity(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeHeadIdentity() error = %v", err)
+	}
+	if revision != hash.String() {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want HEAD %q", revision, hash.String())
+	}
+}
+
+func TestWorktreeStatusCleanCheckout(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	hash := commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+
+	status, err := WorktreeStatus(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeStatus() error = %v", err)
+	}
+	if status.State != WorktreeStateClean || status.Revision != hash.String() {
+		t.Fatalf("WorktreeStatus() = %#v, want clean HEAD %q", status, hash.String())
+	}
+}
+
+func TestWorktreeStatusDirtyTrackedFile(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	hash := commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	if err := os.WriteFile(filepath.Join(root, "manifests", "cm.yaml"), []byte("kind: Secret\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	status, err := WorktreeStatus(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeStatus() error = %v", err)
+	}
+	if status.State != WorktreeStateDirty || status.Revision != hash.String() {
+		t.Fatalf("WorktreeStatus() = %#v, want dirty HEAD %q", status, hash.String())
+	}
+}
+
+func TestWorktreeStatusDirtyTrackedExecutableMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not provide a stable executable mode bit")
+	}
+	root, repo, wt := newSnapshotRepo(t)
+	hash := commitSnapshotFile(t, repo, wt, "scripts/render.sh", "#!/bin/sh\n")
+	if err := os.Chmod(filepath.Join(root, "scripts", "render.sh"), 0o755); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	status, err := WorktreeStatus(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeStatus() error = %v", err)
+	}
+	if status.State != WorktreeStateDirty || status.Revision != hash.String() {
+		t.Fatalf("WorktreeStatus() = %#v, want dirty HEAD %q", status, hash.String())
+	}
+}
+
+func TestWorktreeStatusDirtyUntrackedFile(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	hash := commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	if err := os.WriteFile(filepath.Join(root, "scratch.yaml"), []byte("kind: ConfigMap\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	status, err := WorktreeStatus(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeStatus() error = %v", err)
+	}
+	if status.State != WorktreeStateDirty || status.Revision != hash.String() {
+		t.Fatalf("WorktreeStatus() = %#v, want dirty HEAD %q", status, hash.String())
+	}
+}
+
+func TestWorktreeStatusNonRepositoryIsUnknown(t *testing.T) {
+	status, err := WorktreeStatus(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("WorktreeStatus() error = %v", err)
+	}
+	if status.State != WorktreeStateUnknown || status.Revision != "" {
+		t.Fatalf("WorktreeStatus() = %#v, want unknown non-repository", status)
+	}
+}
+
+func TestWorktreeHeadIdentityModifiedTrackedFileIsDirty(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	if err := os.WriteFile(filepath.Join(root, "manifests", "cm.yaml"), []byte("kind: Secret\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	revision, err := WorktreeHeadIdentity(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeHeadIdentity() error = %v", err)
+	}
+	if revision != "" {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want empty for modified file", revision)
+	}
+}
+
+func TestWorktreeHeadIdentityUntrackedFileIsDirty(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	if err := os.WriteFile(filepath.Join(root, "scratch.yaml"), []byte("kind: ConfigMap\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	revision, err := WorktreeHeadIdentity(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeHeadIdentity() error = %v", err)
+	}
+	if revision != "" {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want empty for untracked file", revision)
+	}
+}
+
+func TestWorktreeHeadIdentityIgnoredFileIsDirty(t *testing.T) {
+	// Ignored files are dirt deliberately: render engines read the filesystem,
+	// and a gitignored values file changes render output while being invisible
+	// to a tracked-only check.
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, ".gitignore", "ignored/\n")
+	if err := os.MkdirAll(filepath.Join(root, "ignored"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ignored", "values.yaml"), []byte("a: 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	revision, err := WorktreeHeadIdentity(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeHeadIdentity() error = %v", err)
+	}
+	if revision != "" {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want empty for ignored file", revision)
+	}
+}
+
+func TestWorktreeHeadIdentityMissingTrackedFileIsDirty(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	commitSnapshotFile(t, repo, wt, "manifests/other.yaml", "kind: ConfigMap\n")
+	if err := os.Remove(filepath.Join(root, "manifests", "cm.yaml")); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	revision, err := WorktreeHeadIdentity(context.Background(), root)
+	if err != nil {
+		t.Fatalf("WorktreeHeadIdentity() error = %v", err)
+	}
+	if revision != "" {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want empty for missing tracked file", revision)
+	}
+}
+
+func TestWorktreeHeadIdentityNonRepositoryErrors(t *testing.T) {
+	if _, err := WorktreeHeadIdentity(context.Background(), t.TempDir()); err == nil {
+		t.Fatalf("WorktreeHeadIdentity() error = nil, want error for non-repository path")
+	}
+}
+
+func TestWorktreeHeadIdentityCanceledContext(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	revision, err := WorktreeHeadIdentity(ctx, root)
+	if err == nil {
+		t.Fatalf("WorktreeHeadIdentity() error = nil, want cancellation")
+	}
+	if revision != "" {
+		t.Fatalf("WorktreeHeadIdentity() = %q, want empty on cancellation", revision)
+	}
+}
+
+func TestAnyWorktreeFileDiffersContextCanceledDuringTrackedComparison(t *testing.T) {
+	root, repo, wt := newSnapshotRepo(t)
+	commitSnapshotFile(t, repo, wt, "manifests/cm.yaml", "kind: ConfigMap\n")
+	headTree, err := treeForRef(repo, "HEAD")
+	if err != nil {
+		t.Fatalf("treeForRef() error = %v", err)
+	}
+	files, err := headTreeFiles(headTree)
+	if err != nil {
+		t.Fatalf("headTreeFiles() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = anyWorktreeFileDiffers(ctx, root, files)
+	if err == nil {
+		t.Fatalf("anyWorktreeFileDiffers() error = nil, want cancellation")
+	}
+}
+
+func TestWorktreeStatusDetectsSameSizeContentEdit(t *testing.T) {
+	dir, _, wt := newSnapshotRepo(t)
+	writeChangedPathFileForTest(t, filepath.Join(dir, "cm.yaml"), "a: 1\n")
+	commitAllSnapshotFiles(t, wt, "fixture")
+	// Same byte length, different content: only a content comparison can
+	// catch this. This pins the blob-hash comparison's exactness.
+	writeChangedPathFileForTest(t, filepath.Join(dir, "cm.yaml"), "a: 2\n")
+
+	status, err := WorktreeStatus(context.Background(), dir)
+	if err != nil || status.State != WorktreeStateDirty {
+		t.Fatalf("status = %+v, %v, want dirty", status, err)
+	}
+}
+
+func TestWorktreeStatusCleanAfterMtimeTouch(t *testing.T) {
+	dir, _, wt := newSnapshotRepo(t)
+	writeChangedPathFileForTest(t, filepath.Join(dir, "cm.yaml"), "a: 1\n")
+	commitAllSnapshotFiles(t, wt, "fixture")
+	now := time.Now()
+	if err := os.Chtimes(filepath.Join(dir, "cm.yaml"), now, now); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	status, err := WorktreeStatus(context.Background(), dir)
+	if err != nil || status.State != WorktreeStateClean {
+		t.Fatalf("status = %+v, %v, want clean (content identical)", status, err)
+	}
+}
+
+func TestWorktreeStatusContextCancellation(t *testing.T) {
+	dir, _, wt := newSnapshotRepo(t)
+	writeChangedPathFileForTest(t, filepath.Join(dir, "cm.yaml"), "a: 1\n")
+	commitAllSnapshotFiles(t, wt, "fixture")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := WorktreeStatus(ctx, dir)
+	if err == nil {
+		t.Fatalf("WorktreeStatus(canceled) error = nil, want context error")
+	}
+}

--- a/internal/render/directory_inputs.go
+++ b/internal/render/directory_inputs.go
@@ -1,0 +1,48 @@
+package render
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/sholdee/drydock/internal/gitref"
+	"github.com/sholdee/drydock/internal/pathsafety"
+)
+
+// DirectoryInputDigestPaths returns conservative committed repository paths for
+// directory rendering. The source directory tree is always included; Jsonnet
+// library roots are included when declared and validated with the same bounded
+// path semantics used by the renderer.
+func DirectoryInputDigestPaths(source ResolvedSource, opts RenderOptions) ([]gitref.PathDigestPath, error) {
+	root, err := sourceRoot(source)
+	if err != nil {
+		return nil, err
+	}
+	sourceRel, err := relativeDigestPath(source.RepoRoot, root)
+	if err != nil {
+		return nil, err
+	}
+	paths := []gitref.PathDigestPath{{Path: sourceRel}}
+	for _, lib := range opts.Jsonnet.Libs {
+		resolved, err := resolveJsonnetLib(source.RepoRoot, lib)
+		if err != nil {
+			return nil, err
+		}
+		libRel, err := relativeDigestPath(source.RepoRoot, resolved)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, gitref.PathDigestPath{Path: libRel})
+	}
+	return paths, nil
+}
+
+func relativeDigestPath(repoRoot, path string) (string, error) {
+	rel, err := filepath.Rel(filepath.Clean(repoRoot), filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(rel) || pathsafety.RelEscapes(rel) {
+		return "", fmt.Errorf("digest path %q escapes repository root %q", path, repoRoot)
+	}
+	return filepath.ToSlash(rel), nil
+}

--- a/internal/render/helm_dependencies.go
+++ b/internal/render/helm_dependencies.go
@@ -326,6 +326,13 @@ func helmChartVersion(chrt helmchart.Charter) string {
 }
 
 func recordHelmDependencyChartCacheEvent(opts RenderOptions, request chart.Request, acquireErr error, acquired chart.Result) {
+	if acquireErr == nil && opts.AcquisitionCollector != nil {
+		opts.AcquisitionCollector.Record(cacheevent.AcquisitionRecord{
+			Kind:              cacheevent.AcquisitionChart,
+			RequestedRevision: request.Version,
+			ResolvedRevision:  acquired.Version,
+		})
+	}
 	if opts.CacheEventRecorder == nil {
 		return
 	}

--- a/internal/render/helm_local_inputs_test.go
+++ b/internal/render/helm_local_inputs_test.go
@@ -1,0 +1,130 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func writeHelmInputTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func TestCollectHelmLocalInputPathsIncludesValueFilesAndFileParameters(t *testing.T) {
+	root := t.TempDir()
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "Chart.yaml"), "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "values-prod.yaml"), "value: prod\n")
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "files", "secret.txt"), "secret\n")
+
+	got, err := CollectHelmLocalInputPaths(HelmLocalInputOptions{
+		RepoRoot: root,
+		Source:   ResolvedSource{Path: "charts/demo"},
+		Options: RenderOptions{
+			ValueFiles: []string{"values-prod.yaml"},
+			HelmFileParameters: []argoappv1.HelmFileParameter{
+				{Name: "secret", Path: "files/secret.txt"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CollectHelmLocalInputPaths() error = %v", err)
+	}
+	want := []HelmLocalInputPath{
+		{Path: "charts/demo"},
+		{Path: "charts/demo/files/secret.txt"},
+		{Path: "charts/demo/values-prod.yaml"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectHelmLocalInputPathsIncludesSameRepoRefValueFile(t *testing.T) {
+	root := t.TempDir()
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "Chart.yaml"), "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+	writeHelmInputTestFile(t, filepath.Join(root, "shared", "demo.yaml"), "value: shared\n")
+
+	got, err := CollectHelmLocalInputPaths(HelmLocalInputOptions{
+		RepoRoot: root,
+		Source:   ResolvedSource{Path: "charts/demo"},
+		Options: RenderOptions{
+			RefRoots:   map[string]string{"$values": "."},
+			ValueFiles: []string{"$values/shared/demo.yaml"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CollectHelmLocalInputPaths() error = %v", err)
+	}
+	want := []HelmLocalInputPath{
+		{Path: "charts/demo"},
+		{Path: "shared/demo.yaml"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectHelmLocalInputPathsIncludesOptionalMissingValueFile(t *testing.T) {
+	root := t.TempDir()
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "Chart.yaml"), "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+
+	got, err := CollectHelmLocalInputPaths(HelmLocalInputOptions{
+		RepoRoot: root,
+		Source:   ResolvedSource{Path: "charts/demo"},
+		Options: RenderOptions{
+			RefRoots:                map[string]string{"$values": "."},
+			ValueFiles:              []string{"$values/optional/demo.yaml"},
+			IgnoreMissingValueFiles: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CollectHelmLocalInputPaths() error = %v", err)
+	}
+	want := []HelmLocalInputPath{
+		{Path: "charts/demo"},
+		{Path: "optional/demo.yaml", Optional: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectHelmLocalInputPathsRejectsRemoteValueFile(t *testing.T) {
+	root := t.TempDir()
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "Chart.yaml"), "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+
+	_, err := CollectHelmLocalInputPaths(HelmLocalInputOptions{
+		RepoRoot: root,
+		Source:   ResolvedSource{Path: "charts/demo"},
+		Options:  RenderOptions{ValueFiles: []string{"https://values.example.invalid/demo.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("CollectHelmLocalInputPaths() error = nil, want remote URL rejection")
+	}
+}
+
+func TestCollectHelmLocalInputPathsRejectsEnvSubstitutedValueFile(t *testing.T) {
+	root := t.TempDir()
+	writeHelmInputTestFile(t, filepath.Join(root, "charts", "demo", "Chart.yaml"), "apiVersion: v2\nname: demo\nversion: 0.1.0\n")
+
+	_, err := CollectHelmLocalInputPaths(HelmLocalInputOptions{
+		RepoRoot: root,
+		Source:   ResolvedSource{Path: "charts/demo"},
+		Options: RenderOptions{
+			RefRoots:   map[string]string{"$values": "."},
+			ValueFiles: []string{"$values/$ARGOCD_APP_NAME.yaml"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("CollectHelmLocalInputPaths() error = nil, want env substitution rejection")
+	}
+}

--- a/internal/render/helm_values.go
+++ b/internal/render/helm_values.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -13,6 +14,247 @@ import (
 	"go.yaml.in/yaml/v3"
 	"helm.sh/helm/v4/pkg/chart/common"
 )
+
+type HelmLocalInputPath struct {
+	Path     string
+	Optional bool
+}
+
+type HelmLocalInputOptions struct {
+	RepoRoot string
+	Source   ResolvedSource
+	Options  RenderOptions
+}
+
+// CollectHelmLocalInputPaths mirrors Helm value-file path resolution for the
+// persistent render cache. It returns repository-relative committed paths only;
+// callers should skip persistence when collection fails.
+func CollectHelmLocalInputPaths(input HelmLocalInputOptions) ([]HelmLocalInputPath, error) {
+	repoRoot := filepath.Clean(input.RepoRoot)
+	if repoRoot == "" || repoRoot == "." {
+		return nil, fmt.Errorf("repository root is required")
+	}
+	opts := input.Options
+	opts.RefRoots = anchorHelmLocalInputRefRoots(repoRoot, opts.RefRoots)
+	sourcePath, err := cleanSourcePath(input.Source.Path)
+	if err != nil {
+		return nil, err
+	}
+	out := &helmLocalInputCollector{
+		repoRoot: repoRoot,
+		source:   input.Source,
+		opts:     opts,
+		paths:    map[string]bool{},
+		explicit: map[string]struct{}{},
+		globSeen: map[string]struct{}{},
+	}
+	if err := out.addRequiredRepoPath(sourcePath); err != nil {
+		return nil, err
+	}
+	paths := append([]string(nil), opts.ValueFiles...)
+	for _, parameter := range opts.HelmFileParameters {
+		paths = append(paths, parameter.Path)
+	}
+	if err := out.collectExplicitIdentities(paths); err != nil {
+		return nil, err
+	}
+	for _, raw := range opts.ValueFiles {
+		if err := out.collectValueFile(raw); err != nil {
+			return nil, err
+		}
+	}
+	for _, parameter := range opts.HelmFileParameters {
+		if err := out.collectFileParameter(parameter.Path); err != nil {
+			return nil, err
+		}
+	}
+	return out.result(), nil
+}
+
+func anchorHelmLocalInputRefRoots(repoRoot string, refRoots map[string]string) map[string]string {
+	if len(refRoots) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(refRoots))
+	for key, root := range refRoots {
+		if filepath.IsAbs(root) {
+			out[key] = filepath.Clean(root)
+			continue
+		}
+		out[key] = filepath.Join(repoRoot, filepath.Clean(root))
+	}
+	return out
+}
+
+type helmLocalInputCollector struct {
+	repoRoot string
+	source   ResolvedSource
+	opts     RenderOptions
+	paths    map[string]bool
+	explicit map[string]struct{}
+	globSeen map[string]struct{}
+}
+
+func (c *helmLocalInputCollector) collectExplicitIdentities(files []string) error {
+	for _, raw := range files {
+		file, err := c.resolvedInput(raw)
+		if err != nil {
+			return err
+		}
+		if hasHelmValueGlob(file) || isRemoteHelmValueFile(file) {
+			continue
+		}
+		root, resolved, err := resolveHelmValueFile(c.repoRoot, helmValueFilesBaseDir(c.source, c.opts), helmValueFilesBoundaryRoot(c.source, c.opts), c.opts.RefRoots, file)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Lstat(resolved); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		identity, err := localHelmValueFileIdentity(root, resolved, file)
+		if err != nil {
+			return err
+		}
+		c.explicit[identity] = struct{}{}
+	}
+	return nil
+}
+
+func (c *helmLocalInputCollector) collectValueFile(raw string) error {
+	file, err := c.resolvedInput(raw)
+	if err != nil {
+		return err
+	}
+	if isRemoteHelmValueFile(file) {
+		return fmt.Errorf("remote Helm value file %q is not persistent-cache eligible", remote.RedactURL(file))
+	}
+	if hasHelmValueGlob(file) {
+		return c.collectGlob(file)
+	}
+	return c.collectLocal(file, c.opts.IgnoreMissingValueFiles)
+}
+
+func (c *helmLocalInputCollector) collectFileParameter(raw string) error {
+	file, err := c.resolvedInput(raw)
+	if err != nil {
+		return err
+	}
+	if isRemoteHelmValueFile(file) {
+		return fmt.Errorf("remote Helm file parameter %q is not persistent-cache eligible", remote.RedactURL(file))
+	}
+	if hasHelmValueGlob(file) {
+		return fmt.Errorf("helm file parameter %q uses an unsupported glob", file)
+	}
+	return c.collectLocal(file, false)
+}
+
+func (c *helmLocalInputCollector) collectGlob(pattern string) error {
+	root, resolvedPattern, err := resolveHelmValueFile(c.repoRoot, helmValueFilesBaseDir(c.source, c.opts), helmValueFilesBoundaryRoot(c.source, c.opts), c.opts.RefRoots, pattern)
+	if err != nil {
+		return err
+	}
+	matches, err := doublestar.FilepathGlob(resolvedPattern)
+	if err != nil {
+		return fmt.Errorf("helm value file glob %q: %w", pattern, err)
+	}
+	if len(matches) == 0 {
+		if c.opts.IgnoreMissingValueFiles {
+			return fmt.Errorf("optional missing Helm value file glob %q cannot be represented in committed path digest", pattern)
+		}
+		return fmt.Errorf("helm value file glob %q matched no files", pattern)
+	}
+	for _, match := range matches {
+		identity, err := localHelmValueFileIdentity(root, match, pattern)
+		if err != nil {
+			return err
+		}
+		if _, ok := c.explicit[identity]; ok {
+			continue
+		}
+		if _, ok := c.globSeen[identity]; ok {
+			continue
+		}
+		c.globSeen[identity] = struct{}{}
+		if err := c.addResolvedRepoPath(root, match, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *helmLocalInputCollector) collectLocal(file string, optional bool) error {
+	root, resolved, err := resolveHelmValueFile(c.repoRoot, helmValueFilesBaseDir(c.source, c.opts), helmValueFilesBoundaryRoot(c.source, c.opts), c.opts.RefRoots, file)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(resolved); err != nil {
+		if optional && os.IsNotExist(err) {
+			return c.addResolvedRepoPath(root, resolved, true)
+		}
+		return err
+	}
+	if err := rejectSymlinkedPath(root, resolved); err != nil {
+		return err
+	}
+	return c.addResolvedRepoPath(root, resolved, false)
+}
+
+func (c *helmLocalInputCollector) resolvedInput(raw string) (string, error) {
+	if strings.Contains(raw, "$") {
+		ref, rest, ok := helmValueFileRefPrefix(raw, c.opts.RefRoots)
+		if !ok || ref == "" {
+			return "", fmt.Errorf("helm input path %q uses unsupported env substitution", raw)
+		}
+		if strings.Contains(rest, "$") {
+			return "", fmt.Errorf("helm input path %q uses unsupported env substitution", raw)
+		}
+	}
+	return envsubstHelmValueFilePath(raw, c.opts, c.opts.RefRoots), nil
+}
+
+func (c *helmLocalInputCollector) addResolvedRepoPath(root, resolved string, optional bool) error {
+	rel, err := filepath.Rel(c.repoRoot, filepath.Clean(resolved))
+	if err != nil {
+		return err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("helm input path %q escapes repository root", resolved)
+	}
+	rootRel, err := filepath.Rel(c.repoRoot, filepath.Clean(root))
+	if err != nil {
+		return err
+	}
+	if rootRel == ".." || strings.HasPrefix(rootRel, ".."+string(filepath.Separator)) || filepath.IsAbs(rootRel) {
+		return fmt.Errorf("helm input root %q escapes repository root", root)
+	}
+	return c.addPath(filepath.ToSlash(rel), optional)
+}
+
+func (c *helmLocalInputCollector) addRequiredRepoPath(path string) error {
+	return c.addPath(filepath.ToSlash(path), false)
+}
+
+func (c *helmLocalInputCollector) addPath(path string, optional bool) error {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if existingOptional, ok := c.paths[clean]; ok {
+		c.paths[clean] = existingOptional && optional
+		return nil
+	}
+	c.paths[clean] = optional
+	return nil
+}
+
+func (c *helmLocalInputCollector) result() []HelmLocalInputPath {
+	paths := make([]HelmLocalInputPath, 0, len(c.paths))
+	for path, optional := range c.paths {
+		paths = append(paths, HelmLocalInputPath{Path: path, Optional: optional})
+	}
+	sort.Slice(paths, func(i, j int) bool { return paths[i].Path < paths[j].Path })
+	return paths
+}
 
 func helmValueFilesBaseDir(source ResolvedSource, opts RenderOptions) string {
 	if opts.ValueFilesBaseDir != "" {

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -56,7 +56,17 @@ func (KustomizeRenderer) Render(ctx context.Context, source ResolvedSource, opts
 	return manifests, append(diags, renderDiags...), err
 }
 
-var kustomizationFileNames = []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+// KustomizationFileNames is the ordered list of kustomization file name
+// variants that kustomize recognizes, in resolution precedence order.
+// selectLocalRenderer in the app package uses this list for source-type
+// classification; kustomize_input_digest uses it for the optional-variant
+// digest paths. The two lists must stay identical — this export is the
+// single source of truth.
+var KustomizationFileNames = []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+
+// kustomizationFileNames is the package-internal alias retained for callers
+// within this package.
+var kustomizationFileNames = KustomizationFileNames
 
 func renderPlainKustomize(ctx context.Context, source ResolvedSource, root string, settings kustomizeBuildSettings) ([]Manifest, []diagnostic.Diagnostic, error) {
 	manifestPath, err := validateKustomizeGraph(ctx, source.RepoRoot, root)
@@ -280,6 +290,13 @@ func resolveKustomizeHelmChart(ctx context.Context, tempRepoRoot, tempSourceRoot
 }
 
 func recordKustomizeChartCacheEvent(opts RenderOptions, request chart.Request, acquireErr error, acquired chart.Result) {
+	if acquireErr == nil && opts.AcquisitionCollector != nil {
+		opts.AcquisitionCollector.Record(cacheevent.AcquisitionRecord{
+			Kind:              cacheevent.AcquisitionChart,
+			RequestedRevision: request.Version,
+			ResolvedRevision:  acquired.Version,
+		})
+	}
 	if opts.CacheEventRecorder == nil {
 		return
 	}
@@ -315,12 +332,7 @@ func redactKustomizeChartAcquireError(err error, repository string, credentials 
 }
 
 func resolveLocalKustomizeHelmChart(repoRoot, kustomizationDir, chartHome string, helmChart types.HelmChart) (string, bool, error) {
-	chartPath := filepath.FromSlash(helmChart.Name)
-	if helmChart.Repo != "" && helmChart.Version != "" {
-		chartPath = filepath.Join(filepath.FromSlash(helmChart.Name+"-"+helmChart.Version), filepath.FromSlash(helmChart.Name))
-	}
-
-	path := filepath.Join(kustomizationDir, filepath.FromSlash(chartHome), chartPath)
+	path := localKustomizeHelmChartPath(kustomizationDir, chartHome, helmChart)
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -336,6 +348,14 @@ func resolveLocalKustomizeHelmChart(repoRoot, kustomizationDir, chartHome string
 		return "", false, err
 	}
 	return rel, true, nil
+}
+
+func localKustomizeHelmChartPath(kustomizationDir, chartHome string, helmChart types.HelmChart) string {
+	chartPath := filepath.FromSlash(helmChart.Name)
+	if helmChart.Repo != "" && helmChart.Version != "" {
+		chartPath = filepath.Join(filepath.FromSlash(helmChart.Name+"-"+helmChart.Version), filepath.FromSlash(helmChart.Name))
+	}
+	return filepath.Join(kustomizationDir, filepath.FromSlash(chartHome), chartPath)
 }
 
 func renderOptionsForKustomizeHelmChart(ctx context.Context, helmChart types.HelmChart, tempRepoRoot, tempSourceRoot, chartRel, valueFilesBaseDir, namespaceFallback, generatedName string, opts RenderOptions, acquirer chart.Acquirer) (RenderOptions, error) {
@@ -392,6 +412,7 @@ func renderOptionsForKustomizeHelmChart(ctx context.Context, helmChart types.Hel
 		RemoteResourceCredentials:    opts.RemoteResourceCredentials,
 		RemoteResourceGitCredentials: opts.RemoteResourceGitCredentials,
 		CacheEventRecorder:           opts.CacheEventRecorder,
+		AcquisitionCollector:         opts.AcquisitionCollector,
 		IncludeCRDs:                  helmChart.IncludeCRDs,
 		IncludeCRDsSet:               true,
 		SkipHooks:                    helmChart.SkipHooks,

--- a/internal/render/kustomize_helm_charts_test.go
+++ b/internal/render/kustomize_helm_charts_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sholdee/drydock/internal/cacheevent"
 	"github.com/sholdee/drydock/internal/chart"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/types"
 )
 
 func TestKustomizeRendererRendersHelmChartsWithoutShellout(t *testing.T) {
@@ -290,9 +291,11 @@ helmCharts:
     version: 1.2.3
 `)
 	recorder := cacheevent.NewRecorder(true)
+	collector := cacheevent.NewAcquisitionCollector()
 	_, diags, err := (KustomizeRenderer{}).Render(context.Background(), ResolvedSource{RepoRoot: root, Path: "."}, RenderOptions{
-		ChartAcquirer:      &fakeChartAcquirer{chartDir: chartDir, fromCache: true},
-		CacheEventRecorder: recorder,
+		ChartAcquirer:        &fakeChartAcquirer{chartDir: chartDir, fromCache: true},
+		CacheEventRecorder:   recorder,
+		AcquisitionCollector: collector,
 	})
 	if err != nil {
 		t.Fatalf("Render() error = %v, diagnostics = %#v", err, diags)
@@ -300,7 +303,38 @@ helmCharts:
 	if !hasRenderCacheEvent(recorder.Events(), "chart", "hit", "https://charts.example.test") {
 		t.Fatalf("Cache events = %#v, want chart hit", recorder.Events())
 	}
+	want := []cacheevent.AcquisitionRecord{{
+		Kind:              cacheevent.AcquisitionChart,
+		RequestedRevision: "1.2.3",
+		ResolvedRevision:  "1.2.3",
+	}}
+	if got := collector.Records(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Acquisition records = %#v, want %#v", got, want)
+	}
 }
+
+func TestKustomizeHelmChartRenderOptionsForwardAcquisitionCollector(t *testing.T) {
+	collector := cacheevent.NewAcquisitionCollector()
+	opts, err := renderOptionsForKustomizeHelmChart(
+		context.Background(),
+		types.HelmChart{Name: "demo", Version: "1.2.3"},
+		t.TempDir(),
+		t.TempDir(),
+		"charts/demo",
+		".",
+		"default",
+		"demo",
+		RenderOptions{AcquisitionCollector: collector},
+		&fakeChartAcquirer{chartDir: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatalf("renderOptionsForKustomizeHelmChart() error = %v", err)
+	}
+	if opts.AcquisitionCollector != collector {
+		t.Fatalf("AcquisitionCollector was not forwarded to nested Helm options")
+	}
+}
+
 func TestKustomizeRendererRecordsHelmChartRefreshCacheEvent(t *testing.T) {
 	root := t.TempDir()
 	chartDir := filepath.Join(t.TempDir(), "demo")

--- a/internal/render/kustomize_input_digest.go
+++ b/internal/render/kustomize_input_digest.go
@@ -1,0 +1,322 @@
+package render
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sholdee/drydock/internal/gitref"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+type kustomizeInputCollector struct {
+	repoRoot string
+	paths    map[string]gitref.PathDigestPath
+}
+
+// KustomizeInputDigestPaths returns the committed repository-relative local
+// inputs needed to key a persistent render cache entry for a Kustomize source.
+func KustomizeInputDigestPaths(ctx context.Context, source ResolvedSource, opts RenderOptions) ([]gitref.PathDigestPath, error) {
+	root, err := sourceRoot(source)
+	if err != nil {
+		return nil, err
+	}
+	_, graph, err := collectKustomizeGraphForPreparation(ctx, source.RepoRoot, root)
+	if err != nil {
+		return nil, err
+	}
+	sourceOptionGraph, sourceOptionPaths, err := sourceKustomizeWorkspaceAdditions(ctx, source.RepoRoot, root, opts)
+	if err != nil {
+		return nil, err
+	}
+	graph = append(graph, sourceOptionGraph...)
+
+	collector := &kustomizeInputCollector{
+		repoRoot: filepath.Clean(source.RepoRoot),
+		paths:    map[string]gitref.PathDigestPath{},
+	}
+	for _, node := range graph {
+		if err := collector.collectNode(ctx, node); err != nil {
+			return nil, err
+		}
+	}
+	for _, path := range sourceOptionPaths {
+		if err := collector.addAbsPath(ctx, path, false); err != nil {
+			return nil, err
+		}
+	}
+	out := make([]gitref.PathDigestPath, 0, len(collector.paths))
+	for _, item := range collector.paths {
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (c *kustomizeInputCollector) collectNode(ctx context.Context, node kustomizeGraphNode) error {
+	if err := c.addAbsPath(ctx, node.File, false); err != nil {
+		return err
+	}
+	// Every kustomization filename variant in the node's directory is a
+	// render input even when absent: kustomize errors on multiple variants
+	// and resolves them by precedence, so a variant appearing or vanishing
+	// must rotate the key. Optional-missing is itself a digest record.
+	for _, name := range kustomizationFileNames {
+		if err := c.addAbsPath(ctx, filepath.Join(node.Dir, name), true); err != nil {
+			return err
+		}
+	}
+	kustomization := node.Kustomization
+	if err := c.collectHelmRefs(ctx, node.Dir, kustomization); err != nil {
+		return err
+	}
+	if err := c.collectOperandRefs(ctx, node.Dir, kustomization); err != nil {
+		return err
+	}
+	if err := c.collectAuxiliaryRefs(ctx, node.Dir, kustomization); err != nil {
+		return err
+	}
+	if err := c.collectPatchRefs(ctx, node.Dir, kustomization); err != nil {
+		return err
+	}
+	for _, generator := range kustomization.ConfigMapGenerator {
+		if err := c.collectGeneratorRefs(ctx, node.Dir, generator.KvPairSources); err != nil {
+			return err
+		}
+	}
+	for _, generator := range kustomization.SecretGenerator {
+		if err := c.collectGeneratorRefs(ctx, node.Dir, generator.KvPairSources); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *kustomizeInputCollector) collectHelmRefs(ctx context.Context, dir string, kustomization types.Kustomization) error {
+	if len(kustomization.HelmCharts) == 0 {
+		return nil
+	}
+	chartHome := kustomizationChartHome(kustomization)
+	for _, helmChart := range kustomization.HelmCharts {
+		chartPath := localKustomizeHelmChartPath(dir, chartHome, helmChart)
+		chartOptional := helmChart.Repo != ""
+		if err := c.addAbsPath(ctx, chartPath, chartOptional); err != nil {
+			return fmt.Errorf("kustomize helmCharts.name %q: %w", helmChart.Name, err)
+		}
+		if err := c.collectHelmValueRef(ctx, dir, "helmCharts.valuesFile", helmChart.ValuesFile); err != nil {
+			return err
+		}
+		for _, valuesFile := range helmChart.AdditionalValuesFiles {
+			if err := c.collectHelmValueRef(ctx, dir, "helmCharts.additionalValuesFiles", valuesFile); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *kustomizeInputCollector) collectHelmValueRef(ctx context.Context, dir, field, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil
+	}
+	if isRemoteHelmValueFile(ref) {
+		return fmt.Errorf("kustomize %s %q is a remote Helm value file", field, redactKustomizeRef(ref))
+	}
+	return c.addLocalRef(ctx, dir, field, ref, false)
+}
+
+func (c *kustomizeInputCollector) collectOperandRefs(ctx context.Context, dir string, kustomization types.Kustomization) error {
+	for _, resource := range kustomization.Resources {
+		if err := c.addKustomizeRef(ctx, dir, "resources", resource, false); err != nil {
+			return err
+		}
+	}
+	for _, base := range kustomization.Bases { //nolint:staticcheck // Kustomize still accepts bases.
+		if err := c.addKustomizeRef(ctx, dir, "bases", base, false); err != nil {
+			return err
+		}
+	}
+	for _, component := range kustomization.Components {
+		if err := c.addKustomizeRef(ctx, dir, "components", component, false); err != nil {
+			return err
+		}
+	}
+	for _, crd := range kustomization.Crds {
+		if err := c.addKustomizeRef(ctx, dir, "crds", crd, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *kustomizeInputCollector) collectAuxiliaryRefs(ctx context.Context, dir string, kustomization types.Kustomization) error {
+	if err := c.addKustomizeRef(ctx, dir, "openapi.path", kustomization.OpenAPI["path"], false); err != nil {
+		return err
+	}
+	for _, ref := range kustomization.Configurations {
+		if err := c.addKustomizeRef(ctx, dir, "configurations", ref, false); err != nil {
+			return err
+		}
+	}
+	for _, ref := range kustomization.Generators {
+		if err := c.addKustomizeRef(ctx, dir, "generators", ref, false); err != nil {
+			return err
+		}
+	}
+	for _, ref := range kustomization.Transformers {
+		if err := c.addKustomizeRef(ctx, dir, "transformers", ref, false); err != nil {
+			return err
+		}
+	}
+	for _, ref := range kustomization.Validators {
+		if err := c.addKustomizeRef(ctx, dir, "validators", ref, false); err != nil {
+			return err
+		}
+	}
+	for _, replacement := range kustomization.Replacements {
+		if err := c.addKustomizeRef(ctx, dir, "replacements.path", replacement.Path, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *kustomizeInputCollector) collectPatchRefs(ctx context.Context, dir string, kustomization types.Kustomization) error {
+	for _, patch := range kustomization.Patches {
+		if err := c.addKustomizeRef(ctx, dir, "patches.path", patch.Path, false); err != nil {
+			return err
+		}
+	}
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Kustomize still accepts patchesJson6902.
+		if err := c.addKustomizeRef(ctx, dir, "patchesJson6902.path", patch.Path, false); err != nil {
+			return err
+		}
+	}
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Kustomize still accepts patchesStrategicMerge.
+		ref := string(patch)
+		if isInlineStrategicMergePatch(ref) {
+			continue
+		}
+		if err := c.addKustomizeRef(ctx, dir, "patchesStrategicMerge", ref, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *kustomizeInputCollector) collectGeneratorRefs(ctx context.Context, dir string, sources types.KvPairSources) error {
+	for _, source := range sources.FileSources {
+		if err := c.addKustomizeRef(ctx, dir, "generator.files", generatorFileSourcePath(source), false); err != nil {
+			return err
+		}
+	}
+	for _, source := range sources.EnvSources {
+		if err := c.addKustomizeRef(ctx, dir, "generator.envs", source, false); err != nil {
+			return err
+		}
+	}
+	return c.addKustomizeRef(ctx, dir, "generator.env", sources.EnvSource, false)
+}
+
+func (c *kustomizeInputCollector) addKustomizeRef(ctx context.Context, dir, field, ref string, optional bool) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil
+	}
+	request, parsed, ok, err := remoteRequestForKustomizeRef(ref)
+	if err != nil {
+		return err
+	}
+	if ok {
+		if request.Kind != "git-repo" || !isPinnedKustomizeRemoteRevision(parsed.Revision) {
+			return fmt.Errorf("kustomize %s %q is not a pinned remote Git ref", field, redactKustomizeRef(ref))
+		}
+		return nil
+	}
+	return c.addLocalRef(ctx, dir, field, ref, optional)
+}
+
+func (c *kustomizeInputCollector) addLocalRef(ctx context.Context, dir, field, ref string, optional bool) error {
+	if filepath.IsAbs(ref) {
+		return fmt.Errorf("kustomize %s %q must be relative", field, ref)
+	}
+	if isRemoteKustomizeRef(ref) {
+		return unsupportedRemoteKustomizeRefError(field, ref)
+	}
+	path := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ref)))
+	if err := rejectPathOutsideBoundary("kustomize "+field, path, c.repoRoot); err != nil {
+		return err
+	}
+	return c.addAbsPath(ctx, path, optional)
+}
+
+func (c *kustomizeInputCollector) addAbsPath(ctx context.Context, path string, optional bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path = filepath.Clean(path)
+	if err := rejectPathOutsideBoundary("kustomize input", path, c.repoRoot); err != nil {
+		return err
+	}
+	if err := rejectSymlinkedPath(c.repoRoot, path); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) && optional {
+			return c.addDigestPath(path, true)
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("path %q is a symlink", path)
+	}
+	if info.IsDir() {
+		if err := rejectSymlinksInTree(ctx, path); err != nil {
+			return err
+		}
+	}
+	return c.addDigestPath(path, optional)
+}
+
+func (c *kustomizeInputCollector) addDigestPath(path string, optional bool) error {
+	rel, err := relativeManifestPath(c.repoRoot, path)
+	if err != nil {
+		return err
+	}
+	rel = filepath.ToSlash(rel)
+	if existing, ok := c.paths[rel]; ok {
+		optional = existing.Optional && optional
+	}
+	c.paths[rel] = gitref.PathDigestPath{Path: rel, Optional: optional}
+	return nil
+}
+
+func rejectSymlinksInTree(ctx context.Context, root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path %q is a symlink", path)
+		}
+		return nil
+	})
+}
+
+func isPinnedKustomizeRemoteRevision(revision string) bool {
+	if len(revision) != 40 {
+		return false
+	}
+	for _, r := range revision {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/render/kustomize_workspace_remote.go
+++ b/internal/render/kustomize_workspace_remote.go
@@ -116,6 +116,17 @@ func (w *kustomizeWorkspace) acquireAndCopyKustomizeRef(ctx context.Context, dir
 }
 
 func recordRemoteCacheEvent(opts RenderOptions, request remote.Request, acquireErr error, acquired remote.Result) {
+	if acquireErr == nil && opts.AcquisitionCollector != nil {
+		kind := cacheevent.AcquisitionRemoteHTTP
+		if request.Kind == remote.RequestGitRepo {
+			kind = cacheevent.AcquisitionRemoteGit
+		}
+		opts.AcquisitionCollector.Record(cacheevent.AcquisitionRecord{
+			Kind:              kind,
+			RequestedRevision: request.Revision,
+			ResolvedRevision:  acquired.Revision,
+		})
+	}
 	if opts.CacheEventRecorder == nil {
 		return
 	}

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -72,6 +72,7 @@ type RenderOptions struct {
 	RemoteResourceGitCredentials remote.GitCredentials
 	RemoteResourceAcquirer       remote.Acquirer
 	CacheEventRecorder           *cacheevent.Recorder
+	AcquisitionCollector         *cacheevent.AcquisitionCollector
 	IncludeCRDs                  bool
 	IncludeCRDsSet               bool
 	SkipHooks                    bool

--- a/internal/rendercache/doc.go
+++ b/internal/rendercache/doc.go
@@ -1,0 +1,7 @@
+// Package rendercache implements the persistent on-disk render-output cache
+// store: content-addressed gzipped JSON envelopes with atomic writes and
+// LRU-by-mtime size-cap eviction. The package stores opaque payload bytes and
+// has no knowledge of internal/app types; the app layer marshals its own
+// payload, so this package can be imported by internal/app without an import
+// cycle.
+package rendercache

--- a/internal/rendercache/eviction.go
+++ b/internal/rendercache/eviction.go
@@ -1,0 +1,135 @@
+package rendercache
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// putTempPrefix matches Store.Put's os.CreateTemp pattern. A crash between
+// CreateTemp and the final rename strands these files; they never match the
+// .json.gz entry filter, so the sweep removes them once they are old enough
+// to be provably abandoned rather than a concurrent Put in flight.
+const putTempPrefix = ".put-"
+
+const orphanTempMaxAge = time.Hour
+
+// SweepResult reports what one eviction sweep did.
+type SweepResult struct {
+	// TotalBytes is the post-sweep sum of entry sizes.
+	TotalBytes int64
+	// EvictedBytes is the sum of deleted entry sizes.
+	EvictedBytes int64
+	// EvictedKeys lists deleted entry keys in eviction order.
+	EvictedKeys []string
+}
+
+type storeEntry struct {
+	path    string
+	key     string
+	size    int64
+	modTime time.Time
+}
+
+// Sweep enforces the size cap. When the summed entry size exceeds the cap, it
+// deletes oldest-mtime entries until at or below 90% of cap. Missing files are
+// tolerated so concurrent sweeps and concurrent corrupt-entry deletes race
+// benignly. Sweep also removes stale orphaned .put-* temp files regardless of
+// the cap.
+func (s *Store) Sweep() (SweepResult, error) {
+	entries, totalBytes, err := s.listEntries()
+	if err != nil {
+		return SweepResult{}, err
+	}
+	result := SweepResult{TotalBytes: totalBytes}
+	if totalBytes <= s.maxSizeBytes {
+		return result, nil
+	}
+	target := s.maxSizeBytes / 10 * 9
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+	for _, entry := range entries {
+		if result.TotalBytes <= target {
+			break
+		}
+		if err := deleteEntryFile(entry.path); err != nil {
+			return result, err
+		}
+		result.TotalBytes -= entry.size
+		result.EvictedBytes += entry.size
+		result.EvictedKeys = append(result.EvictedKeys, entry.key)
+	}
+	return result, nil
+}
+
+func (s *Store) listEntries() ([]storeEntry, int64, error) {
+	var entries []storeEntry
+	var total int64
+	err := filepath.WalkDir(s.root, func(path string, d fs.DirEntry, walkErr error) error {
+		if errors.Is(walkErr, fs.ErrNotExist) {
+			return nil
+		}
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if strings.HasPrefix(name, putTempPrefix) {
+			info, err := d.Info()
+			if err != nil {
+				return ignoreMissingEntry(err)
+			}
+			if time.Since(info.ModTime()) > orphanTempMaxAge {
+				_ = deleteEntryFile(path)
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".json.gz") {
+			return nil
+		}
+		key := strings.TrimSuffix(name, ".json.gz")
+		if !validEntryKey(key) {
+			return nil
+		}
+		entryPath, err := s.entryPath(key)
+		if err != nil {
+			return err
+		}
+		if path != entryPath {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return ignoreMissingEntry(err)
+		}
+		entries = append(entries, storeEntry{
+			path:    path,
+			key:     key,
+			size:    info.Size(),
+			modTime: info.ModTime(),
+		})
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return entries, total, nil
+}
+
+func ignoreMissingEntry(err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func validEntryKey(key string) bool {
+	return validateKey(key) == nil
+}

--- a/internal/rendercache/eviction_test.go
+++ b/internal/rendercache/eviction_test.go
@@ -1,0 +1,229 @@
+package rendercache
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// putRandomEntry writes an entry with an incompressible random payload so gzip
+// cannot collapse it to nothing, then pins its mtime. Tests derive caps from
+// measured on-disk sizes via listEntries rather than guessing compressed sizes.
+func putRandomEntry(t *testing.T, store *Store, dir, seed string, payloadBytes int, modTime time.Time) string {
+	t.Helper()
+	key := testKey(seed)
+	random := rand.New(rand.NewSource(int64(len(seed)) + 7919))
+	data := make([]byte, payloadBytes)
+	random.Read(data)
+	payload := []byte(`{"data":"` + hex.EncodeToString(data) + `"}`)
+	if err := store.Put(key, payload, EntryMeta{}); err != nil {
+		t.Fatalf("Put(%s) error = %v", seed, err)
+	}
+	path := filepath.Join(dir, "v1", key[:2], key+".json.gz")
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("Chtimes(%s) error = %v", path, err)
+	}
+	return key
+}
+
+func entryExists(t *testing.T, dir, key string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, "v1", key[:2], key+".json.gz"))
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	t.Fatalf("Stat() error = %v", err)
+	return false
+}
+
+func TestSweepUnderCapDeletesNothing(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 1024*1024)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := putRandomEntry(t, store, dir, "small", 1024, time.Now())
+
+	result, err := store.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if len(result.EvictedKeys) != 0 {
+		t.Fatalf("EvictedKeys = %v, want none", result.EvictedKeys)
+	}
+	if !entryExists(t, dir, key) {
+		t.Fatalf("entry was deleted under cap")
+	}
+}
+
+func TestSweepEvictsOldestUntilBelowNinetyPercent(t *testing.T) {
+	dir := t.TempDir()
+	prime, err := Open(dir, DefaultMaxSizeBytes)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	base := time.Now().Add(-time.Hour)
+	oldest := putRandomEntry(t, prime, dir, "entry-oldest", 8*1024, base)
+	middle := putRandomEntry(t, prime, dir, "entry-middle", 8*1024, base.Add(time.Minute))
+	newest := putRandomEntry(t, prime, dir, "entry-newest", 8*1024, base.Add(2*time.Minute))
+
+	// Measure real on-disk sizes, then reopen with cap = total-1: the
+	// directory is over cap by one byte, and deleting the oldest entry
+	// (~1/3 of total) lands well under 90% of cap, so the sweep must delete
+	// exactly the oldest entry and stop.
+	_, total, err := prime.listEntries()
+	if err != nil {
+		t.Fatalf("listEntries() error = %v", err)
+	}
+	store, err := Open(dir, total-1)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	result, err := store.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if len(result.EvictedKeys) != 1 || result.EvictedKeys[0] != oldest {
+		t.Fatalf("EvictedKeys = %v, want exactly [%s]", result.EvictedKeys, oldest)
+	}
+	if entryExists(t, dir, oldest) {
+		t.Fatalf("oldest entry survived sweep")
+	}
+	if !entryExists(t, dir, middle) || !entryExists(t, dir, newest) {
+		t.Fatalf("newer entries were evicted")
+	}
+	if result.TotalBytes > (total-1)/10*9 {
+		t.Fatalf("TotalBytes after sweep = %d, want <= %d", result.TotalBytes, (total-1)/10*9)
+	}
+}
+
+func TestSweepStopsAtNinetyPercentNotZero(t *testing.T) {
+	dir := t.TempDir()
+	prime, err := Open(dir, DefaultMaxSizeBytes)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	base := time.Now().Add(-time.Hour)
+	for i := range 6 {
+		putRandomEntry(t, prime, dir, fmt.Sprintf("entry-%d", i), 4*1024, base.Add(time.Duration(i)*time.Minute))
+	}
+	_, total, err := prime.listEntries()
+	if err != nil {
+		t.Fatalf("listEntries() error = %v", err)
+	}
+	store, err := Open(dir, total/2)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	result, err := store.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if result.TotalBytes == 0 {
+		t.Fatalf("Sweep() deleted everything; want prune to ~90%% of cap")
+	}
+	if result.TotalBytes > total/2/10*9 {
+		t.Fatalf("TotalBytes = %d, want <= %d", result.TotalBytes, total/2/10*9)
+	}
+	if len(result.EvictedKeys) == 0 || len(result.EvictedKeys) == 6 {
+		t.Fatalf("EvictedKeys = %d entries, want some but not all evicted", len(result.EvictedKeys))
+	}
+}
+
+func TestSweepToleratesConcurrentlyDeletedEntries(t *testing.T) {
+	// deleteEntryFile is the sweep's deletion primitive; it must tolerate
+	// ENOENT so two concurrent sweeps race benignly.
+	if err := deleteEntryFile(filepath.Join(t.TempDir(), "v1", "ab", testKey("gone")+".json.gz")); err != nil {
+		t.Fatalf("deleteEntryFile() error = %v, want nil for missing file", err)
+	}
+}
+
+func TestSweepIgnoresForeignFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 1024)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	foreign := filepath.Join(dir, "v1", "zz", "README.txt")
+	if err := os.MkdirAll(filepath.Dir(foreign), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(foreign, make([]byte, 4096), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	result, err := store.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if len(result.EvictedKeys) != 0 {
+		t.Fatalf("EvictedKeys = %v, want none (foreign files are not entries)", result.EvictedKeys)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign file was touched: %v", err)
+	}
+}
+
+func TestSweepIgnoresValidKeyOutsideCanonicalShard(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 1024)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("foreign-valid-key")
+	foreign := filepath.Join(dir, "v1", "zz", key+".json.gz")
+	if err := os.MkdirAll(filepath.Dir(foreign), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(foreign, make([]byte, 4096), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	result, err := store.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if len(result.EvictedKeys) != 0 {
+		t.Fatalf("EvictedKeys = %v, want none (wrong-shard files are not entries)", result.EvictedKeys)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("wrong-shard file was touched: %v", err)
+	}
+}
+
+func TestSweepRemovesStaleOrphanTempFiles(t *testing.T) {
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	shard := filepath.Join(store.root, "ab")
+	if err := os.MkdirAll(shard, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	stale := filepath.Join(shard, ".put-stale123")
+	fresh := filepath.Join(shard, ".put-fresh456")
+	for _, path := range []string{stale, fresh} {
+		if err := os.WriteFile(path, []byte("orphan"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("Chtimes() error = %v", err)
+	}
+
+	if _, err := store.Sweep(); err != nil {
+		t.Fatalf("Sweep() error = %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale orphan %q still present after sweep", stale)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh temp file %q was removed; it may belong to a concurrent Put: %v", fresh, err)
+	}
+}

--- a/internal/rendercache/fingerprint.go
+++ b/internal/rendercache/fingerprint.go
@@ -1,0 +1,113 @@
+package rendercache
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Render-relevant engine module paths. These participate in the persistent
+// key; cmd/drydock and the CLI version output alias them so there is exactly
+// one list to extend when a new module starts affecting rendered output.
+const (
+	ArgoCDModulePath       = "github.com/argoproj/argo-cd/v3"
+	GitOpsEngineModulePath = "github.com/argoproj/argo-cd/gitops-engine"
+	HelmModulePath         = "helm.sh/helm/v4"
+	KustomizeModulePath    = "sigs.k8s.io/kustomize/api"
+	JsonnetModulePath      = "github.com/google/go-jsonnet"
+	KubernetesModulePath   = "k8s.io/apimachinery"
+)
+
+// EngineFingerprint identifies the render code that produced or would
+// consume a cache entry. All fields participate in the persistent key.
+type EngineFingerprint struct {
+	Version            string `json:"version"`
+	Commit             string `json:"commit"`
+	ArgoCDModule       string `json:"argoCDModule"`
+	GitOpsEngineModule string `json:"gitOpsEngineModule"`
+	HelmModule         string `json:"helmModule"`
+	KustomizeModule    string `json:"kustomizeModule"`
+	JsonnetModule      string `json:"jsonnetModule"`
+	KubernetesModule   string `json:"kubernetesModule"`
+}
+
+// Known reports whether the fingerprint can prove which render code built an
+// entry. An un-ldflagged dev build ("none"/empty commit, no clean VCS
+// buildinfo) cannot, so persistence is disabled for it.
+func (f EngineFingerprint) Known() bool {
+	commit := strings.TrimSpace(f.Commit)
+	return commit != "" && commit != "none"
+}
+
+// FingerprintFromBuildInfo derives a fingerprint from debug.ReadBuildInfo:
+// module versions from Deps, commit from clean VCS stamping. pkg/drydock uses
+// this so library consumers never supply the fingerprint themselves.
+func FingerprintFromBuildInfo() EngineFingerprint {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return EngineFingerprint{Commit: "none"}
+	}
+	fingerprint := EngineFingerprint{
+		Version:            info.Main.Version,
+		Commit:             "none",
+		ArgoCDModule:       ModuleLabel(info, ArgoCDModulePath),
+		GitOpsEngineModule: ModuleLabel(info, GitOpsEngineModulePath),
+		HelmModule:         ModuleLabel(info, HelmModulePath),
+		KustomizeModule:    ModuleLabel(info, KustomizeModulePath),
+		JsonnetModule:      ModuleLabel(info, JsonnetModulePath),
+		KubernetesModule:   ModuleLabel(info, KubernetesModulePath),
+	}
+	if commit, ok := vcsCommit(info); ok {
+		fingerprint.Commit = commit
+	}
+	return fingerprint
+}
+
+// VCSCommitFromBuildInfo returns the embedded clean VCS revision, if any. A
+// dirty worktree build returns ("", false) because it cannot prove its render
+// code matches any cached entry.
+func VCSCommitFromBuildInfo() (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	return vcsCommit(info)
+}
+
+func vcsCommit(info *debug.BuildInfo) (string, bool) {
+	revision := ""
+	dirty := false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+	if revision == "" || dirty {
+		return "", false
+	}
+	return revision, true
+}
+
+// ModuleLabel formats the version label for modulePath from build info,
+// including any replace directive. Unknown modules return the bare path.
+func ModuleLabel(info *debug.BuildInfo, modulePath string) string {
+	for _, dep := range info.Deps {
+		if dep.Path == modulePath {
+			return formatModuleLabel(*dep)
+		}
+	}
+	return modulePath
+}
+
+func formatModuleLabel(module debug.Module) string {
+	label := module.Path
+	if module.Version != "" {
+		label += "@" + module.Version
+	}
+	if module.Replace != nil {
+		label += " => " + formatModuleLabel(*module.Replace)
+	}
+	return label
+}

--- a/internal/rendercache/fingerprint_test.go
+++ b/internal/rendercache/fingerprint_test.go
@@ -1,0 +1,67 @@
+package rendercache
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestEngineFingerprintKnown(t *testing.T) {
+	cases := []struct {
+		name   string
+		commit string
+		want   bool
+	}{
+		{name: "release commit", commit: "0123456789abcdef0123456789abcdef01234567", want: true},
+		{name: "short commit", commit: "abc1234", want: true},
+		{name: "dev none", commit: "none", want: false},
+		{name: "empty", commit: "", want: false},
+		{name: "whitespace", commit: "   ", want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fingerprint := EngineFingerprint{Commit: testCase.commit}
+			if got := fingerprint.Known(); got != testCase.want {
+				t.Fatalf("Known() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestFingerprintFromBuildInfoIsConsistentWithVCSCommit(t *testing.T) {
+	// Test binaries do not carry VCS stamping, so the exact values depend on
+	// the build; the contract is internal consistency: the fingerprint commit
+	// is "none" exactly when no clean VCS revision is available.
+	fingerprint := FingerprintFromBuildInfo()
+	commit, ok := VCSCommitFromBuildInfo()
+	if ok {
+		if fingerprint.Commit != commit {
+			t.Fatalf("FingerprintFromBuildInfo().Commit = %q, want VCS commit %q", fingerprint.Commit, commit)
+		}
+		if !fingerprint.Known() {
+			t.Fatalf("Known() = false with VCS commit available")
+		}
+		return
+	}
+	if fingerprint.Commit != "none" {
+		t.Fatalf("FingerprintFromBuildInfo().Commit = %q, want \"none\" without VCS data", fingerprint.Commit)
+	}
+	if fingerprint.Known() {
+		t.Fatalf("Known() = true without VCS data")
+	}
+}
+
+func TestModuleLabelIncludesReplacement(t *testing.T) {
+	info := &debug.BuildInfo{Deps: []*debug.Module{{
+		Path:    "helm.sh/helm/v4",
+		Version: "v4.0.0",
+		Replace: &debug.Module{Path: "example.test/fork/helm", Version: "v4.0.1"},
+	}}}
+	got := ModuleLabel(info, "helm.sh/helm/v4")
+	want := "helm.sh/helm/v4@v4.0.0 => example.test/fork/helm@v4.0.1"
+	if got != want {
+		t.Fatalf("ModuleLabel() = %q, want %q", got, want)
+	}
+	if got := ModuleLabel(info, "unknown.test/module"); got != "unknown.test/module" {
+		t.Fatalf("ModuleLabel(unknown) = %q, want bare path", got)
+	}
+}

--- a/internal/rendercache/store.go
+++ b/internal/rendercache/store.go
@@ -1,0 +1,274 @@
+package rendercache
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/sholdee/drydock/internal/pathsafety"
+)
+
+// FormatVersion is the entry schema version. It rotates together with the
+// "v1" path segment on any entry-schema change and participates in the
+// persistent render cache key.
+const FormatVersion = 1
+
+// DefaultMaxSizeBytes is the default eviction cap: 512 MiB.
+const DefaultMaxSizeBytes int64 = 512 * 1024 * 1024
+
+const storeVersionSegment = "v1"
+
+// Store is a handle on one cache directory. It is safe for concurrent use;
+// concurrent processes sharing the directory are safe by construction through
+// atomic rename writes and ENOENT-tolerant deletes.
+type Store struct {
+	root         string
+	maxSizeBytes int64
+	writes       atomic.Int64
+}
+
+// EntryMeta describes the drydock build that produced an entry. It is stored
+// in the envelope for debuggability and never read back into results.
+type EntryMeta struct {
+	Version string
+	Commit  string
+}
+
+type envelopeOrigin struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+type envelope struct {
+	FormatVersion int             `json:"formatVersion"`
+	Key           string          `json:"key"`
+	CreatedAt     string          `json:"createdAt"`
+	Drydock       envelopeOrigin  `json:"drydock"`
+	Result        json.RawMessage `json:"result"`
+}
+
+// DefaultDir returns <os.UserCacheDir()>/drydock/render, consistent with the
+// existing git/chart/remote cache roots.
+func DefaultDir() (string, error) {
+	root, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "drydock", "render"), nil
+}
+
+// Open prepares the versioned cache root under dir. An empty dir uses
+// DefaultDir; a non-positive maxSizeBytes uses DefaultMaxSizeBytes.
+func Open(dir string, maxSizeBytes int64) (*Store, error) {
+	dir, err := ResolveDir(dir, nil)
+	if err != nil {
+		return nil, err
+	}
+	if maxSizeBytes <= 0 {
+		maxSizeBytes = DefaultMaxSizeBytes
+	}
+	root := filepath.Join(dir, storeVersionSegment)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("prepare render cache directory: %w", err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return nil, fmt.Errorf("secure render cache directory: %w", err)
+	}
+	return &Store{root: root, maxSizeBytes: maxSizeBytes}, nil
+}
+
+// ResolveDir resolves the configured render cache root and rejects locations
+// inside repository roots or other protected roots.
+func ResolveDir(dir string, forbiddenRoots []string) (string, error) {
+	if dir == "" {
+		resolved, err := DefaultDir()
+		if err != nil {
+			return "", err
+		}
+		dir = resolved
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	absDir = filepath.Clean(absDir)
+	inside, matchedRoot, err := pathsafety.IsInsideAny(absDir, forbiddenRoots)
+	if err != nil {
+		return "", err
+	}
+	if inside {
+		return "", fmt.Errorf("render cache dir %q must not be inside repository root %q", absDir, matchedRoot)
+	}
+	return absDir, nil
+}
+
+// Writes reports how many entries this handle has written. The post-run
+// eviction sweep only runs when at least one entry was written.
+func (s *Store) Writes() int64 {
+	return s.writes.Load()
+}
+
+func validateKey(key string) error {
+	if len(key) != 64 {
+		return fmt.Errorf("render cache key must be 64 lowercase hex characters")
+	}
+	for _, r := range key {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return fmt.Errorf("render cache key must be 64 lowercase hex characters")
+		}
+	}
+	return nil
+}
+
+func (s *Store) entryPath(key string) (string, error) {
+	if err := validateKey(key); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.root, key[:2], key+".json.gz"), nil
+}
+
+// Get returns the opaque payload for key. A missing entry is (nil, false,
+// nil). A corrupt, unparseable, or wrong-key entry is deleted
+// (ENOENT-tolerant) and reported as an error so callers can emit an
+// error-action cache event and treat it as a miss. A hit refreshes the entry
+// mtime best-effort for LRU eviction.
+func (s *Store) Get(key string) ([]byte, bool, error) {
+	path, err := s.entryPath(key)
+	if err != nil {
+		return nil, false, err
+	}
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	payload, readErr := readEntry(file, key)
+	closeErr := file.Close()
+	if readErr != nil {
+		_ = deleteEntryFile(path)
+		return nil, false, readErr
+	}
+	if closeErr != nil {
+		return nil, false, closeErr
+	}
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
+	return payload, true, nil
+}
+
+func readEntry(reader io.Reader, key string) ([]byte, error) {
+	gz, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("render cache entry %s: decompress: %w", key[:12], err)
+	}
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		return nil, fmt.Errorf("render cache entry %s: decompress: %w", key[:12], err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("render cache entry %s: decompress: %w", key[:12], err)
+	}
+	var entry envelope
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("render cache entry %s: decode: %w", key[:12], err)
+	}
+	if entry.FormatVersion != FormatVersion {
+		return nil, fmt.Errorf("render cache entry %s: format version %d, want %d", key[:12], entry.FormatVersion, FormatVersion)
+	}
+	if entry.Key != key {
+		return nil, fmt.Errorf("render cache entry %s: key mismatch", key[:12])
+	}
+	if len(entry.Result) == 0 {
+		return nil, fmt.Errorf("render cache entry %s: empty result payload", key[:12])
+	}
+	return entry.Result, nil
+}
+
+// Put writes the entry atomically: serialize to a temp file in the destination
+// directory, then rename. A lost write race with a concurrent process costs
+// one redundant render; torn reads are avoided by never writing in place.
+func (s *Store) Put(key string, payload []byte, meta EntryMeta) error {
+	path, err := s.entryPath(key)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("prepare render cache shard directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("secure render cache shard directory: %w", err)
+	}
+	entry := envelope{
+		FormatVersion: FormatVersion,
+		Key:           key,
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
+		Drydock:       envelopeOrigin(meta),
+		Result:        json.RawMessage(payload),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode render cache entry: %w", err)
+	}
+	temp, err := os.CreateTemp(dir, ".put-*")
+	if err != nil {
+		return fmt.Errorf("write render cache entry: %w", err)
+	}
+	tempPath := temp.Name()
+	cleanupTemp := func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		cleanupTemp()
+		return fmt.Errorf("write render cache entry: %w", err)
+	}
+	if err := writeGzip(temp, data); err != nil {
+		cleanupTemp()
+		return fmt.Errorf("write render cache entry: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("write render cache entry: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("write render cache entry: %w", err)
+	}
+	s.writes.Add(1)
+	return nil
+}
+
+func writeGzip(w io.Writer, data []byte) error {
+	gz := gzip.NewWriter(w)
+	if _, err := gz.Write(data); err != nil {
+		_ = gz.Close()
+		return err
+	}
+	return gz.Close()
+}
+
+// Delete removes the entry for key, tolerating a missing file.
+func (s *Store) Delete(key string) error {
+	path, err := s.entryPath(key)
+	if err != nil {
+		return err
+	}
+	return deleteEntryFile(path)
+}
+
+func deleteEntryFile(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/internal/rendercache/store_test.go
+++ b/internal/rendercache/store_test.go
@@ -1,0 +1,361 @@
+package rendercache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func testKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestStorePutGetRoundTrip(t *testing.T) {
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("round-trip")
+	payload := []byte(`{"manifests":[{"sourceIndex":0}]}`)
+
+	if err := store.Put(key, payload, EntryMeta{Version: "1.2.3", Commit: "abc"}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	got, hit, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !hit {
+		t.Fatalf("Get() hit = false, want true")
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("Get() payload = %s, want %s", got, payload)
+	}
+	if got := store.Writes(); got != 1 {
+		t.Fatalf("Writes() = %d, want 1", got)
+	}
+}
+
+func TestStoreGetMissingKeyIsMiss(t *testing.T) {
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	payload, hit, err := store.Get(testKey("missing"))
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if hit || payload != nil {
+		t.Fatalf("Get() = (%v, %t), want (nil, false)", payload, hit)
+	}
+}
+
+func TestDefaultDirUsesUserCacheDir(t *testing.T) {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Skipf("os.UserCacheDir() unavailable: %v", err)
+	}
+	got, err := DefaultDir()
+	if err != nil {
+		t.Fatalf("DefaultDir() error = %v", err)
+	}
+	want := filepath.Join(userCacheDir, "drydock", "render")
+	if got != want {
+		t.Fatalf("DefaultDir() = %s, want %s", got, want)
+	}
+}
+
+func TestResolveDirRejectsSymlinkIntoForbiddenRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink privileges are not guaranteed on Windows")
+	}
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(outside, "render-link")
+	if err := os.Symlink(repoRoot, link); err != nil {
+		t.Skipf("create symlink: %v", err)
+	}
+	_, err := ResolveDir(filepath.Join(link, "render"), []string{repoRoot})
+	if err == nil || !strings.Contains(err.Error(), "render cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+		t.Fatalf("ResolveDir() error = %v, want symlink containment error", err)
+	}
+}
+
+func TestStoreEntryLayoutAndPermissions(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("layout")
+	if err := store.Put(key, []byte(`{}`), EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	entryPath := filepath.Join(dir, "v1", key[:2], key+".json.gz")
+	info, err := os.Stat(entryPath)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", entryPath, err)
+	}
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("entry mode = %v, want 0600", got)
+		}
+		dirInfo, err := os.Stat(filepath.Join(dir, "v1", key[:2]))
+		if err != nil {
+			t.Fatalf("Stat(shard dir) error = %v", err)
+		}
+		if got := dirInfo.Mode().Perm(); got != 0o700 {
+			t.Fatalf("shard dir mode = %v, want 0700", got)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "v1", key[:2]))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("shard dir entries = %d, want 1 (no leftover temp files)", len(entries))
+	}
+}
+
+func TestStoreEnvelopeFields(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("envelope")
+	if err := store.Put(key, []byte(`{"ok":true}`), EntryMeta{Version: "9.9.9", Commit: "feedface"}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "v1", key[:2], key+".json.gz"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("gzip.NewReader() error = %v", err)
+	}
+	var entry struct {
+		FormatVersion int    `json:"formatVersion"`
+		Key           string `json:"key"`
+		CreatedAt     string `json:"createdAt"`
+		Drydock       struct {
+			Version string `json:"version"`
+			Commit  string `json:"commit"`
+		} `json:"drydock"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.NewDecoder(gz).Decode(&entry); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if entry.FormatVersion != FormatVersion {
+		t.Fatalf("formatVersion = %d, want %d", entry.FormatVersion, FormatVersion)
+	}
+	if entry.Key != key {
+		t.Fatalf("key = %s, want %s", entry.Key, key)
+	}
+	if entry.CreatedAt == "" {
+		t.Fatalf("createdAt is empty")
+	}
+	if entry.Drydock.Version != "9.9.9" || entry.Drydock.Commit != "feedface" {
+		t.Fatalf("drydock = %+v, want {9.9.9 feedface}", entry.Drydock)
+	}
+	if string(entry.Result) != `{"ok":true}` {
+		t.Fatalf("result = %s, want {\"ok\":true}", entry.Result)
+	}
+}
+
+func TestStoreCorruptEntryDeletedAndErrors(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	cases := []struct {
+		name string
+		body func(t *testing.T, key, path string)
+	}{
+		{name: "truncated gzip", body: func(t *testing.T, key, path string) {
+			writeTruncatedGzipEntry(t, store, key, path)
+		}},
+		{name: "invalid json", body: writeInvalidJSONEntry},
+		{name: "key mismatch", body: func(t *testing.T, key, path string) {
+			writeMismatchedKeyEntry(t, store, dir, path)
+		}},
+	}
+	for i, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			key := testKey(fmt.Sprintf("corrupt-%d", i))
+			path := filepath.Join(dir, "v1", key[:2], key+".json.gz")
+			testCase.body(t, key, path)
+
+			payload, hit, err := store.Get(key)
+			if err == nil {
+				t.Fatalf("Get() error = nil, want corrupt-entry error")
+			}
+			if hit || payload != nil {
+				t.Fatalf("Get() = (%v, %t), want (nil, false)", payload, hit)
+			}
+			if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+				t.Fatalf("corrupt entry still exists: stat err = %v", statErr)
+			}
+		})
+	}
+}
+
+func writeTruncatedGzipEntry(t *testing.T, store *Store, key, path string) {
+	t.Helper()
+	if err := store.Put(key, []byte(`{}`), EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := os.WriteFile(path, raw[:len(raw)/2], 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeInvalidJSONEntry(t *testing.T, _ string, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	var buffer bytes.Buffer
+	gz := gzip.NewWriter(&buffer)
+	if _, err := gz.Write([]byte("not-json")); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	if err := os.WriteFile(path, buffer.Bytes(), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeMismatchedKeyEntry(t *testing.T, store *Store, dir, path string) {
+	t.Helper()
+	other := testKey("some-other-key")
+	if err := store.Put(other, []byte(`{}`), EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	otherPath := filepath.Join(dir, "v1", other[:2], other+".json.gz")
+	raw, err := os.ReadFile(otherPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func TestStoreRejectsInvalidKeys(t *testing.T) {
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	for _, key := range []string{"", "short", strings.Repeat("z", 64), "../" + strings.Repeat("a", 61)} {
+		if err := store.Put(key, []byte(`{}`), EntryMeta{}); err == nil {
+			t.Fatalf("Put(%q) error = nil, want invalid-key error", key)
+		}
+		if _, _, err := store.Get(key); err == nil {
+			t.Fatalf("Get(%q) error = nil, want invalid-key error", key)
+		}
+	}
+}
+
+func TestStoreDeleteToleratesMissing(t *testing.T) {
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := store.Delete(testKey("never-written")); err != nil {
+		t.Fatalf("Delete() error = %v, want nil for missing entry", err)
+	}
+}
+
+func TestStoreDeleteRemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(dir, 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("delete")
+	if err := store.Put(key, []byte(`{"ok":true}`), EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if err := store.Delete(key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	got, hit, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if hit || got != nil {
+		t.Fatalf("Get() = (%v, %t), want (nil, false)", got, hit)
+	}
+	path := filepath.Join(dir, "v1", key[:2], key+".json.gz")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("deleted entry still exists: stat err = %v", err)
+	}
+}
+
+// Atomicity property: while one goroutine overwrites an entry repeatedly,
+// concurrent readers must never observe a partial entry; every hit parses.
+func TestStoreConcurrentGetNeverSeesPartialEntry(t *testing.T) {
+	// Same OS gate pattern as the permission checks above: Windows cannot
+	// reliably rename over an entry a concurrent reader holds open.
+	if runtime.GOOS == "windows" {
+		t.Skip("rename-over-existing with a concurrent reader is unreliable on Windows")
+	}
+	store, err := Open(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	key := testKey("atomic")
+	payload := []byte(`{"data":"` + strings.Repeat("x", 64*1024) + `"}`)
+	if err := store.Put(key, payload, EntryMeta{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			if err := store.Put(key, payload, EntryMeta{}); err != nil {
+				t.Errorf("Put() error = %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			got, hit, err := store.Get(key)
+			if err != nil {
+				t.Errorf("Get() error = %v", err)
+				return
+			}
+			if hit && !bytes.Equal(got, payload) {
+				t.Errorf("Get() returned partial/foreign payload (%d bytes)", len(got))
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	"github.com/sholdee/drydock/internal/source"
 )
 
@@ -62,6 +63,11 @@ type Options struct {
 	ApplicationSetProviderFixtures []string
 	ApplicationSetProviderData     appset.ProviderData
 	RecordCacheEvents              bool
+	RenderCacheEnabled             bool
+	RenderCacheDir                 string
+	RenderCacheMaxBytes            int64
+	RefreshRenders                 bool
+	EngineFingerprint              rendercache.EngineFingerprint
 }
 
 func (options Options) Build() app.BuildRequest {
@@ -72,6 +78,7 @@ func (options Options) Build() app.BuildRequest {
 		DiscoveryOptions:       options.discoveryOptions(),
 		ValidateLuaHealth:      options.ValidateLuaHealth,
 		AcquisitionOptions:     options.acquisitionOptions(),
+		RenderCacheOptions:     options.renderCacheOptions(),
 		PluginOptions:          options.pluginOptions(),
 		ExecutionOptions:       options.executionOptions(),
 		FilterOptions:          options.filterOptions(),
@@ -101,6 +108,7 @@ func (options Options) Diff() app.DiffRequest {
 		StripAttrs:              append([]string(nil), options.StripAttrs...),
 		ShowIgnoredFields:       options.ShowIgnoredFields,
 		AcquisitionOptions:      options.acquisitionOptions(),
+		RenderCacheOptions:      options.renderCacheOptions(),
 		PluginOptions:           options.pluginOptions(),
 		ExecutionOptions:        options.executionOptions(),
 		FilterOptions:           options.filterOptions(),
@@ -133,6 +141,16 @@ func (options Options) acquisitionOptions() app.AcquisitionOptions {
 		RemoteResourceCredentials:    options.RemoteResourceCredentials,
 		RemoteResourceGitCredentials: options.RemoteResourceGitCredentials,
 		RecordCacheEvents:            options.RecordCacheEvents,
+	}
+}
+
+func (options Options) renderCacheOptions() app.RenderCacheOptions {
+	return app.RenderCacheOptions{
+		RenderCacheEnabled:  options.RenderCacheEnabled,
+		RenderCacheDir:      options.RenderCacheDir,
+		RenderCacheMaxBytes: options.RenderCacheMaxBytes,
+		RefreshRenders:      options.RefreshRenders,
+		EngineFingerprint:   options.EngineFingerprint,
 	}
 }
 

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/remote"
+	"github.com/sholdee/drydock/internal/rendercache"
 	"github.com/sholdee/drydock/internal/source"
 )
 
@@ -53,6 +54,11 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "ApplicationSetProviderFixtures", request.ApplicationSetProviderFixtures, []string{"fixtures.yaml"})
 	assertDeepEqual(t, "ApplicationSetProviderData", request.ApplicationSetProviderData, providerDataFixture())
 	assertDeepEqual(t, "RecordCacheEvents", request.RecordCacheEvents, true)
+	assertDeepEqual(t, "RenderCacheEnabled", request.RenderCacheEnabled, true)
+	assertDeepEqual(t, "RenderCacheDir", request.RenderCacheDir, "render-cache")
+	assertDeepEqual(t, "RenderCacheMaxBytes", request.RenderCacheMaxBytes, int64(123456))
+	assertDeepEqual(t, "RefreshRenders", request.RefreshRenders, true)
+	assertDeepEqual(t, "EngineFingerprint", request.EngineFingerprint, rendercache.EngineFingerprint{Version: "1.2.3", Commit: "abc"})
 
 	mutateOptions(&options)
 	assertDeepEqual(t, "copied DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
@@ -114,6 +120,11 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "ApplicationSetProviderFixtures", request.ApplicationSetProviderFixtures, []string{"fixtures.yaml"})
 	assertDeepEqual(t, "ApplicationSetProviderData", request.ApplicationSetProviderData, providerDataFixture())
 	assertDeepEqual(t, "RecordCacheEvents", request.RecordCacheEvents, true)
+	assertDeepEqual(t, "RenderCacheEnabled", request.RenderCacheEnabled, true)
+	assertDeepEqual(t, "RenderCacheDir", request.RenderCacheDir, "render-cache")
+	assertDeepEqual(t, "RenderCacheMaxBytes", request.RenderCacheMaxBytes, int64(123456))
+	assertDeepEqual(t, "RefreshRenders", request.RefreshRenders, true)
+	assertDeepEqual(t, "EngineFingerprint", request.EngineFingerprint, rendercache.EngineFingerprint{Version: "1.2.3", Commit: "abc"})
 
 	mutateOptions(&options)
 	assertDeepEqual(t, "copied DiscoverKustomizePaths", request.DiscoverKustomizePaths, []string{"argocd/overlays/prod"})
@@ -183,6 +194,11 @@ func fixtureOptions() Options {
 		},
 		ApplicationSetProviderData: providerDataFixture(),
 		RecordCacheEvents:          true,
+		RenderCacheEnabled:         true,
+		RenderCacheDir:             "render-cache",
+		RenderCacheMaxBytes:        123456,
+		RefreshRenders:             true,
+		EngineFingerprint:          rendercache.EngineFingerprint{Version: "1.2.3", Commit: "abc"},
 	}
 }
 

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/app"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/rendercache"
 	"github.com/sholdee/drydock/internal/requestopts"
 )
 
@@ -20,6 +21,23 @@ const (
 	ProjectDiagnosticsModeAll        ProjectDiagnosticsMode = "all"
 	ProjectDiagnosticsModeOff        ProjectDiagnosticsMode = "off"
 )
+
+// RenderCacheOptions controls the persistent render-output cache, which
+// reuses successful Application render outputs across processes.
+type RenderCacheOptions struct {
+	// Enabled toggles the persistent render cache. Nil defaults to enabled.
+	// Persistence additionally requires a provable engine fingerprint; builds
+	// without VCS stamping disable themselves automatically.
+	Enabled *bool
+	// Dir overrides the cache directory. Empty uses
+	// <user cache dir>/drydock/render.
+	Dir string
+	// MaxSizeBytes caps the on-disk cache size before LRU eviction. Zero uses
+	// the 512 MiB default.
+	MaxSizeBytes int64
+	// Refresh ignores existing entries and overwrites them after rendering.
+	Refresh bool
+}
 
 // Config controls render, list, and diff operations.
 //
@@ -150,6 +168,8 @@ type Config struct {
 	RemoteResourceAcquirer RemoteResourceAcquirer
 	// RecordCacheEvents includes source acquisition cache events in results.
 	RecordCacheEvents bool
+	// RenderCache controls the persistent render-output cache.
+	RenderCache RenderCacheOptions
 }
 
 // Client runs drydock operations with a reusable Config and optional
@@ -265,6 +285,10 @@ func (client *Client) requestOptions() requestopts.Options {
 		maxDiscoveryDepth = *client.config.MaxDiscoveryDepth
 		maxDiscoveryDepthSet = true
 	}
+	renderCacheEnabled := true
+	if client.config.RenderCache.Enabled != nil {
+		renderCacheEnabled = *client.config.RenderCache.Enabled
+	}
 	return requestopts.Options{
 		Path:                           client.config.Path,
 		LeftPath:                       client.config.PathOrig,
@@ -313,6 +337,11 @@ func (client *Client) requestOptions() requestopts.Options {
 		ApplicationSetProviderFixtures: append([]string(nil), client.config.ApplicationSetProviderFixtures...),
 		ApplicationSetProviderData:     applicationSetProviderDataToInternal(client.config.ApplicationSetProviderData),
 		RecordCacheEvents:              client.config.RecordCacheEvents,
+		RenderCacheEnabled:             renderCacheEnabled,
+		RenderCacheDir:                 client.config.RenderCache.Dir,
+		RenderCacheMaxBytes:            client.config.RenderCache.MaxSizeBytes,
+		RefreshRenders:                 client.config.RenderCache.Refresh,
+		EngineFingerprint:              rendercache.FingerprintFromBuildInfo(),
 	}
 }
 

--- a/pkg/drydock/drydock_acquisition_test.go
+++ b/pkg/drydock/drydock_acquisition_test.go
@@ -36,6 +36,7 @@ metadata:
 func TestPublicDiffApplicationsReturnsCacheEventsWhenEnabled(t *testing.T) {
 	left := t.TempDir()
 	right := t.TempDir()
+	renderCacheDisabled := false
 	chartDir := filepath.Join(t.TempDir(), "demo")
 	writeAPIChart(t, chartDir, "demo", "1.2.3", `apiVersion: v1
 kind: ConfigMap
@@ -50,6 +51,7 @@ metadata:
 		Path:              right,
 		ChangedOnly:       new(false),
 		RecordCacheEvents: true,
+		RenderCache:       RenderCacheOptions{Enabled: &renderCacheDisabled},
 		ChartAcquirer:     &recordingChartAcquirer{chartDir: chartDir, fromCache: true},
 	})
 	if err != nil {
@@ -68,6 +70,7 @@ metadata:
 func TestPublicDiffImagesReturnsCacheEventsWhenEnabled(t *testing.T) {
 	left := t.TempDir()
 	right := t.TempDir()
+	renderCacheDisabled := false
 	chartDir := filepath.Join(t.TempDir(), "demo")
 	writeAPIChart(t, chartDir, "demo", "1.2.3", `apiVersion: apps/v1
 kind: Deployment
@@ -94,6 +97,7 @@ spec:
 		Path:              right,
 		ChangedOnly:       new(false),
 		RecordCacheEvents: true,
+		RenderCache:       RenderCacheOptions{Enabled: &renderCacheDisabled},
 		ChartAcquirer:     &recordingChartAcquirer{chartDir: chartDir, fromCache: true},
 	})
 	if err != nil {

--- a/pkg/drydock/drydock_render_cache_test.go
+++ b/pkg/drydock/drydock_render_cache_test.go
@@ -1,0 +1,53 @@
+package drydock
+
+import (
+	"testing"
+
+	"github.com/sholdee/drydock/internal/rendercache"
+)
+
+func TestRenderCacheOptionsDefaultEnabled(t *testing.T) {
+	client := NewClient(Config{Path: "."})
+	options := client.requestOptions()
+	if !options.RenderCacheEnabled {
+		t.Fatalf("RenderCacheEnabled = false, want true by default (nil Enabled)")
+	}
+	if options.RenderCacheDir != "" || options.RenderCacheMaxBytes != 0 || options.RefreshRenders {
+		t.Fatalf("unexpected non-zero render cache defaults: %+v", options)
+	}
+}
+
+func TestRenderCacheOptionsExplicit(t *testing.T) {
+	disabled := false
+	client := NewClient(Config{
+		Path: ".",
+		RenderCache: RenderCacheOptions{
+			Enabled:      &disabled,
+			Dir:          "/tmp/render-cache",
+			MaxSizeBytes: 1024,
+			Refresh:      true,
+		},
+	})
+	options := client.requestOptions()
+	if options.RenderCacheEnabled {
+		t.Fatalf("RenderCacheEnabled = true, want false")
+	}
+	if options.RenderCacheDir != "/tmp/render-cache" {
+		t.Fatalf("RenderCacheDir = %q, want /tmp/render-cache", options.RenderCacheDir)
+	}
+	if options.RenderCacheMaxBytes != 1024 {
+		t.Fatalf("RenderCacheMaxBytes = %d, want 1024", options.RenderCacheMaxBytes)
+	}
+	if !options.RefreshRenders {
+		t.Fatalf("RefreshRenders = false, want true")
+	}
+}
+
+func TestRenderCacheFingerprintComputedFromBuildInfo(t *testing.T) {
+	client := NewClient(Config{Path: "."})
+	options := client.requestOptions()
+	want := rendercache.FingerprintFromBuildInfo()
+	if options.EngineFingerprint != want {
+		t.Fatalf("EngineFingerprint = %#v, want buildinfo-derived %#v", options.EngineFingerprint, want)
+	}
+}

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -274,7 +274,7 @@ work_dir="${DRYDOCK_ACTION_WORK_DIR}"
 mkdir -p "${work_dir}"
 cache_path="${DRYDOCK_CACHE_PATH:-}"
 if [[ -n "${cache_path}" ]]; then
-  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes" "${cache_path}/plugin"
+  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes" "${cache_path}/plugin" "${cache_path}/renders"
 fi
 diff_html_artifact_name="${DRYDOCK_DIFF_HTML_ARTIFACT_NAME:-}"
 if [[ -z "${diff_html_artifact_name}" ]]; then
@@ -310,6 +310,7 @@ if [[ -n "${cache_path}" ]]; then
     "--chart-cache-dir" "${cache_path}/charts"
     "--remote-cache-dir" "${cache_path}/remotes"
     "--plugin-cache-dir" "${cache_path}/plugin"
+    "--render-cache-dir" "${cache_path}/renders"
   )
 fi
 append_bool_flag common_args "${DRYDOCK_INPUT_SKIP_SECRETS}" "--skip-secrets"

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -362,7 +362,7 @@ func TestRunPassesChangedOnlyPathFiltersOnlyToDiffCommands(t *testing.T) {
 	}
 }
 
-func TestRunPassesPluginCacheDirToEveryInvocationWhenCachePathSet(t *testing.T) {
+func TestRunPassesCacheDirsToEveryInvocationWhenCachePathSet(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
 	}
@@ -382,13 +382,17 @@ func TestRunPassesPluginCacheDirToEveryInvocationWhenCachePathSet(t *testing.T) 
 	if len(lines) != 4 {
 		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
 	}
-	want := "--plugin-cache-dir " + filepath.Join(cachePath, "plugin")
+	wantPlugin := "--plugin-cache-dir " + filepath.Join(cachePath, "plugin")
+	wantRender := "--render-cache-dir " + filepath.Join(cachePath, "renders")
 	for _, line := range lines {
-		if !strings.Contains(line, want) {
-			t.Fatalf("drydock invocation missing plugin cache dir %q:\n%s", want, line)
+		if !strings.Contains(line, wantPlugin) {
+			t.Fatalf("drydock invocation missing plugin cache dir %q:\n%s", wantPlugin, line)
+		}
+		if !strings.Contains(line, wantRender) {
+			t.Fatalf("drydock invocation missing render cache dir %q:\n%s", wantRender, line)
 		}
 	}
-	for _, name := range []string{"git", "charts", "remotes", "plugin"} {
+	for _, name := range []string{"git", "charts", "remotes", "plugin", "renders"} {
 		path := filepath.Join(cachePath, name)
 		info, err := os.Stat(path)
 		if err != nil {
@@ -420,6 +424,9 @@ func TestRunOmitsPluginCacheDirWhenCachePathEmpty(t *testing.T) {
 	for _, line := range lines {
 		if strings.Contains(line, "--plugin-cache-dir") {
 			t.Fatalf("drydock invocation included plugin cache dir with empty DRYDOCK_CACHE_PATH:\n%s", line)
+		}
+		if strings.Contains(line, "--render-cache-dir") {
+			t.Fatalf("drydock invocation included render cache dir with empty DRYDOCK_CACHE_PATH:\n%s", line)
 		}
 	}
 }

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -134,12 +134,16 @@ drydock test apps --path . --offline
 | --- | --- |
 | `--offline` | Disable Git, Helm chart, and remote Kustomize network fetching. |
 | `--repo-map URL=PATH` | Map a source repository URL to a local checkout. |
-| `--refresh-git` | Fetch cached Git repositories before rendering. |
+| `--refresh-git` | Fetch cached Git repositories and bypass persisted render outputs for those inputs. |
 | `--git-cache-dir PATH` | Override the default Git repository cache root. |
-| `--refresh-charts` | Refresh cached immutable chart entries before rendering. |
+| `--refresh-charts` | Refresh cached immutable chart entries and bypass persisted render outputs for those inputs. |
 | `--chart-cache-dir PATH` | Override the default chart cache root. |
-| `--refresh-remotes` | Refresh cached remote Kustomize resources before rendering. |
+| `--refresh-remotes` | Refresh cached remote Kustomize resources and bypass persisted render outputs for those inputs. |
 | `--remote-cache-dir PATH` | Override the default remote-resource cache root. |
+| `--render-cache` | Reuse persisted Application render outputs across runs (default on). |
+| `--render-cache-dir PATH` | Override the default render-output cache root. |
+| `--render-cache-max-size QUANTITY` | Size cap before LRU eviction (default `512Mi`). |
+| `--refresh-renders` | Ignore persisted render outputs and overwrite them after rendering. |
 | `--plugin-cache-dir PATH` | Runtime override for policy-managed container plugin cache mounts. |
 | `--registry-config PATH` | Supply the only Helm OCI registry credentials. |
 
@@ -147,15 +151,93 @@ Render-time Git, chart, and remote-resource caches must stay outside the
 current repository tree, compared repository trees, repo-map roots, and their
 symlink-resolved equivalents. Drydock validates these roots before cache reads,
 fetches, or writes so a repository cannot double as its own mutable source
-cache.
+cache. A render-cache directory that cannot be opened fails the run at
+validation time, consistent with Git and chart cache validation. Dev builds
+without release version stamping never persist renders, so they do not
+require access to the render-cache directory.
 
 Cache entries include hidden `.drydock-cache/metadata.json` sidecars with
 redacted target metadata. Older hash-only entries are listed as legacy entries
 when their filesystem layout is recognized.
 
 `--plugin-cache-dir` is separate: it is a render-time override for
-policy-managed container plugin cache mounts. Cache lifecycle commands still
-manage only Git, chart, and remote-resource cache entry roots for now.
+policy-managed container plugin cache mounts. Cache lifecycle commands manage
+Git, chart, and remote-resource cache entry roots. They do not list, prune, or
+delete render output entries or plugin cache mount roots.
+
+### Render Output Cache
+
+Successful Application render outputs persist across processes under
+`<user cache dir>/drydock/render`, keyed by the Application spec, Argo
+settings signature, drydock build that produced them, and provable source
+inputs. A warm run returns cached manifests without invoking render engines.
+
+For clean local repositories, drydock hashes committed per-Application input
+paths instead of the whole repository commit. A commit that changes one
+Application's Helm values, Kustomize graph, directory or Jsonnet source, or
+generated Application input invalidates that Application while unchanged
+Applications can still hit the render cache. Generated inputs include static
+Application YAML, ApplicationSet generator files, and rendered bootstrap
+Application parents when discovery records those paths. Local source override
+files (`.argocd-source.yaml` and `.argocd-source-<app>.yaml`) are also part
+of every Application's input digest; adding, editing, or deleting an override
+file invalidates that Application's cached entry.
+
+Local dirty worktrees can also use the render output cache for Applications
+whose proven render inputs are unchanged. In dirty Git-backed roots, drydock
+enumerates the complete set of changed files once per run and decides the cache
+strategy per Application input path set. Applications whose proven input paths
+are untouched by any dirty file keep their clean-worktree cache keys — entries
+persisted from clean runs are served directly across the mode transition, so
+editing one Application re-renders only that Application. Applications whose
+input paths overlap any dirty file are hashed from the working tree, including
+modified, deleted, untracked, and ignored files under those paths. Helm sources
+with glob value-file patterns always re-render and skip persistence in dirty
+mode, because a new untracked file matching the glob would be invisible to the
+path-set intersection. Untouched Applications that skip the working-tree hash
+share clean mode's run-stability contract: the dirty-path enumeration is
+computed once at the start of a run, and any mid-run edits are caught by the
+existing store-time verification rather than by a second scan. A worktree that
+is clean except for nested `.git` directories is classified dirty (the nested
+`.git` content is treated conservatively, consistent with the store guard's
+fail-closed treatment of git links).
+
+This behavior is automatic, including in the PR action; no new action input is
+required. The PR action stores persisted render outputs under
+`${cache-path}/renders` when action caching is enabled.
+
+Renders are persisted only when every input is provably pinned. Floating remote
+Kustomize bases, remote URL Helm value files, plugin sources, repo-mapped
+sources, and unsupported local input graphs always re-render.
+
+Clean Git roots use committed input digests. Dirty Git roots use per-Application
+committed or working-tree input digests, as described above. Symlinks,
+unsupported file types, unreadable files, unbounded input graphs, and non-Git
+roots render normally but skip persistence for the affected Application. Dev
+builds without release version stamping disable persistence automatically.
+Release binaries are always stamped; when building from source, ensure Go's VCS
+stamping is active (the default in a git checkout — `go build -buildvcs=true`
+forces it) or persistence silently stays off. `--cache-events` with `diag`
+shows a `disabled` event with reason `dev-build` when this applies.
+
+Use `--cache-events` with `diag` or structured command output when diagnosing
+render-cache behavior. Render cache events report `hit`, `miss`, `store`,
+`skipped`, and `error` actions. `skipped` reasons include
+`input-graph-unsupported`, `input-digest-error`, `ineligible-source`, and
+`inputs-changed`. All of these mean drydock rendered normally without
+persisting the result. `inputs-changed` indicates drydock could not prove the
+render inputs still match the cache key at store time — usually because source
+files changed between cache-key computation and the end of rendering (a TOCTOU
+guard), and always for sources whose inputs cannot be re-verified, such as
+symlinks. When verification failed with an error, the event carries the error
+text. One inherent limit: an edit that is reverted to its original content
+before the render completes is indistinguishable from no edit, so the
+verification cannot catch it.
+
+Chart-backed renders key on the exact chart name and version. If a registry
+republishes an existing version, for example a mutable OCI chart version, use
+`--refresh-charts` (or `--refresh-renders`) to re-render and overwrite the
+cached entries.
 
 ## Credentials
 
@@ -211,8 +293,9 @@ They do not:
 - retry failed network or authentication acquisitions
 
 `cache prune` and `cache delete` operate only on recognized drydock Git, chart,
-and remote-resource cache entry roots for now. They do not list, prune, or
-delete plugin cache mount roots selected with `--plugin-cache-dir`.
+and remote-resource cache entry roots. They do not list, prune, or delete
+render output entries or plugin cache mount roots selected with
+`--plugin-cache-dir`.
 
 Cache lifecycle commands reject cache roots that resolve inside the current
 working directory, selected repository roots, Git repository trees, or

--- a/site/content/cookbook/source-access.md
+++ b/site/content/cookbook/source-access.md
@@ -25,12 +25,20 @@ local files, repo maps, or existing cache entries.
 ## Inspect Cache Events
 
 ```bash
-drydock diag --path . --cache-events -o json
+drydock diag --path . --render --cache-events -o json
 drydock cache list -o json
 ```
 
 Use cache events to see which source acquisitions were used while rendering
-Applications for diagnostics, then inspect recognized cache entries.
+Applications for diagnostics, then inspect recognized cache entries. Render
+cache `skipped` events explain why an Application rendered normally instead of
+using a persisted render output.
+
+Dirty local worktrees can still hit persisted render outputs for Applications
+whose proven inputs did not change. In `diag --render --cache-events` output,
+look for render cache `hit`, `miss`, `store`, and `skipped` actions. Dirty
+inputs that are unsafe to hash, such as symlinks or unsupported file types,
+render normally and report a `skipped` event for the affected Application.
 
 ## Pass Explicit Credentials
 

--- a/site/content/docs/plugin-policy/cache.md
+++ b/site/content/docs/plugin-policy/cache.md
@@ -16,8 +16,8 @@ backslashes, duplicate paths, or ancestor/descendant overlaps.
 `--plugin-cache-dir PATH` overrides the host root for these policy-managed
 container plugin cache mounts at render time. It does not change the trusted
 policy target paths, and it does not make plugin caches part of `drydock cache`
-lifecycle commands; those commands still manage only Git, chart, and
-remote-resource cache entry roots for now.
+lifecycle commands; those commands manage only Git, chart, and remote-resource
+cache entry roots.
 
 The GitHub PR action sets the plugin cache directory under the action cache
 root, so trusted plugin cache mounts can be restored and saved with the render

--- a/site/content/plugin-policy/_index.md
+++ b/site/content/plugin-policy/_index.md
@@ -119,8 +119,9 @@ drydock diff apps --path-orig ../baseline --path . --enable-plugins
 Container `cacheMounts` are policy-managed durable tool caches mounted only
 under reserved `/drydock-cache` paths. `--plugin-cache-dir` is a render-time
 override for the host root backing those mounts; it does not change trusted
-policy target paths. Cache lifecycle commands still manage only Git, chart, and
-remote-resource cache entry roots for now.
+policy target paths. Cache lifecycle commands manage only Git, chart, and
+remote-resource cache entry roots, not plugin cache mount roots or render
+output entries.
 
 In the GitHub PR action, trusted plugin cache mounts live under the action cache
 root as `${cache-path}/plugin` when trusted plugins are enabled.

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -364,9 +364,11 @@ Dry-runs never require confirmation and leave cache files in place.
 Cache lifecycle commands are local filesystem operations only. They do not
 render Applications, clone or fetch Git repositories, fetch Helm charts, fetch
 remote Kustomize resources, or read credential flags. They operate only on
-recognized drydock cache entry roots and reject cache roots that resolve inside
-the current working directory, selected repository roots, Git repository trees,
-or symlink-resolved equivalents.
+recognized drydock Git, chart, and remote-resource cache entry roots and reject
+cache roots that resolve inside the current working directory, selected
+repository roots, Git repository trees, or symlink-resolved equivalents. They
+do not list, prune, or delete persistent render output entries or plugin cache
+mount roots.
 
 For cache boundaries, offline behavior, and credentials, see
 [Source acquisition](/concepts/source-acquisition/).

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -197,10 +197,14 @@ artifacts.
 
 ## Caching
 
-Binary caching is separate from drydock render caching. Binary cache entries
+Binary caching is separate from drydock repository caches. Binary cache entries
 contain only the released `drydock` archive and are keyed by release checksum.
-Render cache entries contain fetched Git, Helm, and remote Kustomize sources for
+The PR action cache root contains fetched Git, Helm, and remote Kustomize
+sources, policy-managed plugin cache mounts, and persisted render outputs for
 the repository under test.
+
+Dirty-worktree render output reuse uses the existing render cache behavior. No
+new PR action input is required.
 
 Fork pull requests do not restore or save drydock render caches by default,
 because render caches can contain private repository, chart, remote source, or
@@ -210,9 +214,11 @@ runs is acceptable for that repository. Cache save remains disabled for fork
 PRs.
 
 When trusted container plugins are enabled, policy-managed plugin cache mounts
-live under the PR action cache root as `${cache-path}/plugin` and are restored
-or saved with that render cache. `drydock cache` lifecycle commands still manage
-only Git, chart, and remote-resource cache entry roots for now.
+live under the PR action cache root as `${cache-path}/plugin`. Persisted render
+outputs live under `${cache-path}/renders`. Both are restored or saved with the
+same action cache entry. `drydock cache` lifecycle commands still manage only
+Git, chart, and remote-resource cache entry roots; they do not manage plugin
+cache mount roots or render output entries.
 
 ## Input Behavior
 


### PR DESCRIPTION
## Summary

Adds a persistent render output cache: successful Application render outputs persist across runs under `<user cache dir>/drydock/render`, keyed by the Application spec, Argo settings signature, drydock engine fingerprint, and provable source inputs. Warm runs return cached manifests without invoking render engines. On by default (`--render-cache`), with strict fail-closed semantics: every eligibility or verification problem degrades to re-rendering, never to serving unverified content.

## Highlights

- **Content digest engines** (`internal/gitref`, `internal/filedigest`, `internal/digestpath`): committed-object digests for clean worktrees, filesystem content digests for dirty ones, shared canonicalization so the two key spaces cannot drift.
- **Per-application keying**: clean roots hash committed per-Application input paths instead of the repository commit — a commit touching one app invalidates only that app, and entries are byte-identical across checkout locations.
- **Per-path-set dirty-worktree keying**: the complete dirty-path set is enumerated once per run; Applications whose proven inputs are untouched keep their clean-worktree keys. A single edit in a 33-app repository costs 1 miss / 32 hits (previously 33 misses), and reverting serves the original entries with zero stores.
- **Store-time verification**: every input path set is re-checked after the render (committed keys against the pinned revision, filesystem keys by memo-bypassing re-digest), so mid-render edits skip the store with an `inputs-changed` event instead of poisoning the cache.
- **Fail-closed eligibility**: plugin sources, Helm glob value inputs in dirty worktrees, duplicate Application keys, repo-mapped sources, unpinned chart/remote acquisitions, symlinks, gitlinks, and non-git roots always re-render and never persist.
- **Refresh semantics**: `--refresh-renders` and the acquisition refresh flags (`--refresh-charts`, `--refresh-git`, `--refresh-remotes`) bypass lookup and overwrite entries.
- **Store**: content-addressed gzipped envelopes, atomic writes, corrupt-entry self-healing, LRU size-cap eviction (`--render-cache-max-size`, default 512Mi) with orphaned temp-file cleanup. Cache roots are validated fail-fast, including rejection of roots inside repository trees and unopenable directories.
- **Observability**: `--cache-events` render events (hit/miss/store/skipped/evict/error) with skip reasons, sanitized targets, and verification error detail.
- **Engine fingerprint**: entries key on drydock version/commit plus render-relevant module versions; dev builds without VCS stamping or ldflags disable persistence by design.

## Validation

- Test suite includes sabotage-validated guard tests (`internal/app/render_cache_verify_test.go`), mutation-based read-coverage tripwires asserting digest paths cover every render input, and a ~30-test integration matrix (key sensitivity, eviction, refresh, diff flows). `go test ./...`, `-race` on the cache packages, and `golangci-lint` all green.
- Validated against two real Argo CD repositories (31 and 84 apps): warm cached output byte-identical to uncached renders; dirty-worktree invalidation exact per app; override files (`.argocd-source*.yaml`) key correctly in both directions; the in-repo cache-dir guard holds; zero spurious verification failures across ~1000 cache events.
- Real-repo wall time: 84-app repo `diag` 9.9s cold → 1.55s warm; `diff --ref-orig HEAD~10` 13.1s → 1.5s.

## Docs

Operator documentation in `site/content/concepts/source-acquisition.md` (keying model, clean/dirty behavior, refresh bypass, events, known limitations incl. the revert window); agent guidance for the cache invariants in `AGENTS.md` and `docs/agent-reference.md`.

## Notes

- One-time cache invalidation for any pre-release entries (key composition changed during development); entries age out via LRU.
- Follow-up candidates (not in this PR): render-entry inspection in `cache list`, `--cache-events` surfacing on `build`/`test`, removal of the now-unused `gitref.WorktreeStatus` API.