### PR TITLE
fix(pr-action): rotate the render cache key per commit so warm caches refresh

### DIFF
--- a/pr-action/prepare.sh
+++ b/pr-action/prepare.sh
@@ -75,16 +75,25 @@ repo_key="${repo_key//\//-}"
 prefix="${DRYDOCK_INPUT_CACHE_KEY_PREFIX:-drydock}"
 suffix="${DRYDOCK_INPUT_CACHE_KEY_SUFFIX:-v1}"
 version="${DRYDOCK_RESOLVED_VERSION:-unknown}"
+key_stem="${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}"
+key_base="${key_stem}-${version}-${suffix}"
 
 cache_key="${DRYDOCK_INPUT_CACHE_KEY}"
 if [[ -z "${cache_key}" ]]; then
-  cache_key="${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-${version}-${suffix}"
+  # actions/cache keys are immutable, so a static key is written once and then
+  # frozen. Rotate the primary key per commit so the cache refreshes; the
+  # restore-key prefixes below fall back to the most recent matching cache.
+  cache_key="${key_base}"
+  if [[ -n "${GITHUB_SHA:-}" ]]; then
+    cache_key="${key_base}-${GITHUB_SHA}"
+  fi
 fi
 
 restore_keys="${DRYDOCK_INPUT_CACHE_RESTORE_KEYS}"
 if [[ -z "${restore_keys}" ]]; then
-  restore_keys="${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-${version}-
-${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-${repo_key}-
+  restore_keys="${key_base}-
+${key_stem}-${version}-
+${key_stem}-
 ${prefix}-${RUNNER_OS:-unknown}-${RUNNER_ARCH:-unknown}-"
 fi
 

--- a/pr-action/prepare_test.go
+++ b/pr-action/prepare_test.go
@@ -56,3 +56,112 @@ func TestPrepareOutputsDefaultHTMLDiffArtifactName(t *testing.T) {
 		t.Fatalf("GITHUB_OUTPUT = %q, want default HTML diff artifact name", output)
 	}
 }
