### PR TITLE
docs(actions): note cache-key-suffix for cache namespacing

### DIFF
--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -217,6 +217,12 @@ the repository under test.
 Dirty-worktree render output reuse uses the existing render cache behavior. No
 new PR action input is required.
 
+Bump `cache-key-suffix` to start a fresh cache namespace (for example after a
+renderer change you do not want served from older entries). Because render
+outputs are content-addressed by Application input digests, serving a stale
+entry is already safe — a suffix bump is a deliberate clean-slate switch rather
+than a correctness control.
+
 Fork pull requests do not restore or save drydock render caches by default,
 because render caches can contain private repository, chart, remote source, or
 plugin cache material. They also skip PR comments by default. Set


### PR DESCRIPTION
Re-applies the `Release-As: 0.2.0` directive that #145 missed.

#145 was an empty commit; release-please splits commits by path and drops file-less commits, so it never read the `Release-As` footer (the draft #138 stayed at 0.1.22). This commit carries the same `Release-As: 0.2.0` footer but also makes a real, non-excluded docs change, so release-please will process it.

The docs change itself is a small, genuine addition: how to use `cache-key-suffix` to start a fresh cache namespace.

After merge, release-please regenerates #138 as 0.2.0; merge #138 (not before this) to cut the release.