### PR TITLE
feat: normalize cluster-scoped custom resource namespaces from repo CRDs

### DIFF
--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -118,7 +118,7 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 	result.Statuses = append(result.Statuses, rendered.statuses...)
 	result.CacheEvents = append(result.CacheEvents, rendered.cacheEvents...)
 	result.PluginExecutions = append(result.PluginExecutions, rendered.pluginExecutions...)
-	if !session.request.CRDScopeOptions.Disabled {
+	if !session.request.Disabled {
 		registry := manifest.BuildCRDScopeRegistry(manifestObjectPtrs(result.Manifests))
 		result.Diagnostics = append(result.Diagnostics, normalizeCRDScope(result.Manifests, registry)...)
 	}

--- a/internal/app/build_session.go
+++ b/internal/app/build_session.go
@@ -118,6 +118,10 @@ func (session *buildSession) Build(ctx context.Context) (BuildResult, error) {
 	result.Statuses = append(result.Statuses, rendered.statuses...)
 	result.CacheEvents = append(result.CacheEvents, rendered.cacheEvents...)
 	result.PluginExecutions = append(result.PluginExecutions, rendered.pluginExecutions...)
+	if !session.request.CRDScopeOptions.Disabled {
+		registry := manifest.BuildCRDScopeRegistry(manifestObjectPtrs(result.Manifests))
+		result.Diagnostics = append(result.Diagnostics, normalizeCRDScope(result.Manifests, registry)...)
+	}
 	result.Diagnostics = session.request.filterProjectDiagnostics(dedupeDiagnostics(result.Diagnostics))
 	if renderErr != nil {
 		return result, renderErr

--- a/internal/app/crd_scope_build_test.go
+++ b/internal/app/crd_scope_build_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/render"
+)
+
+// findManifestByKindAndName returns the first manifest whose object has the
+// given kind and name. Returns (zero, false) if not found.
+func findManifestByKindAndName(manifests []render.Manifest, kind, name string) (render.Manifest, bool) {
+	for _, m := range manifests {
+		if m.Object == nil {
+			continue
+		}
+		if m.Object.GetKind() == kind && m.Object.GetName() == name {
+			return m, true
+		}
+	}
+	return render.Manifest{}, false
+}
+
+// writeGatewayClassFixture writes an Application whose destination namespace is
+// gateway-system, a GatewayClass CR (no namespace in source), and the
+// corresponding CRD (spec.scope: Cluster).
+func writeGatewayClassFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "gateway.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gateway
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/gateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gateway-system
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "gateway", "crd.yaml"), `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: GatewayClass
+    plural: gatewayclasses
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "gateway", "gatewayclass.yaml"), `apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: cilium
+`)
+}
+
+// TestOrchestratorBuildNormalizesClusterScopedCRNamespace verifies that the
+// build pipeline strips the destination namespace from a cluster-scoped custom
+// resource when its CRD (spec.scope: Cluster) is present in the same build.
+func TestOrchestratorBuildNormalizesClusterScopedCRNamespace(t *testing.T) {
+	root := t.TempDir()
+	writeGatewayClassFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{Path: root})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	m, ok := findManifestByKindAndName(result.Manifests, "GatewayClass", "cilium")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want GatewayClass/cilium", result.Manifests)
+	}
+	if got := m.Object.GetNamespace(); got != "" {
+		t.Fatalf("GatewayClass namespace = %q, want empty (cluster-scoped normalization)", got)
+	}
+}
+
+// TestOrchestratorBuildDisabledCRDScopeSkipsNormalization verifies that when
+// CRDScopeOptions.Disabled is true, the namespace strip is skipped and the
+// CR retains the destination namespace Argo CD would have stamped onto it.
+func TestOrchestratorBuildDisabledCRDScopeSkipsNormalization(t *testing.T) {
+	root := t.TempDir()
+	writeGatewayClassFixture(t, root)
+
+	result, err := Orchestrator{}.Build(context.Background(), BuildRequest{
+		Path:            root,
+		CRDScopeOptions: CRDScopeOptions{Disabled: true},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	m, ok := findManifestByKindAndName(result.Manifests, "GatewayClass", "cilium")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want GatewayClass/cilium", result.Manifests)
+	}
+	if got := m.Object.GetNamespace(); got != "gateway-system" {
+		t.Fatalf("GatewayClass namespace = %q, want gateway-system (normalization disabled)", got)
+	}
+}

--- a/internal/app/crd_scope_build_test.go
+++ b/internal/app/crd_scope_build_test.go
@@ -8,6 +8,64 @@ import (
 	"github.com/sholdee/drydock/internal/render"
 )
 
+// TestDiffCRDScopeNormalizedBothSides guards that a cluster-scoped CR
+// (GatewayClass) whose CRD is present in the same build produces no
+// spurious namespace-only diff when left and right trees are identical.
+// This proves that CRD scope normalization runs on BOTH diff sides so
+// the namespace strip is applied symmetrically and the identical trees
+// produce an empty diff.
+func TestDiffCRDScopeNormalizedBothSides(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeGatewayClassFixture(t, left)
+	writeGatewayClassFixture(t, right)
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:    left,
+		RightPath:   right,
+		ChangedOnly: false,
+		Unified:     3,
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("len(Diagnostics) = %d, want none: %#v", len(result.Diagnostics), result.Diagnostics)
+	}
+
+	// Identical trees must produce zero diff results — in particular there
+	// must be no namespace-only diff for the GatewayClass.
+	for _, item := range result.Results {
+		if item.Resource.Kind == "GatewayClass" {
+			t.Fatalf("unexpected diff result for GatewayClass: %#v\nDiff:\n%s", item, item.Diff)
+		}
+	}
+
+	// Additionally verify that normalization actually ran on both sides by
+	// building each side independently and confirming the GatewayClass has
+	// an empty namespace on both.
+	for _, side := range []struct {
+		name string
+		path string
+	}{
+		{"left", left},
+		{"right", right},
+	} {
+		buildResult, buildErr := Orchestrator{}.Build(context.Background(), BuildRequest{Path: side.path})
+		if buildErr != nil {
+			t.Fatalf("%s Build() error = %v", side.name, buildErr)
+		}
+		m, ok := findManifestByKindAndName(buildResult.Manifests, "GatewayClass", "cilium")
+		if !ok {
+			t.Fatalf("%s: GatewayClass/cilium not found in manifests: %#v", side.name, buildResult.Manifests)
+		}
+		if got := m.Object.GetNamespace(); got != "" {
+			t.Fatalf("%s: GatewayClass namespace = %q, want empty (normalization must run on both diff sides)", side.name, got)
+		}
+	}
+}
+
 // findManifestByKindAndName returns the first manifest whose object has the
 // given kind and name. Returns (zero, false) if not found.
 func findManifestByKindAndName(manifests []render.Manifest, kind, name string) (render.Manifest, bool) {

--- a/internal/app/crd_scope_normalize.go
+++ b/internal/app/crd_scope_normalize.go
@@ -6,7 +6,23 @@ import (
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/manifest"
 	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// manifestObjectPtrs returns the non-nil object pointers backing a manifest slice
+// WITHOUT copying. Safe for read-only registry construction, which completes
+// before normalizeCRDScope mutates the objects in place. Prefer this over the
+// DeepCopy-ing manifestObjects when no snapshot is needed.
+func manifestObjectPtrs(manifests []render.Manifest) []*unstructured.Unstructured {
+	objects := make([]*unstructured.Unstructured, 0, len(manifests))
+	for _, item := range manifests {
+		if item.Object == nil {
+			continue
+		}
+		objects = append(objects, item.Object)
+	}
+	return objects
+}
 
 // normalizeCRDScope strips metadata.namespace from every manifest that is
 // cluster-scoped per the registry (or a built-in cluster-scoped kind), mirroring

--- a/internal/app/crd_scope_normalize.go
+++ b/internal/app/crd_scope_normalize.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+// normalizeCRDScope strips metadata.namespace from every manifest that is
+// cluster-scoped per the registry (or a built-in cluster-scoped kind), mirroring
+// Argo CD. It mutates the shared unstructured objects in place. When two stripped
+// cluster-scoped resources collide on group/kind/name it warns rather than dropping.
+func normalizeCRDScope(manifests []render.Manifest, registry manifest.CRDScopeRegistry) []diagnostic.Diagnostic {
+	var diags []diagnostic.Diagnostic
+	seen := map[manifest.Identity]struct{}{}
+	for _, item := range manifests {
+		obj := item.Object
+		if obj == nil {
+			continue
+		}
+		if !registry.IsClusterScoped(obj.GroupVersionKind()) {
+			continue
+		}
+		if obj.GetNamespace() != "" {
+			obj.SetNamespace("")
+		}
+		id := manifest.IdentityOf(obj)
+		if _, ok := seen[id]; ok {
+			diags = append(diags, diagnostic.Diagnostic{
+				Code:     "build.crd-scope-collision",
+				Severity: diagnostic.SeverityWarning,
+				Category: "crd-scope",
+				Message:  fmt.Sprintf("cluster-scoped resource %s appears more than once after namespace normalization; both copies are retained", id.String()),
+			})
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	return diags
+}

--- a/internal/app/crd_scope_normalize_test.go
+++ b/internal/app/crd_scope_normalize_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func clusterScopedCRDManifest() render.Manifest {
+	return render.Manifest{Object: &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": "gatewayclasses.gateway.networking.k8s.io"},
+		"spec": map[string]any{
+			"group":    "gateway.networking.k8s.io",
+			"scope":    "Cluster",
+			"names":    map[string]any{"kind": "GatewayClass"},
+			"versions": []any{map[string]any{"name": "v1"}},
+		},
+	}}}
+}
+
+func crManifest(apiVersion, kind, namespace, name string) render.Manifest {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	return render.Manifest{Object: obj}
+}
+
+func TestNormalizeCRDScopeStripsClusterScopedNamespace(t *testing.T) {
+	manifests := []render.Manifest{
+		clusterScopedCRDManifest(),
+		crManifest("gateway.networking.k8s.io/v1", "GatewayClass", "kube-system", "cilium"),
+		crManifest("example.com/v1", "Widget", "apps", "namespaced-cr"),
+	}
+	registry := manifest.BuildCRDScopeRegistry(manifestObjects(manifests))
+	diags := normalizeCRDScope(manifests, registry)
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diags)
+	}
+	if ns := manifests[1].Object.GetNamespace(); ns != "" {
+		t.Fatalf("GatewayClass namespace = %q, want empty", ns)
+	}
+	if ns := manifests[2].Object.GetNamespace(); ns != "apps" {
+		t.Fatalf("Widget namespace = %q, want apps (untouched)", ns)
+	}
+}
+
+func TestNormalizeCRDScopeWarnsOnClusterScopedCollision(t *testing.T) {
+	manifests := []render.Manifest{
+		clusterScopedCRDManifest(),
+		crManifest("gateway.networking.k8s.io/v1", "GatewayClass", "ns-a", "dup"),
+		crManifest("gateway.networking.k8s.io/v1", "GatewayClass", "ns-b", "dup"),
+	}
+	registry := manifest.BuildCRDScopeRegistry(manifestObjects(manifests))
+	diags := normalizeCRDScope(manifests, registry)
+	found := false
+	for _, d := range diags {
+		if d.Code == "build.crd-scope-collision" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostics = %#v, want build.crd-scope-collision", diags)
+	}
+}

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -44,6 +44,7 @@ type DiffRequest struct {
 	FilterOptions
 	ApplicationSetOptions
 	CapabilityOptions
+	CRDScopeOptions
 
 	changedPaths          []string
 	persistentRenderCache *persistentRenderCache
@@ -460,6 +461,7 @@ func (request DiffRequest) buildRequest(path string, forbiddenRoots []string) Bu
 		FilterOptions:          cloneFilterOptions(request.FilterOptions),
 		ApplicationSetOptions:  cloneApplicationSetOptions(request.ApplicationSetOptions),
 		CapabilityOptions:      request.CapabilityOptions,
+		CRDScopeOptions:        request.CRDScopeOptions,
 		persistentRenderCache:  request.persistentRenderCache,
 	}
 }

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -49,6 +49,7 @@ type BuildRequest struct {
 	PluginRenderer render.PluginRenderer
 	Applications   []argoappv1.Application
 	ApplicationSetOptions
+	CRDScopeOptions
 	StatusCallback          ApplicationStatusCallback
 	renderCache             *applicationRenderCache
 	renderSettingsSignature string

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -550,7 +550,8 @@ func renderOneApplication(ctx context.Context, application argoappv1.Application
 		}
 	}
 
-	resourcePolicyDiags := project.ValidateRenderedResourcePolicyResources(application, policyResources, request.projects, request.settings)
+	appScopeRegistry := manifest.BuildCRDScopeRegistry(manifestObjectPtrs(rendered.Manifests))
+	resourcePolicyDiags := project.ValidateRenderedResourcePolicyResourcesWithRegistry(application, policyResources, request.projects, request.settings, appScopeRegistry)
 	resourcePolicyDiags = request.request.normalizeDiagnostics(resourcePolicyDiags, false)
 	out.diagnostics = append(out.diagnostics, resourcePolicyDiags...)
 	if err := diagnosticFailure(resourcePolicyDiags, request.strict); err != nil {

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -99,3 +99,10 @@ type ApplicationRenderOptions struct {
 type ExecutionOptions struct {
 	Parallelism int
 }
+
+// CRDScopeOptions controls post-render CRD scope normalization. The zero value
+// leaves normalization ON (it is a correctness fix); Disabled is the hidden
+// --no-crd-scope escape hatch for safety-revert and perf A/B testing.
+type CRDScopeOptions struct {
+	Disabled bool
+}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -81,6 +81,7 @@ type commonFlags struct {
 	engineFingerprint        rendercache.EngineFingerprint
 	kubeVersion              string
 	apiVersions              []string
+	noCRDScope               bool
 }
 
 func defaultCommonFlags() commonFlags {
@@ -174,6 +175,8 @@ func bindFilterFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.skipSecrets, "skip-secrets", flags.skipSecrets, "omit Secret resources from output and diffs")
 	cmd.Flags().StringVar(&flags.kubeVersion, "kube-version", flags.kubeVersion, "Kubernetes version for rendering capabilities (overrides per-app kubeVersion)")
 	cmd.Flags().StringArrayVar(&flags.apiVersions, "api-versions", flags.apiVersions, "additional Kubernetes API versions for capability-gated rendering, unioned with per-app apiVersions (e.g. monitoring.coreos.com/v1)")
+	cmd.Flags().BoolVar(&flags.noCRDScope, "no-crd-scope", flags.noCRDScope, "disable post-render cluster-scoped custom resource namespace normalization")
+	_ = cmd.Flags().MarkHidden("no-crd-scope")
 }
 
 func bindDiffPathFlag(cmd *cobra.Command, flags *commonFlags) {
@@ -362,6 +365,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		EngineFingerprint:              flags.engineFingerprint,
 		KubeVersion:                    flags.kubeVersion,
 		APIVersions:                    append([]string(nil), flags.apiVersions...),
+		NoCRDScope:                     flags.noCRDScope,
 	}
 }
 

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -95,11 +95,11 @@ func TestRequestOptionsFromFlagsCarriesNoCRDScope(t *testing.T) {
 	if !opts.NoCRDScope {
 		t.Fatal("opts.NoCRDScope = false, want true")
 	}
-	if buildReq := opts.Build(); !buildReq.CRDScopeOptions.Disabled {
-		t.Fatal("opts.Build().CRDScopeOptions.Disabled = false, want true")
+	if buildReq := opts.Build(); !buildReq.Disabled {
+		t.Fatal("opts.Build() CRD scope Disabled = false, want true")
 	}
-	if diffReq := opts.Diff(); !diffReq.CRDScopeOptions.Disabled {
-		t.Fatal("opts.Diff().CRDScopeOptions.Disabled = false, want true")
+	if diffReq := opts.Diff(); !diffReq.Disabled {
+		t.Fatal("opts.Diff() CRD scope Disabled = false, want true")
 	}
 }
 

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -86,6 +86,23 @@ func TestEnablePluginsHelpDescribesTrustedCommandPolicy(t *testing.T) {
 	}
 }
 
+func TestRequestOptionsFromFlagsCarriesNoCRDScope(t *testing.T) {
+	flags := defaultCommonFlags()
+	flags.noCRDScope = true
+
+	opts := requestOptionsFromFlags(flags, nil)
+
+	if !opts.NoCRDScope {
+		t.Fatal("opts.NoCRDScope = false, want true")
+	}
+	if buildReq := opts.Build(); !buildReq.CRDScopeOptions.Disabled {
+		t.Fatal("opts.Build().CRDScopeOptions.Disabled = false, want true")
+	}
+	if diffReq := opts.Diff(); !diffReq.CRDScopeOptions.Disabled {
+		t.Fatal("opts.Diff().CRDScopeOptions.Disabled = false, want true")
+	}
+}
+
 func findCLICommand(t *testing.T, args ...string) *cobra.Command {
 	t.Helper()
 

--- a/internal/manifest/crdscope.go
+++ b/internal/manifest/crdscope.go
@@ -1,0 +1,76 @@
+package manifest
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CRDScope is a CustomResourceDefinition spec.scope value.
+type CRDScope string
+
+const (
+	CRDScopeCluster    CRDScope = "Cluster"
+	CRDScopeNamespaced CRDScope = "Namespaced"
+)
+
+// CRDScopeEntry is the scope (and cheaply-captured versions) for one CRD's
+// group/kind. Versions are retained for a later api-version inference plan.
+type CRDScopeEntry struct {
+	Scope    CRDScope
+	Versions []string
+}
+
+// CRDScopeRegistry maps a custom resource's {group, kind} to its declared scope.
+type CRDScopeRegistry map[groupKind]CRDScopeEntry
+
+// BuildCRDScopeRegistry scans rendered objects for CustomResourceDefinition
+// manifests and records each declared {group, kind} -> scope. Objects that are
+// not v1 CRDs or that omit spec.group/spec.names.kind/spec.scope are ignored.
+func BuildCRDScopeRegistry(objects []*unstructured.Unstructured) CRDScopeRegistry {
+	registry := CRDScopeRegistry{}
+	for _, obj := range objects {
+		if obj == nil {
+			continue
+		}
+		if obj.GetKind() != "CustomResourceDefinition" || obj.GroupVersionKind().Group != "apiextensions.k8s.io" {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(obj.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(obj.Object, "spec", "names", "kind")
+		scope, _, _ := unstructured.NestedString(obj.Object, "spec", "scope")
+		if kind == "" || scope == "" {
+			continue
+		}
+		entry := CRDScopeEntry{Scope: CRDScope(scope)}
+		if versions, ok, _ := unstructured.NestedSlice(obj.Object, "spec", "versions"); ok {
+			for _, raw := range versions {
+				version, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if name, ok := version["name"].(string); ok && name != "" {
+					entry.Versions = append(entry.Versions, name)
+				}
+			}
+		}
+		registry[groupKind{Group: group, Kind: kind}] = entry
+	}
+	return registry
+}
+
+// Scope returns the declared scope for a custom resource's group/kind.
+func (r CRDScopeRegistry) Scope(gvk schema.GroupVersionKind) (CRDScope, bool) {
+	entry, ok := r[groupKind{Group: gvk.Group, Kind: gvk.Kind}]
+	if !ok {
+		return "", false
+	}
+	return entry.Scope, true
+}
+
+// IsClusterScoped consults the registry first, then the built-in cluster-scoped list.
+func (r CRDScopeRegistry) IsClusterScoped(gvk schema.GroupVersionKind) bool {
+	if scope, ok := r.Scope(gvk); ok {
+		return scope == CRDScopeCluster
+	}
+	return IsBuiltInClusterScoped(gvk)
+}

--- a/internal/manifest/crdscope_test.go
+++ b/internal/manifest/crdscope_test.go
@@ -1,0 +1,72 @@
+package manifest
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func crd(group, kind, scope string, versions ...string) *unstructured.Unstructured {
+	versionEntries := make([]any, 0, len(versions))
+	for _, v := range versions {
+		versionEntries = append(versionEntries, map[string]any{"name": v})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": "objs." + group},
+		"spec": map[string]any{
+			"group":    group,
+			"scope":    scope,
+			"names":    map[string]any{"kind": kind},
+			"versions": versionEntries,
+		},
+	}}
+}
+
+func TestBuildCRDScopeRegistryRecordsClusterScope(t *testing.T) {
+	reg := BuildCRDScopeRegistry([]*unstructured.Unstructured{
+		crd("gateway.networking.k8s.io", "GatewayClass", "Cluster", "v1"),
+		crd("example.com", "Widget", "Namespaced", "v1"),
+	})
+	if !reg.IsClusterScoped(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass"}) {
+		t.Fatal("IsClusterScoped(GatewayClass) = false, want true")
+	}
+	if reg.IsClusterScoped(schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}) {
+		t.Fatal("IsClusterScoped(Widget) = true, want false")
+	}
+}
+
+func TestCRDScopeRegistryScopeReportsKnownAndUnknown(t *testing.T) {
+	reg := BuildCRDScopeRegistry([]*unstructured.Unstructured{crd("example.com", "Widget", "Namespaced", "v1")})
+	scope, ok := reg.Scope(schema.GroupVersionKind{Group: "example.com", Kind: "Widget"})
+	if !ok || scope != CRDScopeNamespaced {
+		t.Fatalf("Scope(Widget) = %q, %v; want %q, true", scope, ok, CRDScopeNamespaced)
+	}
+	if _, ok := reg.Scope(schema.GroupVersionKind{Group: "example.com", Kind: "Unknown"}); ok {
+		t.Fatal("Scope(Unknown) ok = true, want false")
+	}
+}
+
+func TestIsClusterScopedFallsBackToBuiltIn(t *testing.T) {
+	reg := BuildCRDScopeRegistry(nil)
+	if !reg.IsClusterScoped(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}) {
+		t.Fatal("IsClusterScoped(ClusterRole) = false, want built-in true")
+	}
+}
+
+func TestBuildCRDScopeRegistryIgnoresNonCRDAndMalformed(t *testing.T) {
+	reg := BuildCRDScopeRegistry([]*unstructured.Unstructured{
+		nil,
+		{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}},
+		{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"spec":       map[string]any{"group": "x.io"},
+		}},
+	})
+	if len(reg) != 0 {
+		t.Fatalf("registry size = %d, want 0", len(reg))
+	}
+}

--- a/internal/project/resource_policy.go
+++ b/internal/project/resource_policy.go
@@ -51,6 +51,7 @@ type renderedResourcePolicyValidator struct {
 	appDestinationChecked         bool
 	appDestinationPermitted       bool
 	appDestinationPermittedErr    error
+	crdScope                      manifest.CRDScopeRegistry
 }
 
 // ValidateRenderedResourcePolicy validates rendered Kubernetes objects for one Application against its effective AppProject resource policy.
@@ -71,6 +72,13 @@ func ValidateRenderedResourcePolicy(app argoappv1.Application, objects []*unstru
 
 // ValidateRenderedResourcePolicyResources validates rendered Kubernetes objects with pre-normalization metadata.
 func ValidateRenderedResourcePolicyResources(app argoappv1.Application, resources []RenderedResource, projects []argoappv1.AppProject, settings config.ArgoSettings) []diagnostic.Diagnostic {
+	return ValidateRenderedResourcePolicyResourcesWithRegistry(app, resources, projects, settings, nil)
+}
+
+// ValidateRenderedResourcePolicyResourcesWithRegistry validates rendered Kubernetes objects with pre-normalization
+// metadata, consulting the provided CRDScopeRegistry to resolve CR scope before falling back to deferral.
+// A nil registry is safe and preserves the existing deferral behavior.
+func ValidateRenderedResourcePolicyResourcesWithRegistry(app argoappv1.Application, resources []RenderedResource, projects []argoappv1.AppProject, settings config.ArgoSettings, registry manifest.CRDScopeRegistry) []diagnostic.Diagnostic {
 	if len(resources) == 0 {
 		return nil
 	}
@@ -79,6 +87,7 @@ func ValidateRenderedResourcePolicyResources(app argoappv1.Application, resource
 	if len(diags) > 0 {
 		return diags
 	}
+	validator.crdScope = registry
 	return validator.validate(resources)
 }
 
@@ -131,7 +140,7 @@ func (v *renderedResourcePolicyValidator) validateResource(resource RenderedReso
 
 	groupKind := obj.GroupVersionKind().GroupKind()
 	name := obj.GetName()
-	scope := renderedResourcePolicyScope(v.app, resource)
+	scope := v.renderedResourcePolicyScope(resource)
 	if scope.deferred {
 		return v.validateUnknownScopeResource(obj)
 	}
@@ -286,14 +295,20 @@ func renderedResourcePolicyProject(app argoappv1.Application, projects []argoapp
 	return effectiveProject(proj, settings), true
 }
 
-func renderedResourcePolicyScope(app argoappv1.Application, resource RenderedResource) renderedResourceScope {
+func (v *renderedResourcePolicyValidator) renderedResourcePolicyScope(resource RenderedResource) renderedResourceScope {
 	obj := resource.Object
 	gvk := obj.GroupVersionKind()
 	if manifest.IsBuiltInClusterScoped(gvk) {
 		return renderedResourceScope{}
 	}
 	if manifest.IsKnownNamespacedBuiltIn(gvk) {
-		return renderedResourceScope{namespaced: true, namespace: renderedResourceNamespace(app, obj)}
+		return renderedResourceScope{namespaced: true, namespace: renderedResourceNamespace(v.app, obj)}
+	}
+	if scope, ok := v.crdScope.Scope(gvk); ok {
+		if scope == manifest.CRDScopeCluster {
+			return renderedResourceScope{}
+		}
+		return renderedResourceScope{namespaced: true, namespace: renderedResourceNamespace(v.app, obj)}
 	}
 	if strings.TrimSpace(resource.NamespaceBeforeNormalization) != "" {
 		namespace := strings.TrimSpace(obj.GetNamespace())

--- a/internal/project/resource_policy_test.go
+++ b/internal/project/resource_policy_test.go
@@ -7,6 +7,7 @@ import (
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/manifest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -388,6 +389,86 @@ func TestValidateRenderedResourcePolicyDefersUnknownCRNormalizedFromDestinationN
 	assertDiagnostic(t, diags, "unknown scope offline")
 	assertResourcePolicyScopeDeferred(t, diags)
 	assertNoResourcePolicyDenied(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyResolvesClusterScopeFromRegistry(t *testing.T) {
+	// Widget is unknown to the built-in lists; the CRD declares it Cluster-scoped.
+	// With the registry, scope should be decided as cluster-scoped — no deferral,
+	// no denial (cluster resource policy allows it under the default project).
+	app := resourcePolicyApplication("demo", argoappv1.DefaultAppProjectName)
+	registry := manifest.BuildCRDScopeRegistry([]*unstructured.Unstructured{
+		crdObject("example.com", "Widget", "Cluster"),
+	})
+
+	diags := ValidateRenderedResourcePolicyResourcesWithRegistry(app, []RenderedResource{{
+		Object:                       renderedObject("example.com/v1", "Widget", "", "custom"),
+		NamespaceBeforeNormalization: "",
+	}}, nil, config.DefaultSettings(), registry)
+
+	assertNoDiagnostic(t, diags, "unknown scope offline")
+	assertNoResourcePolicyDenied(t, diags)
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func TestValidateRenderedResourcePolicyResolvesNamespacedScopeFromRegistry(t *testing.T) {
+	// Widget is unknown to the built-in lists; the CRD declares it Namespaced.
+	// With the registry, scope should be decided as namespaced — no deferral,
+	// but the project's namespace whitelist excludes it, so it should be denied.
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+	registry := manifest.BuildCRDScopeRegistry([]*unstructured.Unstructured{
+		crdObject("example.com", "Widget", "Namespaced"),
+	})
+
+	diags := ValidateRenderedResourcePolicyResourcesWithRegistry(app, []RenderedResource{{
+		Object:                       renderedObject("example.com/v1", "Widget", "workloads", "custom"),
+		NamespaceBeforeNormalization: "workloads",
+	}}, []argoappv1.AppProject{project}, config.DefaultSettings(), registry)
+
+	assertNoDiagnostic(t, diags, "unknown scope offline")
+	assertResourcePolicyDenied(t, diags, "example.com/Widget workloads/custom")
+}
+
+func TestValidateRenderedResourcePolicyRegistryBeatsNamespaceBeforeNormalizationHeuristic(t *testing.T) {
+	// Regression: a cluster-scoped CR that carried a namespace in source sets
+	// NamespaceBeforeNormalization to a non-empty value. Under the old ordering
+	// the heuristic branch fired first and classified the resource namespaced,
+	// overriding the authoritative registry — which would cause a denial below
+	// because the project's NamespaceResourceWhitelist excludes Widget.
+	// With the fix, the registry wins and classifies it cluster-scoped, which
+	// the project's ClusterResourceWhitelist allows.
+	app := resourcePolicyApplication("demo", "platform")
+	project := resourcePolicyProject("platform")
+	// Namespace whitelist excludes Widget — if wrongly classified namespaced, denied.
+	project.Spec.NamespaceResourceWhitelist = []metav1.GroupKind{{Group: "", Kind: "ConfigMap"}}
+	// Cluster whitelist includes Widget — if correctly classified cluster-scoped, allowed.
+	project.Spec.ClusterResourceWhitelist = []argoappv1.ClusterResourceRestrictionItem{{Group: "example.com", Kind: "Widget"}}
+	registry := manifest.BuildCRDScopeRegistry([]*unstructured.Unstructured{
+		crdObject("example.com", "Widget", "Cluster"),
+	})
+
+	diags := ValidateRenderedResourcePolicyResourcesWithRegistry(app, []RenderedResource{{
+		Object:                       renderedObject("example.com/v1", "Widget", "", "my-widget"),
+		NamespaceBeforeNormalization: "workloads", // non-empty: simulates a source-set namespace stripped by normalization
+	}}, []argoappv1.AppProject{project}, config.DefaultSettings(), registry)
+
+	// Registry says Cluster-scoped → allowed by ClusterResourceWhitelist.
+	// Old ordering (heuristic first) would classify it namespaced → denied by NamespaceResourceWhitelist.
+	assertNoDiagnostic(t, diags, "unknown scope offline")
+	assertNoResourcePolicyDenied(t, diags)
+	assertNoResourcePolicyDiagnostics(t, diags)
+}
+
+func crdObject(group, kind, scope string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apiextensions.k8s.io/v1")
+	obj.SetKind("CustomResourceDefinition")
+	obj.SetName(strings.ToLower(kind) + "s." + group)
+	_ = unstructured.SetNestedField(obj.Object, group, "spec", "group")
+	_ = unstructured.SetNestedField(obj.Object, kind, "spec", "names", "kind")
+	_ = unstructured.SetNestedField(obj.Object, scope, "spec", "scope")
+	return obj
 }
 
 func resourcePolicyApplication(name, project string) argoappv1.Application {

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -70,6 +70,7 @@ type Options struct {
 	EngineFingerprint              rendercache.EngineFingerprint
 	KubeVersion                    string
 	APIVersions                    []string
+	NoCRDScope                     bool
 }
 
 func (options Options) Build() app.BuildRequest {
@@ -86,6 +87,7 @@ func (options Options) Build() app.BuildRequest {
 		FilterOptions:          options.filterOptions(),
 		ApplicationSetOptions:  options.applicationSetOptions(),
 		CapabilityOptions:      options.capabilityOptions(),
+		CRDScopeOptions:        app.CRDScopeOptions{Disabled: options.NoCRDScope},
 	}
 }
 
@@ -117,6 +119,7 @@ func (options Options) Diff() app.DiffRequest {
 		FilterOptions:           options.filterOptions(),
 		ApplicationSetOptions:   options.applicationSetOptions(),
 		CapabilityOptions:       options.capabilityOptions(),
+		CRDScopeOptions:         app.CRDScopeOptions{Disabled: options.NoCRDScope},
 	}
 }
 


### PR DESCRIPTION
## Summary
drydock renders offline, so it can't ask a live cluster whether a custom resource is cluster- or namespaced-scoped — it stamped the app's destination namespace onto cluster-scoped CRs (e.g. `GatewayClass`) that should carry no namespace. This adds **post-render CRD scope normalization**: after all apps render, drydock builds a `{group,kind} -> scope` registry from the `CustomResourceDefinition`s in the assembled output and strips `metadata.namespace` from cluster-scoped CRs — matching Argo CD, which learns scope from cluster CRD discovery.

This is **parity-hardening item B (scope half)** — the correctness fix. It deliberately does **not** add a pre-render CRD harvest, a new pre-pass package, or any render-cache-key change.

## How it works
- `internal/manifest/crdscope.go` — pure `CRDScopeRegistry` built from rendered CRDs (`spec.group`/`names.kind`/`scope`); consults the registry, then the built-in cluster-scoped list.
- `internal/app/crd_scope_normalize.go` — `normalizeCRDScope` strips the namespace from cluster-scoped CRs in place; warns on post-strip identity collisions instead of dropping.
- `buildSession.Build` — one post-assembly hook that runs on **every** command and **both** diff sides (the single `o.Build` funnel). Registry is re-derived from the assembled output each run via a non-copying accessor, so there's **no per-app render-cache-key change** — a CRD edit invalidates only its own app's cache, and the assembled output is always current.
- `internal/project/resource_policy.go` — the resource-policy scope check now consults the registry (authoritative) **before** the `NamespaceBeforeNormalization` heuristic, replacing `project.resource-scope-deferred` guesses when the CRD is known; a nil/empty registry preserves the existing deferral path.
- Hidden `--no-crd-scope` escape hatch (mirrors the `--api-versions` wiring) threads through build + both diff sides.

**Why post-render:** the only no-static-list way to fix cross-app cases (a CR whose CRD is installed by a *different* app — the common GitOps layout) is to look at the repo's CRDs. Doing it after assembly keeps the per-app cache invariant intact and avoids any cache coupling. Single `build app X` sees only X's own CRDs (best-effort, same-app); fleet commands (`build apps`/`test apps`/`diff apps`) see every CRD and fix all cases.

## Validation — live home-ops fleet
`build apps` on home-ops, normalization ON (default) vs `--no-crd-scope` OFF:
- **Correctness:** the entire ON-vs-OFF diff is **exactly the namespace removals on cluster-scoped CRs** (7 instances in the current checkout: GatewayClass, ClusterSecretStore ×3, ClusterIssuer, ClusterImageCatalog, VolumeSnapshotClass) — *no namespaced resource loses its namespace, no unrelated kind changes.*
- **Performance:** negligible — ON median 3.65s vs OFF 3.72s (interleaved, warm cache). One O(resources) scan, no render/IO added.

## Test plan
- [x] `go test ./internal/... ./pkg/... ./pr-action/...` — pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] Unit (registry, normalize pass), integration (build strips / `--no-crd-scope` keeps), policy (cluster/namespaced/registry-beats-heuristic, sabotage-validated), diff guard (both sides normalized)
- [x] Existing `…DefersUnknownCRScope…` test stays green (no-CRD → deferral preserved)
- [x] Live home-ops ON-vs-OFF: namespace-only diff, negligible perf