### PR TITLE
fix(pr-action): diff against the merge base instead of the base branch tip

### DIFF
--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -379,6 +379,7 @@ runs:
       env:
         DRYDOCK_GITHUB_TOKEN: ${{ steps.app-token-client.outputs.token || steps.app-token-legacy.outputs.token || inputs.github-token || github.token }}
         DRYDOCK_INPUT_BASE_REF: ${{ inputs.base-ref }}
+        DRYDOCK_INPUT_HEAD_REF: ${{ inputs.head-ref }}
         DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: '"${GITHUB_ACTION_PATH}/fetch-base.sh"'
 

--- a/pr-action/fetch-base.sh
+++ b/pr-action/fetch-base.sh
@@ -14,7 +14,13 @@ if ! git check-ref-format --branch "${base_ref}" >/dev/null 2>&1; then
   exit 1
 fi
 
-fetch_cmd=(git)
+head_ref="${DRYDOCK_INPUT_HEAD_REF:-}"
+if [[ -z "${head_ref}" ]]; then
+  head_ref="HEAD"
+fi
+
+# git invocation prefix carrying optional one-shot auth, reused for every fetch.
+git_cmd=(git)
 if [[ -n "${DRYDOCK_GITHUB_TOKEN:-}" ]]; then
   server_url="${GITHUB_SERVER_URL:-https://github.com}"
   existing_auth_header=false
@@ -23,13 +29,65 @@ if [[ -n "${DRYDOCK_GITHUB_TOKEN:-}" ]]; then
   fi
   if [[ "${existing_auth_header}" == "false" ]]; then
     basic_auth="$(printf 'x-access-token:%s' "${DRYDOCK_GITHUB_TOKEN}" | base64 | tr -d '\n')"