+
+func TestPrepareRotatesCacheKeyByCommitSha(t *testing.T) {
+	out := runPrepare(t, map[string]string{"GITHUB_SHA": "abc123def456"})
+
+	got := outputValue(t, out, "cache-key")
+	want := "drydock-Linux-X64-example-repo-test-v1-abc123def456"
+	if got != want {
+		t.Fatalf("cache-key = %q, want commit-rotated %q", got, want)
+	}
+	// The rotated key must fall back through the version+suffix restore prefix
+	// so other runs in scope restore the most recent cache.
+	if !strings.HasPrefix(got, "drydock-Linux-X64-example-repo-test-v1-") {
+		t.Fatalf("rotated key %q does not start with its restore prefix", got)
+	}
+	if !strings.Contains(out, "restore-keys<<EOF\ndrydock-Linux-X64-example-repo-test-v1-\n") {
+		t.Fatalf("GITHUB_OUTPUT = %q, want version+suffix restore prefix first", out)
+	}
+}
+
+func TestPrepareCacheKeyStaticWithoutCommitSha(t *testing.T) {
+	out := runPrepare(t, map[string]string{"GITHUB_SHA": ""})
+
+	got := outputValue(t, out, "cache-key")
+	want := "drydock-Linux-X64-example-repo-test-v1"
+	if got != want {
+		t.Fatalf("cache-key = %q, want static %q when no commit sha is set", got, want)
+	}
+}
+
+func TestPrepareRespectsExplicitCacheKey(t *testing.T) {
+	out := runPrepare(t, map[string]string{
+		"GITHUB_SHA":              "abc123def456",
+		"DRYDOCK_INPUT_CACHE_KEY": "custom-key",
+	})
+
+	got := outputValue(t, out, "cache-key")
+	if got != "custom-key" {
+		t.Fatalf("cache-key = %q, want the explicit custom-key without rotation", got)
+	}
+}
+
+// runPrepare runs prepare.sh with a deterministic default environment merged
+// with overrides (overrides win), and returns the GITHUB_OUTPUT contents.
+func runPrepare(t *testing.T, overrides map[string]string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	outputPath := filepath.Join(tmp, "github-output")
+
+	defaults := map[string]string{
+		"GITHUB_OUTPUT":                           outputPath,
+		"GITHUB_RUN_ID":                           "12345",
+		"GITHUB_RUN_ATTEMPT":                      "1",
+		"GITHUB_EVENT_NAME":                       "pull_request",
+		"GITHUB_REPOSITORY":                       "example/repo",
+		"GITHUB_SHA":                              "",
+		"RUNNER_TEMP":                             tmp,
+		"RUNNER_OS":                               "Linux",
+		"RUNNER_ARCH":                             "X64",
+		"DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS":   "",
+		"DRYDOCK_INPUT_CACHE":                     "true",
+		"DRYDOCK_INPUT_CACHE_KEY":                 "",
+		"DRYDOCK_INPUT_CACHE_KEY_PREFIX":          "drydock",
+		"DRYDOCK_INPUT_CACHE_KEY_SUFFIX":          "v1",
+		"DRYDOCK_INPUT_CACHE_PATH":                "",
+		"DRYDOCK_INPUT_CACHE_RESTORE_KEYS":        "",
+		"DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE":   "false",
+		"DRYDOCK_INPUT_COMMENT_CONTINUE_ON_ERROR": "false",
+		"DRYDOCK_INPUT_COMMENT_EMPTY":             "false",
+		"DRYDOCK_INPUT_COMMENT_MODE":              "both",
+		"DRYDOCK_INPUT_DIFF_ARTIFACT_NAME":        "",
+		"DRYDOCK_INPUT_DIFF_MAX_BYTES":            "60000",
+		"DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME":       "",
+		"DRYDOCK_INPUT_SAVE_CACHE":                "true",
+		"DRYDOCK_INPUT_UPLOAD_ARTIFACTS":          "true",
+		"DRYDOCK_PR_HEAD_REPO":                    "example/repo",
+		"DRYDOCK_RESOLVED_VERSION":                "test",
+	}
+
+	env := os.Environ()
+	for key, value := range defaults {
+		env = append(env, key+"="+value)
+	}
+	for key, value := range overrides {
+		env = append(env, key+"="+value)
+	}
+
+	cmd := exec.Command("bash", "prepare.sh")
+	cmd.Dir = "."
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("prepare.sh failed: %v\n%s", err, out)
+	}
+	return readFile(t, outputPath)
+}
+
+func outputValue(t *testing.T, output, key string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(output, "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok && k == key {
+			return v
+		}
+	}
+	t.Fatalf("GITHUB_OUTPUT %q has no %q line", output, key)
+	return ""
+}

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -232,6 +232,65 @@ chart, remote-resource, and render output cache entry roots (use
 `--render-cache-dir ${cache-path}/renders` to target the action's persisted
 renders); they do not manage plugin cache mount roots.
 
