### PR TITLE
feat(pr-action): add cache-mode for local caching on self-hosted runners

### DIFF
--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -151,6 +151,14 @@ inputs:
     description: Restore and save drydock render caches for trusted runs.
     required: false
     default: "true"
+  cache-mode:
+    description: >-
+      Cache backend. auto (default) and github use the remote actions/cache
+      backend on any runner. local persists the cache on the runner filesystem
+      at cache-path and skips actions/cache, for self-hosted runners with
+      durable storage. off keeps no cache between runs. cache "false" forces off.
+    required: false
+    default: auto
   save-cache:
     description: Save drydock render caches after trusted runs.
     required: false
@@ -345,6 +353,7 @@ runs:
       env:
         DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS: ${{ inputs.artifact-retention-days }}
         DRYDOCK_INPUT_CACHE: ${{ inputs.cache }}
+        DRYDOCK_INPUT_CACHE_MODE: ${{ inputs.cache-mode }}
         DRYDOCK_INPUT_CACHE_KEY: ${{ inputs.cache-key }}
         DRYDOCK_INPUT_CACHE_KEY_PREFIX: ${{ inputs.cache-key-prefix }}
         DRYDOCK_INPUT_CACHE_KEY_SUFFIX: ${{ inputs.cache-key-suffix }}

--- a/pr-action/prepare.sh
+++ b/pr-action/prepare.sh
@@ -42,11 +42,33 @@ case "${DRYDOCK_INPUT_COMMENT_MODE}" in
     ;;
 esac
 
+cache_mode="${DRYDOCK_INPUT_CACHE_MODE:-auto}"
+case "${cache_mode}" in
+  auto | github | local | off) ;;
+  *)
+    echo "cache-mode must be auto, github, local, or off, got '${cache_mode}'." >&2
+    exit 1
+    ;;
+esac
+# Back-compat: cache: false disables persistence regardless of cache-mode.
+if [[ "${DRYDOCK_INPUT_CACHE}" != "true" ]]; then
+  cache_mode="off"
+fi
+
+runner_environment="${RUNNER_ENVIRONMENT:-}"
+
 runner_temp="${RUNNER_TEMP:-/tmp}"
 work_dir="$(mktemp -d "${runner_temp%/}/drydock-pr-action.XXXXXX")"
 cache_path="${DRYDOCK_INPUT_CACHE_PATH}"
 if [[ -z "${cache_path}" ]]; then
-  cache_path="${runner_temp%/}/drydock-cache"
+  if [[ "${cache_mode}" == "local" ]]; then
+    # Prefer the persistent tool cache so a self-hosted runner keeps the cache
+    # across jobs; RUNNER_TEMP is cleaned each job.
+    cache_root="${RUNNER_TOOL_CACHE:-${runner_temp}}"
+    cache_path="${cache_root%/}/drydock-cache"
+  else
+    cache_path="${runner_temp%/}/drydock-cache"
+  fi
 fi
 mkdir -p "${cache_path}"
 
@@ -59,15 +81,34 @@ case "${GITHUB_EVENT_NAME:-}" in
     ;;
 esac
 
+# auto and github use the remote actions/cache backend; local and off do not
+# (local persists at cache_path on the runner, off keeps no cache between runs).
 cache_restore=false
 cache_save=false