-    fetch_cmd+=(-c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${basic_auth}")
+    git_cmd+=(-c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${basic_auth}")
   fi
 fi
-fetch_cmd+=(fetch --no-tags --depth=1 origin "${base_ref}:refs/remotes/origin/${base_ref}")
-"${fetch_cmd[@]}"
+
+base_refspec="${base_ref}:refs/remotes/origin/${base_ref}"
+
+# Bring the base branch tip into the local repository.
+"${git_cmd[@]}" fetch --no-tags --depth=1 origin "${base_refspec}"
+
+repo_is_shallow() {
+  local git_dir
+  git_dir="$(git rev-parse --git-dir 2>/dev/null)" || return 1
+  [[ -f "${git_dir}/shallow" ]]
+}
+
+resolve_merge_base() {
+  git merge-base "origin/${base_ref}" "${head_ref}" 2>/dev/null
+}
+
+# Diff against the merge base of the base branch and the pull request head, not
+# the base branch tip. A stale or diverged head would otherwise surface every
+# change already merged into the base branch as a spurious difference. Deepen
+# the shallow checkout (both base and head) until the common ancestor is in
+# history, mirroring how GitHub computes the pull request diff.
+#
+# The base branch and the head are deepened with separate fetches on purpose: a
+# single fetch that mixes a refspec and a bare commit only deepens the bare
+# commit, leaving the named base ref at its tip and the merge base unreachable.
+merge_base="$(resolve_merge_base || true)"
+if [[ -z "${merge_base}" ]]; then
+  head_sha="$(git rev-parse "${head_ref}" 2>/dev/null || true)"
+  deepen=16
+  deepen_cap=2048
+  while [[ -z "${merge_base}" ]] && repo_is_shallow; do
+    if [[ "${deepen}" -gt "${deepen_cap}" ]]; then
+      "${git_cmd[@]}" fetch --no-tags --unshallow origin "${base_refspec}" >/dev/null 2>&1 || true
+      if [[ -n "${head_sha}" ]]; then
+        "${git_cmd[@]}" fetch --no-tags --deepen="${deepen}" origin "${head_sha}" >/dev/null 2>&1 || true
+      fi
+      merge_base="$(resolve_merge_base || true)"
+      break
+    fi
+    "${git_cmd[@]}" fetch --no-tags --deepen="${deepen}" origin "${base_refspec}" >/dev/null 2>&1 || true
+    if [[ -n "${head_sha}" ]]; then
+      "${git_cmd[@]}" fetch --no-tags --deepen="${deepen}" origin "${head_sha}" >/dev/null 2>&1 || true
+    fi
+    merge_base="$(resolve_merge_base || true)"
+    deepen=$((deepen * 2))
+  done
+fi
+
+if [[ -n "${merge_base}" ]]; then
+  compare_ref="${merge_base}"
+else
+  echo "warning: could not determine the merge base of '${base_ref}' and '${head_ref}'; diffing against the '${base_ref}' tip, which can surface changes already merged into the base branch." >&2
+  compare_ref="origin/${base_ref}"
+fi
 
 {
   echo "base-ref=${base_ref}"
-  echo "compare-ref=origin/${base_ref}"
+  echo "compare-ref=${compare_ref}"
 } >> "${GITHUB_OUTPUT}"

--- a/pr-action/fetch_base_test.go
+++ b/pr-action/fetch_base_test.go
@@ -9,6 +9,65 @@ import (
 	"testing"
 )
 
+// fakeGitScript is a stand-in git used by fetch-base tests. Behavior is driven
+// by DRYDOCK_TEST_* environment variables so individual tests can model the
+// merge-base, shallow, and fetch interactions without a real repository.
+const fakeGitScript = `#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  check-ref-format)
+    exit 0
+    ;;
+  config)
+    if [[ "${DRYDOCK_TEST_EXISTING_AUTH_HEADER:-false}" == "true" ]]; then
+      echo "AUTHORIZATION: basic existing"
+      exit 0
+    fi
+    exit 1
+    ;;
+  rev-parse)
+    if [[ "${2:-}" == "--git-dir" ]]; then
+      echo "${DRYDOCK_TEST_GIT_DIR:-.git}"
+    else
+      echo "${DRYDOCK_TEST_HEAD_SHA:-headsha}"
+    fi
+    exit 0
+    ;;
+  merge-base)
+    case "${DRYDOCK_TEST_MERGE_BASE_MODE:-immediate}" in
+      immediate)
+        echo "${DRYDOCK_TEST_MERGE_BASE_SHA:-mergebasesha}"
+        ;;
+      after-deepen)
+        if [[ -n "${DRYDOCK_TEST_DEEPEN_MARKER:-}" && -f "${DRYDOCK_TEST_DEEPEN_MARKER}" ]]; then
+          echo "${DRYDOCK_TEST_MERGE_BASE_SHA:-mergebasesha}"
+        fi
+        ;;
+      never)
+        :
+        ;;
+    esac
+    exit 0
+    ;;
+  -c | fetch)
+    if [[ -n "${DRYDOCK_TEST_FETCH_ARGS:-}" ]]; then
+      printf '%s\n' "$*" > "${DRYDOCK_TEST_FETCH_ARGS}"
+    fi
+    if [[ -n "${DRYDOCK_TEST_FETCH_LOG:-}" ]]; then
+      printf '%s\n' "$*" >> "${DRYDOCK_TEST_FETCH_LOG}"
+    fi
+    if [[ "$*" == *"--deepen"* && -n "${DRYDOCK_TEST_DEEPEN_MARKER:-}" ]]; then
+      touch "${DRYDOCK_TEST_DEEPEN_MARKER}"
+    fi
+    exit 0
+    ;;
+esac
+
+echo "unexpected git invocation: $*" >&2
+exit 2
+`
+
 func TestFetchBaseReusesExistingGitAuthHeader(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -31,11 +90,187 @@ func TestFetchBaseAddsAuthHeaderWhenGitHasNoCredential(t *testing.T) {
 	}
 }
 
+func TestFetchBaseUsesMergeBaseAsCompareRef(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	res := runFetchBaseScenario(t, map[string]string{
+		"DRYDOCK_TEST_MERGE_BASE_MODE": "immediate",
+		"DRYDOCK_TEST_MERGE_BASE_SHA":  "abc123mergebase",
+	})
+
+	if got := res.output["compare-ref"]; got != "abc123mergebase" {
+		t.Fatalf("compare-ref = %q, want the merge-base sha abc123mergebase", got)
+	}
+	if got := res.output["base-ref"]; got != "master" {
+		t.Fatalf("base-ref = %q, want master", got)
+	}
+	if strings.Contains(res.fetchLog, "--deepen") {
+		t.Fatalf("fetch log = %q, want no deepen when merge base resolves immediately", res.fetchLog)
+	}
+}
+
+func TestFetchBaseDeepensBaseOnlyWhenHeadShaUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	gitDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(gitDir, "shallow"), []byte("shallow\n"), 0o600); err != nil {
+		t.Fatalf("write shallow marker: %v", err)
+	}
+
+	res := runFetchBaseScenario(t, map[string]string{
+		"DRYDOCK_TEST_MERGE_BASE_MODE": "after-deepen",
+		"DRYDOCK_TEST_MERGE_BASE_SHA":  "deep123mergebase",
+		"DRYDOCK_TEST_GIT_DIR":         gitDir,
+		// Empty head sha models git rev-parse failing; only the base is deepened.
+		"DRYDOCK_TEST_HEAD_SHA":      "",
+		"DRYDOCK_TEST_DEEPEN_MARKER": filepath.Join(t.TempDir(), "deepened"),
+	})
+
+	if got := res.output["compare-ref"]; got != "deep123mergebase" {
+		t.Fatalf("compare-ref = %q, want the merge-base sha deep123mergebase", got)
+	}
+	if !strings.Contains(res.fetchLog, "--deepen") || !strings.Contains(res.fetchLog, "refs/remotes/origin/master") {
+		t.Fatalf("fetch log = %q, want a deepen fetch of the base ref", res.fetchLog)
+	}
+}
+
+// TestFetchBaseResolvesMergeBaseForDivergedShallowClone exercises fetch-base.sh
+// against a real git repository: a depth-1 checkout of a head that is behind
+// its base. This is the case that the fake-git tests cannot model, because the
+// defect it guards against (deepening only the head, not the base) depends on
+// real git fetch semantics, not on the command arguments.
+func TestFetchBaseResolvesMergeBaseForDivergedShallowClone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := t.TempDir()
+	git := func(dir string, args ...string) string {
+		t.Helper()
+		full := append([]string{
+			"-c", "user.email=t@example.invalid",
+			"-c", "user.name=drydock test",
+			"-c", "init.defaultBranch=main",
+			"-c", "protocol.file.allow=always",
+		}, args...)
+		cmd := exec.Command("git", full...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	upstream := filepath.Join(root, "up.git")
+	work := filepath.Join(root, "work")
+	git(root, "init", "--bare", upstream)
+	git(root, "init", work)
+
+	commit := func(msg, file, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(work, file), []byte(content+"\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+		git(work, "add", file)
+		git(work, "commit", "-m", msg)
+	}
+
+	for _, c := range []string{"c1", "c2", "c3"} {
+		commit(c, "f", c)
+	}
+	git(work, "branch", "feat")
+	for _, m := range []string{"m4", "m5", "m6", "m7", "m8"} {
+		commit(m, "f", m)
+	}
+	git(work, "checkout", "feat")
+	commit("feat1", "g", "feat1")
+	git(work, "remote", "add", "origin", upstream)
+	git(work, "push", "origin", "main", "feat")
+
+	wantMergeBase := git(work, "merge-base", "main", "feat")
+
+	// Depth-1 clone of the feat head, simulating actions/checkout fetch-depth: 1.
+	shallow := filepath.Join(root, "shallow")
+	git(root, "clone", "--depth=1", "--branch", "feat", "file://"+upstream, shallow)
+	if shallowFile := filepath.Join(shallow, ".git", "shallow"); !fileExists(shallowFile) {
+		t.Fatalf("expected a shallow clone at %s", shallowFile)
+	}
+
+	scriptPath, err := filepath.Abs("fetch-base.sh")
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	outputPath := filepath.Join(root, "github-output")
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = shallow
+	cmd.Env = append(os.Environ(),
+		"DRYDOCK_PR_BASE_REF=main",
+		"GITHUB_OUTPUT="+outputPath,
+		"GITHUB_SERVER_URL=https://github.com",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=protocol.file.allow",
+		"GIT_CONFIG_VALUE_0=always",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fetch-base.sh failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read github output: %v", err)
+	}
+	compareRef := ""
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		if key, value, found := strings.Cut(line, "="); found && key == "compare-ref" {
+			compareRef = value
+		}
+	}
+	if compareRef != wantMergeBase {
+		t.Fatalf("compare-ref = %q, want the true merge base %q", compareRef, wantMergeBase)
+	}
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func TestFetchBaseFallsBackToBaseTipWithoutMergeBase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	// Not shallow (no shallow marker) and merge base never resolves: keep the
+	// pre-merge-base behavior of diffing against the base tip, with a warning.
+	res := runFetchBaseScenario(t, map[string]string{
+		"DRYDOCK_TEST_MERGE_BASE_MODE": "never",
+		"DRYDOCK_TEST_GIT_DIR":         t.TempDir(),
+	})
+
+	if got := res.output["compare-ref"]; got != "origin/master" {
+		t.Fatalf("compare-ref = %q, want fallback origin/master", got)
+	}
+	if !strings.Contains(res.stderr, "could not determine the merge base") {
+		t.Fatalf("stderr = %q, want a merge-base warning", res.stderr)
+	}
+	if strings.Contains(res.fetchLog, "--deepen") {
+		t.Fatalf("fetch log = %q, want no deepen when the repository is not shallow", res.fetchLog)
+	}
+}
+
 func runFetchBase(t *testing.T, existingAuthHeader bool) string {
 	t.Helper()
 
 	tmp := t.TempDir()
-	gitPath := filepath.Join(tmp, "git")
 	resultPath := filepath.Join(tmp, "fetch-args")
 
 	existingValue := "false"
@@ -43,53 +278,76 @@ func runFetchBase(t *testing.T, existingAuthHeader bool) string {
 		existingValue = "true"
 	}
 
-	fakeGit := `#!/usr/bin/env bash
-set -euo pipefail
+	res := runFetchBaseScenario(t, map[string]string{
+		"DRYDOCK_TEST_EXISTING_AUTH_HEADER": existingValue,
+		"DRYDOCK_TEST_FETCH_ARGS":           resultPath,
+	})
+	return res.fetchArgs
+}
 
-if [[ "$1" == "check-ref-format" ]]; then
-  exit 0
-fi
+type fetchBaseResult struct {
+	fetchArgs string
+	fetchLog  string
+	output    map[string]string
+	stderr    string
+}
 
-if [[ "$1" == "config" ]]; then
-  if [[ "${DRYDOCK_TEST_EXISTING_AUTH_HEADER}" == "true" ]]; then
-    echo "AUTHORIZATION: basic existing"
-    exit 0
-  fi
-  exit 1
-fi
+func runFetchBaseScenario(t *testing.T, extraEnv map[string]string) fetchBaseResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
 
-if [[ "$1" == "fetch" || "$1" == "-c" ]]; then
-  printf '%s\n' "$*" > "${DRYDOCK_TEST_FETCH_ARGS}"
-  exit 0
-fi
-
-echo "unexpected git invocation: $*" >&2
-exit 2
-`
-	if err := os.WriteFile(gitPath, []byte(fakeGit), 0o700); err != nil {
+	tmp := t.TempDir()
+	gitPath := filepath.Join(tmp, "git")
+	if err := os.WriteFile(gitPath, []byte(fakeGitScript), 0o700); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
 
 	outputPath := filepath.Join(tmp, "github-output")
-	cmd := exec.Command("bash", "fetch-base.sh")
-	cmd.Dir = "."
-	cmd.Env = append(os.Environ(),
+	fetchLogPath := filepath.Join(tmp, "fetch-log")
+
+	env := append(os.Environ(),
 		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"DRYDOCK_GITHUB_TOKEN=test-token",
 		"DRYDOCK_PR_BASE_REF=master",
-		"DRYDOCK_TEST_EXISTING_AUTH_HEADER="+existingValue,
-		"DRYDOCK_TEST_FETCH_ARGS="+resultPath,
 		"GITHUB_OUTPUT="+outputPath,
 		"GITHUB_SERVER_URL=https://github.com",
+		"DRYDOCK_TEST_FETCH_LOG="+fetchLogPath,
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("fetch-base.sh failed: %v\n%s", err, out)
+	for key, value := range extraEnv {
+		env = append(env, key+"="+value)
 	}
 
-	result, err := os.ReadFile(resultPath)
-	if err != nil {
-		t.Fatalf("read fetch args: %v", err)
+	cmd := exec.Command("bash", "fetch-base.sh")
+	cmd.Dir = "."
+	cmd.Env = env
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if out, err := cmd.Output(); err != nil {
+		t.Fatalf("fetch-base.sh failed: %v\nstdout: %s\nstderr: %s", err, out, stderr.String())
 	}
-	return string(result)
+
+	result := fetchBaseResult{
+		output: map[string]string{},
+		stderr: stderr.String(),
+	}
+	if data, err := os.ReadFile(outputPath); err == nil {
+		for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+			key, value, found := strings.Cut(line, "=")
+			if found {
+				result.output[key] = value
+			}
+		}
+	}
+	if data, err := os.ReadFile(fetchLogPath); err == nil {
+		result.fetchLog = string(data)
+	}
+	if fetchArgs, ok := extraEnv["DRYDOCK_TEST_FETCH_ARGS"]; ok {
+		if data, err := os.ReadFile(fetchArgs); err == nil {
+			result.fetchArgs = string(data)
+		}
+	}
+	return result
 }

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -66,6 +66,13 @@ jobs:
           --ref-orig origin/${{ github.base_ref }} -o markdown
 ```
 
+This lower-level example diffs against the base branch tip. When the pull
+request branch is behind its base, that surfaces changes already merged into
+the base as spurious differences. With full history checked out
+(`fetch-depth: 0`), diff against the merge base instead — for example
+`--ref-orig "$(git merge-base origin/${{ github.base_ref }} HEAD)"`. The PR
+action resolves this merge base automatically.
+
 The setup action accepts `latest`, `vX.Y.Z`, or bare `X.Y.Z`. It verifies the
 release archive with `checksums.txt` unless `allow-unverified: "true"` is set.
 
@@ -118,9 +125,13 @@ By default the action:
 - checks out the pull request head with credentials not persisted into Git;
 - restores or saves a verified drydock binary archive when installation is
   enabled;
-- fetches the pull request base branch for ref-based diffs;
+- fetches the pull request base branch and resolves its merge base with the
+  head for ref-based diffs, deepening a shallow checkout as needed;
 - runs `drydock test apps --path .`;
-- runs `drydock diff apps --repo . --ref HEAD --ref-orig origin/<base>`;
+- runs `drydock diff apps --repo . --ref HEAD --ref-orig <merge-base>`, where
+  `<merge-base>` is the common ancestor of the base branch and the pull request
+  head, so changes already merged into the base branch are not surfaced as
+  spurious differences;
 - runs `drydock diff images` to report rendered image reference changes;
 - records current-only image additions for the added image artifact;
 - uses drydock render caches under the runner temp directory;


### PR DESCRIPTION
## Summary

The PR action diffed rendered manifests against the **tip of the base branch** (`origin/<base>`), fetched shallow (`--depth=1`). When a pull request branch is behind its base (diverged), this surfaces every change already merged into the base since the branch point as a spurious "reversion," and a base-only changed path (e.g. `mise.toml`) trips `changed-only` into rendering every Application.

This change resolves the **merge base** of the base branch and the pull request head and diffs against that — mirroring how GitHub computes the pull request diff — so the diff reflects only what the PR introduces.

## Evidence

On a downstream repo, a 1-file renovate image bump produced a **6-app diff**. The branch was `ahead 1 / behind 10`; the merge-base…head diff was the single file, but the action diffed against the base tip, so the 5 apps the base had advanced (e.g. `dragonfly v1.6.1 → v1.5.0`, `ghostfolio 3.9.0 → 3.8.0` — base *newer* than head) showed as spurious changes, and `mise.toml` (a base-only change, outside the app tree) escalated `changed-only` to render everything.

## Fix

`pr-action/fetch-base.sh`:
- After fetching the base tip, resolve `git merge-base origin/<base> <head>` and output that SHA as `compare-ref`.
- On a shallow checkout, deepen the base branch and the head **with separate fetches** in a bounded loop (16→2048), then `--unshallow` as a last resort. (A single fetch that mixes a refspec and a bare commit only deepens the bare commit, leaving the base ref at its tip — verified on git 2.54.0.)
- If no merge base can be determined, fall back to the base tip with a warning, preserving the prior behavior so this can never be worse than before.
- Honor a custom `head-ref` for the merge-base computation (`action.yml` passes `DRYDOCK_INPUT_HEAD_REF`).

`run.sh` consumes `compare-ref` unchanged (it is opaque to `--ref-orig`; a SHA works the same as a branch).

## Tests

- `TestFetchBaseUsesMergeBaseAsCompareRef` — merge base becomes `compare-ref` with no deepen when it resolves immediately.
- `TestFetchBaseResolvesMergeBaseForDivergedShallowClone` — **real-git integration test**: builds a depth-1 clone of a head behind its base and asserts `compare-ref` equals the true `git merge-base`. This is the case the argument-inspecting fake-git harness cannot model; it is sabotage-proven to fail on the broken mixed-target fetch form.
- `TestFetchBaseDeepensBaseOnlyWhenHeadShaUnavailable` — covers the empty-head-sha branch.
- `TestFetchBaseFallsBackToBaseTipWithoutMergeBase` — fallback path emits `origin/<base>` and a warning.
- Existing auth-header tests retained.

## Validation

`go test ./pr-action/`, `go vet`, `golangci-lint run` (0 issues), and `shellcheck pr-action/fetch-base.sh` all clean.

## Notes

Docs updated (`site/content/workflows/github-actions.md`): the action now diffs against the merge base; the lower-level manual example notes the base-tip caveat and how to use `git merge-base` with full history.
