### PR TITLE
feat(cache): LRU max-size cache prune with pr-action local cache bounding

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -40,7 +40,11 @@ type Entry struct {
 	ModifiedAt   time.Time `json:"modifiedAt" yaml:"modifiedAt"`
 	Legacy       bool      `json:"legacy" yaml:"legacy"`
 	Metadata     *Metadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	cacheRoot    string
+	// PruneReason is set to "age" or "size" only on entries selected for removal
+	// by Prune(). Zero value is omitted from JSON/YAML output so that cache list
+	// output remains byte-identical to pre-prune output.
+	PruneReason string `json:"pruneReason,omitempty" yaml:"pruneReason,omitempty"`
+	cacheRoot   string
 }
 
 type OperationOptions struct {
@@ -53,6 +57,11 @@ type OperationOptions struct {
 	Key                 string
 	All                 bool
 	RenderCacheMaxBytes int64
+	// MaxBytes caps the summed SizeBytes of the entries selected by the source/kind
+	// filters. Evicts least-recently-used (oldest entryAgeTime) entries until the
+	// total is at or below this cap. 0 disables the size phase. Named to parallel
+	// RenderCacheMaxBytes.
+	MaxBytes int64
 }
 
 type OperationResult struct {
@@ -60,6 +69,15 @@ type OperationResult struct {
 	RemovedCount int                      `json:"removedCount" yaml:"removedCount"`
 	DryRun       bool                     `json:"dryRun" yaml:"dryRun"`
 	RenderSweep  *rendercache.SweepResult `json:"renderSweep,omitempty" yaml:"renderSweep,omitempty"`
+	// SizeEvictedBytes is the sum of SizeBytes for all entries removed by the size
+	// phase. Populated on both dry-run and real runs. Always present in JSON/YAML
+	// output (not omitempty) for a consistent numeric summary.
+	SizeEvictedBytes int64 `json:"sizeEvictedBytes" yaml:"sizeEvictedBytes"`
+	// TotalSizeBytes is the selected-set total after both age and size phases,
+	// BEFORE the render sweep. The sweep (which runs after removals on real runs,
+	// never on dry-run) can trim renders further; its effect is reported separately
+	// in RenderSweep. Always present in JSON/YAML output (not omitempty).
+	TotalSizeBytes int64 `json:"totalSizeBytes" yaml:"totalSizeBytes"`
 }
 
 func List(opts Options) ([]Entry, error) {
@@ -98,8 +116,8 @@ func List(opts Options) ([]Entry, error) {
 }
 
 func Prune(opts OperationOptions) (OperationResult, error) {
-	if opts.OlderThan <= 0 {
-		return OperationResult{}, fmt.Errorf("older-than must be greater than zero")
+	if opts.OlderThan <= 0 && opts.MaxBytes <= 0 {
+		return OperationResult{}, fmt.Errorf("at least one of older-than or max-size is required")
 	}
 	if !opts.DryRun && !opts.Yes {
 		return OperationResult{}, fmt.Errorf("--yes is required for non-dry-run cache prune")
@@ -108,9 +126,7 @@ func Prune(opts OperationOptions) (OperationResult, error) {
 	if err != nil {
 		return OperationResult{}, err
 	}
-	cutoff := time.Now().Add(-opts.OlderThan)
-	selected := selectPruneEntries(entries, opts.Source, opts.Kind, cutoff)
-	result := OperationResult{Entries: selected, DryRun: opts.DryRun}
+	selected, result := buildPruneResult(entries, opts)
 	if opts.DryRun {
 		return result, nil
 	}
@@ -128,6 +144,96 @@ func Prune(opts OperationOptions) (OperationResult, error) {
 	return result, nil
 }
 
+// buildPruneResult runs phase A (age) and phase B (size) selection and
+// assembles the OperationResult fields that are populated on both dry and real
+// runs. It is extracted from Prune to keep Prune's cyclomatic complexity low.
+func buildPruneResult(entries []Entry, opts OperationOptions) ([]Entry, OperationResult) {
+	ageSelected := selectAgeEntries(entries, opts)
+	sizeSelected := selectSizePhase(entries, ageSelected, opts)
+
+	// Merge: age-selected first, then size-selected.
+	selected := make([]Entry, 0, len(ageSelected)+len(sizeSelected))
+	selected = append(selected, ageSelected...)
+	selected = append(selected, sizeSelected...)
+
+	totalSizeBytes := computeTotalSizeBytes(entries, selected, opts)
+	sizeEvictedBytes := sumSizeBytes(sizeSelected)
+
+	result := OperationResult{
+		Entries:          selected,
+		DryRun:           opts.DryRun,
+		SizeEvictedBytes: sizeEvictedBytes,
+		TotalSizeBytes:   totalSizeBytes,
+	}
+	return selected, result
+}
+
+// selectAgeEntries runs phase A: selects entries older than opts.OlderThan and
+// tags them with PruneReason "age". Returns nil when OlderThan is not set.
+func selectAgeEntries(entries []Entry, opts OperationOptions) []Entry {
+	if opts.OlderThan <= 0 {
+		return nil
+	}
+	cutoff := time.Now().Add(-opts.OlderThan)
+	selected := selectPruneEntries(entries, opts.Source, opts.Kind, cutoff)
+	for i := range selected {
+		selected[i].PruneReason = "age"
+	}
+	return selected
+}
+
+// selectSizePhase runs phase B: LRU eviction until the filtered-source total
+// is at or below opts.MaxBytes, excluding entries already selected by the age
+// phase. Tags the selected (evicted) entries with PruneReason "size". Returns
+// nil when MaxBytes is not set.
+//
+// Note: the render cache already uses a 90% hysteresis target to avoid
+// re-triggering on every post-run write. We evict to exactly ≤ cap here
+// because this is a manual command with no re-trigger loop — predictability
+// wins over hysteresis.
+func selectSizePhase(entries []Entry, ageSelected []Entry, opts OperationOptions) []Entry {
+	if opts.MaxBytes <= 0 {
+		return nil
+	}
+	selected := selectSizeEntries(entries, ageSelected, opts.Source, opts.Kind, opts.MaxBytes)
+	for i := range selected {
+		selected[i].PruneReason = "size"
+	}
+	return selected
+}
+
+// computeTotalSizeBytes returns the sum of SizeBytes for all in-scope entries
+// that were NOT selected for removal (i.e. entries surviving both phases),
+// BEFORE the render sweep runs.
+func computeTotalSizeBytes(entries []Entry, selected []Entry, opts OperationOptions) int64 {
+	selectedPaths := make(map[string]struct{}, len(selected))
+	for _, e := range selected {
+		selectedPaths[e.Path] = struct{}{}
+	}
+	var total int64
+	for _, e := range entries {
+		if opts.Source != "" && e.Source != opts.Source {
+			continue
+		}
+		if opts.Kind != "" && e.Kind != opts.Kind {
+			continue
+		}
+		if _, removed := selectedPaths[e.Path]; !removed {
+			total += e.SizeBytes
+		}
+	}
+	return total
+}
+
+// sumSizeBytes returns the sum of SizeBytes across a slice of entries.
+func sumSizeBytes(entries []Entry) int64 {
+	var total int64
+	for _, e := range entries {
+		total += e.SizeBytes
+	}
+	return total
+}
+
 func selectPruneEntries(entries []Entry, source Source, kind string, cutoff time.Time) []Entry {
 	selected := make([]Entry, 0, len(entries))
 	for _, entry := range entries {
@@ -140,6 +246,69 @@ func selectPruneEntries(entries []Entry, source Source, kind string, cutoff time
 		if entryAgeTime(entry).Before(cutoff) {
 			selected = append(selected, entry)
 		}
+	}
+	return selected
+}
+
+// selectSizeEntries evicts oldest-first (by entryAgeTime) until the total size
+// of in-scope entries is at or below maxBytes. alreadySelected is the age-phase
+// result; its entries are excluded from the candidate pool and their sizes are
+// already subtracted from the total. Ties in entryAgeTime are broken by Source,
+// Kind, then Key for deterministic output.
+func selectSizeEntries(entries []Entry, alreadySelected []Entry, source Source, kind string, maxBytes int64) []Entry {
+	// Build a set of paths already removed by the age phase.
+	excludePaths := make(map[string]struct{}, len(alreadySelected))
+	for _, e := range alreadySelected {
+		excludePaths[e.Path] = struct{}{}
+	}
+
+	// Collect candidates (in scope, not yet age-selected) and compute current total.
+	var candidates []Entry
+	var total int64
+	for _, e := range entries {
+		if source != "" && e.Source != source {
+			continue
+		}
+		if kind != "" && e.Kind != kind {
+			continue
+		}
+		if _, excluded := excludePaths[e.Path]; excluded {
+			continue
+		}
+		candidates = append(candidates, e)
+		total += e.SizeBytes
+	}
+
+	if total <= maxBytes {
+		// Already at or below cap; nothing to evict.
+		return nil
+	}
+
+	// Sort candidates oldest-first (LRU) with deterministic tie-break:
+	// (entryAgeTime, Source, Kind, Key) ascending.
+	sort.Slice(candidates, func(i, j int) bool {
+		ti := entryAgeTime(candidates[i])
+		tj := entryAgeTime(candidates[j])
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		if candidates[i].Source != candidates[j].Source {
+			return candidates[i].Source < candidates[j].Source
+		}
+		if candidates[i].Kind != candidates[j].Kind {
+			return candidates[i].Kind < candidates[j].Kind
+		}
+		return candidates[i].Key < candidates[j].Key
+	})
+
+	// Evict oldest first until total ≤ cap.
+	var selected []Entry
+	for _, e := range candidates {
+		if total <= maxBytes {
+			break
+		}
+		selected = append(selected, e)
+		total -= e.SizeBytes
 	}
 	return selected
 }

--- a/internal/cache/prune_size_test.go
+++ b/internal/cache/prune_size_test.go
@@ -1,0 +1,749 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeGitEntry creates a git cache entry at root/git/<key> with a .git/HEAD
+// file and optional metadata with a controlled UpdatedAt timestamp.
+// If updatedAt is zero, no metadata file is written (legacy entry).
+func makeGitEntry(t *testing.T, root, key string, updatedAt time.Time) {
+	t.Helper()
+	entryRoot := filepath.Join(root, "git", key)
+	writeCacheFile(t, filepath.Join(entryRoot, ".git", "HEAD"), "ref: refs/heads/main\n")
+	if !updatedAt.IsZero() {
+		if err := WriteMetadata(entryRoot, Metadata{
+			SchemaVersion: 1,
+			Source:        SourceGit,
+			Kind:          "git",
+			Key:           key,
+			UpdatedAt:     updatedAt,
+			CreatedAt:     updatedAt,
+		}); err != nil {
+			t.Fatalf("WriteMetadata(%s) error = %v", key, err)
+		}
+	}
+}
+
+// makeRemoteHTTPEntry creates a remote/http-file cache entry at root/remotes/<key>
+// with optional metadata.
+func makeRemoteHTTPEntry(t *testing.T, root, key string, updatedAt time.Time) {
+	t.Helper()
+	entryRoot := filepath.Join(root, "remotes", key)
+	writeCacheFile(t, filepath.Join(entryRoot, "resource.yaml"), "kind: ConfigMap\n")
+	if !updatedAt.IsZero() {
+		if err := WriteMetadata(entryRoot, Metadata{
+			SchemaVersion: 1,
+			Source:        SourceRemote,
+			Kind:          "http-file",
+			Key:           key,
+			UpdatedAt:     updatedAt,
+			CreatedAt:     updatedAt,
+		}); err != nil {
+			t.Fatalf("WriteMetadata(%s) error = %v", key, err)
+		}
+	}
+}
+
+var (
+	keyA = strings.Repeat("a", 64)
+	keyB = strings.Repeat("b", 64)
+	keyC = strings.Repeat("c", 64)
+)
+
+// TestPruneSizePhaseEvictsOldestFirst verifies that the size phase evicts
+// least-recently-used (oldest entryAgeTime) entries first and stops at exactly
+// ≤ cap. Sabotage-validated during implementation: inverting the LRU sort
+// makes this test fail (wrong entries evicted).
+func TestPruneSizePhaseEvictsOldestFirst(t *testing.T) {
+	root := t.TempDir()
+
+	// Three entries with controlled UpdatedAt; all have the same .git/HEAD content
+	// so their SizeBytes differ only by the content written. We use metadata to
+	// control their timestamps precisely, avoiding sleeps.
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	oldest := base                    // evicted first
+	middle := base.Add(time.Hour)     // evicted second
+	newest := base.Add(2 * time.Hour) // survives
+
+	makeGitEntry(t, root, keyA, oldest)
+	makeGitEntry(t, root, keyB, middle)
+	makeGitEntry(t, root, keyC, newest)
+
+	// List to learn actual SizeBytes values.
+	entries, err := List(Options{GitCacheDir: filepath.Join(root, "git")})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Compute the per-entry sizes by key.
+	sizeByKey := map[string]int64{}
+	for _, e := range entries {
+		sizeByKey[e.Key] = e.SizeBytes
+	}
+
+	// Cap = sizeByKey[keyC] (one entry's worth). This forces eviction of at least
+	// two entries (oldest + middle) since all entries have similar sizes due to
+	// metadata files. We want the cap to be: total - (size_oldest + size_middle),
+	// i.e. just the newest entry's size. Use that as the cap.
+	capBytes := sizeByKey[keyC]
+
+	result, err := Prune(OperationOptions{
+		Options:  Options{GitCacheDir: filepath.Join(root, "git")},
+		MaxBytes: capBytes,
+		Yes:      true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	// Expect oldest (keyA) and middle (keyB) evicted, newest (keyC) survives.
+	if len(result.Entries) != 2 {
+		t.Fatalf("Prune() removed %d entries, want 2; entries=%v", len(result.Entries), result.Entries)
+	}
+	removedKeys := map[string]bool{}
+	for _, e := range result.Entries {
+		removedKeys[e.Key] = true
+		if e.PruneReason != "size" {
+			t.Errorf("entry %s PruneReason = %q, want \"size\"", e.Key, e.PruneReason)
+		}
+	}
+	if !removedKeys[keyA] || !removedKeys[keyB] {
+		t.Errorf("expected keyA and keyB removed; got %v", removedKeys)
+	}
+	if removedKeys[keyC] {
+		t.Errorf("keyC (newest) should survive, but was removed")
+	}
+
+	// RemovedCount matches selected length.
+	if result.RemovedCount != 2 {
+		t.Errorf("RemovedCount = %d, want 2", result.RemovedCount)
+	}
+
+	// SizeEvictedBytes = sum of removed entries' sizes.
+	wantEvicted := sizeByKey[keyA] + sizeByKey[keyB]
+	if result.SizeEvictedBytes != wantEvicted {
+		t.Errorf("SizeEvictedBytes = %d, want %d", result.SizeEvictedBytes, wantEvicted)
+	}
+
+	// TotalSizeBytes = size of surviving entry (keyC).
+	if result.TotalSizeBytes != sizeByKey[keyC] {
+		t.Errorf("TotalSizeBytes = %d, want %d", result.TotalSizeBytes, sizeByKey[keyC])
+	}
+
+	// File system: keyA and keyB dirs are gone; keyC dir exists.
+	assertNotExists(t, filepath.Join(root, "git", keyA))
+	assertNotExists(t, filepath.Join(root, "git", keyB))
+	assertExists(t, filepath.Join(root, "git", keyC))
+}
+
+// TestPruneSizePhaseStopsAtCapExactly verifies that when removing one more entry
+// than necessary to reach cap, the function stops immediately at ≤ cap.
+func TestPruneSizePhaseStopsAtCapExactly(t *testing.T) {
+	root := t.TempDir()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	makeGitEntry(t, root, keyA, base)
+	makeGitEntry(t, root, keyB, base.Add(time.Hour))
+	makeGitEntry(t, root, keyC, base.Add(2*time.Hour))
+
+	entries, err := List(Options{GitCacheDir: filepath.Join(root, "git")})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	var totalSize int64
+	for _, e := range entries {
+		totalSize += e.SizeBytes
+	}
+
+	// Cap = totalSize - size(keyA): removing only keyA is sufficient.
+	sizeA := entries[0].SizeBytes // entries sorted by key; keyA is first
+	capBytes := totalSize - sizeA
+
+	result, err := Prune(OperationOptions{
+		Options:  Options{GitCacheDir: filepath.Join(root, "git")},
+		MaxBytes: capBytes,
+		Yes:      true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	// Only keyA (oldest) should be removed.
+	if len(result.Entries) != 1 || result.Entries[0].Key != keyA {
+		t.Fatalf("expected only keyA removed; got %v", result.Entries)
+	}
+	if result.TotalSizeBytes > capBytes {
+		t.Errorf("TotalSizeBytes %d exceeds cap %d", result.TotalSizeBytes, capBytes)
+	}
+}
+
+// TestPruneDryRunParity verifies that dry-run Entries exactly matches the set
+// of entries a subsequent real run would remove, for age-only, size-only, and
+// combined runs. Sabotage-validated during implementation: making dry-run skip
+// the size phase makes this test fail. (Inverting the LRU sort does NOT fail
+// this test — both runs invert identically, so parity trivially holds; that
+// sabotage is caught by TestPruneSizePhaseEvictsOldestFirst instead.)
+func TestPruneDryRunParity(t *testing.T) {
+	t.Run("age-only", func(t *testing.T) {
+		root := t.TempDir()
+		now := time.Now().UTC()
+		oldTime := now.Add(-48 * time.Hour)   // > 24h ago: age-evicted
+		recentTime := now.Add(-1 * time.Hour) // < 24h ago: survives
+
+		makeGitEntry(t, root, keyA, oldTime)
+		makeGitEntry(t, root, keyB, recentTime)
+
+		gitDir := filepath.Join(root, "git")
+		opts := OperationOptions{
+			Options:   Options{GitCacheDir: gitDir},
+			OlderThan: 24 * time.Hour,
+		}
+
+		dry, err := Prune(OperationOptions{
+			Options:   opts.Options,
+			OlderThan: opts.OlderThan,
+			DryRun:    true,
+		})
+		if err != nil {
+			t.Fatalf("dry-run Prune() error = %v", err)
+		}
+
+		real, err := Prune(OperationOptions{
+			Options:   opts.Options,
+			OlderThan: opts.OlderThan,
+			Yes:       true,
+		})
+		if err != nil {
+			t.Fatalf("real Prune() error = %v", err)
+		}
+
+		assertEntrySetEqual(t, dry.Entries, real.Entries)
+		if dry.RemovedCount != 0 {
+			t.Errorf("dry-run RemovedCount = %d, want 0", dry.RemovedCount)
+		}
+	})
+
+	t.Run("size-only", func(t *testing.T) {
+		root := t.TempDir()
+		base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		makeGitEntry(t, root, keyA, base)
+		makeGitEntry(t, root, keyB, base.Add(time.Hour))
+		makeGitEntry(t, root, keyC, base.Add(2*time.Hour))
+
+		gitDir := filepath.Join(root, "git")
+		entries, err := List(Options{GitCacheDir: gitDir})
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		// Cap to newest entry's size only — forces 2 evictions.
+		// Build a size-by-key map to look up keyC directly.
+		sizeByKey := map[string]int64{}
+		for _, e := range entries {
+			sizeByKey[e.Key] = e.SizeBytes
+		}
+		capBytes := sizeByKey[keyC]
+
+		opts := OperationOptions{
+			Options:  Options{GitCacheDir: gitDir},
+			MaxBytes: capBytes,
+		}
+
+		dry, err := Prune(OperationOptions{
+			Options:  opts.Options,
+			MaxBytes: opts.MaxBytes,
+			DryRun:   true,
+		})
+		if err != nil {
+			t.Fatalf("dry-run Prune() error = %v", err)
+		}
+
+		real, err := Prune(OperationOptions{
+			Options:  opts.Options,
+			MaxBytes: opts.MaxBytes,
+			Yes:      true,
+		})
+		if err != nil {
+			t.Fatalf("real Prune() error = %v", err)
+		}
+
+		assertEntrySetEqual(t, dry.Entries, real.Entries)
+		if dry.RemovedCount != 0 {
+			t.Errorf("dry-run RemovedCount = %d, want 0", dry.RemovedCount)
+		}
+		if dry.SizeEvictedBytes != real.SizeEvictedBytes {
+			t.Errorf("dry SizeEvictedBytes %d != real %d", dry.SizeEvictedBytes, real.SizeEvictedBytes)
+		}
+	})
+
+	t.Run("combined", func(t *testing.T) {
+		root := t.TempDir()
+		now := time.Now().UTC()
+		// keyA: old enough for age phase (>24h).
+		makeGitEntry(t, root, keyA, now.Add(-48*time.Hour))
+		// keyB: not old enough for age (1h), but gets size-evicted.
+		makeGitEntry(t, root, keyB, now.Add(-1*time.Hour))
+		// keyC: newest; survives both phases.
+		makeGitEntry(t, root, keyC, now)
+
+		gitDir := filepath.Join(root, "git")
+		entries, err := List(Options{GitCacheDir: gitDir})
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		sizeByKey := map[string]int64{}
+		for _, e := range entries {
+			sizeByKey[e.Key] = e.SizeBytes
+		}
+		// Cap to only keyC's size: after age removes keyA, size phase removes keyB.
+		capBytes := sizeByKey[keyC]
+
+		opts := OperationOptions{
+			Options:   Options{GitCacheDir: gitDir},
+			OlderThan: 24 * time.Hour,
+			MaxBytes:  capBytes,
+		}
+
+		dry, err := Prune(OperationOptions{
+			Options:   opts.Options,
+			OlderThan: opts.OlderThan,
+			MaxBytes:  opts.MaxBytes,
+			DryRun:    true,
+		})
+		if err != nil {
+			t.Fatalf("dry-run Prune() error = %v", err)
+		}
+
+		real, err := Prune(OperationOptions{
+			Options:   opts.Options,
+			OlderThan: opts.OlderThan,
+			MaxBytes:  opts.MaxBytes,
+			Yes:       true,
+		})
+		if err != nil {
+			t.Fatalf("real Prune() error = %v", err)
+		}
+
+		assertEntrySetEqual(t, dry.Entries, real.Entries)
+		if dry.RemovedCount != 0 {
+			t.Errorf("dry-run RemovedCount = %d, want 0", dry.RemovedCount)
+		}
+	})
+}
+
+// TestPruneCombinedPhasesNoCrossCount verifies that age-selected entries are
+// excluded from size accounting and that PruneReason is set correctly.
+func TestPruneCombinedPhasesNoCrossCount(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now().UTC()
+
+	// keyA: age-selected (>48h ago, well past the 24h cutoff).
+	makeGitEntry(t, root, keyA, now.Add(-48*time.Hour))
+	// keyB: not old enough for age phase (1h ago), but will be size-evicted.
+	makeGitEntry(t, root, keyB, now.Add(-1*time.Hour))
+	// keyC: newest (just now); survives both phases.
+	makeGitEntry(t, root, keyC, now)
+
+	gitDir := filepath.Join(root, "git")
+	entries, err := List(Options{GitCacheDir: gitDir})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	sizeByKey := map[string]int64{}
+	for _, e := range entries {
+		sizeByKey[e.Key] = e.SizeBytes
+	}
+
+	// Cap: only keyC should remain after both phases.
+	capBytes := sizeByKey[keyC]
+
+	result, err := Prune(OperationOptions{
+		Options:   Options{GitCacheDir: gitDir},
+		OlderThan: 24 * time.Hour,
+		MaxBytes:  capBytes,
+		Yes:       true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	if result.RemovedCount != 2 {
+		t.Fatalf("RemovedCount = %d, want 2", result.RemovedCount)
+	}
+
+	reasonByKey := map[string]string{}
+	for _, e := range result.Entries {
+		reasonByKey[e.Key] = e.PruneReason
+	}
+
+	if reasonByKey[keyA] != "age" {
+		t.Errorf("keyA PruneReason = %q, want \"age\"", reasonByKey[keyA])
+	}
+	if reasonByKey[keyB] != "size" {
+		t.Errorf("keyB PruneReason = %q, want \"size\"", reasonByKey[keyB])
+	}
+
+	// SizeEvictedBytes counts only the size phase (keyB).
+	if result.SizeEvictedBytes != sizeByKey[keyB] {
+		t.Errorf("SizeEvictedBytes = %d, want %d (keyB only)", result.SizeEvictedBytes, sizeByKey[keyB])
+	}
+
+	// TotalSizeBytes = keyC only (survivors after both phases).
+	if result.TotalSizeBytes != sizeByKey[keyC] {
+		t.Errorf("TotalSizeBytes = %d, want %d (keyC only)", result.TotalSizeBytes, sizeByKey[keyC])
+	}
+}
+
+// TestPruneSourceFilterScopesCapToFilteredSource verifies that --source=git
+// applies the cap only to git entries, leaving remote entries untouched.
+func TestPruneSourceFilterScopesCapToFilteredSource(t *testing.T) {
+	root := t.TempDir()
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Two git entries.
+	makeGitEntry(t, root, keyA, base)
+	makeGitEntry(t, root, keyB, base.Add(time.Hour))
+
+	// One remote entry.
+	makeRemoteHTTPEntry(t, root, keyC, base.Add(2*time.Hour))
+
+	gitDir := filepath.Join(root, "git")
+	remoteDir := filepath.Join(root, "remotes")
+
+	// List git only to get sizes.
+	gitEntries, err := List(Options{GitCacheDir: gitDir, Sources: []Source{SourceGit}})
+	if err != nil {
+		t.Fatalf("List(git) error = %v", err)
+	}
+	sizeByKey := map[string]int64{}
+	for _, e := range gitEntries {
+		sizeByKey[e.Key] = e.SizeBytes
+	}
+
+	// Cap to only keyB (newest git) size: should evict keyA from git only.
+	capBytes := sizeByKey[keyB]
+
+	result, err := Prune(OperationOptions{
+		Options: Options{
+			GitCacheDir:    gitDir,
+			RemoteCacheDir: remoteDir,
+		},
+		Source:   SourceGit,
+		MaxBytes: capBytes,
+		Yes:      true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	// Only keyA (oldest git) should be removed.
+	if len(result.Entries) != 1 || result.Entries[0].Key != keyA {
+		t.Fatalf("expected only keyA removed; got %v", result.Entries)
+	}
+
+	// Remote entry keyC must still exist.
+	assertExists(t, filepath.Join(root, "remotes", keyC))
+	// keyB git entry survives.
+	assertExists(t, filepath.Join(root, "git", keyB))
+}
+
+// TestPruneLegacyEntriesFallBackToMtime verifies that entries without metadata
+// files are sorted by directory mtime (ModifiedAt) as fallback.
+func TestPruneLegacyEntriesFallBackToMtime(t *testing.T) {
+	root := t.TempDir()
+
+	// Create entries without metadata (legacy).
+	writeCacheFile(t, filepath.Join(root, "git", keyA, ".git", "HEAD"), "legacy-a")
+	writeCacheFile(t, filepath.Join(root, "git", keyB, ".git", "HEAD"), "legacy-b")
+
+	// Assign distinct mtimes so the eviction order is deterministic:
+	// keyA is older (evicted first), keyB is newer (survives).
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	mtimeA := base
+	mtimeB := base.Add(time.Hour)
+	if err := os.Chtimes(filepath.Join(root, "git", keyA), mtimeA, mtimeA); err != nil {
+		t.Fatalf("Chtimes(keyA) error = %v", err)
+	}
+	if err := os.Chtimes(filepath.Join(root, "git", keyB), mtimeB, mtimeB); err != nil {
+		t.Fatalf("Chtimes(keyB) error = %v", err)
+	}
+
+	gitDir := filepath.Join(root, "git")
+	entries, err := List(Options{GitCacheDir: gitDir})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	for _, e := range entries {
+		if !e.Legacy {
+			t.Errorf("entry %s Legacy = false, want true", e.Key)
+		}
+	}
+
+	// Both entries have no metadata; entryAgeTime uses ModifiedAt.
+	// keyA has the older mtime and must be evicted first.
+	sizeByKey := map[string]int64{}
+	for _, e := range entries {
+		sizeByKey[e.Key] = e.SizeBytes
+	}
+
+	// Cap to keyB's size: keyA (oldest mtime) gets evicted, keyB survives.
+	capBytes := sizeByKey[keyB]
+
+	result, err := Prune(OperationOptions{
+		Options:  Options{GitCacheDir: gitDir},
+		MaxBytes: capBytes,
+		Yes:      true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry removed; got %v", result.Entries)
+	}
+	if result.Entries[0].Key != keyA {
+		t.Errorf("evicted entry key = %q, want keyA (oldest mtime)", result.Entries[0].Key)
+	}
+	if result.TotalSizeBytes != sizeByKey[keyB] {
+		t.Errorf("TotalSizeBytes = %d, want %d (keyB only)", result.TotalSizeBytes, sizeByKey[keyB])
+	}
+	assertNotExists(t, filepath.Join(root, "git", keyA))
+	assertExists(t, filepath.Join(root, "git", keyB))
+}
+
+// TestPruneNeitherConstraintErrors verifies that calling Prune without either
+// OlderThan or MaxBytes returns the expected error.
+func TestPruneNeitherConstraintErrors(t *testing.T) {
+	root := t.TempDir()
+	makeGitEntry(t, root, keyA, time.Now())
+
+	_, err := Prune(OperationOptions{
+		Options: Options{GitCacheDir: filepath.Join(root, "git")},
+		Yes:     true,
+	})
+	if err == nil {
+		t.Fatal("Prune() error = nil, want error for missing constraints")
+	}
+	if !strings.Contains(err.Error(), "at least one of older-than or max-size is required") {
+		t.Errorf("error = %q, want message about older-than or max-size", err.Error())
+	}
+}
+
+// TestPruneSizeOnlyUnderCapIsNoop verifies that when all entries are already
+// within the cap, no entries are evicted and TotalSizeBytes is still populated.
+// The cap is set to exactly the total (not total+1) to pin the total <= maxBytes
+// boundary. Sabotage-validated during implementation: changing both <= guards in
+// selectSizeEntries to < causes this test to fail with 1 entry incorrectly evicted.
+func TestPruneSizeOnlyUnderCapIsNoop(t *testing.T) {
+	root := t.TempDir()
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	makeGitEntry(t, root, keyA, base)
+	makeGitEntry(t, root, keyB, base.Add(time.Hour))
+
+	gitDir := filepath.Join(root, "git")
+	entries, err := List(Options{GitCacheDir: gitDir})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	var totalSize int64
+	for _, e := range entries {
+		totalSize += e.SizeBytes
+	}
+
+	// Cap equals exact total: nothing should be evicted (tests the total <= cap
+	// early-return boundary — would fail if the condition were total < cap).
+	capBytes := totalSize
+
+	result, err := Prune(OperationOptions{
+		Options:  Options{GitCacheDir: gitDir},
+		MaxBytes: capBytes,
+		Yes:      true,
+	})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	if len(result.Entries) != 0 {
+		t.Errorf("expected no entries removed; got %v", result.Entries)
+	}
+	if result.RemovedCount != 0 {
+		t.Errorf("RemovedCount = %d, want 0", result.RemovedCount)
+	}
+	if result.TotalSizeBytes != totalSize {
+		t.Errorf("TotalSizeBytes = %d, want %d", result.TotalSizeBytes, totalSize)
+	}
+	if result.SizeEvictedBytes != 0 {
+		t.Errorf("SizeEvictedBytes = %d, want 0", result.SizeEvictedBytes)
+	}
+
+	// Both entries still on disk.
+	assertExists(t, filepath.Join(root, "git", keyA))
+	assertExists(t, filepath.Join(root, "git", keyB))
+}
+
+// assertEntrySetEqual asserts that two entry slices contain the same Keys,
+// regardless of order or slice position.
+func assertEntrySetEqual(t *testing.T, a, b []Entry) {
+	t.Helper()
+	keysA := entryKeySet(a)
+	keysB := entryKeySet(b)
+	if !reflect.DeepEqual(keysA, keysB) {
+		t.Errorf("entry key sets differ:\n  dry-run: %v\n  real:    %v", keysA, keysB)
+	}
+}
+
+func entryKeySet(entries []Entry) map[string]bool {
+	m := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		m[e.Key] = true
+	}
+	return m
+}
+
+// makeChartHTTPEntry creates a chart cache entry at root/charts/http/<key>
+// with metadata (Source chart, Kind "http") and a controlled UpdatedAt.
+func makeChartHTTPEntry(t *testing.T, root, key string, updatedAt time.Time) {
+	t.Helper()
+	entryRoot := filepath.Join(root, "charts", "http", key)
+	writeCacheFile(t, filepath.Join(entryRoot, "mychart", "Chart.yaml"), "name: mychart\n")
+	if err := WriteMetadata(entryRoot, Metadata{
+		SchemaVersion: 1,
+		Source:        SourceChart,
+		Kind:          "http",
+		Key:           key,
+		UpdatedAt:     updatedAt,
+		CreatedAt:     updatedAt,
+	}); err != nil {
+		t.Fatalf("WriteMetadata(%s) error = %v", key, err)
+	}
+}
+
+// makeRemoteGitRepoEntry creates a remote/git-repo cache entry at
+// root/remotes/<key> (the repo/ dir marks the git-repo kind) with metadata.
+func makeRemoteGitRepoEntry(t *testing.T, root, key string, updatedAt time.Time) {
+	t.Helper()
+	entryRoot := filepath.Join(root, "remotes", key)
+	writeCacheFile(t, filepath.Join(entryRoot, "repo", "HEAD"), "ref: refs/heads/main\n")
+	if err := WriteMetadata(entryRoot, Metadata{
+		SchemaVersion: 1,
+		Source:        SourceRemote,
+		Kind:          "git-repo",
+		Key:           key,
+		UpdatedAt:     updatedAt,
+		CreatedAt:     updatedAt,
+	}); err != nil {
+		t.Fatalf("WriteMetadata(%s) error = %v", key, err)
+	}
+}
+
+// TestPruneSizeEqualTimestampTieBreak verifies that when entries share an
+// identical UpdatedAt timestamp the eviction sort falls back to
+// (Source, Kind, Key) ascending. Each comparator is pinned by a pair whose
+// lower-priority orderings OPPOSE it, so deleting that comparator flips the
+// outcome:
+//
+//   - source: chart/http (Source "chart", key "bbb…") vs git/git (Source
+//     "git", key "aaa…"). Source orders the chart entry first; both fallbacks
+//     — Kind ("git" < "http") and Key ("aaa…" < "bbb…") — order the git entry
+//     first. Only the Source comparator evicts the chart entry.
+//   - kind: remote git-repo (key "bbb…") vs remote http-file (key "aaa…").
+//     Sources are equal; Kind ("git-repo" < "http-file") orders the git-repo
+//     entry first while Key orders the http-file entry first. Only the Kind
+//     comparator evicts the git-repo entry.
+//   - key: two git entries with equal timestamps; Key orders "aaa…" first.
+//     List() pre-sorts candidates by key in the same direction, so deleting
+//     the Key comparator alone is masked by arrival order — this case pins
+//     the deterministic outcome, not the comparator line itself.
+//
+// Sabotage-validated: deleting the Source comparator fails the "source"
+// case; deleting the Kind comparator fails the "kind" case.
+func TestPruneSizeEqualTimestampTieBreak(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	// evictOne runs Prune with the given options capped to the expected
+	// survivor's size and asserts exactly one entry was evicted.
+	evictOne := func(t *testing.T, opts Options, capBytes int64) Entry {
+		t.Helper()
+		result, err := Prune(OperationOptions{Options: opts, MaxBytes: capBytes, Yes: true})
+		if err != nil {
+			t.Fatalf("Prune() error = %v", err)
+		}
+		if len(result.Entries) != 1 {
+			t.Fatalf("expected 1 entry evicted; got %v", result.Entries)
+		}
+		return result.Entries[0]
+	}
+
+	sizesByKey := func(t *testing.T, opts Options, want int) map[string]int64 {
+		t.Helper()
+		entries, err := List(opts)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(entries) != want {
+			t.Fatalf("expected %d entries, got %d", want, len(entries))
+		}
+		sizes := map[string]int64{}
+		for _, e := range entries {
+			sizes[e.Key] = e.SizeBytes
+		}
+		return sizes
+	}
+
+	t.Run("source", func(t *testing.T) {
+		root := t.TempDir()
+		makeChartHTTPEntry(t, root, keyB, ts) // Source "chart" — must be evicted
+		makeGitEntry(t, root, keyA, ts)       // Source "git" — must survive
+		opts := Options{
+			GitCacheDir:   filepath.Join(root, "git"),
+			ChartCacheDir: filepath.Join(root, "charts"),
+		}
+		sizes := sizesByKey(t, opts, 2)
+		evicted := evictOne(t, opts, sizes[keyA])
+		if evicted.Source != SourceChart || evicted.Key != keyB {
+			t.Errorf("tie-break evicted source=%q key=%q, want source=chart key=%s (Source \"chart\" sorts before \"git\")", evicted.Source, evicted.Key, keyB)
+		}
+		assertNotExists(t, filepath.Join(root, "charts", "http", keyB))
+		assertExists(t, filepath.Join(root, "git", keyA))
+	})
+
+	t.Run("kind", func(t *testing.T) {
+		root := t.TempDir()
+		makeRemoteGitRepoEntry(t, root, keyB, ts) // Kind "git-repo" — must be evicted
+		makeRemoteHTTPEntry(t, root, keyA, ts)    // Kind "http-file" — must survive
+		opts := Options{RemoteCacheDir: filepath.Join(root, "remotes")}
+		sizes := sizesByKey(t, opts, 2)
+		evicted := evictOne(t, opts, sizes[keyA])
+		if evicted.Kind != "git-repo" || evicted.Key != keyB {
+			t.Errorf("tie-break evicted kind=%q key=%q, want kind=git-repo key=%s (Kind \"git-repo\" sorts before \"http-file\")", evicted.Kind, evicted.Key, keyB)
+		}
+		assertNotExists(t, filepath.Join(root, "remotes", keyB))
+		assertExists(t, filepath.Join(root, "remotes", keyA))
+	})
+
+	t.Run("key", func(t *testing.T) {
+		root := t.TempDir()
+		makeGitEntry(t, root, keyA, ts)
+		makeGitEntry(t, root, keyB, ts)
+		opts := Options{GitCacheDir: filepath.Join(root, "git")}
+		sizes := sizesByKey(t, opts, 2)
+		evicted := evictOne(t, opts, sizes[keyB])
+		if evicted.Key != keyA {
+			t.Errorf("tie-break evicted key=%q, want %s (Key ascending)", evicted.Key, keyA)
+		}
+		assertNotExists(t, filepath.Join(root, "git", keyA))
+		assertExists(t, filepath.Join(root, "git", keyB))
+	})
+}

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -24,6 +24,7 @@ type cacheFlags struct {
 	remoteCacheDir     string
 	renderCacheDir     string
 	renderCacheMaxSize quantityFlag
+	maxSize            quantityFlag
 	source             string
 	output             string
 	olderThan          string
@@ -122,6 +123,7 @@ func newCacheCommand() *cobra.Command {
 	bindCacheOperationFlags(pruneCmd, &pruneFlags)
 	pruneCmd.Flags().StringVar(&pruneFlags.olderThan, "older-than", pruneFlags.olderThan, "remove cache entries older than this duration")
 	pruneCmd.Flags().Var(&pruneFlags.renderCacheMaxSize, "render-cache-max-size", "size cap enforced by the render cache sweep during prune (Kubernetes quantity, default 512Mi)")
+	pruneCmd.Flags().Var(&pruneFlags.maxSize, "max-size", "evict least-recently-used cache entries from the selected sources until their total size is at or below this cap (Kubernetes quantity, e.g. 4Gi)")
 
 	deleteFlags := defaultCacheFlags()
 	deleteCmd := &cobra.Command{
@@ -224,6 +226,7 @@ func cacheOperationOptions(flags cacheFlags) (cache.OperationOptions, error) {
 		Key:                 strings.TrimSpace(flags.key),
 		All:                 flags.all,
 		RenderCacheMaxBytes: flags.renderCacheMaxSize.bytes,
+		MaxBytes:            flags.maxSize.bytes,
 	}, nil
 }
 
@@ -362,6 +365,24 @@ func renderCacheOperation(cmd *cobra.Command, output cliformat.Output, result ca
 		if result.DryRun {
 			verb = "would remove"
 			count = len(result.Entries)
+		}
+		if result.SizeEvictedBytes > 0 {
+			// Size phase ran: break down counts by reason, report bytes freed and
+			// the post-prune selected-set total.
+			ageCount := 0
+			sizeCount := 0
+			for _, e := range result.Entries {
+				switch e.PruneReason {
+				case "age":
+					ageCount++
+				case "size":
+					sizeCount++
+				}
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(),
+				"%s %d cache entries (%d by age, %d by size); freed %d bytes by size, %d bytes remain\n",
+				verb, count, ageCount, sizeCount, result.SizeEvictedBytes, result.TotalSizeBytes)
+			return err
 		}
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s %d cache entries\n", verb, count)
 		return err

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -624,3 +624,219 @@ func writeCacheEntry(t *testing.T, path string) {
 	t.Helper()
 	writeCLITestFile(t, path, "cache")
 }
+
+// --- Chunk 2: --max-size flag tests ---
+
+// TestCachePruneMaxSizeFlagParsesOptions verifies that --max-size is wired into
+// MaxBytes on the OperationOptions produced by cacheOperationOptions.
+func TestCachePruneMaxSizeFlagParsesOptions(t *testing.T) {
+	flags := defaultCacheFlags()
+	if err := flags.maxSize.Set("1Gi"); err != nil {
+		t.Fatalf("maxSize.Set(1Gi) error = %v", err)
+	}
+	opts, err := cacheOperationOptions(flags)
+	if err != nil {
+		t.Fatalf("cacheOperationOptions() error = %v", err)
+	}
+	const want = 1 << 30
+	if opts.MaxBytes != want {
+		t.Fatalf("MaxBytes = %d, want %d", opts.MaxBytes, want)
+	}
+}
+
+// TestCachePruneMaxSizeZeroRejected verifies that quantityFlag.Set rejects "0".
+func TestCachePruneMaxSizeZeroRejected(t *testing.T) {
+	var q quantityFlag
+	if err := q.Set("0"); err == nil {
+		t.Fatal("quantityFlag.Set(0) error = nil, want error")
+	}
+}
+
+// TestCachePruneMaxSizeNegativeRejected verifies that quantityFlag.Set rejects
+// negative quantities (e.g. "-1").
+func TestCachePruneMaxSizeNegativeRejected(t *testing.T) {
+	var q quantityFlag
+	if err := q.Set("-1"); err == nil {
+		t.Fatal("quantityFlag.Set(-1) error = nil, want error")
+	}
+}
+
+// TestCachePruneMaxSizeDefaultEmpty verifies that the zero-value quantityFlag
+// has an empty String() so cobra help shows no default cap.
+func TestCachePruneMaxSizeDefaultEmpty(t *testing.T) {
+	flags := defaultCacheFlags()
+	if got := flags.maxSize.String(); got != "" {
+		t.Fatalf("defaultCacheFlags().maxSize.String() = %q, want empty string", got)
+	}
+	if flags.maxSize.bytes != 0 {
+		t.Fatalf("defaultCacheFlags().maxSize.bytes = %d, want 0", flags.maxSize.bytes)
+	}
+}
+
+// TestCachePruneHelpIncludesMaxSize verifies that cobra renders the --max-size
+// flag in the prune command help output.
+func TestCachePruneHelpIncludesMaxSize(t *testing.T) {
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"cache", "prune", "--help"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	// Help exits with a non-nil error on some cobra versions; ignore it.
+	_ = cmd.Execute()
+	if !strings.Contains(out.String(), "max-size") {
+		t.Fatalf("prune --help output missing 'max-size':\n%s", out.String())
+	}
+}
+
+// TestCachePruneMaxSizeOnlyAccepted verifies that prune with only --max-size
+// (no --older-than) succeeds end-to-end against a temp cache.
+func TestCachePruneMaxSizeOnlyAccepted(t *testing.T) {
+	root := t.TempDir()
+	gitCacheDir := filepath.Join(root, "git")
+	chartCacheDir := filepath.Join(root, "charts")
+	remoteCacheDir := filepath.Join(root, "remotes")
+	renderCacheDir := filepath.Join(root, "render")
+
+	// Seed a git entry with a known size so --max-size 1 forces eviction.
+	entryRoot := filepath.Join(gitCacheDir, cacheCLITestKey)
+	writeCacheEntry(t, filepath.Join(entryRoot, ".git", "HEAD"))
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{
+		"cache", "prune",
+		"--git-cache-dir", gitCacheDir,
+		"--chart-cache-dir", chartCacheDir,
+		"--remote-cache-dir", remoteCacheDir,
+		"--render-cache-dir", renderCacheDir,
+		"--max-size", "1", // 1 byte cap forces eviction
+		"--yes",
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	// Entry should have been removed.
+	if _, err := os.Stat(entryRoot); !os.IsNotExist(err) {
+		t.Fatalf("cache entry still exists after --max-size prune: %v", err)
+	}
+}
+
+// TestCachePruneNeitherFlagErrors verifies that prune with neither --older-than
+// nor --max-size returns an error naming both flags.
+func TestCachePruneNeitherFlagErrors(t *testing.T) {
+	root := t.TempDir()
+	gitCacheDir := filepath.Join(root, "git")
+	chartCacheDir := filepath.Join(root, "charts")
+	remoteCacheDir := filepath.Join(root, "remotes")
+	renderCacheDir := filepath.Join(root, "render")
+	writeCacheEntry(t, filepath.Join(gitCacheDir, cacheCLITestKey, ".git", "HEAD"))
+
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{
+		"cache", "prune",
+		"--git-cache-dir", gitCacheDir,
+		"--chart-cache-dir", chartCacheDir,
+		"--remote-cache-dir", remoteCacheDir,
+		"--render-cache-dir", renderCacheDir,
+		"--yes",
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error when neither --older-than nor --max-size set")
+	}
+	if !strings.Contains(err.Error(), "older-than") || !strings.Contains(err.Error(), "max-size") {
+		t.Fatalf("error = %q, want message naming both flags", err.Error())
+	}
+}
+
+// TestRenderCacheOperationTableAgeOnly verifies that the legacy table line is
+// unchanged when only age entries are present (SizeEvictedBytes == 0).
+func TestRenderCacheOperationTableAgeOnly(t *testing.T) {
+	result := cache.OperationResult{
+		Entries:          []cache.Entry{{PruneReason: "age"}, {PruneReason: "age"}},
+		RemovedCount:     2,
+		DryRun:           false,
+		SizeEvictedBytes: 0,
+		TotalSizeBytes:   0,
+	}
+	cmd := NewRootCommand(VersionInfo{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := renderCacheOperation(cmd, "table", result); err != nil {
+		t.Fatalf("renderCacheOperation() error = %v", err)
+	}
+	got := out.String()
+	if got != "removed 2 cache entries\n" {
+		t.Fatalf("got %q, want %q", got, "removed 2 cache entries\n")
+	}
+}
+
+// TestRenderCacheOperationTableSizePhaseReal verifies the extended line format
+// when the size phase ran (SizeEvictedBytes > 0) on a real (non-dry-run) run.
+func TestRenderCacheOperationTableSizePhaseReal(t *testing.T) {
+	result := cache.OperationResult{
+		Entries: []cache.Entry{
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "age"},
+			{PruneReason: "size"},
+			{PruneReason: "size"},
+			{PruneReason: "size"},
+			{PruneReason: "size"},
+		},
+		RemovedCount:     12,
+		DryRun:           false,
+		SizeEvictedBytes: 1234567,
+		TotalSizeBytes:   4096,
+	}
+	cmd := NewRootCommand(VersionInfo{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := renderCacheOperation(cmd, "table", result); err != nil {
+		t.Fatalf("renderCacheOperation() error = %v", err)
+	}
+	want := "removed 12 cache entries (8 by age, 4 by size); freed 1234567 bytes by size, 4096 bytes remain\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+// TestRenderCacheOperationTableSizePhaseDryRun verifies the extended dry-run
+// line format when the size phase ran.
+func TestRenderCacheOperationTableSizePhaseDryRun(t *testing.T) {
+	result := cache.OperationResult{
+		Entries: []cache.Entry{
+			{PruneReason: "size"},
+			{PruneReason: "size"},
+		},
+		RemovedCount:     0, // dry-run: count stays 0
+		DryRun:           true,
+		SizeEvictedBytes: 999,
+		TotalSizeBytes:   1,
+	}
+	cmd := NewRootCommand(VersionInfo{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := renderCacheOperation(cmd, "table", result); err != nil {
+		t.Fatalf("renderCacheOperation() error = %v", err)
+	}
+	want := "would remove 2 cache entries (0 by age, 2 by size); freed 999 bytes by size, 1 bytes remain\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -165,6 +165,17 @@ inputs:
       durable storage. off keeps no cache between runs. cache "false" forces off.
     required: false
     default: auto
+  cache-prune-max-size:
+    description: >-
+      Size cap for the on-runner drydock source and render caches when
+      cache-mode is local. After each run, least-recently-used cache entries
+      are pruned until the total cache size is at or below this cap (Kubernetes
+      quantity, e.g. 4Gi). Empty string disables pruning. Automatically
+      disabled when offline is true — evicted source cache entries would
+      hard-fail later offline runs with no self-heal path. An invalid quantity
+      surfaces as a per-run warning from the prune step, never a job failure.
+    required: false
+    default: "4Gi"
   save-cache:
     description: Save drydock render caches after trusted runs.
     required: false
@@ -372,6 +383,8 @@ runs:
         DRYDOCK_INPUT_DIFF_ARTIFACT_NAME: ${{ inputs.diff-artifact-name }}
         DRYDOCK_INPUT_DIFF_MAX_BYTES: ${{ inputs.diff-max-bytes }}
         DRYDOCK_INPUT_IMAGE_ARTIFACT_NAME: ${{ inputs.image-artifact-name }}
+        DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE: ${{ inputs.cache-prune-max-size }}
+        DRYDOCK_INPUT_OFFLINE: ${{ inputs.offline }}
         DRYDOCK_INPUT_SAVE_CACHE: ${{ inputs.save-cache }}
         DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
         DRYDOCK_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
@@ -462,6 +475,16 @@ runs:
       with:
         key: ${{ steps.prepare.outputs.cache-key }}
         path: ${{ steps.prepare.outputs.cache-path }}
+
+    - name: Prune drydock local cache
+      if: ${{ always() && steps.prepare.outputs.cache-prune == 'true' }}
+      shell: bash
+      env:
+        DRYDOCK_BIN: ${{ inputs.install == 'true' && format('{0}/drydock', steps.setup.outputs.install-dir) || inputs.drydock-bin }}
+        DRYDOCK_CACHE_PATH: ${{ steps.prepare.outputs.cache-path }}
+        DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE: ${{ steps.prepare.outputs.cache-prune-max-size }}
+        DRYDOCK_INPUT_PATH: ${{ inputs.path }}
+      run: '"${GITHUB_ACTION_PATH}/prune.sh"'
 
     - name: Upload rendered manifest diff
       if: ${{ inputs.upload-artifacts == 'true' && steps.run.outputs.has-diff == 'true' }}

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -6,12 +6,18 @@ import (
 	"testing"
 )
 
-func TestActionUploadsHTMLDiffBeforeCommentAndAppendsURL(t *testing.T) {
-	actionYAMLBytes, err := os.ReadFile("action.yml")
+// loadActionYAML reads action.yml once and returns it as a string.
+func loadActionYAML(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("action.yml")
 	if err != nil {
 		t.Fatalf("read action.yml: %v", err)
 	}
-	actionYAML := string(actionYAMLBytes)
+	return string(b)
+}
+
+func TestActionUploadsHTMLDiffBeforeCommentAndAppendsURL(t *testing.T) {
+	actionYAML := loadActionYAML(t)
 
 	rawUpload := strings.Index(actionYAML, "- name: Upload rendered manifest diff\n")
 	htmlUpload := strings.Index(actionYAML, "- name: Upload rendered manifest diff HTML\n")
@@ -62,5 +68,131 @@ func TestActionUploadsHTMLDiffBeforeCommentAndAppendsURL(t *testing.T) {
 	}
 	if strings.Contains(linkBlock, "Full Diff Report") {
 		t.Fatalf("HTML link block should use Full Rendered Diff View label:\n%s", linkBlock)
+	}
+}
+
+func TestActionCachePruneMaxSizeInputDeclaredWithDefault(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	// New input must be declared.
+	if !strings.Contains(actionYAML, "cache-prune-max-size:") {
+		t.Fatalf("action.yml missing cache-prune-max-size input declaration")
+	}
+	// Default must be 4Gi.
+	inputIdx := strings.Index(actionYAML, "cache-prune-max-size:")
+	// Find the default: line within the next 800 chars.
+	snippet := actionYAML[inputIdx:min(inputIdx+800, len(actionYAML))]
+	if !strings.Contains(snippet, `default: "4Gi"`) {
+		t.Fatalf("cache-prune-max-size input block = %q, want default: \"4Gi\"", snippet)
+	}
+}
+
+func TestActionPrepareStepEnvContainsNewVars(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	// Locate the prepare step.
+	prepareIdx := strings.Index(actionYAML, "- name: Prepare drydock action\n")
+	if prepareIdx == -1 {
+		t.Fatalf("action.yml missing 'Prepare drydock action' step")
+	}
+	// Find the boundary of the next step to scope the search.
+	nextStep := strings.Index(actionYAML[prepareIdx+1:], "\n    - name: ")
+	var prepareBlock string
+	if nextStep == -1 {
+		prepareBlock = actionYAML[prepareIdx:]
+	} else {
+		prepareBlock = actionYAML[prepareIdx : prepareIdx+1+nextStep]
+	}
+
+	for _, want := range []string{
+		"DRYDOCK_INPUT_OFFLINE: ${{ inputs.offline }}",
+		"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE: ${{ inputs.cache-prune-max-size }}",
+	} {
+		if !strings.Contains(prepareBlock, want) {
+			t.Fatalf("prepare step env block missing %q:\n%s", want, prepareBlock)
+		}
+	}
+}
+
+func TestActionPruneStepExistsAfterSaveStep(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	saveIdx := strings.Index(actionYAML, "- name: Save drydock render cache\n")
+	pruneIdx := strings.Index(actionYAML, "- name: Prune drydock local cache\n")
+	uploadIdx := strings.Index(actionYAML, "- name: Upload rendered manifest diff\n")
+
+	if saveIdx == -1 {
+		t.Fatalf("action.yml missing 'Save drydock render cache' step")
+	}
+	if pruneIdx == -1 {
+		t.Fatalf("action.yml missing 'Prune drydock local cache' step")
+	}
+	if uploadIdx == -1 {
+		t.Fatalf("action.yml missing 'Upload rendered manifest diff' step")
+	}
+	if saveIdx >= pruneIdx {
+		t.Fatalf("prune step (pos %d) must come after save step (pos %d)", pruneIdx, saveIdx)
+	}
+	if pruneIdx >= uploadIdx {
+		t.Fatalf("prune step (pos %d) must come before upload step (pos %d)", pruneIdx, uploadIdx)
+	}
+}
+
+func TestActionPruneStepIfGuardAndEnvWiring(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	pruneIdx := strings.Index(actionYAML, "- name: Prune drydock local cache\n")
+	if pruneIdx == -1 {
+		t.Fatalf("action.yml missing 'Prune drydock local cache' step")
+	}
+	// Scope to the prune step block (until the next step).
+	nextStep := strings.Index(actionYAML[pruneIdx+1:], "\n    - name: ")
+	var pruneBlock string
+	if nextStep == -1 {
+		pruneBlock = actionYAML[pruneIdx:]
+	} else {
+		pruneBlock = actionYAML[pruneIdx : pruneIdx+1+nextStep]
+	}
+
+	// if: guard must reference cache-prune output from prepare.
+	if !strings.Contains(pruneBlock, "steps.prepare.outputs.cache-prune == 'true'") {
+		t.Fatalf("prune step missing cache-prune output guard:\n%s", pruneBlock)
+	}
+	if !strings.Contains(pruneBlock, "always()") {
+		t.Fatalf("prune step if: must include always():\n%s", pruneBlock)
+	}
+
+	// Env: DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE must come from prepare OUTPUT
+	// (not the raw input), to keep prepare the single source of truth.
+	if !strings.Contains(pruneBlock, "DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE: ${{ steps.prepare.outputs.cache-prune-max-size }}") {
+		t.Fatalf("prune step must wire DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE from prepare output:\n%s", pruneBlock)
+	}
+	// DRYDOCK_BIN must use the same format expression as the Run step.
+	if !strings.Contains(pruneBlock, "format('{0}/drydock', steps.setup.outputs.install-dir)") {
+		t.Fatalf("prune step DRYDOCK_BIN missing install-dir format expression:\n%s", pruneBlock)
+	}
+	if !strings.Contains(pruneBlock, "DRYDOCK_CACHE_PATH: ${{ steps.prepare.outputs.cache-path }}") {
+		t.Fatalf("prune step missing DRYDOCK_CACHE_PATH wiring:\n%s", pruneBlock)
+	}
+}
+
+func TestActionNoPinnedActionRefsInPruneStep(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	pruneIdx := strings.Index(actionYAML, "- name: Prune drydock local cache\n")
+	if pruneIdx == -1 {
+		t.Fatalf("action.yml missing 'Prune drydock local cache' step")
+	}
+	nextStep := strings.Index(actionYAML[pruneIdx+1:], "\n    - name: ")
+	var pruneBlock string
+	if nextStep == -1 {
+		pruneBlock = actionYAML[pruneIdx:]
+	} else {
+		pruneBlock = actionYAML[pruneIdx : pruneIdx+1+nextStep]
+	}
+
+	// The prune step must not introduce any new external action references.
+	if strings.Contains(pruneBlock, "\n      uses:") {
+		t.Fatalf("prune step must not use any external actions (nothing to SHA-pin):\n%s", pruneBlock)
 	}
 }

--- a/pr-action/prepare.sh
+++ b/pr-action/prepare.sh
@@ -31,6 +31,7 @@ bool "${DRYDOCK_INPUT_CACHE_UNTRUSTED_RESTORE}" cache-untrusted-restore
 bool "${DRYDOCK_INPUT_UPLOAD_ARTIFACTS}" upload-artifacts
 bool "${DRYDOCK_INPUT_COMMENT_EMPTY}" comment-empty
 bool "${DRYDOCK_INPUT_COMMENT_CONTINUE_ON_ERROR}" comment-continue-on-error
+bool "${DRYDOCK_INPUT_OFFLINE:-false}" offline
 positive_int "${DRYDOCK_INPUT_ARTIFACT_RETENTION_DAYS}" artifact-retention-days
 positive_int "${DRYDOCK_INPUT_DIFF_MAX_BYTES}" diff-max-bytes
 
@@ -151,6 +152,12 @@ if [[ -z "${image_artifact_name}" ]]; then
   image_artifact_name="drydock-images-${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}"
 fi
 
+cache_prune_max_size="${DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE:-}"
+cache_prune=false
+if [[ "${cache_mode}" == "local" && -n "${cache_prune_max_size}" && "${DRYDOCK_INPUT_OFFLINE:-false}" != "true" ]]; then
+  cache_prune=true
+fi
+
 {
   echo "work-dir=${work_dir}"
   echo "cache-path=${cache_path}"
@@ -161,6 +168,8 @@ fi
   echo "diff-artifact-name=${diff_artifact_name}"
   echo "diff-html-artifact-name=${diff_html_artifact_name}"
   echo "image-artifact-name=${image_artifact_name}"
+  echo "cache-prune=${cache_prune}"
+  echo "cache-prune-max-size=${cache_prune_max_size}"
   echo "restore-keys<<EOF"
   printf '%s\n' "${restore_keys}"
   echo "EOF"

--- a/pr-action/prepare_test.go
+++ b/pr-action/prepare_test.go
@@ -158,6 +158,135 @@ func TestPrepareCacheModeInvalidFails(t *testing.T) {
 	}
 }
 
+func TestPrepareCachePruneTruthTable(t *testing.T) {
+	toolCache := t.TempDir()
+
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		wantPrune string
+	}{
+		{
+			name: "local+set+offline-false → true",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "local",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+				"DRYDOCK_INPUT_OFFLINE":              "false",
+				"RUNNER_TOOL_CACHE":                  toolCache,
+			},
+			wantPrune: "true",
+		},
+		{
+			name: "local+empty → false",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "local",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "",
+				"RUNNER_TOOL_CACHE":                  toolCache,
+			},
+			wantPrune: "false",
+		},
+		{
+			name: "auto+set → false",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "auto",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+			},
+			wantPrune: "false",
+		},
+		{
+			name: "github+set → false",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "github",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+			},
+			wantPrune: "false",
+		},
+		{
+			name: "off+set → false",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "off",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+			},
+			wantPrune: "false",
+		},
+		{
+			// DRYDOCK_INPUT_OFFLINE entirely unset: the ${VAR:-false} guard must
+			// default to false and still enable pruning.
+			name: "local+set+offline-unset → true",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "local",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+				"RUNNER_TOOL_CACHE":                  toolCache,
+			},
+			wantPrune: "true",
+		},
+		{
+			name: "local+set+offline-true → false",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE_MODE":           "local",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+				"DRYDOCK_INPUT_OFFLINE":              "true",
+				"RUNNER_TOOL_CACHE":                  toolCache,
+			},
+			wantPrune: "false",
+		},
+		{
+			name: "cache:false+cache-mode:local+set → false via mode forced off",
+			overrides: map[string]string{
+				"DRYDOCK_INPUT_CACHE":                "false",
+				"DRYDOCK_INPUT_CACHE_MODE":           "local",
+				"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "4Gi",
+				"RUNNER_TOOL_CACHE":                  toolCache,
+			},
+			wantPrune: "false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := runPrepare(t, tc.overrides)
+			if got := outputValue(t, res.output, "cache-prune"); got != tc.wantPrune {
+				t.Fatalf("cache-prune = %q, want %q", got, tc.wantPrune)
+			}
+		})
+	}
+}
+
+func TestPrepareCachePruneMaxSizePassthrough(t *testing.T) {
+	toolCache := t.TempDir()
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE":           "local",
+		"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "8Gi",
+		"RUNNER_TOOL_CACHE":                  toolCache,
+	})
+
+	if got := outputValue(t, res.output, "cache-prune-max-size"); got != "8Gi" {
+		t.Fatalf("cache-prune-max-size = %q, want 8Gi", got)
+	}
+}
+
+func TestPrepareCachePruneMaxSizeEmptyPassthrough(t *testing.T) {
+	// Even when prune is disabled (empty max-size), the output value is passed through.
+	res := runPrepare(t, map[string]string{
+		"DRYDOCK_INPUT_CACHE_MODE":           "auto",
+		"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE": "",
+	})
+
+	if got := outputValue(t, res.output, "cache-prune-max-size"); got != "" {
+		t.Fatalf("cache-prune-max-size = %q, want empty", got)
+	}
+}
+
+func TestPrepareExistingTestsUnaffectedByNewEnvVars(t *testing.T) {
+	// Existing test harness does not set the new vars; verify prepare.sh
+	// handles their absence (via ${VAR:-} default-guards) without error.
+	res := runPrepare(t, map[string]string{})
+	// The default cache-mode is auto, so cache-prune must be false.
+	if got := outputValue(t, res.output, "cache-prune"); got != "false" {
+		t.Fatalf("cache-prune = %q, want false when new vars are unset", got)
+	}
+}
+
 func TestPrepareSelfHostedAutoEmitsNotice(t *testing.T) {
 	res := runPrepare(t, map[string]string{
 		"DRYDOCK_INPUT_CACHE_MODE": "auto",

--- a/pr-action/prune.sh
+++ b/pr-action/prune.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+drydock_bin="${DRYDOCK_BIN:-drydock}"
+cache_path="${DRYDOCK_CACHE_PATH}"
+max_size="${DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE}"
+path="${DRYDOCK_INPUT_PATH:-.}"
+
+if ! command -v "${drydock_bin}" > /dev/null 2>&1; then
+  echo "::notice::drydock: prune skipped — drydock binary not found at '${drydock_bin}'"
+  exit 0
+fi
+
+stderr_tmp="$(mktemp)"
+prune_exit=0
+prune_output="$(
+  "${drydock_bin}" cache prune \
+    --max-size "${max_size}" \
+    --yes \
+    --path "${path}" \
+    --git-cache-dir "${cache_path}/git" \
+    --chart-cache-dir "${cache_path}/charts" \
+    --remote-cache-dir "${cache_path}/remotes" \
+    --render-cache-dir "${cache_path}/renders" \
+    -o json \
+    2>"${stderr_tmp}"
+)" || prune_exit=$?
+prune_err="$(cat "${stderr_tmp}")"
+rm -f "${stderr_tmp}"
+
+if [[ "${prune_exit}" -ne 0 ]]; then
+  if echo "${prune_err}" | grep -q "unknown flag: --max-size"; then
+    echo "::notice::drydock: prune skipped — installed drydock binary does not support cache prune --max-size; upgrade to a release that includes this flag"
+    exit 0
+  fi
+  # Collapse newlines so drydock stderr cannot smuggle extra lines into the
+  # runner log where they would be re-scanned for workflow commands.
+  echo "::warning::drydock: cache prune failed (exit ${prune_exit}): ${prune_err//$'\n'/ }"
+  exit 0
+fi
+
+# Log a one-line summary from the JSON output; jq may be absent, so this is
+# best-effort — absence of jq is not an error.
+if command -v jq > /dev/null 2>&1; then
+  removed="$(echo "${prune_output}" | jq -r '.removedCount // 0' 2>/dev/null || echo '?')"
+  freed="$(echo "${prune_output}" | jq -r '.sizeEvictedBytes // 0' 2>/dev/null || echo '?')"
+  remaining="$(echo "${prune_output}" | jq -r '.totalSizeBytes // 0' 2>/dev/null || echo '?')"
+  echo "drydock: cache prune complete — removed ${removed} entries, freed ${freed} bytes by size, ${remaining} bytes remain"
+else
+  echo "drydock: cache prune complete"
+fi

--- a/pr-action/prune_test.go
+++ b/pr-action/prune_test.go
@@ -1,0 +1,193 @@
+package praction
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// runPrune executes prune.sh with the given environment overlay and expects
+// success (exit 0). It returns the combined stdout+stderr output.
+func runPrune(t *testing.T, env []string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+	cmd := exec.Command("bash", "prune.sh")
+	cmd.Dir = "."
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("prune.sh failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// defaultPruneEnv builds a minimal environment for prune.sh tests, with the
+// drydock binary resolved from tmp (prepended to PATH).
+func defaultPruneEnv(t *testing.T, tmp, cachePath string) []string {
+	t.Helper()
+	return append(
+		withoutEnvKeys(os.Environ(), "PATH", "DRYDOCK_BIN", "DRYDOCK_CACHE_PATH", "DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE", "DRYDOCK_INPUT_PATH"),
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DRYDOCK_BIN=drydock",
+		"DRYDOCK_CACHE_PATH="+cachePath,
+		"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE=4Gi",
+		"DRYDOCK_INPUT_PATH=.",
+	)
+}
+
+func TestPrunePassesExactFlagsAndCacheDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+
+	// Record the argv to a file; emit valid JSON output.
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "`+tmp+`/drydock-args.txt"
+printf '{"removedCount":3,"sizeEvictedBytes":1048576,"totalSizeBytes":2097152}\n'
+`)
+
+	env := defaultPruneEnv(t, tmp, cachePath)
+	runPrune(t, env)
+
+	args := readFile(t, filepath.Join(tmp, "drydock-args.txt"))
+
+	// Required flags and values
+	for _, want := range []string{
+		"cache prune",
+		"--max-size 4Gi",
+		"--yes",
+		"--path .",
+		"--git-cache-dir " + cachePath + "/git",
+		"--chart-cache-dir " + cachePath + "/charts",
+		"--remote-cache-dir " + cachePath + "/remotes",
+		"--render-cache-dir " + cachePath + "/renders",
+		"-o json",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("drydock args = %q, want %q", args, want)
+		}
+	}
+
+	// Must NOT pass --render-cache-max-size (render sweep runs at its 512Mi default)
+	if strings.Contains(args, "--render-cache-max-size") {
+		t.Fatalf("drydock args = %q, must not include --render-cache-max-size", args)
+	}
+
+	// Must NOT reference the plugin cache dir
+	if strings.Contains(args, "plugin") {
+		t.Fatalf("drydock args = %q, must not touch plugin cache dir", args)
+	}
+}
+
+func TestPruneUnknownFlagExitsZeroWithNotice(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+
+	// Simulate an older drydock that does not know --max-size.
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+echo "unknown flag: --max-size" >&2
+exit 2
+`)
+
+	env := defaultPruneEnv(t, tmp, cachePath)
+	out := runPrune(t, env)
+
+	if !strings.Contains(out, "::notice::") {
+		t.Fatalf("output = %q, want ::notice:: for unknown-flag degradation", out)
+	}
+	if strings.Contains(out, "::warning::") {
+		t.Fatalf("output = %q, must not emit ::warning:: for unknown-flag case", out)
+	}
+}
+
+func TestPruneOtherFailureExitsZeroWithWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+
+	// Simulate a failure unrelated to the unknown-flag case.
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+echo "cache prune: unexpected internal error" >&2
+exit 1
+`)
+
+	env := defaultPruneEnv(t, tmp, cachePath)
+	out := runPrune(t, env)
+
+	if !strings.Contains(out, "::warning::") {
+		t.Fatalf("output = %q, want ::warning:: for unexpected failure", out)
+	}
+}
+
+func TestPruneMissingBinaryExitsZeroWithNotice(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+
+	// Do NOT write a drydock stub — binary is absent from tmp.
+	// Use a PATH that does not contain any real drydock binary either.
+	env := append(
+		withoutEnvKeys(os.Environ(), "PATH", "DRYDOCK_BIN", "DRYDOCK_CACHE_PATH", "DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE", "DRYDOCK_INPUT_PATH"),
+		"PATH="+tmp, // only the empty tmp dir — no drydock here
+		"DRYDOCK_BIN=drydock",
+		"DRYDOCK_CACHE_PATH="+cachePath,
+		"DRYDOCK_INPUT_CACHE_PRUNE_MAX_SIZE=4Gi",
+		"DRYDOCK_INPUT_PATH=.",
+	)
+
+	out := runPrune(t, env)
+
+	if !strings.Contains(out, "::notice::") {
+		t.Fatalf("output = %q, want ::notice:: when binary is missing", out)
+	}
+	if strings.Contains(out, "::warning::") {
+		t.Fatalf("output = %q, must not emit ::warning:: when binary is missing", out)
+	}
+}
+
+func TestPruneSummaryLoggedOnSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	cachePath := filepath.Join(tmp, "cache")
+
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+printf '{"removedCount":5,"sizeEvictedBytes":2097152,"totalSizeBytes":4194304}\n'
+`)
+	// Ensure jq is available in the PATH for this test.
+	jqPath, err := exec.LookPath("jq")
+	if err != nil {
+		t.Skip("jq not available in PATH; skipping summary assertion")
+	}
+	_ = jqPath
+
+	env := defaultPruneEnv(t, tmp, cachePath)
+	out := runPrune(t, env)
+
+	for _, want := range []string{"removed 5 entries", "freed 2097152 bytes", "4194304 bytes remain"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q in summary line", out, want)
+		}
+	}
+}

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -300,6 +300,7 @@ Cache lifecycle commands are local filesystem operations only:
 drydock cache path
 drydock cache list -o json
 drydock cache prune --older-than 720h --dry-run
+drydock cache prune --max-size 4Gi --yes
 ```
 
 They do not:
@@ -319,6 +320,42 @@ Cache lifecycle commands reject cache roots that resolve inside the current
 working directory, selected repository roots, Git repository trees, or
 symlink-resolved equivalents. Non-dry-run deletion requires `--yes`; dry-runs
 never require confirmation.
+
+### Pruning by age
+
+`--older-than DURATION` removes cache entries whose last-used timestamp
+(`Metadata.UpdatedAt`, refreshed on every cache hit and fetch) predates the
+given duration. Legacy entries without metadata fall back to filesystem mtime.
+
+### Pruning by size (`--max-size`)
+
+`--max-size QUANTITY` evicts the least-recently-used entries from the selected
+sources until their total size is at or below the cap. Recency is measured by
+`Metadata.UpdatedAt`, which is refreshed on every cache use — not just the
+initial fetch. This means the oldest (least-recently-used) entries are evicted
+first. Eviction proceeds to at or below the cap exactly, not to a hysteresis
+target.
+
+`--max-size` composes with `--source` and `--older-than`. When both flags are
+set, age-based entries are removed first; the size cap is then applied to the
+survivors. The cap applies to the sum of `SizeBytes` across entries matching
+the selected source and kind filters — the same per-entry sizes `cache list`
+reports.
+
+> **Warning:** Evicted source cache entries hard-fail subsequent runs that use
+> `--offline`, because offline mode cannot re-fetch missing entries
+> (`"offline cache miss for ..."`). Do not use `--max-size` before an offline
+> run unless you are confident the remaining entries cover all sources that
+> offline run will need.
+
+### Automation
+
+The Cache Lifecycle Boundary is defined by explicit invocation with explicit
+caps — not by whether a human issued the command. Automation such as the
+pr-action's local-mode post-run prune step may invoke `cache prune` on the
+operator's behalf; the same boundary and `--offline` warning apply.
+
+### Deferred design
 
 A shared content-addressed store with ref tables, leases, and mark-sweep
 collection is intentionally deferred. It would be useful only after drydock has

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -365,6 +365,7 @@ Report stale entries without deleting them:
 
 ```bash
 drydock cache prune --older-than 720h --dry-run
+drydock cache prune --max-size 4Gi --dry-run
 ```
 
 Delete a specific entry or all selected entries:

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -334,10 +334,25 @@ repopulates the cache each run. The action emits a notice on self-hosted runners
 that suggests `local`, and warns when `local` is used on a GitHub-hosted runner
 (whose filesystem is always ephemeral).
 
-With `local`, eviction is yours to manage: drydock's render-cache size cap and
-`drydock cache prune` bound the directory rather than GitHub's cache budget. A
-shared on-disk cache is readable by every job on the runner, so use it only for
-trusted workloads.
+With `local`, drydock's render-cache size cap and `drydock cache prune` bound
+the directory rather than GitHub's cache budget; outside the action's own
+prune step, eviction is yours to manage. A shared on-disk cache is readable by
+every job on the runner, so use it only for trusted workloads.
+
+The action automatically prunes the on-runner cache after each run when
+`cache-mode: local` is in effect: the `cache-prune-max-size` input (default
+`4Gi`, any Kubernetes quantity) caps the cache, and the prune step evicts
+least-recently-used entries from the source and render caches until the total
+is at or below the cap.
+Pruning is automatically disabled when `offline: true` because evicting source
+cache entries would hard-fail later offline runs (the `"offline cache miss"`
+error has no self-heal path). Pruning is housekeeping and never fails the job:
+if the installed drydock version does not yet support `cache prune --max-size`,
+the step emits a notice and exits cleanly; any other prune failure emits a
+warning. The render sweep inside the prune command runs at its 512 Mi default,
+matching run-time behavior. Set `cache-prune-max-size: ""` to opt out entirely.
+Assume one job per `cache-path` at a time: concurrent jobs sharing a cache-path
+can race the prune step against in-flight renders.
 
 ## Input Behavior
 
@@ -450,6 +465,7 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | --- | --- | --- |
 | `cache` | `true` | Restore and save drydock render caches for trusted runs. |
 | `cache-mode` | `auto` | Cache backend. `auto`/`github` use the remote `actions/cache` backend; `local` persists at `cache-path` on the runner and skips `actions/cache`; `off` disables persistence. `cache: "false"` forces `off`. |
+| `cache-prune-max-size` | `4Gi` | Size cap for the on-runner drydock source and render caches when `cache-mode: local`. Least-recently-used entries are pruned after each run until the total is at or below this Kubernetes quantity. Empty string disables pruning. Automatically disabled when `offline: true` to protect load-bearing cache entries. The render sweep inside the prune command runs at its 512 Mi default. An invalid quantity surfaces as a per-run warning, never a job failure. |
 | `save-cache` | `true` | Save drydock render caches after trusted runs. |
 | `cache-untrusted-restore` | `false` | Restore drydock render caches for fork pull requests. Cache save remains disabled for forks. |
 | `cache-path` | runner temp directory | Local drydock cache root. |


### PR DESCRIPTION
## What

Source caches (git / chart / remote) have no size bound: cache keys are content-addressed per URL+revision / chart+version, so renovate churn mints a new immutable entry per version bump, forever. On persistent self-hosted runners using the pr-action's `cache-mode: local`, nobody runs `drydock cache prune` by hand — the cache grows without bound.

Three slices:

**1. `internal/cache` — size-capped LRU eviction in `Prune()`.** New `MaxBytes` option adds a second prune phase: after the age phase, least-recently-used entries (oldest `Metadata.UpdatedAt`, which every cache surface already refreshes on *use*, falling back to dir mtime for legacy entries) are evicted from the selected sources until their total size is at or below the cap. Deterministic tie-break on `(entryAgeTime, Source, Kind, Key)`. Dry-run predicts the real run's removal set exactly. New result fields: per-entry `pruneReason` (`age`|`size`), `sizeEvictedBytes`, `totalSizeBytes` (post-phases, pre-render-sweep). Evicts to exactly ≤ cap — unlike the render sweep's 90% hysteresis target — because a manual command has no re-trigger loop. All removals flow through the existing containment-validated removal path; the render sweep is unchanged.

**2. CLI — `cache prune --max-size <quantity>`.** Kubernetes-quantity flag (matching `--render-cache-max-size` conventions), no default cap. Composes with `--older-than` (age first, size on survivors) and `--source`. The prune table output breaks down removals by reason and reports bytes freed / bytes remaining when the size phase ran. Lifecycle docs gain pruning-by-age / pruning-by-size sections, an explicit `--offline` warning (evicted sources hard-fail later offline runs until re-fetched), and an automation clarification: the lifecycle boundary is explicit invocation with explicit caps, not a human at a keyboard.

**3. pr-action — `cache-prune-max-size` input (default `4Gi`).** When `cache-mode` resolves to `local`, a post-run step prunes the runner-local source+render caches to the cap. Automatically disabled when `offline: true` — evicting source entries would hard-fail later offline runs with no self-heal path (the `offline` input is now validated as a boolean at prepare time like the action's other booleans, closing a quoted-`"True"` bypass). The step is housekeeping and **never fails the job**: missing binary → notice; installed release without `--max-size` (e.g. v0.2.2, verified against the real binary) → notice with upgrade hint; any other failure → warning. Version-skew safe, so there is no release-ordering constraint. `github`/`auto` modes are untouched (actions/cache has its own eviction); the `plugin/` cache dir stays out of lifecycle scope per the documented boundary.

## Verification

- Full gate green: repo-wide `golangci-lint` 0 issues, `go test ./...` all packages, `-race` on the three changed packages, shellcheck / zizmor / actionlint / docs-check / whitespace clean.
- Guard tests are sabotage-validated: LRU order inversion, dry-run size-phase skip, cap-boundary `<=`→`<`, and individual deletion of the Source and Kind tie-break comparators each fail exactly the test that claims to pin them (comparators are pinned with opposition pairs where the fallback orderings disagree).
- pr-action never-fail contract covered per degradation path (missing binary / unknown flag / other failure), plus an 8-case truth table for the prune gate (cache-mode × max-size × offline × `cache: false` back-compat).
- End-to-end trace verified across every boundary: action input → prepare gate → prune step env → `prune.sh` argv → CLI flags → `OperationOptions` → `Prune()` → result JSON → jq summary.