+### Cache Scope And Warming
+
+GitHub Actions scopes every cache to the Git ref that created it. A run can
+restore caches created in its own ref, the pull request base branch, and the
+repository default branch. Caches created on the default branch are readable by
+all branches and pull requests, but a cache saved during a pull request run is
+scoped to that pull request and is reused only by later runs of the same pull
+request — never by other pull requests.
+
+A workflow that triggers only on `pull_request` therefore never populates a
+shared cache. Every pull request misses on restore, renders cold, and saves a
+cache that no other pull request can read. To make the render cache effective
+across pull requests, warm it from the default branch: run the action on pushes
+to the default branch with `save-cache: "true"`. The action rotates the cache
+key per commit (it appends the commit SHA), and `actions/cache` keys are
+immutable, so each push writes a fresh entry rather than freezing the first one.
+Pull request runs restore the most recent matching entry through the generated
+`cache-restore-keys` prefixes and re-render only the Applications whose inputs
+changed.
+
+```yaml
+name: drydock cache warm
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sholdee/drydock/pr-action@main
+        with:
+          version: vX.Y.Z
+          run-diff: "false"
+          run-image-diff: "false"
+          comment-mode: none
+          save-cache: "true"
+```
+
+The warm run renders the default branch's desired state with `drydock test
+apps`; diffs are disabled because they need a base ref that a push event does
+not provide. Leave `path` at its default (the repository root) so discovery
+covers every Application your pull requests render. Keep `version`,
+`cache-key-prefix`, and `cache-key-suffix` the same as the pull request workflow
+so both runs share the same restore-key prefix; the action appends the commit
+SHA to the primary key, so the keys differ per commit but resolve through that
+prefix. Add a `paths:` filter to the `push` trigger if you only want to warm
+when manifests change.
+
+To keep pull request runs from consuming the cache budget and evicting the
+shared default-branch entry, set `save-cache: "false"` on the pull request
+action so those runs restore only. The render cache is content-addressed by
+Application input digests, so a default-branch warm covers every unchanged
+Application regardless of which commit a pull request branched from.
+
 ## Input Behavior
 
 Newline-delimited inputs are passed as repeated drydock flags:


### PR DESCRIPTION
## Summary

The PR action's render cache key was **static** (`drydock-${OS}-${ARCH}-${repo}-${version}-${suffix}`, no commit or content component). `actions/cache` keys are immutable, and the action's save step is guarded by `cache-hit != 'true'`, so a static key is **written once and then frozen**:

- A default-branch "warm" run never refreshes past its first save.
- Within a pull request, later commits never update the cache.

A tell that this was an oversight: the action already emits `cache-restore-keys` prefixes, which only add value when the primary key *rotates*.

## Fix

Append `${GITHUB_SHA}` to the default cache key so each commit writes a fresh, immutable entry, and prepend a most-specific `version+suffix` restore-key prefix so runs in scope restore the most recent matching cache (the canonical `actions/cache` rotating-key pattern). The key stays static when `GITHUB_SHA` is unset (local use), and an explicit `cache-key` override is still used verbatim.

This makes a default-branch warm cache self-refreshing and also gives within-PR commits incremental reuse.

## Why it matters

GitHub Actions scopes caches by the ref that created them: a cache saved during a pull request run is reused only by later runs of the **same** PR, never by other PRs. Only default-branch caches are readable by all branches. A `pull_request`-only workflow therefore never populates a shared cache — every PR misses and renders cold (observed on a downstream repo: a render-cache restore missed all keys, then re-saved a PR-scoped entry no other PR could read). The fix makes warming from the default branch actually effective.

## Docs

Adds a **Cache Scope And Warming** section to `site/content/workflows/github-actions.md`:
- Explains GitHub's branch-scoped cache isolation.
- A `push: [main]` cache-warming workflow (diffs disabled so no base ref is needed; `path` left at the repository-root default).
- The recommended pairing: `save-cache: "false"` on pull request runs (restore-only) so PRs don't consume the cache budget or evict the shared default-branch entry.

## Tests

- `TestPrepareRotatesCacheKeyByCommitSha` — key rotates by SHA and resolves through the version+suffix restore prefix (sabotage-proven to fail on a static-key reversion).
- `TestPrepareCacheKeyStaticWithoutCommitSha` — stays static when `GITHUB_SHA` is unset.
- `TestPrepareRespectsExplicitCacheKey` — an explicit `cache-key` override is used verbatim.

## Validation

`go test ./pr-action/`, `go vet`, `golangci-lint run` (0 issues), `shellcheck pr-action/prepare.sh`, and `mise run markdownlint` (no new findings) all clean.
