### PR TITLE
fix(render): preserve helm resources' explicit namespaces under a kustomize namespace transformer

### DIFF
--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/manifest"
 	goyaml "go.yaml.in/yaml/v3"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -495,11 +496,24 @@ func writeGeneratedHelmManifests(path string, manifests []Manifest) error {
 		return err
 	}
 	var buffer bytes.Buffer
-	for _, manifest := range manifests {
-		if manifest.Object == nil {
+	for _, m := range manifests {
+		if m.Object == nil {
 			continue
 		}
-		data, err := goyaml.Marshal(manifest.Object.Object)
+		// Mark drydock-pre-rendered helm manifests as helm-generated so kustomize's
+		// NamespaceTransformer skips them — matching the native HelmChartInflationGenerator,
+		// which preserves resources' explicit namespaces (e.g. chart RBAC pinned to
+		// kube-system) instead of rewriting them to the kustomization namespace. kustomize
+		// strips this build annotation from final output (resource.BuildAnnotations), and
+		// ApplyDestinationNamespace still defaults namespace-less resources downstream.
+		obj := m.Object.DeepCopy()
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[konfig.HelmGeneratedAnnotation] = "true"
+		obj.SetAnnotations(annotations)
+		data, err := goyaml.Marshal(obj.Object)
 		if err != nil {
 			return fmt.Errorf("encode generated helm manifest: %w", err)
 		}

--- a/internal/render/kustomize_helm_namespace_test.go
+++ b/internal/render/kustomize_helm_namespace_test.go
@@ -1,0 +1,86 @@
+package render
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/kustomize/api/konfig"
+)
+
+// A helm chart that hardcodes an explicit namespace different from the
+// kustomization's namespace transformer (mirrors cert-manager's leaderelection
+// RBAC pinned to kube-system) must keep that namespace — kustomize's
+// NamespaceTransformer skips helm-generated resources, and drydock must too.
+func TestKustomizeRendererPreservesHelmExplicitNamespaceUnderNamespaceTransformer(t *testing.T) {
+	root := t.TempDir()
+	chartDir := filepath.Join(root, "charts", "demo")
+	// Role: explicit namespace different from the kustomization transformer (must be preserved).
+	// ConfigMap: namespace-less (must stay namespace-less at render time — the transformer skips
+	// it too — so ApplyDestinationNamespace can later default it to the destination namespace).
+	writeTestChart(t, chartDir, `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: demo:leaderelection
+  namespace: kube-system
+rules: []
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-marker
+data:
+  marker: present
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: demo
+helmCharts:
+  - name: demo
+    repo: https://charts.example.test
+    version: 1.2.3
+    releaseName: demo
+    valuesFile: values.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "values.yaml"), "{}\n")
+
+	acquirer := &fakeChartAcquirer{chartDir: chartDir}
+	result, diags, err := (KustomizeRenderer{}).Render(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     filepath.Join("apps", "demo"),
+	}, RenderOptions{ChartAcquirer: acquirer})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+
+	roles := filterObjects(result, "Role")
+	if len(roles) != 1 {
+		t.Fatalf("len(roles) = %d, want 1", len(roles))
+	}
+	if ns := roles[0].GetNamespace(); ns != "kube-system" {
+		t.Fatalf("Role namespace = %q, want %q (namespace transformer must skip helm-generated resources)", ns, "kube-system")
+	}
+	if _, ok := roles[0].GetAnnotations()[konfig.HelmGeneratedAnnotation]; ok {
+		t.Fatalf("helm-generated build annotation leaked into rendered output")
+	}
+
+	configmaps := filterObjects(result, "ConfigMap")
+	if len(configmaps) != 1 {
+		t.Fatalf("len(configmaps) = %d, want 1", len(configmaps))
+	}
+	// Namespace-less helm resource must stay namespace-less at render time (transformer
+	// skips it); ApplyDestinationNamespace defaults it to the destination namespace
+	// downstream — matching ArgoCD. Without the fix the transformer would stamp the
+	// kustomization namespace ("demo") here.
+	if ns := configmaps[0].GetNamespace(); ns != "" {
+		t.Fatalf("ConfigMap namespace = %q, want empty (namespace transformer must skip helm-generated resources)", ns)
+	}
+	if _, ok := configmaps[0].GetAnnotations()[konfig.HelmGeneratedAnnotation]; ok {
+		t.Fatalf("helm-generated build annotation leaked into rendered output")
+	}
+}

--- a/scripts/argocd-parity-smoke.sh
+++ b/scripts/argocd-parity-smoke.sh
@@ -68,6 +68,7 @@ APPLICATIONS=(
   parity-kustomize-labels
   parity-kustomize-generators
   parity-kustomize-helm-capabilities
+  parity-kustomize-helm-cross-namespace
   parity-ft-alpha
   parity-ft-beta
   parity-fn-gamma-one

--- a/testdata/argocd-parity/repo/applications/kustomize-helm-cross-namespace.yaml
+++ b/testdata/argocd-parity/repo/applications/kustomize-helm-cross-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: parity-kustomize-helm-cross-namespace
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: workloads/kustomize-helm-cross-namespace
+    kustomize:
+      namespace: parity-kustomize-helm-cross-namespace
+  destination:
+    name: in-cluster
+    namespace: parity-kustomize-helm-cross-namespace

--- a/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/Chart.yaml
+++ b/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cross-ns-widget
+version: 0.1.0

--- a/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/templates/resources.yaml
+++ b/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/templates/resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}:leaderelection
+  namespace: kube-system
+rules: []
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-marker
+data:
+  marker: {{ .Values.marker }}

--- a/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/values.yaml
+++ b/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/charts/cross-ns-widget/values.yaml
@@ -1,0 +1,1 @@
+marker: from-chart-default

--- a/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/kustomization.yaml
+++ b/testdata/argocd-parity/repo/workloads/kustomize-helm-cross-namespace/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: parity-kustomize-helm-cross-namespace
+helmCharts:
+  - name: cross-ns-widget
+    releaseName: parity-cnx


### PR DESCRIPTION
## Summary
- drydock relocated helm-rendered resources' explicit namespaces (e.g. cert-manager's `:leaderelection` RBAC pinned to `kube-system`) to the app namespace whenever a kustomization had both a top-level `namespace:` transformer and `helmCharts:`. This diverged from real ArgoCD, which renders helm via kustomize's native `HelmChartInflationGenerator` — output the namespace transformer skips.
- **Root cause:** drydock pre-renders helm with its own renderer and injects the manifests as plain kustomize `resources:`, which the `namespace:` transformer then overrides.
- **Fix:** stamp drydock's pre-rendered helm manifests with kustomize's helm-generated build annotation (`konfig.HelmGeneratedAnnotation`) so the `NamespaceTransformer` skips them — matching native inflation. The annotation is auto-stripped from final output (it is in `resource.BuildAnnotations`), all other kustomize transforms still apply, and `ApplyDestinationNamespace` still defaults namespace-less resources to the destination namespace.
- Added a cross-namespace helm fixture to the Argo CD parity smoke, closing the fixture gap that hid this bug (no prior fixture rendered a chart resource into a namespace different from the kustomization transformer).

## Test Plan
- [x] `go test ./internal/... ./pkg/...`, `go vet ./...`, `golangci-lint run ./...` — all green
- [x] Unit guard test: a helm Role pinned to `kube-system` stays there; a namespace-less resource stays namespace-less; the build annotation does not leak. Sabotage-validated (fails when the fix is reverted).
- [x] Argo CD render parity smoke (kind + argo-cd v3.4.3): 53 applications / 68 resources / **0 differences**, including the new cross-namespace fixture.
- [x] Real repo (home-ops `cert-manager`): `:leaderelection` Role/RoleBinding now render in `kube-system`, matching the live Argo CD-managed cluster.