### PR TITLE
feat(diffhtml): drag-to-close diff-view sidebar and fix sticking resize handle

### DIFF
--- a/internal/report/diffhtml/assets.go
+++ b/internal/report/diffhtml/assets.go
@@ -227,6 +227,32 @@ body.is-resizing-sidebar .sidebar-resizer::before {
 body.is-resizing-sidebar .sidebar-resizer::before {
 	transition-delay: 0ms;
 }
+body.sidebar-will-close .sidebar-resizer::before {
+	background: var(--rust-bright);
+	box-shadow: 0 0 12px rgba(240, 138, 81, 0.72);
+	transition-delay: 0ms;
+}
+.sidebar-resizer-hint {
+	position: absolute;
+	top: 50%;
+	right: calc(var(--sidebar-resizer-hit) / 2 + 6px);
+	transform: translateY(-50%);
+	white-space: nowrap;
+	padding: 4px 8px;
+	border-radius: 5px;
+	background: var(--rust-bright);
+	color: #0a1421;
+	font-size: 9.5px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 150ms ease;
+}
+body.sidebar-will-close .sidebar-resizer-hint {
+	opacity: 1;
+}
 .tree-search {
 	box-sizing: border-box;
 	width: 100%;
@@ -1500,32 +1526,59 @@ const reviewScript = `
 	if (sidebarResizer) {
 		let dragStartX = 0;
 		let dragStartWidth = 0;
+		let resizing = false;
+		let willClose = false;
+
+		// Drag the handle a third past the minimum width to arm a snap-close.
+		const closeThreshold = () => sidebarBounds().min * (2 / 3);
+
+		const onSidebarPointerMove = (event) => {
+			if (!resizing) {
+				return;
+			}
+			const desired = dragStartWidth + event.clientX - dragStartX;
+			willClose = desired < closeThreshold();
+			body.classList.toggle('sidebar-will-close', willClose);
+			setSidebarWidth(desired);
+		};
+		const stopSidebarResize = (event) => {
+			if (!resizing) {
+				return;
+			}
+			resizing = false;
+			// Listeners live on window (not the handle) so the release is caught even
+			// when pointer capture is dropped mid-drag -- otherwise the handle sticks
+			// to the cursor after the button is released.
+			window.removeEventListener('pointermove', onSidebarPointerMove);
+			window.removeEventListener('pointerup', stopSidebarResize);
+			window.removeEventListener('pointercancel', stopSidebarResize);
+			sidebarResizer.releasePointerCapture?.(event.pointerId);
+			body.classList.remove('is-resizing-sidebar', 'sidebar-will-close');
+			if (willClose) {
+				// setSidebarWidth clamps, so persist the pre-drag width for the next open.
+				setSidebarWidth(dragStartWidth, { persist: true });
+				setSidebar('closed');
+			} else {
+				setSidebarWidth(cssPixels('--sidebar-width', sidebarBounds().defaultWidth), { persist: true });
+			}
+			willClose = false;
+		};
 
 		sidebarResizer.addEventListener('pointerdown', (event) => {
 			if (mobileQuery.matches) {
 				return;
 			}
 			event.preventDefault();
+			resizing = true;
+			willClose = false;
 			dragStartX = event.clientX;
 			dragStartWidth = cssPixels('--sidebar-width', sidebarBounds().defaultWidth);
 			sidebarResizer.setPointerCapture?.(event.pointerId);
 			body.classList.add('is-resizing-sidebar');
+			window.addEventListener('pointermove', onSidebarPointerMove);
+			window.addEventListener('pointerup', stopSidebarResize);
+			window.addEventListener('pointercancel', stopSidebarResize);
 		});
-		sidebarResizer.addEventListener('pointermove', (event) => {
-			if (!body.classList.contains('is-resizing-sidebar')) {
-				return;
-			}
-			setSidebarWidth(dragStartWidth + event.clientX - dragStartX, { persist: true });
-		});
-		const stopSidebarResize = (event) => {
-			if (!body.classList.contains('is-resizing-sidebar')) {
-				return;
-			}
-			sidebarResizer.releasePointerCapture?.(event.pointerId);
-			body.classList.remove('is-resizing-sidebar');
-		};
-		sidebarResizer.addEventListener('pointerup', stopSidebarResize);
-		sidebarResizer.addEventListener('pointercancel', stopSidebarResize);
 		sidebarResizer.addEventListener('dblclick', (event) => {
 			event.preventDefault();
 			resetSidebarWidth();

--- a/internal/report/diffhtml/render.go
+++ b/internal/report/diffhtml/render.go
@@ -58,7 +58,7 @@ func Render(result app.DiffResult, options Options) ([]byte, error) {
 	builder.WriteString("</header>\n")
 	builder.WriteString("<div class=\"review-layout\">\n")
 	renderTree(&builder, groups)
-	builder.WriteString("<div class=\"sidebar-resizer\" data-sidebar-resizer role=\"separator\" aria-orientation=\"vertical\" aria-label=\"Resize changed resources sidebar\" aria-valuemin=\"240\" aria-valuemax=\"480\" aria-valuenow=\"320\" tabindex=\"0\"></div>\n")
+	builder.WriteString("<div class=\"sidebar-resizer\" data-sidebar-resizer role=\"separator\" aria-orientation=\"vertical\" aria-label=\"Resize changed resources sidebar\" aria-valuemin=\"240\" aria-valuemax=\"480\" aria-valuenow=\"320\" tabindex=\"0\"><span class=\"sidebar-resizer-hint\" aria-hidden=\"true\">Release to close</span></div>\n")
 	builder.WriteString("<div class=\"sidebar-backdrop\" data-sidebar-backdrop></div>\n")
 	builder.WriteString("<main class=\"review-main\">\n")
 	if len(groups) == 0 {

--- a/internal/report/diffhtml/render_test.go
+++ b/internal/report/diffhtml/render_test.go
@@ -135,6 +135,7 @@ func TestRenderIncludesStaticReviewUI(t *testing.T) {
 		`role="separator"`,
 		`aria-orientation="vertical"`,
 		`aria-label="Resize changed resources sidebar"`,
+		`<span class="sidebar-resizer-hint" aria-hidden="true">Release to close</span>`,
 		`class="tree-search"`,
 		`data-tree-search`,
 		`placeholder="Search resources (/)"`,
@@ -378,6 +379,17 @@ func TestRenderIncludesTypographyAndLogoContract(t *testing.T) {
 	if want := ".sidebar-resizer:focus-visible::before,\nbody.is-resizing-sidebar .sidebar-resizer::before {\n\ttransition-delay: 0ms;\n}"; !strings.Contains(text, want) {
 		t.Fatalf("HTML missing immediate sidebar-resizer activation contract %q:\n%s", want, text)
 	}
+	assertStyleRuleContains(t, text, "body.sidebar-will-close .sidebar-resizer::before",
+		`background: var(--rust-bright);`,
+	)
+	assertStyleRuleContains(t, text, ".sidebar-resizer-hint",
+		`position: absolute;`,
+		`pointer-events: none;`,
+		`opacity: 0;`,
+	)
+	assertStyleRuleContains(t, text, "body.sidebar-will-close .sidebar-resizer-hint",
+		`opacity: 1;`,
+	)
 	assertStyleRuleContains(t, text, ".review-main", `grid-column: 3;`, `min-height: 0;`, `overflow: auto;`)
 	assertStyleRuleContains(t, text, ".tree-app summary",
 		`display: grid;`,
@@ -1279,13 +1291,28 @@ func TestRenderSidebarResizeScriptContract(t *testing.T) {
 		`const sidebarBounds = () => {`,
 		`--sidebar-width-min`,
 		`--sidebar-width-max`,
-		`setSidebarWidth(dragStartWidth + event.clientX - dragStartX, { persist: true });`,
+		`const desired = dragStartWidth + event.clientX - dragStartX;`,
+		// Width persists on release, not on every move (move call omits persist).
+		`setSidebarWidth(desired);`,
 		`store.set('drydock-sidebar-width', String(next));`,
 		`store.remove('drydock-sidebar-width');`,
 		`sidebarResizer.addEventListener('dblclick'`,
 		`body.classList.add('is-resizing-sidebar');`,
-		`body.classList.remove('is-resizing-sidebar');`,
+		`body.classList.remove('is-resizing-sidebar', 'sidebar-will-close');`,
 		`restoreSidebarWidth();`,
+		// Drag past the close threshold arms a snap-close.
+		`const closeThreshold = () => sidebarBounds().min * (2 / 3);`,
+		`willClose = desired < closeThreshold();`,
+		`body.classList.toggle('sidebar-will-close', willClose);`,
+		`setSidebar('closed');`,
+		// Release is caught on window so a dropped pointer capture cannot leave the
+		// handle stuck to the cursor.
+		`window.addEventListener('pointermove', onSidebarPointerMove);`,
+		`window.addEventListener('pointerup', stopSidebarResize);`,
+		`window.addEventListener('pointercancel', stopSidebarResize);`,
+		`window.removeEventListener('pointermove', onSidebarPointerMove);`,
+		`window.removeEventListener('pointerup', stopSidebarResize);`,
+		`window.removeEventListener('pointercancel', stopSidebarResize);`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("HTML missing sidebar resize JS contract %q:\n%s", want, text)

--- a/site/static/examples/full-rendered-diff-view.html
+++ b/site/static/examples/full-rendered-diff-view.html
@@ -232,6 +232,32 @@ body.is-resizing-sidebar .sidebar-resizer::before {
 body.is-resizing-sidebar .sidebar-resizer::before {
 	transition-delay: 0ms;
 }
+body.sidebar-will-close .sidebar-resizer::before {
+	background: var(--rust-bright);
+	box-shadow: 0 0 12px rgba(240, 138, 81, 0.72);
+	transition-delay: 0ms;
+}
+.sidebar-resizer-hint {
+	position: absolute;
+	top: 50%;
+	right: calc(var(--sidebar-resizer-hit) / 2 + 6px);
+	transform: translateY(-50%);
+	white-space: nowrap;
+	padding: 4px 8px;
+	border-radius: 5px;
+	background: var(--rust-bright);
+	color: #0a1421;
+	font-size: 9.5px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 150ms ease;
+}
+body.sidebar-will-close .sidebar-resizer-hint {
+	opacity: 1;
+}
 .tree-search {
 	box-sizing: border-box;
 	width: 100%;
@@ -807,7 +833,7 @@ body[data-view="unified"] .diff-table.side-by-side {
 <button class="tree-resource" type="button" data-target-resource="resource-3" data-search-text="argocd/renovate renovate-operator.mogenius.com renovatejob renovate/renovate modified" title="renovate-operator.mogenius.com RenovateJob renovate/renovate" aria-label="renovate-operator.mogenius.com RenovateJob renovate/renovate, modified, plus 5, minus 5"><span class="tree-status-dot tree-status-modified" aria-hidden="true"></span><span class="tree-resource-label">RenovateJob · renovate</span><span class="tree-delta" aria-hidden="true"><span class="tree-delta-added">+5</span><span class="tree-delta-removed">-5</span></span></button>
 </details>
 </aside>
-<div class="sidebar-resizer" data-sidebar-resizer role="separator" aria-orientation="vertical" aria-label="Resize changed resources sidebar" aria-valuemin="240" aria-valuemax="480" aria-valuenow="320" tabindex="0"></div>
+<div class="sidebar-resizer" data-sidebar-resizer role="separator" aria-orientation="vertical" aria-label="Resize changed resources sidebar" aria-valuemin="240" aria-valuemax="480" aria-valuenow="320" tabindex="0"><span class="sidebar-resizer-hint" aria-hidden="true">Release to close</span></div>
 <div class="sidebar-backdrop" data-sidebar-backdrop></div>
 <main class="review-main">
 <section class="applications">
@@ -1774,32 +1800,59 @@ body[data-view="unified"] .diff-table.side-by-side {
 	if (sidebarResizer) {
 		let dragStartX = 0;
 		let dragStartWidth = 0;
+		let resizing = false;
+		let willClose = false;
+
+		// Drag the handle a third past the minimum width to arm a snap-close.
+		const closeThreshold = () => sidebarBounds().min * (2 / 3);
+
+		const onSidebarPointerMove = (event) => {
+			if (!resizing) {
+				return;
+			}
+			const desired = dragStartWidth + event.clientX - dragStartX;
+			willClose = desired < closeThreshold();
+			body.classList.toggle('sidebar-will-close', willClose);
+			setSidebarWidth(desired);
+		};
+		const stopSidebarResize = (event) => {
+			if (!resizing) {
+				return;
+			}
+			resizing = false;
+			// Listeners live on window (not the handle) so the release is caught even
+			// when pointer capture is dropped mid-drag -- otherwise the handle sticks
+			// to the cursor after the button is released.
+			window.removeEventListener('pointermove', onSidebarPointerMove);
+			window.removeEventListener('pointerup', stopSidebarResize);
+			window.removeEventListener('pointercancel', stopSidebarResize);
+			sidebarResizer.releasePointerCapture?.(event.pointerId);
+			body.classList.remove('is-resizing-sidebar', 'sidebar-will-close');
+			if (willClose) {
+				// setSidebarWidth clamps, so persist the pre-drag width for the next open.
+				setSidebarWidth(dragStartWidth, { persist: true });
+				setSidebar('closed');
+			} else {
+				setSidebarWidth(cssPixels('--sidebar-width', sidebarBounds().defaultWidth), { persist: true });
+			}
+			willClose = false;
+		};
 
 		sidebarResizer.addEventListener('pointerdown', (event) => {
 			if (mobileQuery.matches) {
 				return;
 			}
 			event.preventDefault();
+			resizing = true;
+			willClose = false;
 			dragStartX = event.clientX;
 			dragStartWidth = cssPixels('--sidebar-width', sidebarBounds().defaultWidth);
 			sidebarResizer.setPointerCapture?.(event.pointerId);
 			body.classList.add('is-resizing-sidebar');
+			window.addEventListener('pointermove', onSidebarPointerMove);
+			window.addEventListener('pointerup', stopSidebarResize);
+			window.addEventListener('pointercancel', stopSidebarResize);
 		});
-		sidebarResizer.addEventListener('pointermove', (event) => {
-			if (!body.classList.contains('is-resizing-sidebar')) {
-				return;
-			}
-			setSidebarWidth(dragStartWidth + event.clientX - dragStartX, { persist: true });
-		});
-		const stopSidebarResize = (event) => {
-			if (!body.classList.contains('is-resizing-sidebar')) {
-				return;
-			}
-			sidebarResizer.releasePointerCapture?.(event.pointerId);
-			body.classList.remove('is-resizing-sidebar');
-		};
-		sidebarResizer.addEventListener('pointerup', stopSidebarResize);
-		sidebarResizer.addEventListener('pointercancel', stopSidebarResize);
 		sidebarResizer.addEventListener('dblclick', (event) => {
 			event.preventDefault();
 			resetSidebarWidth();


### PR DESCRIPTION
## What

Two interaction fixes for the rendered diff view's changed-resources sidebar (`internal/report/diffhtml`), ported from a sibling project's sidebar and adapted to drydock's left-hand sidebar (drag-right = wider).

**1. Resize handle no longer sticks.** The `pointermove`/`pointerup`/`pointercancel` listeners now live on `window` — added on `pointerdown`, removed on release, guarded by a `resizing` flag — instead of on the handle element relying on `setPointerCapture`. If pointer capture is dropped mid-drag, the release is still caught, so the handle can't stay glued to the cursor after the button is released.

**2. Drag past the minimum to close.** Dragging the handle a third under the minimum width arms a snap-close: the divider turns rust and a "Release to close" pill appears. Releasing collapses the sidebar (same state as the ☰ toggle) and persists the **pre-drag** width, so reopening restores a sensible size rather than the sliver it was dragged to. Width now persists on release instead of on every move.

## Operator-facing impact

Only the diff-view HTML output changes. No CLI, compatibility, source-acquisition, or runtime-boundary behavior is touched; the runtime-offline contract is unaffected.

## Tests

- Extended the sidebar guard tests in `render_test.go` to pin the new contract: window-level drag listeners (add + remove for all three events), the `min * 2/3` snap-close arming, `setSidebar('closed')`, persist-on-release (move call omits `persist`), the `body.sidebar-will-close` cue, and the default-hidden "Release to close" pill.
- Regenerated the tracked golden snapshot (`site/static/examples/full-rendered-diff-view.html`) via `UPDATE_DIFFHTML_EXAMPLE=1`.
- `go build ./...`, `go vet`, `gofmt -l`, `go test ./internal/report/diffhtml/...`, and `golangci-lint run` all clean locally.

## AI disclosure

Implemented with Claude Code (Opus 4.8): I directed the port and reviewed the result; Claude located the source/target code, wrote the JS/CSS/Go edits and the guard-test assertions, and ran the local build/lint/test gate. The diff was run through an adversarial review agent (approved, no blocking issues; three of its hardening suggestions were applied) before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)