-if [[ "${DRYDOCK_INPUT_CACHE}" == "true" ]]; then
-  if [[ "${trusted_context}" == "true" || "${DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE}" == "true" ]]; then
-    cache_restore=true
-  fi
-  if [[ "${trusted_context}" == "true" && "${DRYDOCK_INPUT_SAVE_CACHE}" == "true" ]]; then
-    cache_save=true
-  fi
+case "${cache_mode}" in
+  auto | github)
+    if [[ "${trusted_context}" == "true" || "${DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE}" == "true" ]]; then
+      cache_restore=true
+    fi
+    if [[ "${trusted_context}" == "true" && "${DRYDOCK_INPUT_SAVE_CACHE}" == "true" ]]; then
+      cache_save=true
+    fi
+    ;;
+  local | off) ;;
+esac
+
+# Guidance and guardrails keyed on the runner environment. runner.environment
+# distinguishes github-hosted from self-hosted, but not whether a self-hosted
+# runner has a persistent filesystem, so the default never switches modes on
+# its own.
+if [[ "${cache_mode}" == "auto" && "${runner_environment}" == "self-hosted" ]]; then
+  echo "::notice::drydock: self-hosted runner detected. If this runner has persistent storage, set cache-mode: local with a persistent cache-path to skip actions/cache round-trips and the cross-pull-request cache scope limits."
+fi
+if [[ "${cache_mode}" == "local" && "${runner_environment}" == "github-hosted" ]]; then
+  echo "::warning::drydock: cache-mode: local does not persist on a GitHub-hosted runner (its filesystem is ephemeral); use cache-mode: auto or github."
+fi
+if [[ "${cache_mode}" == "local" && "${cache_path}" == "${runner_temp%/}"/* ]]; then
+  echo "::warning::drydock: cache-mode: local cache-path is under RUNNER_TEMP, which is cleaned each job and will not persist; set cache-path to a directory that survives across jobs."
 fi
 
 repo_key="${GITHUB_REPOSITORY:-repository}"

--- a/pr-action/prepare_test.go
+++ b/pr-action/prepare_test.go
@@ -58,9 +58,9 @@ func TestPrepareOutputsDefaultHTMLDiffArtifactName(t *testing.T) {
 }
 
 func TestPrepareRotatesCacheKeyByCommitSha(t *testing.T) {
-	out := runPrepare(t, map[string]string{"GITHUB_SHA": "abc123def456"})
+	res := runPrepare(t, map[string]string{"GITHUB_SHA": "abc123def456"})
 
-	got := outputValue(t, out, "cache-key")
+	got := outputValue(t, res.output, "cache-key")
 	want := "drydock-Linux-X64-example-repo-test-v1-abc123def456"
 	if got != want {
 		t.Fatalf("cache-key = %q, want commit-rotated %q", got, want)
@@ -70,15 +70,15 @@ func TestPrepareRotatesCacheKeyByCommitSha(t *testing.T) {
 	if !strings.HasPrefix(got, "drydock-Linux-X64-example-repo-test-v1-") {
 		t.Fatalf("rotated key %q does not start with its restore prefix", got)
 	}
-	if !strings.Contains(out, "restore-keys<<EOF\ndrydock-Linux-X64-example-repo-test-v1-\n") {
-		t.Fatalf("GITHUB_OUTPUT = %q, want version+suffix restore prefix first", out)
+	if !strings.Contains(res.output, "restore-keys<<EOF\ndrydock-Linux-X64-example-repo-test-v1-\n") {
+		t.Fatalf("GITHUB_OUTPUT = %q, want version+suffix restore prefix first", res.output)
 	}
 }
 
 func TestPrepareCacheKeyStaticWithoutCommitSha(t *testing.T) {
-	out := runPrepare(t, map[string]string{"GITHUB_SHA": ""})
+	res := runPrepare(t, map[string]string{"GITHUB_SHA": ""})
 
-	got := outputValue(t, out, "cache-key")
+	got := outputValue(t, res.output, "cache-key")
 	want := "drydock-Linux-X64-example-repo-test-v1"
 	if got != want {
 		t.Fatalf("cache-key = %q, want static %q when no commit sha is set", got, want)
@@ -86,27 +86,150 @@ func TestPrepareCacheKeyStaticWithoutCommitSha(t *testing.T) {
 }
 
 func TestPrepareRespectsExplicitCacheKey(t *testing.T) {
-	out := runPrepare(t, map[string]string{
+	res := runPrepare(t, map[string]string{
 		"GITHUB_SHA":              "abc123def456",
 		"DRYDOCK_INPUT_CACHE_KEY": "custom-key",
 	})
 
-	got := outputValue(t, out, "cache-key")
+	got := outputValue(t, res.output, "cache-key")
 	if got != "custom-key" {
 		t.Fatalf("cache-key = %q, want the explicit custom-key without rotation", got)
 	}
 }
 
+func TestPrepareCacheModeAutoUsesActionsCache(t *testing.T) {
+	res := runPrepare(t, map[string]string{"DRYDOCK_INPUT_CACHE_MODE": "auto"})
+
+	if got := outputValue(t, res.output, "cache-restore"); got != "true" {
+		t.Fatalf("cache-restore = %q, want true for auto on a trusted run", got)
+	}
+	if got := outputValue(t, res.output, "cache-save"); got != "true" {
+		t.Fatalf("cache-save = %q, want true for auto on a trusted run", got)
+	}
+}
+
+func TestPrepareCacheModeLocalSkipsActionsCache(t *testing.T) {
+	toolCache := t.TempDir()
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE": "local",
+		"RUNNER_TOOL_CACHE":        toolCache,
+	})
+
+	if got := outputValue(t, res.output, "cache-restore"); got != "false" {
+		t.Fatalf("cache-restore = %q, want false for local mode", got)
+	}
+	if got := outputValue(t, res.output, "cache-save"); got != "false" {
+		t.Fatalf("cache-save = %q, want false for local mode", got)
+	}
+	// local defaults its cache-path to the persistent tool cache.
+	if got := outputValue(t, res.output, "cache-path"); got != filepath.Join(toolCache, "drydock-cache") {
+		t.Fatalf("cache-path = %q, want it under the tool cache %q", got, toolCache)
+	}
+}
+
+func TestPrepareCacheModeOffDisablesActionsCache(t *testing.T) {
+	res := runPrepare(t, map[string]string{"DRYDOCK_INPUT_CACHE_MODE": "off"})
+
+	if got := outputValue(t, res.output, "cache-restore"); got != "false" {
+		t.Fatalf("cache-restore = %q, want false for off mode", got)
+	}
+	if got := outputValue(t, res.output, "cache-save"); got != "false" {
+		t.Fatalf("cache-save = %q, want false for off mode", got)
+	}
+}
+
+func TestPrepareCacheFalseForcesOff(t *testing.T) {
+	// Back-compat: cache: false disables persistence even though cache-mode
+	// defaults to auto.
+	res := runPrepare(t, map[string]string{"DRYDOCK_INPUT_CACHE": "false"})
+
+	if got := outputValue(t, res.output, "cache-restore"); got != "false" {
+		t.Fatalf("cache-restore = %q, want false when cache is false", got)
+	}
+	if got := outputValue(t, res.output, "cache-save"); got != "false" {
+		t.Fatalf("cache-save = %q, want false when cache is false", got)
+	}
+}
+
+func TestPrepareCacheModeInvalidFails(t *testing.T) {
+	logs := runPrepareExpectFailure(t, map[string]string{"DRYDOCK_INPUT_CACHE_MODE": "bogus"})
+	if !strings.Contains(logs, "cache-mode must be auto, github, local, or off") {
+		t.Fatalf("stderr = %q, want a cache-mode validation error", logs)
+	}
+}
+
+func TestPrepareSelfHostedAutoEmitsNotice(t *testing.T) {
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE": "auto",
+		"RUNNER_ENVIRONMENT":       "self-hosted",
+	})
+
+	if !strings.Contains(res.logs, "::notice::") || !strings.Contains(res.logs, "cache-mode: local") {
+		t.Fatalf("logs = %q, want a self-hosted local-cache notice", res.logs)
+	}
+}
+
+func TestPrepareCacheModeGithubSilencesSelfHostedNotice(t *testing.T) {
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE": "github",
+		"RUNNER_ENVIRONMENT":       "self-hosted",
+	})
+
+	if got := outputValue(t, res.output, "cache-restore"); got != "true" {
+		t.Fatalf("cache-restore = %q, want true for github mode", got)
+	}
+	if strings.Contains(res.logs, "::notice::") {
+		t.Fatalf("logs = %q, want no notice when cache-mode is explicitly github", res.logs)
+	}
+}
+
+func TestPrepareLocalOnGitHubHostedWarns(t *testing.T) {
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE": "local",
+		"RUNNER_ENVIRONMENT":       "github-hosted",
+		"RUNNER_TOOL_CACHE":        t.TempDir(),
+	})
+
+	if !strings.Contains(res.logs, "::warning::") || !strings.Contains(res.logs, "does not persist on a GitHub-hosted runner") {
+		t.Fatalf("logs = %q, want a github-hosted local-cache warning", res.logs)
+	}
+}
+
+type prepareResult struct {
+	output string // GITHUB_OUTPUT file contents
+	logs   string // prepare.sh stdout+stderr (::notice::/::warning:: commands)
+}
+
 // runPrepare runs prepare.sh with a deterministic default environment merged
-// with overrides (overrides win), and returns the GITHUB_OUTPUT contents.
-func runPrepare(t *testing.T, overrides map[string]string) string {
+// with overrides (overrides win) and expects success.
+func runPrepare(t *testing.T, overrides map[string]string) prepareResult {
+	t.Helper()
+	outputPath, logs, err := execPrepare(t, overrides)
+	if err != nil {
+		t.Fatalf("prepare.sh failed: %v\n%s", err, logs)
+	}
+	return prepareResult{output: readFile(t, outputPath), logs: logs}
+}
+
+// runPrepareExpectFailure runs prepare.sh expecting a non-zero exit and returns
+// its combined output.
+func runPrepareExpectFailure(t *testing.T, overrides map[string]string) string {
+	t.Helper()
+	_, logs, err := execPrepare(t, overrides)
+	if err == nil {
+		t.Fatalf("prepare.sh succeeded, want failure\n%s", logs)
+	}
+	return logs
+}
+
+func execPrepare(t *testing.T, overrides map[string]string) (outputPath, logs string, err error) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
 	}
 
 	tmp := t.TempDir()
-	outputPath := filepath.Join(tmp, "github-output")
+	outputPath = filepath.Join(tmp, "github-output")
 
 	defaults := map[string]string{
 		"GITHUB_OUTPUT":                           outputPath,
@@ -118,8 +241,11 @@ func runPrepare(t *testing.T, overrides map[string]string) string {
 		"RUNNER_TEMP":                             tmp,
 		"RUNNER_OS":                               "Linux",
 		"RUNNER_ARCH":                             "X64",
+		"RUNNER_ENVIRONMENT":                      "",
+		"RUNNER_TOOL_CACHE":                       "",
 		"DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS":   "",
 		"DRYDOCK_INPUT_CACHE":                     "true",
+		"DRYDOCK_INPUT_CACHE_MODE":                "",
 		"DRYDOCK_INPUT_CACHE_KEY":                 "",
 		"DRYDOCK_INPUT_CACHE_KEY_PREFIX":          "drydock",
 		"DRYDOCK_INPUT_CACHE_KEY_SUFFIX":          "v1",
@@ -149,10 +275,8 @@ func runPrepare(t *testing.T, overrides map[string]string) string {
 	cmd := exec.Command("bash", "prepare.sh")
 	cmd.Dir = "."
 	cmd.Env = env
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("prepare.sh failed: %v\n%s", err, out)
-	}
-	return readFile(t, outputPath)
+	out, runErr := cmd.CombinedOutput()
+	return outputPath, string(out), runErr
 }
 
 func outputValue(t *testing.T, output, key string) string {

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -291,6 +291,48 @@ action so those runs restore only. The render cache is content-addressed by
 Application input digests, so a default-branch warm covers every unchanged
 Application regardless of which commit a pull request branched from.
 
+### Self-Hosted Runners And Local Caching
+
+`actions/cache` is a remote, branch-scoped backend, so the scope limits above
+apply on self-hosted runners too. On a self-hosted runner with durable storage,
+persist the cache on the runner's own filesystem instead: it avoids the
+upload/download round-trips and the cross-pull-request scope limits entirely —
+every pull request and push on that runner shares one on-disk cache, which is
+safe because the render cache is content-addressed by Application input digests.
+
+Select the backend with `cache-mode`:
+
+| `cache-mode` | Backend | Use for |
+| --- | --- | --- |
+| `auto` (default) | `actions/cache` (remote) | any runner; works everywhere |
+| `github` | `actions/cache` (remote) | self-hosted that wants remote caching |
+| `local` | runner filesystem at `cache-path` | self-hosted with durable storage |
+| `off` | none | disable persistence |
+
+```yaml
+- uses: sholdee/drydock/pr-action@vX.Y.Z
+  with:
+    version: vX.Y.Z
+    cache-mode: local
+    cache-path: /var/lib/drydock-cache # a path that persists across jobs
+```
+
+`local` mode defaults `cache-path` to `${RUNNER_TOOL_CACHE}/drydock-cache`, which
+persists across jobs on a long-lived self-hosted runner. It cannot detect
+whether a runner is actually persistent: GitHub's `runner.environment` only
+distinguishes GitHub-hosted from self-hosted, not durable from ephemeral.
+Ephemeral self-hosted runners — actions-runner-controller pods and `--ephemeral`
+runners — get fresh storage each job, so `local` helps them only if you mount a
+durable volume at `cache-path`; otherwise keep `auto` so the remote backend
+repopulates the cache each run. The action emits a notice on self-hosted runners
+that suggests `local`, and warns when `local` is used on a GitHub-hosted runner
+(whose filesystem is always ephemeral).
+
+With `local`, eviction is yours to manage: drydock's render-cache size cap and
+`drydock cache prune` bound the directory rather than GitHub's cache budget. A
+shared on-disk cache is readable by every job on the runner, so use it only for
+trusted workloads.
+
 ## Input Behavior
 
 Newline-delimited inputs are passed as repeated drydock flags:
@@ -399,6 +441,7 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | Input | Default | Purpose |
 | --- | --- | --- |
 | `cache` | `true` | Restore and save drydock render caches for trusted runs. |
+| `cache-mode` | `auto` | Cache backend. `auto`/`github` use the remote `actions/cache` backend; `local` persists at `cache-path` on the runner and skips `actions/cache`; `off` disables persistence. `cache: "false"` forces `off`. |
 | `save-cache` | `true` | Save drydock render caches after trusted runs. |
 | `cache-untrusted-restore` | `false` | Restore drydock render caches for fork pull requests. Cache save remains disabled for forks. |
 | `cache-path` | runner temp directory | Local drydock cache root. |


### PR DESCRIPTION
## Summary

The action persists caches through `actions/cache` — a **remote, GitHub branch-scoped** backend. On a self-hosted runner with durable storage that means upload/download round-trips on every job, and the cross-pull-request scope limits still apply, even though the runner could keep the cache on local disk for free.

This adds a **`cache-mode`** input so operators can persist the render cache on the runner filesystem instead, while keeping the safe remote default for everyone else.

## The constraint that shapes the design

You cannot simply default self-hosted runners to local caching: **"self-hosted" does not imply "persistent filesystem."** Ephemeral self-hosted runners — actions-runner-controller pods, `--ephemeral` runners — get fresh storage each job. Defaulting them to local-only would give them a permanently cold cache and remove their `actions/cache` fallback (strictly worse).

GitHub exposes `runner.environment` / `RUNNER_ENVIRONMENT` (`github-hosted` vs `self-hosted`) but **not** durable-vs-ephemeral, and the action can't detect persistence. So persistence must be a declared intent, never an auto-default.

## Design

`cache-mode`:

| mode | backend | for |
| --- | --- | --- |
| `auto` *(default)* | `actions/cache` (remote) | any runner — unchanged behavior |
| `github` | `actions/cache` (remote) | self-hosted that wants remote caching (silences the notice) |
| `local` | runner filesystem at `cache-path` | self-hosted with durable storage |
| `off` | none | disable persistence |

- **Safe default:** `auto` is byte-identical to today for every existing user; `cache: "false"` still forces `off` (back-compat).
- **`local`** skips `actions/cache`, defaults `cache-path` to the persistent tool cache, and lets drydock persist its caches on disk — no round-trips, no branch scoping (one content-addressed cache shared by all PRs/pushes on that runner).
- **`runner.environment` drives guidance only, never behavior:** a `::notice::` on self-hosted suggesting `local`; a `::warning::` when `local` runs on a GitHub-hosted (ephemeral) runner; a `::warning::` when a `local` cache-path is under `RUNNER_TEMP` (cleaned each job).

## Usage (persistent self-hosted runner)

```yaml
- uses: sholdee/drydock/pr-action@vX.Y.Z
  with:
    version: vX.Y.Z
    cache-mode: local
    cache-path: /var/lib/drydock-cache   # a path that persists across jobs
```

## Tests

Eight new `prepare.sh` tests: auto-uses-actions-cache, local-skips + tool-cache default path, off-disables, `cache: false` forces off, invalid-mode fails, self-hosted notice, `github` silences the notice, local-on-github-hosted warns. Two sabotage-validated.

## Docs

`cache-mode` inputs-table row + a "Self-Hosted Runners And Local Caching" section (mode table, persistent-vs-ephemeral / ARC caveat, prune and trust notes).

## Validation

`go test ./pr-action/`, `go vet`, `golangci-lint run` (0 issues), `shellcheck pr-action/prepare.sh`, `mise run markdownlint` (no new findings) all clean. Back-compat verified byte-identical for the default config.
