### PR TITLE
feat(render): native KSOPS placeholder rendering (--enable-ksops-compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ inspect locally and in CI:
   changed-only selection, default noisy-field filtering, and structured or
   markdown output.
 - **Plugins:** native safe Kustomize compatibility, `avp-compat` placeholder
-  redaction, native policy overrides, static `plugin-policy init` and
+  redaction, `ksops-compat` placeholder rendering for KSOPS generators,
+  native policy overrides, static `plugin-policy init` and
   `plugin-policy doctor` onboarding, trusted exec/container policy with
   `--enable-plugins`, and policy bootstrap entrypoints.
 - **Diagnostics:** render status, custom health Lua validation, redacted

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -59,13 +59,19 @@ paths do not execute plugin commands unless trusted drydock plugin policy
 provenance matches `engine: exec` or `engine: container` and the caller
 explicitly sets `--enable-plugins`. Discovered Argo CD CMP definitions that
 normalize to a safe `kustomize build` command may be interpreted through
-drydock's native Kustomize renderer without shelling out. Other native engines
-must remain narrow, in-process compatibility paths with fail-closed validators.
-Keep detailed policy behavior in `site/content/docs/plugin-policy/`. Public
-API plugin rendering is allowed only through explicit in-process
-`Config.PluginRenderer` or registry injection. Preserve `plugin.unsupported`,
-`plugin.failed`, and `plugin.unspecified` diagnostics, and do not reclassify
-caller cancellation as plugin timeout.
+drydock's native Kustomize renderer without shelling out. Native compat paths
+include `avp-compat` (AVP placeholder redaction; default-on for AVP-shaped
+sources, flag-forced via `--enable-avp-compat` for ordinary ones) and
+`ksops-compat` (KSOPS generator placeholder rendering without decryption;
+opt-in via `--enable-ksops-compat`, and fail-closed — a KSOPS generator
+without the flag fails the source with an actionable error). Neither executes
+external commands or contacts secret backends. Other native engines must remain narrow,
+in-process compatibility paths with fail-closed validators. Keep detailed
+policy behavior in `site/content/docs/plugin-policy/`. Public API plugin
+rendering is allowed only through explicit in-process `Config.PluginRenderer`
+or registry injection. Preserve `plugin.unsupported`, `plugin.failed`, and
+`plugin.unspecified` diagnostics, and do not reclassify caller cancellation as
+plugin timeout.
 
 ## Validation, Benchmarks, And Profiling
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -169,8 +169,13 @@ Supported:
   libraries with extVars, TLAs, code mode, env substitution, and repo-relative
   libs, and skips drydock cache metadata sidecars.
 - Local Kustomize rendering with supported `kustomize.buildOptions`:
-  `--enable-helm`, `--helm-api-versions`, and
-  `--load-restrictor=LoadRestrictionsRootOnly|LoadRestrictionsNone`.
+  `--enable-helm`, `--helm-api-versions`,
+  `--load-restrictor=LoadRestrictionsRootOnly|LoadRestrictionsNone`,
+  `--enable-alpha-plugins`, and `--enable-exec`. The latter two are accepted
+  without error — Argo CD sets them repo-wide in `argocd-cm`, so rejecting
+  the option would fail every app in such repositories, including ones with no
+  generators. They do NOT enable arbitrary exec: drydock never executes
+  generator commands.
   Kustomize `helmCharts` render through drydock's Go-library Helm path, so
   chart inflation does not require an external Kustomize binary or CLI
   `--enable-helm`.
@@ -194,6 +199,28 @@ Supported:
   source. drydock does not execute `discover.find.command`.
 - Native AVP compatibility for explicit `argocd-vault-plugin` sources and
   discovered simple AVP CMP aliases.
+- KSOPS kustomize generator compatibility under `--enable-ksops-compat`. When
+  the mode is active, `apiVersion: viaduct.ai/v1 / kind: ksops` generator
+  entries are rendered as deterministic placeholder manifests without
+  decryption: SOPS-encrypted file structure and key names are preserved; every
+  encrypted value is replaced by a deterministic placeholder
+  (`drydock-ksops-redacted-<12hex>` marker). Secret `data:` values are valid
+  base64 of the placeholder. The secret VALUES are never decrypted and no
+  decryption key, KMS network call, or exec is involved.
+  Builtin generator configs (`apiVersion: builtin`) are left for krusty and
+  render successfully with or without the flag. Exec transformers, exec
+  validators, container KRM functions, and other non-KSOPS generators remain
+  unsupported and fail closed. krusty's own errors surface for unsupported
+  transformer and validator kinds.
+  KSOPS manifests using `secretFrom`, `binaryFiles`, `envs`, or non-YAML sops
+  targets fail closed with explicit unsupported diagnostics. A KSOPS generator
+  encountered without `--enable-ksops-compat` fails the source with an
+  actionable error naming the flag.
+  Important: value-only sops rotations (changing only an `ENC[...]` ciphertext
+  without adding, removing, or renaming keys) render identically under
+  `--enable-ksops-compat`. The placeholder derives from key identity, not from
+  ciphertext, so a rotation produces no diff in drydock output even though the
+  live secret changes. "No diff" does not mean "no change" for rotated values.
 - Trusted drydock plugin policy entries for native plugin overrides and
   explicitly enabled exec/container CMP compatibility.
 - Trusted plugin policy bootstrap entrypoints for plugin-rendered Argo CD

--- a/internal/app/native_kustomize_cmp.go
+++ b/internal/app/native_kustomize_cmp.go
@@ -139,6 +139,8 @@ func normalizeNativeKustomizeBuildTokens(tokens []string) ([]string, error) {
 		}
 		switch {
 		case token == "--enable-helm",
+			token == "--enable-alpha-plugins",
+			token == "--enable-exec",
 			strings.HasPrefix(token, "--helm-api-versions="),
 			strings.HasPrefix(token, "--load-restrictor="):
 			options = append(options, token)

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -1779,6 +1779,26 @@ func TestApplicationRenderCacheDisablesMatchedExecPolicy(t *testing.T) {
 	}
 }
 
+func TestApplicationRenderCacheKeyRotatesOnKSOPSCompat(t *testing.T) {
+	application := pluginApplication("plugin")
+	base, err := applicationRenderCacheKey(renderContext{request: BuildRequest{}}, application)
+	if err != nil {
+		t.Fatalf("applicationRenderCacheKey() error = %v", err)
+	}
+	if base == "" {
+		t.Fatal("applicationRenderCacheKey() = empty baseline key")
+	}
+	flagged, err := applicationRenderCacheKey(renderContext{
+		request: BuildRequest{PluginOptions: PluginOptions{EnableKSOPSCompat: true}},
+	}, application)
+	if err != nil {
+		t.Fatalf("applicationRenderCacheKey() error = %v", err)
+	}
+	if flagged == base {
+		t.Fatalf("applicationRenderCacheKey() did not rotate on EnableKSOPSCompat: %q", base)
+	}
+}
+
 func TestApplicationRenderCacheDisablesUnnamedStaticExecPolicyMatch(t *testing.T) {
 	policy, _ := testExecPluginPolicyWithMatch(t, "cue", appExecCommand(t, "manifest"), `    match:
       discover:
@@ -2233,7 +2253,7 @@ func TestOrchestratorBuildRejectsUnsafeAutoNativeKustomizePlugins(t *testing.T) 
 				writePluginBuildApplication(t, root, "plugin", "kustomize-build")
 			},
 			writeCMP: func(t *testing.T, root string) {
-				writeNativeKustomizeCMPHelmValues(t, root, "kustomize-build", "", "kustomize, build", "--enable-alpha-plugins")
+				writeNativeKustomizeCMPHelmValues(t, root, "kustomize-build", "", "kustomize, build", "--network")
 			},
 			writeSource: func(t *testing.T, root string) {
 				writeNativeKustomizeSource(t, root, "plugin", "should-not-render")
@@ -2496,9 +2516,17 @@ func TestNativeKustomizePluginBuildOptionsFailClosed(t *testing.T) {
 			plugin: config.ConfigManagementPlugin{
 				Name:            "kustomize-build",
 				GenerateCommand: []string{"kustomize", "build"},
-				GenerateArgs:    []string{"--enable-alpha-plugins"},
+				GenerateArgs:    []string{"--network"},
 			},
 			wantErr: true,
+		},
+		{
+			name: "plugin flags accepted",
+			plugin: config.ConfigManagementPlugin{
+				Name:            "kustomize-build",
+				GenerateCommand: []string{"kustomize", "build"},
+				GenerateArgs:    []string{"--enable-alpha-plugins", "--enable-exec"},
+			},
 		},
 	}
 

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -92,6 +92,7 @@ func renderSourcePlan(ctx context.Context, application argoappv1.Application, pr
 		return fmt.Errorf("%s: %w", renderSourceContext(application, sourcePlan), err)
 	}
 	opts.EnableAVPCompat = pluginOpts.EnableAVPCompat
+	opts.EnableKSOPSCompat = pluginOpts.EnableKSOPSCompat
 	opts.EnablePlugins = pluginOpts.EnablePlugins
 	opts.SourceIndex = sourcePlan.Index
 	opts.SourceName = sourcePlan.Name

--- a/internal/app/render_cache.go
+++ b/internal/app/render_cache.go
@@ -196,6 +196,7 @@ func applicationRenderCacheKey(ctx renderContext, application argoappv1.Applicat
 		RemoteResourceCacheDir  string                      `json:"remoteResourceCacheDir,omitempty"`
 		PluginTimeout           string                      `json:"pluginTimeout,omitempty"`
 		EnableAVPCompat         bool                        `json:"enableAVPCompat,omitempty"`
+		EnableKSOPSCompat       bool                        `json:"enableKSOPSCompat,omitempty"`
 		EnablePlugins           bool                        `json:"enablePlugins,omitempty"`
 		PluginPolicyFingerprint string                      `json:"pluginPolicyFingerprint,omitempty"`
 		HasInjectedPluginRender bool                        `json:"hasInjectedPluginRender"`
@@ -216,6 +217,7 @@ func applicationRenderCacheKey(ctx renderContext, application argoappv1.Applicat
 		RemoteResourceCacheDir:  ctx.request.RemoteResourceCacheDir,
 		PluginTimeout:           ctx.request.PluginTimeout.String(),
 		EnableAVPCompat:         ctx.request.EnableAVPCompat,
+		EnableKSOPSCompat:       ctx.request.EnableKSOPSCompat,
 		EnablePlugins:           ctx.request.EnablePlugins,
 		PluginPolicyFingerprint: ctx.request.pluginPolicyFingerprint,
 		HasInjectedPluginRender: ctx.request.PluginRenderer != nil,

--- a/internal/app/render_cache_persistent.go
+++ b/internal/app/render_cache_persistent.go
@@ -935,6 +935,7 @@ type persistentRenderKeyInput struct {
 	SettingsSignature       string                        `json:"settingsSignature"`
 	PluginTimeout           string                        `json:"pluginTimeout,omitempty"`
 	EnableAVPCompat         bool                          `json:"enableAVPCompat"`
+	EnableKSOPSCompat       bool                          `json:"enableKSOPSCompat"`
 	EnablePlugins           bool                          `json:"enablePlugins"`
 	PluginPolicyFingerprint string                        `json:"pluginPolicyFingerprint,omitempty"`
 	HasInjectedPluginRender bool                          `json:"hasInjectedPluginRender"`
@@ -1062,6 +1063,7 @@ func preparePersistentRender(ctx context.Context, application argoappv1.Applicat
 		SettingsSignature:       options.persistent.settingsSignature,
 		PluginTimeout:           options.PluginOptions.PluginTimeout.String(),
 		EnableAVPCompat:         options.PluginOptions.EnableAVPCompat,
+		EnableKSOPSCompat:       options.PluginOptions.EnableKSOPSCompat,
 		EnablePlugins:           options.PluginOptions.EnablePlugins,
 		PluginPolicyFingerprint: options.PluginOptions.pluginPolicyFingerprint,
 		HasInjectedPluginRender: options.persistent.hasInjectedPluginRender,

--- a/internal/app/render_cache_persistent_test.go
+++ b/internal/app/render_cache_persistent_test.go
@@ -981,6 +981,7 @@ func TestPersistentRenderCacheKeyRotatesOnEveryInput(t *testing.T) {
 		{"settings signature", func(input *persistentRenderKeyInput) { input.SettingsSignature = "other" }},
 		{"plugin timeout", func(input *persistentRenderKeyInput) { input.PluginTimeout = "2m0s" }},
 		{"avp compat", func(input *persistentRenderKeyInput) { input.EnableAVPCompat = true }},
+		{"ksops compat", func(input *persistentRenderKeyInput) { input.EnableKSOPSCompat = true }},
 		{"enable plugins", func(input *persistentRenderKeyInput) { input.EnablePlugins = true }},
 		{"policy fingerprint", func(input *persistentRenderKeyInput) { input.PluginPolicyFingerprint = "policy" }},
 		{"injected plugin render", func(input *persistentRenderKeyInput) { input.HasInjectedPluginRender = true }},

--- a/internal/app/render_input_coverage_test.go
+++ b/internal/app/render_input_coverage_test.go
@@ -77,7 +77,7 @@ func renderCoverageFixtureProvider(repoRoot string) localProvider {
 // apiVersion/kind, and the directory renderer silently skips non-manifest
 // decode failures — a file that only produces decode errors when corrupted
 // will not register as an outcome change.
-func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoappv1.Application) {
+func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoappv1.Application, pluginOptions ...PluginOptions) {
 	t.Helper()
 	provider := renderCoverageFixtureProvider(repoRoot)
 	plan := mustPlan(t, application)
@@ -95,7 +95,7 @@ func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoap
 		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
 	}
 
-	baselineResult, baselineErr := RenderApplication(context.Background(), application, provider)
+	baselineResult, baselineErr := RenderApplication(context.Background(), application, provider, pluginOptions...)
 	if baselineErr != nil {
 		t.Fatalf("baseline render must succeed, got %v", baselineErr)
 	}
@@ -134,7 +134,7 @@ func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoap
 			t.Fatalf("mutate %q: %v", file, err)
 		}
 
-		result, renderErr := RenderApplication(context.Background(), application, renderCoverageFixtureProvider(repoRoot))
+		result, renderErr := RenderApplication(context.Background(), application, renderCoverageFixtureProvider(repoRoot), pluginOptions...)
 		mutated := renderOutcomeSignature(t, result, renderErr)
 
 		if err := os.WriteFile(file, original, 0o600); err != nil {
@@ -201,6 +201,31 @@ func TestRenderInputCoverageHelmSource(t *testing.T) {
 		},
 	}
 	assertRenderInputCoverage(t, repoRoot, application)
+}
+
+// TestRenderInputCoverageKustomizeKSOPSGenerator pins that the sops files
+// referenced by a KSOPS generator manifest (including cross-directory targets
+// above the source path) AND by an inline KSOPS generators: entry are covered
+// by the persistent render cache digest — a sops edit must rotate the render
+// cache key under --enable-ksops-compat.
+func TestRenderInputCoverageKustomizeKSOPSGenerator(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/app/kustomization.yaml", "generators:\n  - ./secret-generator.yaml\n  - |\n    apiVersion: viaduct.ai/v1\n    kind: ksops\n    metadata:\n      name: inline-secret-generator\n    files:\n      - ./inline-secret.sops.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/app/secret-generator.yaml", "apiVersion: viaduct.ai/v1\nkind: ksops\nmetadata:\n  name: demo-secret-generator\nfiles:\n  - ./demo-secret.sops.yaml\n  - ../../secrets/shared.sops.yaml\n")
+	writeTestFile(t, repoRoot+"/manifests/app/demo-secret.sops.yaml", "apiVersion: v1\nkind: Secret\nmetadata:\n    name: demo-secret\ndata:\n    TOKEN: ENC[AES256_GCM,data:abc123,type:str]\nsops:\n    version: 3.10.2\n")
+	writeTestFile(t, repoRoot+"/manifests/app/inline-secret.sops.yaml", "apiVersion: v1\nkind: Secret\nmetadata:\n    name: inline-secret\ndata:\n    INLINE: ENC[AES256_GCM,data:ghi789,type:str]\nsops:\n    version: 3.10.2\n")
+	writeTestFile(t, repoRoot+"/secrets/shared.sops.yaml", "apiVersion: v1\nkind: Secret\nmetadata:\n    name: shared-secret\ndata:\n    SHARED: ENC[AES256_GCM,data:def456,type:str]\nsops:\n    version: 3.10.2\n")
+	writeTestFile(t, repoRoot+"/unrelated/README.md", "not a render input\n")
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "argocd"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/app", TargetRevision: "main",
+			},
+			Destination: argoappv1.ApplicationDestination{Namespace: "default"},
+		},
+	}
+	assertRenderInputCoverage(t, repoRoot, application, PluginOptions{EnableKSOPSCompat: true})
 }
 
 // TestRenderInputCoverageHelmSourceOutOfChartDirValueFile pins that a valueFile

--- a/internal/app/render_test.go
+++ b/internal/app/render_test.go
@@ -354,6 +354,30 @@ func TestRenderApplicationPassesAVPCompatibilityOption(t *testing.T) {
 	}
 }
 
+func TestRenderApplicationPassesKSOPSCompatibilityOption(t *testing.T) {
+	application := argoappv1.Application{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "argocd", Name: "demo"},
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL: "https://repo",
+				Path:    "manifests/demo",
+			},
+		},
+	}
+	var got render.RenderOptions
+	provider := providerFunc(func(_ context.Context, _ render.ResolvedSource, opts render.RenderOptions) ([]render.Manifest, []diagnostic.Diagnostic, error) {
+		got = opts
+		return nil, nil, nil
+	})
+
+	if _, err := RenderApplication(context.Background(), application, provider, PluginOptions{EnableKSOPSCompat: true}); err != nil {
+		t.Fatalf("RenderApplication() error = %v", err)
+	}
+	if !got.EnableKSOPSCompat {
+		t.Fatal("RenderOptions.EnableKSOPSCompat = false, want true")
+	}
+}
+
 func TestRenderApplicationAVPCompatibilityReplacesRenderedManifestPlaceholders(t *testing.T) {
 	fixture := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -59,6 +59,7 @@ type ApplicationSetOptions struct {
 type PluginOptions struct {
 	PluginTimeout            time.Duration
 	EnableAVPCompat          bool
+	EnableKSOPSCompat        bool
 	EnablePlugins            bool
 	PluginCacheDir           string
 	PluginPolicyPath         string

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -48,6 +48,7 @@ type commonFlags struct {
 	remotePassword           string
 	remoteBearerToken        string
 	enableAVPCompat          bool
+	enableKSOPSCompat        bool
 	enablePlugins            bool
 	pluginCacheDir           string
 	pluginPolicyPath         string
@@ -157,6 +158,7 @@ func bindRemoteAcquisitionCacheFlags(cmd *cobra.Command, flags *commonFlags) {
 
 func bindPluginFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().BoolVar(&flags.enableAVPCompat, "enable-avp-compat", flags.enableAVPCompat, "force argocd-vault-plugin placeholder redaction for native-rendered sources")
+	cmd.Flags().BoolVar(&flags.enableKSOPSCompat, "enable-ksops-compat", flags.enableKSOPSCompat, "render KSOPS kustomize generators as deterministic placeholder manifests without decryption")
 	cmd.Flags().BoolVar(&flags.enablePlugins, "enable-plugins", flags.enablePlugins, "enable trusted exec/container plugin policy entries")
 	cmd.Flags().StringVar(&flags.pluginCacheDir, "plugin-cache-dir", flags.pluginCacheDir, "directory for policy-managed container plugin caches")
 	cmd.Flags().StringVar(&flags.pluginPolicyPath, "plugin-policy-path", flags.pluginPolicyPath, "trusted plugin policy path relative to the selected policy root")
@@ -345,6 +347,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		RemoteResourceCredentials:      flags.remoteCredentials(),
 		RemoteResourceGitCredentials:   flags.remoteGitCredentials(),
 		EnableAVPCompat:                flags.enableAVPCompat,
+		EnableKSOPSCompat:              flags.enableKSOPSCompat,
 		EnablePlugins:                  flags.enablePlugins,
 		PluginCacheDir:                 flags.pluginCacheDir,
 		PluginPolicyPath:               flags.pluginPolicyPath,

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -42,7 +42,7 @@ func TestRepresentativeCommandsExposeFocusedFlagGroups(t *testing.T) {
 		{
 			name:    "build apps common acquisition discovery fixtures filters",
 			command: []string{"build", "apps"},
-			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-plugins", "plugin-cache-dir", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind", "project-diagnostics"},
+			flags:   []string{"offline", "repo-map", "enable-avp-compat", "enable-ksops-compat", "enable-plugins", "plugin-cache-dir", "plugin-policy-path", "plugin-policy-ref", "plugin-policy-repo", "appset-provider-fixture", "skip-kind", "project-diagnostics"},
 		},
 		{
 			name:    "diff apps common specialized diff flags",
@@ -83,6 +83,33 @@ func TestEnablePluginsHelpDescribesTrustedCommandPolicy(t *testing.T) {
 		if !strings.Contains(flag.Usage, want) {
 			t.Fatalf("--enable-plugins usage = %q, want %q", flag.Usage, want)
 		}
+	}
+}
+
+func TestEnableKSOPSCompatHelpDescribesPlaceholderRendering(t *testing.T) {
+	cmd := findCLICommand(t, "build", "apps")
+	flag := cmd.Flags().Lookup("enable-ksops-compat")
+	if flag == nil {
+		t.Fatal("build apps missing --enable-ksops-compat")
+	}
+	for _, want := range []string{"KSOPS", "placeholder", "decryption"} {
+		if !strings.Contains(flag.Usage, want) {
+			t.Fatalf("--enable-ksops-compat usage = %q, want %q", flag.Usage, want)
+		}
+	}
+}
+
+func TestRequestOptionsFromFlagsCarriesKSOPSCompat(t *testing.T) {
+	flags := defaultCommonFlags()
+	flags.enableKSOPSCompat = true
+
+	opts := requestOptionsFromFlags(flags, nil)
+
+	if !opts.EnableKSOPSCompat {
+		t.Fatal("opts.EnableKSOPSCompat = false, want true")
+	}
+	if buildReq := opts.Build(); !buildReq.EnableKSOPSCompat {
+		t.Fatal("opts.Build() EnableKSOPSCompat = false, want true")
 	}
 }
 

--- a/internal/pluginonboarding/engine_hint.go
+++ b/internal/pluginonboarding/engine_hint.go
@@ -104,6 +104,8 @@ func normalizeNativeKustomizeTokens(tokens []string) ([]string, error) {
 		}
 		switch {
 		case token == "--enable-helm",
+			token == "--enable-alpha-plugins",
+			token == "--enable-exec",
 			strings.HasPrefix(token, "--helm-api-versions="),
 			strings.HasPrefix(token, "--load-restrictor="):
 			options = append(options, token)

--- a/internal/pluginonboarding/onboarding_test.go
+++ b/internal/pluginonboarding/onboarding_test.go
@@ -371,6 +371,31 @@ func TestGenerateInfersNativeKustomize(t *testing.T) {
 	}
 }
 
+func TestGenerateInfersNativeKustomizeWithPluginFlags(t *testing.T) {
+	root := t.TempDir()
+	app := pluginApp("argocd", "demo", "apps/demo", "kustomize-build-ksops")
+	settings := settingsWithCMP("kustomize-build-ksops", config.ConfigManagementPlugin{
+		Name:            "kustomize-build-ksops",
+		GenerateCommand: []string{"sh", "-c"},
+		GenerateArgs:    []string{"kustomize build --enable-helm --enable-alpha-plugins --enable-exec"},
+		Discover:        config.ConfigManagementPluginDiscovery{FileName: "kustomization.yaml"},
+	})
+	report, err := Analyze(root, []ApplicationInput{{Application: app}}, settings, nil, AnalyzeOptions{})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	data, err := Generate(report, GenerateOptions{Comments: false})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{`engine: native-kustomize`, `args: ["--enable-helm", "--enable-alpha-plugins", "--enable-exec"]`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated policy missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestAnalyzeUsesEmbeddedCMPForUnnamedStaticDiscovery(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), "resources: []\n")

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -44,7 +44,10 @@ func (KustomizeRenderer) Render(ctx context.Context, source ResolvedSource, opts
 	if err != nil {
 		return nil, nil, err
 	}
-	if kustomizeGraphHasHelmCharts(graph) || hasAcquirableRemoteKustomizeGraphRefs(graph) {
+	// Generator-bearing kustomizations always take the prepared-workspace
+	// path: generator classification and ksops-compat emulation happen in
+	// prepareKustomizationDir, so the plain path must be unreachable for them.
+	if kustomizeGraphHasHelmCharts(graph) || hasAcquirableRemoteKustomizeGraphRefs(graph) || kustomizeGraphHasGenerators(graph) {
 		manifests, renderDiags, err := renderKustomizeWithPreparedWorkspace(ctx, source, graph, opts, buildSettings)
 		return manifests, append(diags, renderDiags...), err
 	}
@@ -240,11 +243,7 @@ func renderKustomizeHelmCharts(ctx context.Context, tempRepoRoot, tempSourceRoot
 		}
 
 		generatedResource := filepath.ToSlash(filepath.Join(".drydock", "helm", generatedName+".yaml"))
-		generatedPath, err := generatedKustomizeWorkspacePath(tempSourceRoot, generatedResource)
-		if err != nil {
-			return nil, err
-		}
-		if err := writeGeneratedHelmManifests(generatedPath, rendered); err != nil {
+		if err := writeGeneratedHelmManifests(tempSourceRoot, generatedResource, rendered); err != nil {
 			return nil, err
 		}
 		generatedResources = append(generatedResources, generatedResource)
@@ -458,18 +457,15 @@ func writeKustomizeHelmGeneratedValuesFile(ctx context.Context, tempRepoRoot, te
 	}
 
 	generatedRel := filepath.ToSlash(filepath.Join(".drydock", "values", generatedName+".yaml"))
-	generatedPath, err := generatedKustomizeWorkspacePath(tempSourceRoot, generatedRel)
-	if err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(filepath.Dir(generatedPath), 0o755); err != nil {
-		return "", err
-	}
 	data, err := goyaml.Marshal(values)
 	if err != nil {
 		return "", fmt.Errorf("encode generated helm values %s: %w", generatedRel, err)
 	}
-	if err := os.WriteFile(generatedPath, data, 0o644); err != nil {
+	// writeGeneratedKustomizeWorkspaceFile rejects pre-existing paths with an
+	// O_EXCL create: workspace files are hard links to the original repository
+	// tree, so a plain O_TRUNC write here could write through a repo-committed
+	// collision. Do not revert to os.WriteFile.
+	if err := writeGeneratedKustomizeWorkspaceFile(tempSourceRoot, generatedRel, data); err != nil {
 		return "", fmt.Errorf("write generated helm values %s: %w", generatedRel, err)
 	}
 	return generatedRel, nil
@@ -491,10 +487,7 @@ func kustomizationChartHome(kustomization types.Kustomization) string {
 	return types.HelmDefaultHome
 }
 
-func writeGeneratedHelmManifests(path string, manifests []Manifest) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
+func writeGeneratedHelmManifests(root, rel string, manifests []Manifest) error {
 	var buffer bytes.Buffer
 	for _, m := range manifests {
 		if m.Object == nil {
@@ -524,8 +517,12 @@ func writeGeneratedHelmManifests(path string, manifests []Manifest) error {
 			return err
 		}
 	}
-	if err := os.WriteFile(path, buffer.Bytes(), 0o644); err != nil {
-		return fmt.Errorf("write generated helm manifests %s: %w", path, err)
+	// writeGeneratedKustomizeWorkspaceFile rejects pre-existing paths with an
+	// O_EXCL create: workspace files are hard links to the original repository
+	// tree, so a plain O_TRUNC write here could write through a repo-committed
+	// collision. Do not revert to os.WriteFile.
+	if err := writeGeneratedKustomizeWorkspaceFile(root, rel, buffer.Bytes()); err != nil {
+		return fmt.Errorf("write generated helm manifests %s: %w", rel, err)
 	}
 	return nil
 }

--- a/internal/render/kustomize_build_options.go
+++ b/internal/render/kustomize_build_options.go
@@ -8,8 +8,10 @@ import (
 )
 
 type kustomizeBuildSettings struct {
-	LoadRestrictions types.LoadRestrictions
-	APIVersions      []string
+	LoadRestrictions   types.LoadRestrictions
+	APIVersions        []string
+	EnableAlphaPlugins bool
+	EnableExec         bool
 }
 
 func defaultKustomizeBuildSettings() kustomizeBuildSettings {
@@ -31,6 +33,17 @@ func parseKustomizeBuildOptions(options []string) (kustomizeBuildSettings, error
 		switch {
 		case option == "--enable-helm":
 			continue
+		// Argo CD accepts --enable-alpha-plugins and --enable-exec repo-wide via
+		// argocd-cm; rejecting the options failed every kustomize app in such
+		// repos, including apps with no generators at all. Accepting them does
+		// NOT enable arbitrary exec: drydock still executes nothing — generator
+		// entries are classified and either emulated natively (KSOPS under
+		// --enable-ksops-compat), left to krusty's statically linked builtins,
+		// or rejected with a diagnostic.
+		case option == "--enable-alpha-plugins":
+			settings.EnableAlphaPlugins = true
+		case option == "--enable-exec":
+			settings.EnableExec = true
 		case option == "--helm-api-versions":
 			if i+1 >= len(options) {
 				return settings, fmt.Errorf("kustomize build option %q requires a value", option)

--- a/internal/render/kustomize_graph_validate.go
+++ b/internal/render/kustomize_graph_validate.go
@@ -222,7 +222,7 @@ func (v *kustomizeGraphValidator) validateAuxiliaryRefs(dir string, kustomizatio
 		}
 	}
 	for _, generator := range kustomization.Generators {
-		if err := v.validatePathRef(dir, "generators", generator); err != nil {
+		if err := v.validateGeneratorManifestRef(dir, generator); err != nil {
 			return err
 		}
 	}
@@ -324,6 +324,43 @@ func (v *kustomizeGraphValidator) validatePathRef(dir, field, ref string) error 
 	}
 	_, _, err := v.validateLocalRef(dir, field, ref)
 	return err
+}
+
+// validateGeneratorManifestRef validates one generators: entry. Inline
+// entries (YAML documents, not paths — kustomize tries NewResMapFromBytes
+// before treating an entry as a path) have no manifest path to validate;
+// treating them as paths risks spurious ENAMETOOLONG failures. An inline
+// KSOPS document's files: referents ARE paths, though — render inputs read
+// during ksops-compat emulation, resolved relative to the kustomization
+// directory (matching prepareKustomizeGeneratorEntry) — so they are
+// boundary-validated here. Path entries are validated like other path refs,
+// and when the referenced manifest parses as a KSOPS generator its files:
+// referents are boundary-validated relative to the manifest's own directory.
+// Fork-PR content is attacker-influenced in both shapes.
+func (v *kustomizeGraphValidator) validateGeneratorManifestRef(dir, ref string) error {
+	if docs, inline := inlineKustomizeGeneratorDocuments(ref); inline {
+		for _, fileRef := range ksopsGeneratorFileRefsFromDocuments(docs) {
+			if _, _, err := v.validateLocalRef(dir, "generators.files", fileRef); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if v.allowAcquirableRemoteRefs {
+		if _, _, ok, err := remoteRequestForKustomizeRef(ref); err == nil && ok {
+			return nil
+		}
+	}
+	path, info, err := v.validateLocalRef(dir, "generators", ref)
+	if err != nil || info == nil || !info.Mode().IsRegular() {
+		return err
+	}
+	for _, fileRef := range ksopsGeneratorFileRefs(path) {
+		if _, _, err := v.validateLocalRef(filepath.Dir(path), "generators.files", fileRef); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (v *kustomizeGraphValidator) validateGeneratorRefs(dir, field string, sources types.KvPairSources) error {

--- a/internal/render/kustomize_input_digest.go
+++ b/internal/render/kustomize_input_digest.go
@@ -161,7 +161,7 @@ func (c *kustomizeInputCollector) collectAuxiliaryRefs(ctx context.Context, dir 
 		}
 	}
 	for _, ref := range kustomization.Generators {
-		if err := c.addKustomizeRef(ctx, dir, "generators", ref, false); err != nil {
+		if err := c.collectGeneratorManifestRef(ctx, dir, ref); err != nil {
 			return err
 		}
 	}
@@ -200,6 +200,42 @@ func (c *kustomizeInputCollector) collectPatchRefs(ctx context.Context, dir stri
 			continue
 		}
 		if err := c.addKustomizeRef(ctx, dir, "patchesStrategicMerge", ref, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectGeneratorManifestRef digests one generators: entry. Inline entries
+// are part of the kustomization file, which is always digested — but an
+// inline KSOPS document's files: referents are separate render inputs of
+// ksops-compat emulation, so they join the digest too, resolved relative to
+// the kustomization directory (the base directory emulation uses for inline
+// entries). Local path entries are digested by content, and when the manifest
+// parses as a KSOPS generator its files: referents join the digest too —
+// sops edits must rotate the render cache key.
+func (c *kustomizeInputCollector) collectGeneratorManifestRef(ctx context.Context, dir, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil
+	}
+	if docs, inline := inlineKustomizeGeneratorDocuments(ref); inline {
+		for _, fileRef := range ksopsGeneratorFileRefsFromDocuments(docs) {
+			if err := c.addLocalRef(ctx, dir, "generators.files", fileRef, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := c.addKustomizeRef(ctx, dir, "generators", ref, false); err != nil {
+		return err
+	}
+	if _, _, ok, err := remoteRequestForKustomizeRef(ref); err != nil || ok {
+		return err
+	}
+	path := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ref)))
+	for _, fileRef := range ksopsGeneratorFileRefs(path) {
+		if err := c.addLocalRef(ctx, filepath.Dir(path), "generators.files", fileRef, false); err != nil {
 			return err
 		}
 	}

--- a/internal/render/kustomize_ksops_compat.go
+++ b/internal/render/kustomize_ksops_compat.go
@@ -1,0 +1,567 @@
+package render
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	goyaml "go.yaml.in/yaml/v3"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+// KSOPS generator manifests are matched by the exact apiVersion/kind strings
+// the KSOPS README documents (apiVersion: viaduct.ai/v1, kind: ksops).
+// Upstream KSOPS never validates these fields itself — kustomize dispatches on
+// the config.kubernetes.io/function exec annotation and ksops.go unmarshals
+// only files/secretFrom — so the README convention is the only identity the
+// manifest shape carries. Exact matching fails closed: a variant-cased
+// manifest is classified unsupported and rejected loudly instead of being
+// silently dropped or handed to krusty unclassified.
+const (
+	ksopsGeneratorAPIVersion = "viaduct.ai/v1"
+	ksopsGeneratorKind       = "ksops"
+
+	ksopsRedactedPrefix       = "drydock-ksops-redacted-"
+	ksopsEncryptedValuePrefix = "ENC["
+)
+
+// ksopsGeneratorOptionAnnotations are KSOPS's documented generator-option
+// annotations. Real KSOPS output flows through kustomize's generator
+// merge/hash machinery (AbsorbAll), which placeholder resources: injection
+// cannot reproduce — manifests carrying them are rejected in both modes.
+var ksopsGeneratorOptionAnnotations = []string{
+	"kustomize.config.k8s.io/behavior",
+	"kustomize.config.k8s.io/needs-hash",
+}
+
+type generatorDocumentClass int
+
+const (
+	generatorDocumentBuiltin generatorDocumentClass = iota
+	generatorDocumentKSOPS
+	generatorDocumentUnsupported
+)
+
+// classifyGeneratorDocument sorts one generator document into drydock's
+// three-way scheme: KSOPS manifests (emulated under --enable-ksops-compat,
+// actionable diagnostic without it), kustomize builtin generator configs
+// (left in place — krusty's PluginRestrictionsBuiltinsOnly +
+// BploUseStaticallyLinked options load them natively and they render today),
+// and everything else (exec/container KRM functions, unknown kinds), which
+// fails the source in both modes.
+//
+// CMP-native-fallback decision: a config management plugin wrapping
+// kustomize+ksops is deliberately NOT forced into ksops-compat the way
+// AVP-shaped CMPs force EnableAVPCompat (app/plugin_render_native.go). A
+// ksops CMP's semantics are decryption; silently substituting placeholders
+// under a policy plugin the operator explicitly trusted would be surprising.
+// The mode-off diagnostic (actionable, names the flag) is the intended
+// outcome there.
+func classifyGeneratorDocument(root *goyaml.Node) (generatorDocumentClass, string, string) {
+	apiVersion := yamlMappingString(root, "apiVersion")
+	kind := yamlMappingString(root, "kind")
+	switch {
+	case apiVersion == ksopsGeneratorAPIVersion && kind == ksopsGeneratorKind:
+		return generatorDocumentKSOPS, apiVersion, kind
+	case apiVersion == konfig.BuiltinPluginApiVersion:
+		return generatorDocumentBuiltin, apiVersion, kind
+	default:
+		return generatorDocumentUnsupported, apiVersion, kind
+	}
+}
+
+func kustomizeGraphHasGenerators(graph []kustomizeGraphNode) bool {
+	for _, node := range graph {
+		if len(node.Kustomization.Generators) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func ksopsCompatDiagnostic(substituted int) diagnostic.Diagnostic {
+	return diagnostic.Diagnostic{
+		Code:     "kustomize.ksops-compat-substituted",
+		Severity: diagnostic.SeverityWarning,
+		Category: "kustomize",
+		Message:  fmt.Sprintf("KSOPS generators were rendered as deterministic placeholder manifests without decryption (%d sops files substituted)", substituted),
+	}
+}
+
+// prepareKustomizeGenerators classifies every generators: entry of a prepared
+// kustomization and rewrites the kustomization so krusty never sees a
+// generator entry drydock has not classified: KSOPS entries are dropped and
+// replaced by generated placeholder resource files (mode ON) or fail the
+// source (mode OFF); builtin generator configs are kept for krusty; anything
+// else fails the source in both modes.
+func (w *kustomizeWorkspace) prepareKustomizeGenerators(ctx context.Context, dir, boundaryRoot string, graphIndex int, kustomization *types.Kustomization) error {
+	if len(kustomization.Generators) == 0 {
+		return nil
+	}
+	remaining := make([]string, 0, len(kustomization.Generators))
+	for entryIndex, entry := range kustomization.Generators {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		keep, generated, err := w.prepareKustomizeGeneratorEntry(dir, boundaryRoot, graphIndex, entryIndex, entry)
+		if err != nil {
+			return err
+		}
+		if keep {
+			remaining = append(remaining, entry)
+		}
+		kustomization.Resources = append(kustomization.Resources, generated...)
+	}
+	kustomization.Generators = remaining
+	return nil
+}
+
+//nolint:gocyclo // Coordinates the inline-vs-path branch and three-way generator classification explicitly.
+func (w *kustomizeWorkspace) prepareKustomizeGeneratorEntry(dir, boundaryRoot string, graphIndex, entryIndex int, entry string) (bool, []string, error) {
+	docs, inline := inlineKustomizeGeneratorDocuments(entry)
+	manifestDir := dir
+	describe := strings.TrimSpace(entry)
+	if inline {
+		describe = describeInlineGeneratorEntry(docs)
+	} else {
+		path, info, err := validateWorkspaceLocalRef(boundaryRoot, dir, "generators", entry)
+		if err != nil {
+			return false, nil, err
+		}
+		if info == nil {
+			return false, nil, fmt.Errorf("kustomize generators %q: generator manifest not found", entry)
+		}
+		if !info.Mode().IsRegular() {
+			return false, nil, fmt.Errorf("kustomize generators %q: generator manifest must be a regular file", entry)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return false, nil, err
+		}
+		docs, err = decodeYAMLDocumentNodes(content)
+		if err != nil {
+			return false, nil, fmt.Errorf("kustomize generators %q: decode generator manifest: %w", entry, err)
+		}
+		manifestDir = filepath.Dir(path)
+	}
+
+	ksopsDocs := make([]*goyaml.Node, 0, len(docs))
+	builtins := 0
+	for _, doc := range docs {
+		root := yamlDocumentRoot(doc)
+		if root == nil {
+			continue
+		}
+		class, apiVersion, kind := classifyGeneratorDocument(root)
+		switch class {
+		case generatorDocumentBuiltin:
+			builtins++
+		case generatorDocumentKSOPS:
+			ksopsDocs = append(ksopsDocs, root)
+		case generatorDocumentUnsupported:
+			return false, nil, fmt.Errorf("kustomize generators entry %q: generator %s/%s is unsupported (drydock supports KSOPS generators via --enable-ksops-compat and kustomize builtin generator configs)", describe, apiVersion, kind)
+		}
+	}
+	if len(ksopsDocs) == 0 && builtins == 0 {
+		return false, nil, fmt.Errorf("kustomize generators entry %q: generator manifest has no generator documents", describe)
+	}
+	if len(ksopsDocs) != 0 && builtins != 0 {
+		// Splitting a mixed manifest would require rewriting the workspace
+		// copy of the file, which is hard-linked to the original repository
+		// tree; reject loudly rather than render incompletely.
+		return false, nil, fmt.Errorf("kustomize generators entry %q mixes KSOPS and builtin generator documents; split them into separate generator manifests", describe)
+	}
+	if len(ksopsDocs) == 0 {
+		return true, nil, nil
+	}
+	if !w.opts.EnableKSOPSCompat {
+		return false, nil, fmt.Errorf("kustomize generators entry %q is a KSOPS generator; pass --enable-ksops-compat to render deterministic placeholder manifests without decryption", describe)
+	}
+	generated := make([]string, 0, len(ksopsDocs))
+	fileIndex := 0
+	for _, root := range ksopsDocs {
+		files, err := ksopsGeneratorFilesFromDocument(describe, root)
+		if err != nil {
+			return false, nil, err
+		}
+		for _, fileRef := range files {
+			rel, err := w.emulateKSOPSGeneratorFile(dir, boundaryRoot, manifestDir, graphIndex, entryIndex, fileIndex, fileRef)
+			if err != nil {
+				return false, nil, err
+			}
+			fileIndex++
+			generated = append(generated, rel)
+		}
+	}
+	return false, generated, nil
+}
+
+func ksopsGeneratorFilesFromDocument(describe string, root *goyaml.Node) ([]string, error) {
+	if annotation, ok := generatorOptionAnnotation(root); ok {
+		return nil, fmt.Errorf("kustomize generators entry %q: generator option annotation %q is unsupported", describe, annotation)
+	}
+	for _, field := range []string{"secretFrom", "binaryFiles", "envs"} {
+		if yamlMappingValue(root, field) != nil {
+			return nil, fmt.Errorf("kustomize generators entry %q: ksops %s is unsupported (only files: entries referencing YAML sops manifests are supported)", describe, field)
+		}
+	}
+	files := yamlMappingValue(root, "files")
+	if files == nil || files.Kind != goyaml.SequenceNode || len(files.Content) == 0 {
+		return nil, fmt.Errorf("kustomize generators entry %q: ksops manifest requires a files: list", describe)
+	}
+	out := make([]string, 0, len(files.Content))
+	for _, item := range files.Content {
+		if item.Kind != goyaml.ScalarNode || strings.TrimSpace(item.Value) == "" {
+			return nil, fmt.Errorf("kustomize generators entry %q: ksops files entries must be relative paths", describe)
+		}
+		out = append(out, strings.TrimSpace(item.Value))
+	}
+	return out, nil
+}
+
+// emulateKSOPSGeneratorFile renders one KSOPS files: referent as deterministic
+// placeholder manifests in the prepared workspace and returns the generated
+// resource path (relative to the kustomization directory). KSOPS emits
+// finished manifests — kustomize's nameReference and generator-option
+// machinery does not treat generator output differently from raw resources
+// unless the generator-option annotations (rejected above) are present — so
+// resources: injection is faithful to real KSOPS semantics.
+func (w *kustomizeWorkspace) emulateKSOPSGeneratorFile(dir, boundaryRoot, manifestDir string, graphIndex, entryIndex, fileIndex int, fileRef string) (string, error) {
+	// KSOPS resolves files: entries relative to the generator manifest's
+	// directory (README: paths are "relative to manifest files"; ksops.go
+	// reads them from the exec function's working directory).
+	path, info, err := validateWorkspaceLocalRef(boundaryRoot, manifestDir, "generators.files", fileRef)
+	if err != nil {
+		return "", err
+	}
+	if info == nil {
+		return "", fmt.Errorf("kustomize generators.files %q: sops file not found", fileRef)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("kustomize generators.files %q must be a regular file", fileRef)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	relPath, err := relativeManifestPath(w.tempRepoRoot, path)
+	if err != nil {
+		return "", err
+	}
+	substituted, err := substituteKSOPSSopsFile(filepath.ToSlash(relPath), content)
+	if err != nil {
+		return "", fmt.Errorf("kustomize generators.files %q: %w", fileRef, err)
+	}
+	// The fail-closed create in writeGeneratedKustomizeWorkspaceFile is
+	// load-bearing: workspace files are hard links, so a repo-committed file
+	// at this predictable path would otherwise be written through.
+	generatedRel := filepath.ToSlash(filepath.Join(".drydock", "ksops", fmt.Sprintf("%03d-%03d-%03d-%s", graphIndex, entryIndex, fileIndex, safeGeneratedKSOPSBaseName(fileRef))))
+	if err := writeGeneratedKustomizeWorkspaceFile(dir, generatedRel, substituted); err != nil {
+		return "", fmt.Errorf("write ksops-compat manifests %s: %w", generatedRel, err)
+	}
+	w.ksopsSubstitutedFiles++
+	return generatedRel, nil
+}
+
+// substituteKSOPSSopsFile derives deterministic placeholder manifests from a
+// sops-encrypted YAML file without decryption: per document, the top-level
+// sops metadata key is stripped and every string leaf beginning with ENC[ is
+// replaced by an identity-derived marker. Identical input bytes yield
+// identical output bytes (the yaml.Node round trip preserves document
+// structure and key order).
+func substituteKSOPSSopsFile(relPath string, content []byte) ([]byte, error) {
+	docs, err := decodeYAMLDocumentNodes(content)
+	if err != nil {
+		return nil, fmt.Errorf("decode sops file: %w", err)
+	}
+	var buffer bytes.Buffer
+	emitted := 0
+	for docIndex, doc := range docs {
+		root := yamlDocumentRoot(doc)
+		if root == nil {
+			continue
+		}
+		if annotation, ok := generatorOptionAnnotation(root); ok {
+			return nil, fmt.Errorf("generator option annotation %q is unsupported", annotation)
+		}
+		removeYAMLMappingKey(root, "sops")
+		substituteEncryptedYAMLValues(root, relPath, docIndex, nil, false)
+		data, err := goyaml.Marshal(doc)
+		if err != nil {
+			return nil, fmt.Errorf("encode placeholder manifest: %w", err)
+		}
+		buffer.WriteString("---\n")
+		buffer.Write(data)
+		emitted++
+	}
+	if emitted == 0 {
+		return nil, errors.New("sops file has no YAML documents")
+	}
+	return buffer.Bytes(), nil
+}
+
+// substituteEncryptedYAMLValues replaces every string leaf beginning with
+// ENC[ — sops repositories vary encrypted_regex, so replacement is by value
+// prefix, not by field name. Leaves under a data: map are base64-encoded
+// (kustomize and downstream consumers expect valid base64 there); everywhere
+// else the plain grep-able marker is emitted.
+func substituteEncryptedYAMLValues(node *goyaml.Node, relPath string, docIndex int, path []string, underData bool) {
+	switch node.Kind {
+	case goyaml.DocumentNode:
+		for _, child := range node.Content {
+			substituteEncryptedYAMLValues(child, relPath, docIndex, path, underData)
+		}
+	case goyaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			substituteEncryptedYAMLValues(node.Content[i+1], relPath, docIndex, append(path, key), underData || key == "data")
+		}
+	case goyaml.SequenceNode:
+		for i, child := range node.Content {
+			substituteEncryptedYAMLValues(child, relPath, docIndex, append(path, strconv.Itoa(i)), underData)
+		}
+	case goyaml.ScalarNode:
+		if node.Tag != "!!str" || !strings.HasPrefix(node.Value, ksopsEncryptedValuePrefix) {
+			return
+		}
+		marker := ksopsRedactedValue(relPath, docIndex, strings.Join(path, "."))
+		if underData {
+			marker = base64.StdEncoding.EncodeToString([]byte(marker))
+		}
+		node.SetString(marker)
+	case goyaml.AliasNode:
+		// Alias targets are rewritten at their anchor definition.
+	}
+}
+
+// ksopsRedactedValue derives the deterministic placeholder for one encrypted
+// string leaf. The identity is the repository-relative sops file path, the
+// document index within it, and the YAML key path to the leaf — NOT the
+// ciphertext — so value-only sops rotations render byte-identical
+// placeholders while structural edits (new keys, renames) change the
+// placeholder set.
+func ksopsRedactedValue(sopsRelPath string, docIndex int, keyPath string) string {
+	sum := sha256.Sum256([]byte(sopsRelPath + "\x00" + strconv.Itoa(docIndex) + "\x00" + keyPath))
+	return ksopsRedactedPrefix + hex.EncodeToString(sum[:])[:12]
+}
+
+func safeGeneratedKSOPSBaseName(fileRef string) string {
+	base := filepath.Base(filepath.FromSlash(strings.TrimSpace(fileRef)))
+	base = strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(base)
+	if base == "" || base == "." || base == ".." {
+		base = "sops"
+	}
+	if !strings.HasSuffix(base, ".yaml") && !strings.HasSuffix(base, ".yml") {
+		base += ".yaml"
+	}
+	return base
+}
+
+// inlineKustomizeGeneratorDocuments mirrors kustomize's inline-vs-path branch:
+// kusttarget tries NewResMapFromBytes(entry) before treating an entry as a
+// path (kustomize api internal/target/kusttarget.go,
+// configureExternalGenerators), and only YAML mapping documents with
+// apiVersion and kind parse as resources. Entries decoding to anything else
+// (scalars, mappings without apiVersion/kind, invalid YAML) are paths.
+func inlineKustomizeGeneratorDocuments(entry string) ([]*goyaml.Node, bool) {
+	docs, err := decodeYAMLDocumentNodes([]byte(entry))
+	if err != nil || len(docs) == 0 {
+		return nil, false
+	}
+	seen := false
+	for _, doc := range docs {
+		root := yamlDocumentRoot(doc)
+		if root == nil {
+			continue
+		}
+		if root.Kind != goyaml.MappingNode {
+			return nil, false
+		}
+		if yamlMappingString(root, "apiVersion") == "" || yamlMappingString(root, "kind") == "" {
+			return nil, false
+		}
+		seen = true
+	}
+	if !seen {
+		return nil, false
+	}
+	return docs, true
+}
+
+func isInlineKustomizeGeneratorEntry(entry string) bool {
+	_, inline := inlineKustomizeGeneratorDocuments(entry)
+	return inline
+}
+
+func describeInlineGeneratorEntry(docs []*goyaml.Node) string {
+	for _, doc := range docs {
+		root := yamlDocumentRoot(doc)
+		if root == nil {
+			continue
+		}
+		return fmt.Sprintf("inline %s/%s", yamlMappingString(root, "apiVersion"), yamlMappingString(root, "kind"))
+	}
+	return "inline generator"
+}
+
+// ksopsGeneratorFileRefs best-effort parses a local generator manifest and
+// returns the files: referents of any KSOPS documents inside it. Errors are
+// deliberately swallowed: prepareKustomizeGenerators is the authoritative
+// gate and reports them loudly; here (graph validation, input digest, and
+// workspace-copy walks) the refs only widen boundary validation, cache-key
+// coverage, and the copy set.
+func ksopsGeneratorFileRefs(path string) []string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	docs, err := decodeYAMLDocumentNodes(content)
+	if err != nil {
+		return nil
+	}
+	return ksopsGeneratorFileRefsFromDocuments(docs)
+}
+
+// ksopsGeneratorFileRefsFromDocuments collects the files: referents of the
+// KSOPS documents among docs. For inline generators: entries these referents
+// resolve relative to the kustomization directory — the same base directory
+// prepareKustomizeGeneratorEntry uses during emulation (manifestDir stays the
+// kustomization dir for inline entries).
+func ksopsGeneratorFileRefsFromDocuments(docs []*goyaml.Node) []string {
+	var refs []string
+	for _, doc := range docs {
+		root := yamlDocumentRoot(doc)
+		if root == nil {
+			continue
+		}
+		if class, _, _ := classifyGeneratorDocument(root); class != generatorDocumentKSOPS {
+			continue
+		}
+		refs = append(refs, yamlMappingStringSequence(root, "files")...)
+	}
+	return refs
+}
+
+// ksopsGeneratorFilePaths resolves a generator entry's KSOPS files: referents
+// to cleaned absolute paths for the workspace copier. The copier walks source
+// directories and directly referenced files only; a sops file living outside
+// every copied path (legal under repo-root containment) would otherwise be
+// absent from the temp tree when ksops-compat emulation reads it.
+func ksopsGeneratorFilePaths(dir, ref string) []string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || isRemoteKustomizeRef(ref) || filepath.IsAbs(ref) {
+		return nil
+	}
+	manifestPath := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ref)))
+	manifestDir := filepath.Dir(manifestPath)
+	fileRefs := ksopsGeneratorFileRefs(manifestPath)
+	out := make([]string, 0, len(fileRefs))
+	for _, fileRef := range fileRefs {
+		fileRef = strings.TrimSpace(fileRef)
+		if fileRef == "" || isRemoteKustomizeRef(fileRef) || filepath.IsAbs(fileRef) {
+			continue
+		}
+		out = append(out, filepath.Clean(filepath.Join(manifestDir, filepath.FromSlash(fileRef))))
+	}
+	return out
+}
+
+func generatorOptionAnnotation(root *goyaml.Node) (string, bool) {
+	annotations := yamlMappingValue(yamlMappingValue(root, "metadata"), "annotations")
+	for _, annotation := range ksopsGeneratorOptionAnnotations {
+		if yamlMappingValue(annotations, annotation) != nil {
+			return annotation, true
+		}
+	}
+	return "", false
+}
+
+func decodeYAMLDocumentNodes(content []byte) ([]*goyaml.Node, error) {
+	decoder := goyaml.NewDecoder(bytes.NewReader(content))
+	var docs []*goyaml.Node
+	for {
+		var node goyaml.Node
+		if err := decoder.Decode(&node); err != nil {
+			if errors.Is(err, io.EOF) {
+				return docs, nil
+			}
+			return nil, err
+		}
+		docs = append(docs, &node)
+	}
+}
+
+func yamlDocumentRoot(doc *goyaml.Node) *goyaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == goyaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return nil
+		}
+		return doc.Content[0]
+	}
+	if doc.Kind == 0 {
+		return nil
+	}
+	return doc
+}
+
+func yamlMappingValue(node *goyaml.Node, key string) *goyaml.Node {
+	if node == nil || node.Kind != goyaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func yamlMappingString(node *goyaml.Node, key string) string {
+	value := yamlMappingValue(node, key)
+	if value == nil || value.Kind != goyaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(value.Value)
+}
+
+func yamlMappingStringSequence(node *goyaml.Node, key string) []string {
+	value := yamlMappingValue(node, key)
+	if value == nil || value.Kind != goyaml.SequenceNode {
+		return nil
+	}
+	out := make([]string, 0, len(value.Content))
+	for _, item := range value.Content {
+		if item.Kind == goyaml.ScalarNode {
+			out = append(out, item.Value)
+		}
+	}
+	return out
+}
+
+func removeYAMLMappingKey(node *goyaml.Node, key string) {
+	if node == nil || node.Kind != goyaml.MappingNode {
+		return
+	}
+	filtered := make([]*goyaml.Node, 0, len(node.Content))
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			continue
+		}
+		filtered = append(filtered, node.Content[i], node.Content[i+1])
+	}
+	node.Content = filtered
+}

--- a/internal/render/kustomize_ksops_compat_test.go
+++ b/internal/render/kustomize_ksops_compat_test.go
@@ -1,0 +1,868 @@
+package render
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/diagnostic"
+	goyaml "go.yaml.in/yaml/v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const ksopsTestGeneratorManifest = `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: demo-secret-generator
+files:
+  - ./demo-secret.sops.yaml
+`
+
+// ksopsTestSopsSecret mirrors the real-world KSOPS fixture shape
+// (lehmanju/homecluster): a complete Secret manifest with plaintext structure
+// and key names, ENC[AES256_GCM,...] data values, and a trailing sops
+// metadata block.
+func ksopsTestSopsSecret(name, key, ciphertext string) string {
+	return `apiVersion: v1
+kind: Secret
+metadata:
+    name: ` + name + `
+data:
+    ` + key + `: ENC[AES256_GCM,data:` + ciphertext + `,iv:aksv1mXYiMja9Guq9SCT6wPjrXTo2MHX6JMGGyYmIo8=,tag:IBjPwh9GgBEIClIjaXyyVQ==,type:str]
+sops:
+    age:
+        - recipient: age1zc4knw29dcgns9zdpyxyx56xsax6s9vsu82sgef3mph56mdr7fusp6v9yh
+    lastmodified: "2025-06-29T07:49:54Z"
+    mac: ENC[AES256_GCM,data:mv+e2VOLIb3om/Rm95A+lchk7xWjCLwCEjTYqB1ULwM8k7ekXHM4vzEhIJ6pt2PPKptW2Pj1BavyLjg4er/go8Z51ZZEt/1g9E85BphdiDH4G6ksYY9GEjf/wKNXNMTH5MZeWaKvzJQVgU=,iv:Wx0pFIZpeuWr4hIzoB1j1mPPH80V4+CvtMZGGi+EpZU=,tag:gkmsqAnezpZs7S4dW5c+NA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2
+`
+}
+
+func writeKSOPSFixtureApp(t *testing.T, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), ksopsTestGeneratorManifest)
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "NYI8Q9o3original"))
+}
+
+func renderKSOPSFixture(t *testing.T, root string, enableKSOPSCompat bool) ([]Manifest, []diagnostic.Diagnostic, error) {
+	t.Helper()
+	return (KustomizeRenderer{}).Render(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     filepath.Join("apps", "demo"),
+	}, RenderOptions{EnableKSOPSCompat: enableKSOPSCompat})
+}
+
+func serializeRenderedManifests(t *testing.T, manifests []Manifest) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, manifest := range manifests {
+		data, err := goyaml.Marshal(manifest.Object.Object)
+		if err != nil {
+			t.Fatalf("marshal rendered manifest: %v", err)
+		}
+		builder.WriteString("---\n")
+		builder.Write(data)
+	}
+	return builder.String()
+}
+
+func manifestNamed(t *testing.T, manifests []Manifest, kind, name string) *unstructured.Unstructured {
+	t.Helper()
+	for _, manifest := range manifests {
+		if manifest.Object.GetKind() == kind && manifest.Object.GetName() == name {
+			return manifest.Object
+		}
+	}
+	t.Fatalf("no %s named %q in %#v", kind, name, manifests)
+	return nil
+}
+
+func TestKustomizeKSOPSCompatRendersPlaceholderSecret(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	manifests, diags, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(manifests) != 1 {
+		t.Fatalf("len(manifests) = %d, want 1: %#v", len(manifests), manifests)
+	}
+	secret := manifestNamed(t, manifests, "Secret", "demo-secret")
+	data, found, err := unstructured.NestedStringMap(secret.Object, "data")
+	if err != nil || !found {
+		t.Fatalf("Secret data missing: found=%v err=%v object=%#v", found, err, secret.Object)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(data["TOKEN"])
+	if err != nil {
+		t.Fatalf("data.TOKEN = %q is not valid base64: %v", data["TOKEN"], err)
+	}
+	if !strings.HasPrefix(string(decoded), ksopsRedactedPrefix) {
+		t.Fatalf("decoded data.TOKEN = %q, want %q prefix", decoded, ksopsRedactedPrefix)
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(secret.Object, "sops"); found {
+		t.Fatalf("rendered Secret retains sops metadata: %#v", secret.Object)
+	}
+	if len(diags) != 1 || diags[0].Code != "kustomize.ksops-compat-substituted" || diags[0].Severity != diagnostic.SeverityWarning {
+		t.Fatalf("diagnostics = %#v, want one kustomize.ksops-compat-substituted warning", diags)
+	}
+	if !strings.Contains(diags[0].Message, "1 sops files substituted") {
+		t.Fatalf("diagnostic message = %q, want substituted-file count", diags[0].Message)
+	}
+}
+
+func TestKustomizeKSOPSGeneratorWithoutCompatFailsActionably(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	_, _, err := renderKSOPSFixture(t, root, false)
+	if err == nil {
+		t.Fatal("Render() error = nil, want actionable KSOPS diagnostic")
+	}
+	if !strings.Contains(err.Error(), "./secret-generator.yaml") {
+		t.Fatalf("Render() error = %v, want generator manifest path", err)
+	}
+	if !strings.Contains(err.Error(), "--enable-ksops-compat") {
+		t.Fatalf("Render() error = %v, want --enable-ksops-compat suggestion", err)
+	}
+}
+
+func TestKustomizeBuiltinGeneratorConfigStillRenders(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./cm-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "cm-generator.yaml"), `
+apiVersion: builtin
+kind: ConfigMapGenerator
+metadata:
+  name: generated-cm
+literals:
+  - key=value
+`)
+
+	manifests, diags, err := renderKSOPSFixture(t, root, false)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	if len(manifests) != 1 || manifests[0].Object.GetKind() != "ConfigMap" || !strings.HasPrefix(manifests[0].Object.GetName(), "generated-cm") {
+		t.Fatalf("manifests = %#v, want generated-cm ConfigMap", manifests)
+	}
+}
+
+func TestKustomizeKSOPSInputDigestCoversSopsFiles(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	paths, err := KustomizeInputDigestPaths(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     filepath.Join("apps", "demo"),
+	}, RenderOptions{EnableKSOPSCompat: true})
+	if err != nil {
+		t.Fatalf("KustomizeInputDigestPaths() error = %v", err)
+	}
+	found := false
+	for _, path := range paths {
+		if path.Path == "apps/demo/demo-secret.sops.yaml" {
+			found = true
+			if path.Optional {
+				t.Fatalf("sops file digest path is optional: %#v", path)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("digest paths %#v missing apps/demo/demo-secret.sops.yaml — a sops edit would not rotate the render cache key", paths)
+	}
+}
+
+// TestKustomizeInlineKSOPSInputDigestCoversSopsFiles mirrors the path-entry
+// digest test above for inline generators: entries: the inline manifest lives
+// in the kustomization file (always digested), but its files: referents are
+// separate render inputs of ksops-compat emulation. Before they joined the
+// digest, a sops edit behind an inline generator produced a stale persistent
+// cache hit.
+func TestKustomizeInlineKSOPSInputDigestCoversSopsFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |
+    apiVersion: viaduct.ai/v1
+    kind: ksops
+    metadata:
+      name: inline-generator
+    files:
+      - ./demo-secret.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "inlineCipher"))
+
+	paths, err := KustomizeInputDigestPaths(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     filepath.Join("apps", "demo"),
+	}, RenderOptions{EnableKSOPSCompat: true})
+	if err != nil {
+		t.Fatalf("KustomizeInputDigestPaths() error = %v", err)
+	}
+	found := false
+	for _, path := range paths {
+		if path.Path == "apps/demo/demo-secret.sops.yaml" {
+			found = true
+			if path.Optional {
+				t.Fatalf("sops file digest path is optional: %#v", path)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("digest paths %#v missing apps/demo/demo-secret.sops.yaml — a sops edit behind an inline generator would not rotate the render cache key", paths)
+	}
+}
+
+func TestKustomizeKSOPSCompatStructuralEditChangesPlaceholders(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	baseline := serializeRenderedManifests(t, manifests)
+
+	// Structural edit: add a key to the sops fixture. The placeholder set in
+	// the output must change (new identity), distinct from the value-only
+	// rotation case below.
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), strings.Replace(
+		ksopsTestSopsSecret("demo-secret", "TOKEN", "NYI8Q9o3original"),
+		"data:\n    TOKEN:",
+		"data:\n    EXTRA: ENC[AES256_GCM,data:extravalue,type:str]\n    TOKEN:",
+		1,
+	))
+
+	manifests, _, err = renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() after structural edit error = %v", err)
+	}
+	edited := serializeRenderedManifests(t, manifests)
+	if edited == baseline {
+		t.Fatal("structural sops edit did not change the rendered placeholder set")
+	}
+	secret := manifestNamed(t, manifests, "Secret", "demo-secret")
+	data, _, _ := unstructured.NestedStringMap(secret.Object, "data")
+	if len(data) != 2 {
+		t.Fatalf("Secret data = %#v, want TOKEN and EXTRA placeholders", data)
+	}
+	if data["EXTRA"] == data["TOKEN"] {
+		t.Fatalf("placeholders are not identity-derived: EXTRA == TOKEN == %q", data["EXTRA"])
+	}
+}
+
+func TestKustomizeKSOPSCompatValueOnlyRotationRendersIdentically(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	baseline := serializeRenderedManifests(t, manifests)
+
+	// Value-only rotation: only the ENC[...] ciphertext changes. The file
+	// bytes change (cache miss via the digest path pinned above), but the
+	// placeholder derives from identity, not ciphertext, so the rendered
+	// output must be byte-identical.
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "rotatedCiphertext"))
+
+	manifests, _, err = renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() after rotation error = %v", err)
+	}
+	if rotated := serializeRenderedManifests(t, manifests); rotated != baseline {
+		t.Fatalf("value-only sops rotation changed rendered output:\nbaseline:\n%s\nrotated:\n%s", baseline, rotated)
+	}
+}
+
+func TestKustomizeKSOPSCompatReplacesStringDataAndCustomFields(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), ksopsTestGeneratorManifest)
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), `apiVersion: v1
+kind: Secret
+metadata:
+    name: demo-secret
+stringData:
+    PASSWORD: ENC[AES256_GCM,data:plainfield,type:str]
+customField: ENC[AES256_GCM,data:customregex,type:str]
+sops:
+    encrypted_regex: ^(data|stringData|customField)$
+    version: 3.10.2
+`)
+
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	secret := manifestNamed(t, manifests, "Secret", "demo-secret")
+	stringData, _, _ := unstructured.NestedStringMap(secret.Object, "stringData")
+	if !strings.HasPrefix(stringData["PASSWORD"], ksopsRedactedPrefix) {
+		t.Fatalf("stringData.PASSWORD = %q, want plain %q marker", stringData["PASSWORD"], ksopsRedactedPrefix)
+	}
+	custom, _, _ := unstructured.NestedString(secret.Object, "customField")
+	if !strings.HasPrefix(custom, ksopsRedactedPrefix) {
+		t.Fatalf("customField = %q, want plain %q marker (custom encrypted_regex values must be replaced too)", custom, ksopsRedactedPrefix)
+	}
+}
+
+func TestKustomizeKSOPSCompatSupportsMultiDocMultiFileMultiGenerator(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./generator-a.yaml
+  - ./generator-b.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "generator-a.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: generator-a
+files:
+  - ./a.sops.yaml
+  - ./b.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "generator-b.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: generator-b
+files:
+  - ./c.sops.yaml
+`)
+	multiDoc := ksopsTestSopsSecret("secret-a-one", "TOKEN", "aOne") + "---\n" + ksopsTestSopsSecret("secret-a-two", "TOKEN", "aTwo")
+	writeFile(t, filepath.Join(root, "apps", "demo", "a.sops.yaml"), multiDoc)
+	writeFile(t, filepath.Join(root, "apps", "demo", "b.sops.yaml"), ksopsTestSopsSecret("secret-b", "TOKEN", "bOne"))
+	writeFile(t, filepath.Join(root, "apps", "demo", "c.sops.yaml"), ksopsTestSopsSecret("secret-c", "TOKEN", "cOne"))
+
+	manifests, diags, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(manifests) != 4 {
+		t.Fatalf("len(manifests) = %d, want 4: %#v", len(manifests), manifests)
+	}
+	for _, name := range []string{"secret-a-one", "secret-a-two", "secret-b", "secret-c"} {
+		manifestNamed(t, manifests, "Secret", name)
+	}
+	if len(diags) != 1 || !strings.Contains(diags[0].Message, "3 sops files substituted") {
+		t.Fatalf("diagnostics = %#v, want one warning counting 3 substituted sops files", diags)
+	}
+}
+
+func TestKustomizeKSOPSCompatRejectsBoundaryEscapingFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: escaping-generator
+files:
+  - ../../../outside.sops.yaml
+`)
+
+	_, _, err := renderKSOPSFixture(t, root, true)
+	if err == nil {
+		t.Fatal("Render() error = nil, want boundary escape error")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("Render() error = %v, want boundary escape error", err)
+	}
+}
+
+// TestKustomizeInlineKSOPSGeneratorRejectsBoundaryEscapingFiles pins that an
+// inline generator's files: referents are boundary-validated at the graph
+// level, resolved relative to the kustomization directory — fork-PR content
+// is attacker-influenced, and inline entries must not be a validation bypass.
+func TestKustomizeInlineKSOPSGeneratorRejectsBoundaryEscapingFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |
+    apiVersion: viaduct.ai/v1
+    kind: ksops
+    metadata:
+      name: escaping-inline-generator
+    files:
+      - ../../../outside.sops.yaml
+`)
+
+	if _, err := validateKustomizeGraph(context.Background(), root, filepath.Join(root, "apps", "demo")); err == nil {
+		t.Fatal("validateKustomizeGraph() error = nil, want boundary escape error")
+	} else if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("validateKustomizeGraph() error = %v, want boundary escape error", err)
+	}
+
+	_, _, err := renderKSOPSFixture(t, root, true)
+	if err == nil {
+		t.Fatal("Render() error = nil, want boundary escape error")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("Render() error = %v, want boundary escape error", err)
+	}
+}
+
+// TestKustomizeMixedKSOPSAndBuiltinGeneratorManifestFailsLoudly pins the
+// loud rejection of a single generator manifest mixing KSOPS and builtin
+// documents: splitting it would require rewriting a hard-linked workspace
+// file, so drydock refuses to render incompletely in both modes.
+func TestKustomizeMixedKSOPSAndBuiltinGeneratorManifestFailsLoudly(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./mixed-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "mixed-generator.yaml"), ksopsTestGeneratorManifest+`---
+apiVersion: builtin
+kind: ConfigMapGenerator
+metadata:
+  name: mixed-cm
+literals:
+  - key=value
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "mixedCipher"))
+
+	for _, enable := range []bool{false, true} {
+		_, _, err := renderKSOPSFixture(t, root, enable)
+		if err == nil {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = nil, want mixed-generator error", enable)
+		}
+		if !strings.Contains(err.Error(), "mixes KSOPS and builtin generator documents") {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = %v, want mixed-generator error", enable, err)
+		}
+	}
+}
+
+func TestKustomizeUnsupportedGeneratorFailsBothModes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./custom-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "custom-generator.yaml"), `
+apiVersion: someteam.example.com/v1
+kind: SecretsFetcher
+metadata:
+  name: custom
+`)
+
+	for _, enable := range []bool{false, true} {
+		_, _, err := renderKSOPSFixture(t, root, enable)
+		if err == nil {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = nil, want unsupported generator error", enable)
+		}
+		if !strings.Contains(err.Error(), "someteam.example.com/v1/SecretsFetcher is unsupported") {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = %v, want unsupported generator kind", enable, err)
+		}
+	}
+}
+
+func TestKustomizeInlineKSOPSGeneratorIsEmulated(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |
+    apiVersion: viaduct.ai/v1
+    kind: ksops
+    metadata:
+      name: inline-generator
+    files:
+      - ./demo-secret.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "inlineCipher"))
+
+	manifests, diags, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	manifestNamed(t, manifests, "Secret", "demo-secret")
+	if len(diags) != 1 || diags[0].Code != "kustomize.ksops-compat-substituted" {
+		t.Fatalf("diagnostics = %#v, want ksops-compat-substituted warning", diags)
+	}
+
+	_, _, err = renderKSOPSFixture(t, root, false)
+	if err == nil || !strings.Contains(err.Error(), "--enable-ksops-compat") {
+		t.Fatalf("Render() without the mode error = %v, want --enable-ksops-compat suggestion", err)
+	}
+}
+
+func TestKustomizeInlineBuiltinGeneratorLeftForKrusty(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |
+    apiVersion: builtin
+    kind: ConfigMapGenerator
+    metadata:
+      name: inline-cm
+    literals:
+      - key=value
+`)
+
+	manifests, diags, err := renderKSOPSFixture(t, root, false)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	if len(manifests) != 1 || !strings.HasPrefix(manifests[0].Object.GetName(), "inline-cm") {
+		t.Fatalf("manifests = %#v, want inline-cm ConfigMap", manifests)
+	}
+}
+
+func TestKustomizeInlineExecGeneratorFailsBothModes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |
+    apiVersion: example.com/v1
+    kind: MyExecGenerator
+    metadata:
+      name: exec-generator
+      annotations:
+        config.kubernetes.io/function: |
+          exec:
+            path: my-generator
+`)
+
+	for _, enable := range []bool{false, true} {
+		_, _, err := renderKSOPSFixture(t, root, enable)
+		if err == nil {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = nil, want unsupported generator error", enable)
+		}
+		if !strings.Contains(err.Error(), "unsupported") {
+			t.Fatalf("Render(enableKSOPSCompat=%v) error = %v, want unsupported generator error", enable, err)
+		}
+	}
+}
+
+func TestKustomizeKSOPSCompatRejectsUnsupportedKSOPSFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		extra string
+	}{
+		{"secretFrom", "secretFrom:\n  - metadata:\n      name: from-files\n    files:\n      - ./secret.enc.conf\n"},
+		{"binaryFiles", "binaryFiles:\n  - ./secret.enc\n"},
+		{"envs", "envs:\n  - ./secret.enc.env\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+			writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), "apiVersion: viaduct.ai/v1\nkind: ksops\nmetadata:\n  name: demo\n"+tt.extra)
+
+			_, _, err := renderKSOPSFixture(t, root, true)
+			if err == nil {
+				t.Fatalf("Render() error = nil, want unsupported ksops %s error", tt.name)
+			}
+			if !strings.Contains(err.Error(), "ksops "+tt.name+" is unsupported") {
+				t.Fatalf("Render() error = %v, want unsupported ksops %s error", err, tt.name)
+			}
+		})
+	}
+}
+
+func TestKustomizeKSOPSCompatRejectsGeneratorOptionAnnotations(t *testing.T) {
+	t.Run("on generator manifest", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+		writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: demo
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+files:
+  - ./demo-secret.sops.yaml
+`)
+		writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), ksopsTestSopsSecret("demo-secret", "TOKEN", "cipher"))
+
+		_, _, err := renderKSOPSFixture(t, root, true)
+		if err == nil || !strings.Contains(err.Error(), `annotation "kustomize.config.k8s.io/behavior" is unsupported`) {
+			t.Fatalf("Render() error = %v, want unsupported generator option annotation error", err)
+		}
+	})
+
+	t.Run("inside sops document", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+		writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), ksopsTestGeneratorManifest)
+		writeFile(t, filepath.Join(root, "apps", "demo", "demo-secret.sops.yaml"), `apiVersion: v1
+kind: Secret
+metadata:
+    name: demo-secret
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+data:
+    TOKEN: ENC[AES256_GCM,data:cipher,type:str]
+sops:
+    version: 3.10.2
+`)
+
+		_, _, err := renderKSOPSFixture(t, root, true)
+		if err == nil || !strings.Contains(err.Error(), `annotation "kustomize.config.k8s.io/needs-hash" is unsupported`) {
+			t.Fatalf("Render() error = %v, want unsupported generator option annotation error", err)
+		}
+	})
+}
+
+func TestParseKustomizeBuildOptionsAcceptsPluginFlags(t *testing.T) {
+	settings, err := parseKustomizeBuildOptions([]string{"--enable-alpha-plugins", "--enable-exec"})
+	if err != nil {
+		t.Fatalf("parseKustomizeBuildOptions() error = %v", err)
+	}
+	if !settings.EnableAlphaPlugins {
+		t.Fatal("EnableAlphaPlugins = false, want true")
+	}
+	if !settings.EnableExec {
+		t.Fatal("EnableExec = false, want true")
+	}
+}
+
+func TestKustomizeRendererAcceptsPluginBuildOptionsWithoutGenerators(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "cm.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+`)
+
+	manifests, diags, err := (KustomizeRenderer{}).Render(context.Background(), ResolvedSource{
+		RepoRoot: root,
+		Path:     filepath.Join("apps", "demo"),
+	}, RenderOptions{BuildOptions: []string{"--enable-helm", "--enable-alpha-plugins", "--enable-exec"}})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	if len(manifests) != 1 || manifests[0].Object.GetName() != "demo" {
+		t.Fatalf("manifests = %#v, want demo ConfigMap", manifests)
+	}
+}
+
+func TestKustomizeKSOPSCompatIsDeterministic(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+
+	first, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	second, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if serializeRenderedManifests(t, first) != serializeRenderedManifests(t, second) {
+		t.Fatal("two renders of identical inputs produced different placeholder output bytes")
+	}
+}
+
+func TestKustomizeKSOPSCompatReadsCrossDirectorySopsFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: cross-dir-generator
+files:
+  - ../../secrets/demo.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "secrets", "demo.sops.yaml"), ksopsTestSopsSecret("cross-dir-secret", "TOKEN", "crossDirCipher"))
+
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v (the workspace copier must cover ksops files targets outside copied directories)", err)
+	}
+	manifestNamed(t, manifests, "Secret", "cross-dir-secret")
+}
+
+func TestKustomizeInlineKSOPSCompatReadsCrossDirectorySopsFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - |-
+    apiVersion: viaduct.ai/v1
+    kind: ksops
+    metadata:
+      name: inline-cross-dir-generator
+    files:
+      - ../../secrets/demo.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "secrets", "demo.sops.yaml"), ksopsTestSopsSecret("inline-cross-dir-secret", "TOKEN", "inlineCrossDirCipher"))
+
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v (the workspace copier must cover inline ksops files targets outside copied directories)", err)
+	}
+	manifestNamed(t, manifests, "Secret", "inline-cross-dir-secret")
+}
+
+// snapshotTree records every regular file under root by relative path and
+// content, for asserting that a render leaves the original repository tree
+// untouched.
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out[filepath.ToSlash(rel)] = string(content)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot tree %q: %v", root, err)
+	}
+	return out
+}
+
+// TestKustomizeKSOPSCompatRejectsPlantedGeneratedPathCollision is the
+// permanent regression test for the hard-link write-through exploit: the
+// workspace copier materializes repository files as hard links, and the ksops
+// placeholder path (.drydock/ksops/<graph>-<entry>-<file>-<basename>.yaml) is
+// predictable, so a repository (e.g. a fork PR) committing a file at that
+// exact path shares an inode with the workspace copy. Without the O_EXCL
+// guard, os.WriteFile's O_TRUNC would write the placeholder THROUGH the
+// shared inode into the user's original repository file. The render must
+// fail loudly AND the planted original must stay byte-identical.
+func TestKustomizeKSOPSCompatRejectsPlantedGeneratedPathCollision(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+	planted := filepath.Join(root, "apps", "demo", ".drydock", "ksops", "000-000-000-demo-secret.sops.yaml")
+	const plantedContent = "planted: repository content at drydock's predictable generated path\n"
+	writeFile(t, planted, plantedContent)
+
+	_, _, err := renderKSOPSFixture(t, root, true)
+	if err == nil {
+		t.Fatal("Render() error = nil, want generated-path collision error")
+	}
+	if !strings.Contains(err.Error(), "already exists in the source tree") {
+		t.Fatalf("Render() error = %v, want generated-path collision error", err)
+	}
+
+	after, readErr := os.ReadFile(planted)
+	if readErr != nil {
+		t.Fatalf("read planted file after render attempt: %v", readErr)
+	}
+	if string(after) != plantedContent {
+		t.Fatalf("planted repository file was mutated through the workspace hard link:\nbefore: %q\nafter:  %q", plantedContent, after)
+	}
+}
+
+// TestKustomizeKSOPSCompatRenderDoesNotMutateOriginalTree is the baseline for
+// the collision test above: a normal mode-ON render must leave every file in
+// the original repository tree byte-identical — all generated-file writes
+// happen in the temp workspace only.
+func TestKustomizeKSOPSCompatRenderDoesNotMutateOriginalTree(t *testing.T) {
+	root := t.TempDir()
+	writeKSOPSFixtureApp(t, root)
+	before := snapshotTree(t, root)
+
+	if _, _, err := renderKSOPSFixture(t, root, true); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	after := snapshotTree(t, root)
+	for rel, content := range before {
+		got, ok := after[rel]
+		if !ok {
+			t.Errorf("render removed original file %q", rel)
+			continue
+		}
+		if got != content {
+			t.Errorf("render mutated original file %q", rel)
+		}
+	}
+	for rel := range after {
+		if _, ok := before[rel]; !ok {
+			t.Errorf("render created %q in the original tree", rel)
+		}
+	}
+}

--- a/internal/render/kustomize_path_safety_test.go
+++ b/internal/render/kustomize_path_safety_test.go
@@ -1033,7 +1033,7 @@ func TestParseKustomizeBuildOptionsSupportsHelmAPIVersions(t *testing.T) {
 }
 
 func TestParseKustomizeBuildOptionsRejectsUnsupportedOptions(t *testing.T) {
-	_, err := parseKustomizeBuildOptions([]string{"--enable-alpha-plugins"})
+	_, err := parseKustomizeBuildOptions([]string{"--network"})
 	if err == nil {
 		t.Fatal("parseKustomizeBuildOptions() error = nil, want unsupported option error")
 	}

--- a/internal/render/kustomize_workspace.go
+++ b/internal/render/kustomize_workspace.go
@@ -12,13 +12,24 @@ import (
 )
 
 type kustomizeWorkspace struct {
-	originalRepoRoot string
-	tempRepoRoot     string
-	sourceRoot       string
-	opts             RenderOptions
-	visited          map[string]struct{}
-	nextGraphIndex   int
-	nextPathIndex    int
+	originalRepoRoot      string
+	tempRepoRoot          string
+	sourceRoot            string
+	opts                  RenderOptions
+	visited               map[string]struct{}
+	nextGraphIndex        int
+	nextPathIndex         int
+	ksopsSubstitutedFiles int
+}
+
+// diagnostics surfaces warnings accumulated while preparing the workspace —
+// one ksops-compat substitution warning per source, mirroring the
+// avp-compat-substituted pattern.
+func (w *kustomizeWorkspace) diagnostics() []diagnostic.Diagnostic {
+	if w.ksopsSubstitutedFiles == 0 {
+		return nil
+	}
+	return []diagnostic.Diagnostic{ksopsCompatDiagnostic(w.ksopsSubstitutedFiles)}
 }
 
 func renderKustomizeWithPreparedWorkspace(ctx context.Context, source ResolvedSource, graph []kustomizeGraphNode, opts RenderOptions, buildSettings kustomizeBuildSettings) ([]Manifest, []diagnostic.Diagnostic, error) {
@@ -57,7 +68,11 @@ func renderKustomizeWithPreparedWorkspace(ctx context.Context, source ResolvedSo
 		return nil, nil, err
 	}
 
-	return renderPlainKustomize(ctx, tempSource, tempRoot, buildSettings)
+	manifests, renderDiags, err := renderPlainKustomize(ctx, tempSource, tempRoot, buildSettings)
+	if err != nil {
+		return nil, nil, err
+	}
+	return manifests, append(workspace.diagnostics(), renderDiags...), nil
 }
 
 //nolint:gocyclo // Coordinates helm inflation, remote graph rewriting, and validation.
@@ -147,6 +162,13 @@ func (w *kustomizeWorkspace) prepareKustomizationDir(ctx context.Context, dir, b
 		graphIndex:   graphIndex,
 	}
 	if err := w.rewriteKustomizePathBearingRefs(ctx, node, &kustomization); err != nil {
+		return fmt.Errorf("%s: %w", manifestPath, err)
+	}
+
+	// Generator classification runs after the path-ref rewrite above so
+	// remote-acquired generator manifests are materialized in the workspace
+	// before they are classified.
+	if err := w.prepareKustomizeGenerators(ctx, dir, boundaryRoot, graphIndex, &kustomization); err != nil {
 		return fmt.Errorf("%s: %w", manifestPath, err)
 	}
 

--- a/internal/render/kustomize_workspace_copy.go
+++ b/internal/render/kustomize_workspace_copy.go
@@ -200,7 +200,22 @@ func referencedKustomizeWorkspacePaths(dir string, kustomization types.Kustomiza
 		appendLocalRef(ref)
 	}
 	for _, ref := range kustomization.Generators {
+		// Inline generator entries are YAML documents, not paths — but their
+		// KSOPS files: referents (resolved from the kustomization dir, matching
+		// emulation/digest/validation) still need copying into the temp tree.
+		if isInlineKustomizeGeneratorEntry(ref) {
+			if docs, ok := inlineKustomizeGeneratorDocuments(ref); ok {
+				for _, fileRef := range ksopsGeneratorFileRefsFromDocuments(docs) {
+					appendLocalRef(fileRef)
+				}
+			}
+			continue
+		}
 		appendLocalRef(ref)
+		// KSOPS files: referents resolve relative to the generator manifest
+		// (which may sit outside every copied directory); copy them so
+		// ksops-compat emulation can read them from the temp tree.
+		refs = append(refs, ksopsGeneratorFilePaths(dir, ref)...)
 	}
 	for _, ref := range kustomization.Transformers {
 		appendLocalRef(ref)

--- a/internal/render/kustomize_workspace_validate.go
+++ b/internal/render/kustomize_workspace_validate.go
@@ -121,6 +121,11 @@ func validateWorkspacePathBearingRefs(boundaryRoot, dir string, kustomization *t
 		}
 	}
 	for _, generator := range kustomization.Generators {
+		// Inline generator entries (left for krusty by classification) are
+		// YAML documents, not paths.
+		if isInlineKustomizeGeneratorEntry(generator) {
+			continue
+		}
 		if err := validateWorkspacePathRef(boundaryRoot, dir, "generators", generator); err != nil {
 			return err
 		}
@@ -277,4 +282,44 @@ func generatedKustomizeWorkspacePath(root, rel string) (string, error) {
 		return "", fmt.Errorf("generated kustomize path %q: %w", rel, err)
 	}
 	return generatedPath, nil
+}
+
+// writeGeneratedKustomizeWorkspaceFile writes a drydock-generated file at rel
+// under root, failing closed when anything already exists at the destination.
+// Prepared workspace trees materialize repository files as hard links
+// (copyWorkspaceFile), so an O_TRUNC rewrite of a path the repository already
+// committed would write THROUGH the shared inode into the user's original
+// file. All generated-file writers (ksops-compat placeholders, generated helm
+// values, generated helm manifests) must route through this helper: the Lstat
+// produces the actionable error, and the O_EXCL open makes the rejection
+// race-free.
+func writeGeneratedKustomizeWorkspaceFile(root, rel string, data []byte) error {
+	path, err := generatedKustomizeWorkspacePath(root, rel)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(path); err == nil {
+		return generatedKustomizeWorkspacePathExistsError(rel)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return generatedKustomizeWorkspacePathExistsError(rel)
+		}
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func generatedKustomizeWorkspacePathExistsError(rel string) error {
+	return fmt.Errorf("generated workspace path %q already exists in the source tree; the repository contains a file colliding with drydock's generated namespace — rename or remove it", rel)
 }

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -30,6 +30,7 @@ type RenderOptions struct {
 	Namespace                    string
 	EnableAVPCompat              bool
 	QuietAVPCompat               bool
+	EnableKSOPSCompat            bool
 	EnablePlugins                bool
 	Plugin                       *PluginConfig
 	KubeVersion                  string

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	RemoteResourceCredentials      remote.Credentials
 	RemoteResourceGitCredentials   remote.GitCredentials
 	EnableAVPCompat                bool
+	EnableKSOPSCompat              bool
 	EnablePlugins                  bool
 	PluginCacheDir                 string
 	PluginPolicyPath               string
@@ -165,6 +166,7 @@ func (options Options) pluginOptions() app.PluginOptions {
 	return app.PluginOptions{
 		PluginTimeout:            options.PluginTimeout,
 		EnableAVPCompat:          options.EnableAVPCompat,
+		EnableKSOPSCompat:        options.EnableKSOPSCompat,
 		EnablePlugins:            options.EnablePlugins,
 		PluginCacheDir:           options.PluginCacheDir,
 		PluginPolicyPath:         options.PluginPolicyPath,

--- a/internal/requestopts/options_test.go
+++ b/internal/requestopts/options_test.go
@@ -39,6 +39,7 @@ func TestOptionsBuildCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RemoteResourceCredentials", request.RemoteResourceCredentials, remote.Credentials{Username: "remote-user"})
 	assertDeepEqual(t, "RemoteResourceGitCredentials", request.RemoteResourceGitCredentials, remote.GitCredentials{Username: "remote-git-user"})
 	assertDeepEqual(t, "EnableAVPCompat", request.EnableAVPCompat, true)
+	assertDeepEqual(t, "EnableKSOPSCompat", request.EnableKSOPSCompat, true)
 	assertDeepEqual(t, "EnablePlugins", request.EnablePlugins, true)
 	assertDeepEqual(t, "PluginCacheDir", request.PluginCacheDir, "plugin-cache")
 	assertDeepEqual(t, "PluginPolicyPath", request.PluginPolicyPath, ".drydock/custom-plugins.yaml")
@@ -105,6 +106,7 @@ func TestOptionsDiffCopiesSharedFields(t *testing.T) {
 	assertDeepEqual(t, "RemoteResourceCredentials", request.RemoteResourceCredentials, remote.Credentials{Username: "remote-user"})
 	assertDeepEqual(t, "RemoteResourceGitCredentials", request.RemoteResourceGitCredentials, remote.GitCredentials{Username: "remote-git-user"})
 	assertDeepEqual(t, "EnableAVPCompat", request.EnableAVPCompat, true)
+	assertDeepEqual(t, "EnableKSOPSCompat", request.EnableKSOPSCompat, true)
 	assertDeepEqual(t, "EnablePlugins", request.EnablePlugins, true)
 	assertDeepEqual(t, "PluginCacheDir", request.PluginCacheDir, "plugin-cache")
 	assertDeepEqual(t, "PluginPolicyPath", request.PluginPolicyPath, ".drydock/custom-plugins.yaml")
@@ -178,6 +180,7 @@ func fixtureOptions() Options {
 		RemoteResourceCredentials:    remote.Credentials{Username: "remote-user"},
 		RemoteResourceGitCredentials: remote.GitCredentials{Username: "remote-git-user"},
 		EnableAVPCompat:              true,
+		EnableKSOPSCompat:            true,
 		EnablePlugins:                true,
 		PluginCacheDir:               "plugin-cache",
 		PluginPolicyPath:             ".drydock/custom-plugins.yaml",

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -110,6 +110,9 @@ type Config struct {
 	// native-rendered sources. Explicit argocd-vault-plugin sources use native
 	// compatibility by default.
 	EnableAVPCompat bool
+	// EnableKSOPSCompat renders KSOPS kustomize generators as deterministic
+	// placeholder manifests without decryption.
+	EnableKSOPSCompat bool
 	// EnablePlugins allows trusted PluginPolicy exec or container engines to run
 	// when policy provenance matches.
 	EnablePlugins bool
@@ -323,6 +326,7 @@ func (client *Client) requestOptions() requestopts.Options {
 		RemoteResourceCredentials:      remoteResourceCredentialsToInternal(client.config.RemoteResourceCredentials),
 		RemoteResourceGitCredentials:   gitCredentialsToRemoteInternal(client.config.GitCredentials),
 		EnableAVPCompat:                client.config.EnableAVPCompat,
+		EnableKSOPSCompat:              client.config.EnableKSOPSCompat,
 		EnablePlugins:                  client.config.EnablePlugins,
 		PluginPolicyPath:               client.config.PluginPolicyPath,
 		PluginPolicyPathExplicit:       client.config.PluginPolicyPathExplicit,

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -2,6 +2,7 @@ package drydock
 
 import (
 	"context"
+	"encoding/base64"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -48,6 +49,77 @@ data:
 	}
 	if !hasDiagnosticCode(result.Diagnostics, "plugin.avp-compat-substituted") {
 		t.Fatalf("Diagnostics = %#v, want AVP compatibility diagnostic", result.Diagnostics)
+	}
+}
+
+func TestRenderKSOPSCompatibilityReplacesGeneratorWithPlaceholder(t *testing.T) {
+	root := t.TempDir()
+
+	// Application pointing to a Kustomize source with a KSOPS generator.
+	writeAPIFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: main
+    path: manifests/demo
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	// Kustomize entrypoint with a KSOPS generator reference.
+	writeAPIFile(t, filepath.Join(root, "manifests", "demo", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	// KSOPS generator manifest (apiVersion: viaduct.ai/v1, kind: ksops).
+	writeAPIFile(t, filepath.Join(root, "manifests", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: demo-secret-generator
+files:
+  - ./demo-secret.sops.yaml
+`)
+	// SOPS-encrypted Secret fixture with plaintext structure and ENC[...] values.
+	writeAPIFile(t, filepath.Join(root, "manifests", "demo", "demo-secret.sops.yaml"), `apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-secret
+data:
+  TOKEN: ENC[AES256_GCM,data:NYI8Q9o3original,iv:aksv1mXYiMja9Guq9SCT6wPjrXTo2MHX6JMGGyYmIo8=,tag:IBjPwh9GgBEIClIjaXyyVQ==,type:str]
+sops:
+  encrypted_regex: ^(data|stringData)$
+  version: 3.10.2
+`)
+
+	result, err := Render(context.Background(), Config{Path: root, EnableKSOPSCompat: true})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, "kustomize.ksops-compat-substituted") {
+		t.Fatalf("Diagnostics = %#v, want kustomize.ksops-compat-substituted diagnostic", result.Diagnostics)
+	}
+	if len(result.Manifests) != 1 {
+		t.Fatalf("Manifests = %d, want 1", len(result.Manifests))
+	}
+	data, ok := result.Manifests[0].Object["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("Object[data] = %#v, want map", result.Manifests[0].Object["data"])
+	}
+	token, _ := data["TOKEN"].(string)
+	if strings.HasPrefix(token, "ENC[") {
+		t.Fatalf("data.TOKEN = %q, still contains the encrypted value", token)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		t.Fatalf("data.TOKEN = %q, want valid base64: %v", token, err)
+	}
+	if !strings.HasPrefix(string(decoded), "drydock-ksops-redacted-") {
+		t.Fatalf("data.TOKEN decodes to %q, want drydock-ksops-redacted- placeholder", decoded)
 	}
 }
 

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -127,6 +127,10 @@ inputs:
     description: Force argocd-vault-plugin placeholder redaction for native-rendered sources.
     required: false
     default: "false"
+  enable-ksops-compat:
+    description: Render KSOPS kustomize generators as deterministic placeholder manifests without decryption.
+    required: false
+    default: "false"
   enable-plugins:
     description: Enable trusted exec and container plugin policy entries.
     required: false
@@ -441,6 +445,7 @@ runs:
         DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY: ${{ inputs.disable-plugin-policy }}
         DRYDOCK_INPUT_DISCOVER_KUSTOMIZE: ${{ inputs.discover-kustomize }}
         DRYDOCK_INPUT_ENABLE_AVP_COMPAT: ${{ inputs.enable-avp-compat }}
+        DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT: ${{ inputs.enable-ksops-compat }}
         DRYDOCK_INPUT_ENABLE_PLUGINS: ${{ inputs.enable-plugins }}
         DRYDOCK_INPUT_EXTRA_DIFF_ARGS: ${{ inputs.extra-diff-args }}
         DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS: ${{ inputs.extra-image-diff-args }}

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -176,6 +176,37 @@ func TestActionPruneStepIfGuardAndEnvWiring(t *testing.T) {
 	}
 }
 
+func TestActionKSOPSCompatInputDeclaredAndWiredToRunStep(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	// Input must be declared.
+	if !strings.Contains(actionYAML, "enable-ksops-compat:") {
+		t.Fatalf("action.yml missing enable-ksops-compat input declaration")
+	}
+	// Default must be "false".
+	inputIdx := strings.Index(actionYAML, "enable-ksops-compat:")
+	snippet := actionYAML[inputIdx:min(inputIdx+300, len(actionYAML))]
+	if !strings.Contains(snippet, `default: "false"`) {
+		t.Fatalf("enable-ksops-compat input block = %q, want default: \"false\"", snippet)
+	}
+
+	// Run step must wire the env var.
+	runIdx := strings.Index(actionYAML, "- name: Run drydock\n")
+	if runIdx == -1 {
+		t.Fatalf("action.yml missing 'Run drydock' step")
+	}
+	nextStep := strings.Index(actionYAML[runIdx+1:], "\n    - name: ")
+	var runBlock string
+	if nextStep == -1 {
+		runBlock = actionYAML[runIdx:]
+	} else {
+		runBlock = actionYAML[runIdx : runIdx+1+nextStep]
+	}
+	if !strings.Contains(runBlock, "DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT: ${{ inputs.enable-ksops-compat }}") {
+		t.Fatalf("Run step env block missing DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT wiring:\n%s", runBlock)
+	}
+}
+
 func TestActionNoPinnedActionRefsInPruneStep(t *testing.T) {
 	actionYAML := loadActionYAML(t)
 

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -244,6 +244,7 @@ bool "${DRYDOCK_INPUT_STRICT}" strict
 bool "${DRYDOCK_INPUT_STRICT_CHANGED_ONLY}" strict-changed-only
 bool "${DRYDOCK_INPUT_SHOW_IGNORED_FIELDS}" show-ignored-fields
 bool "${DRYDOCK_INPUT_ENABLE_AVP_COMPAT}" enable-avp-compat
+bool "${DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT}" enable-ksops-compat
 bool "${DRYDOCK_INPUT_ENABLE_PLUGINS}" enable-plugins
 bool "${DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY}" disable-plugin-policy
 bool "${DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR}" fail-on-render-error
@@ -318,6 +319,7 @@ append_bool_flag common_args "${DRYDOCK_INPUT_OFFLINE}" "--offline"
 append_bool_flag common_args "${DRYDOCK_INPUT_STRICT}" "--strict"
 append_bool_flag common_args "${DRYDOCK_INPUT_STRICT_CHANGED_ONLY}" "--strict-changed-only"
 append_bool_flag common_args "${DRYDOCK_INPUT_ENABLE_AVP_COMPAT}" "--enable-avp-compat"
+append_bool_flag common_args "${DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT}" "--enable-ksops-compat"
 append_bool_flag common_args "${DRYDOCK_INPUT_ENABLE_PLUGINS}" "--enable-plugins"
 append_bool_flag common_args "${DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY}" "--disable-plugin-policy"
 append_value_flag common_args "${DRYDOCK_INPUT_PARALLELISM}" "--parallelism"

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -431,6 +431,95 @@ func TestRunOmitsPluginCacheDirWhenCachePathEmpty(t *testing.T) {
 	}
 }
 
+func TestRunPassesEnableKSOPSCompatFlagWhenInputTrue(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	workDir := filepath.Join(tmp, "work")
+	outputPath := filepath.Join(tmp, "github-output")
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+`)
+	cmd := exec.Command("bash", "run.sh")
+	cmd.Dir = "."
+	cmd.Env = append(defaultRunEnv(tmp, workDir, outputPath),
+		"DRYDOCK_INPUT_RUN_TEST=true",
+		"DRYDOCK_INPUT_RUN_DIFF=true",
+		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
+		"DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT=true",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run.sh failed: %v\n%s", err, out)
+	}
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	for line := range strings.SplitSeq(strings.TrimSpace(args), "\n") {
+		if !strings.Contains(line, "--enable-ksops-compat") {
+			t.Fatalf("drydock invocation missing --enable-ksops-compat:\n%s", line)
+		}
+	}
+}
+
+func TestRunRejectsInvalidEnableKSOPSCompatValue(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	workDir := filepath.Join(tmp, "work")
+	outputPath := filepath.Join(tmp, "github-output")
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+`)
+	cmd := exec.Command("bash", "run.sh")
+	cmd.Dir = "."
+	cmd.Env = append(defaultRunEnv(tmp, workDir, outputPath),
+		"DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT=maybe",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("run.sh accepted invalid enable-ksops-compat value; output:\n%s", output)
+	}
+	if !strings.Contains(string(output), "enable-ksops-compat") {
+		t.Fatalf("run.sh error output = %q, want mention of enable-ksops-compat", output)
+	}
+}
+
+func TestRunOmitsEnableKSOPSCompatFlagWhenInputFalse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	workDir := filepath.Join(tmp, "work")
+	outputPath := filepath.Join(tmp, "github-output")
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+`)
+	cmd := exec.Command("bash", "run.sh")
+	cmd.Dir = "."
+	cmd.Env = append(defaultRunEnv(tmp, workDir, outputPath),
+		"DRYDOCK_INPUT_RUN_TEST=true",
+		"DRYDOCK_INPUT_RUN_DIFF=true",
+		"DRYDOCK_INPUT_RUN_IMAGE_DIFF=true",
+		"DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT=false",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run.sh failed: %v\n%s", err, out)
+	}
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	if strings.Contains(args, "--enable-ksops-compat") {
+		t.Fatalf("drydock args contain --enable-ksops-compat when input is false:\n%s", args)
+	}
+}
+
 func TestRunImageCommentsUseMarkdownAfterExtraImageArgs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -947,6 +1036,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY=false",
 		"DRYDOCK_INPUT_DISCOVER_KUSTOMIZE=",
 		"DRYDOCK_INPUT_ENABLE_AVP_COMPAT=false",
+		"DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT=false",
 		"DRYDOCK_INPUT_ENABLE_PLUGINS=false",
 		"DRYDOCK_INPUT_EXTRA_DIFF_ARGS=",
 		"DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS=",

--- a/site/content/docs/plugin-policy/engines.md
+++ b/site/content/docs/plugin-policy/engines.md
@@ -21,6 +21,18 @@ Kustomize CLI. Generic `<KEY>` placeholders are redacted only when the rendered
 manifest has `metadata.annotations["avp.kubernetes.io/path"]`; inline
 `<path:...#...>` placeholders remain supported.
 
+`ksops-compat` renders the source with drydock's native Kustomize renderer and
+replaces `apiVersion: viaduct.ai/v1 / kind: ksops` kustomize generator entries
+with deterministic placeholder manifests. Encrypted values become
+`drydock-ksops-redacted-<12hex>` markers (base64-encoded in `data:` fields).
+No decryption key, KMS network call, or exec is involved. Enable the mode
+globally with `--enable-ksops-compat` (CLI) or `enable-ksops-compat: true`
+(GitHub Action). Builtin generator configs render normally without this flag.
+Exec transformers and validators remain unsupported and fail closed.
+Note that `ksops-compat` is a native compatibility mode enabled only by the
+`--enable-ksops-compat` flag (or the action input); it is not a valid policy
+`engine:` value.
+
 `native-kustomize` explicitly permits a named plugin to use drydock's native
 Kustomize adapter. The same adapter also runs by default when drydock discovers
 a compatible Kustomize build CMP definition for that plugin from Argo CD
@@ -49,6 +61,7 @@ discovered CMP definitions only when they map to a known in-process renderer
 with a fail-closed validator. Discovered CMP definitions are never ambient
 permission to execute commands or emulate arbitrary plugin behavior.
 `--enable-avp-compat` forces the same redaction pass for ordinary native
-rendered sources, but it is not support for arbitrary sidecar CMPs or
+rendered sources, and `--enable-ksops-compat` enables the KSOPS generator
+placeholder path. Neither flag is support for arbitrary sidecar CMPs or
 arbitrary plugin commands. Use `engine: exec` or
 `engine: container` for trusted command-backed plugins.

--- a/site/content/docs/plugin-policy/trust.md
+++ b/site/content/docs/plugin-policy/trust.md
@@ -16,8 +16,8 @@ are true:
 
 No plugin command execution occurs unless `--enable-plugins` is passed. Native
 rendering paths, including `engine: avp-compat`, `engine: native-kustomize`,
-explicit `argocd-vault-plugin` sources, and `--enable-avp-compat`, do not
-execute plugin commands.
+explicit `argocd-vault-plugin` sources, `--enable-avp-compat`, and
+`--enable-ksops-compat`, do not execute plugin commands.
 
 Discovered Argo CD CMP definitions that normalize to a safe `kustomize build`
 command are interpreted by drydock's native Kustomize renderer by default.
@@ -28,7 +28,8 @@ Application plugin sources named `argocd-vault-plugin` use the same native
 compatibility path by default. Discovered CMP aliases use it when their
 generate command safely normalizes to `argocd-vault-plugin generate .`. The
 `--enable-avp-compat` flag forces the same redaction pass for ordinary
-native-rendered sources.
+native-rendered sources. The `--enable-ksops-compat` flag enables the same
+opt-in, fail-closed native path for KSOPS kustomize generators.
 
 When a discovered sidecar CMP has static discovery rules and an Application
 does not name a plugin, drydock may warn that Argo CD sidecar auto-discovery

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -154,6 +154,24 @@ command, a shell, the Helm CLI, or the Kustomize CLI. For trusted
 command-backed plugins, use [Plugin policy](/plugin-policy/) with
 `engine: exec` or `engine: container` and `--enable-plugins`.
 
+Repositories using [KSOPS](https://github.com/viaduct-ai/kustomize-sops) can
+use `--enable-ksops-compat` to render `apiVersion: viaduct.ai/v1 / kind: ksops`
+kustomize generators as deterministic placeholder manifests without decryption.
+Secret structure and key names are preserved; encrypted values are replaced by
+a deterministic placeholder (`drydock-ksops-redacted-<12hex>`), with `data:`
+values encoded as valid base64. No decryption key, network call, or exec is
+involved. Pair with `--skip-secrets` to suppress placeholder Secrets from diff
+output.
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig origin/main --enable-ksops-compat --skip-secrets
+```
+
+Value-only sops rotations (changing only the ciphertext without renaming keys)
+render identically under `--enable-ksops-compat` because the placeholder
+derives from key identity, not ciphertext. "No diff" does not mean "no change"
+for rotated secrets.
+
 Repositories tagged with `argocd` or `gitops` are not always Argo CD
 Application fleet repositories. `drydock test apps` reports zero Applications
 when no `Application` or supported `ApplicationSet` objects are discovered.

--- a/site/content/reference/go-api.md
+++ b/site/content/reference/go-api.md
@@ -60,6 +60,8 @@ not execute plugin commands and reject Application plugin env and parameters.
 Explicit `argocd-vault-plugin` sources and discovered simple AVP CMP aliases
 use native AVP compatibility by default. `Config.EnableAVPCompat` forces the
 same placeholder redaction pass for ordinary native-rendered sources.
+`Config.EnableKSOPSCompat` enables the KSOPS kustomize generator placeholder
+path for repositories that use KSOPS for secret management.
 
 Embedders can pass a renderer directly or use
 `drydock.NewPluginRegistry(map[string]drydock.PluginRenderer{...})` to dispatch

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -445,6 +445,22 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | `parallelism` | unset | Maximum number of Applications to render concurrently. |
 | `max-discovery-depth` | unset | Maximum recursive rendered Application discovery depth. |
 | `enable-avp-compat` | `false` | Force argocd-vault-plugin placeholder redaction for native-rendered sources. |
+| `enable-ksops-compat` | `false` | Render KSOPS kustomize generators as deterministic placeholder manifests without decryption. |
+
+### SOPS/KSOPS Repositories
+
+Repositories that use [KSOPS](https://github.com/viaduct-ai/kustomize-sops) for
+secret management can enable `enable-ksops-compat: true` to render KSOPS
+generator entries as placeholder manifests without any decryption keys or
+network access. Secret structure and key names are preserved; encrypted values
+become deterministic placeholders (`drydock-ksops-redacted-<12hex>`) that are
+grep-able and unmistakably synthetic. Pair with `skip-secrets: true` to exclude
+placeholder Secrets from diff comments entirely.
+
+Note: value-only sops rotations render identically under this mode because
+placeholders derive from key identity, not ciphertext. A rotation produces no
+diff in drydock output even though the live secret changes; use an out-of-band
+rotation audit rather than relying on drydock diff for this class of change.
 
 ### Plugins And Extra Arguments
 


### PR DESCRIPTION
## What

KSOPS (`viaduct.ai/v1 kind: ksops` kustomize exec generators decrypting SOPS files) is a widespread Argo CD pattern drydock could not render — the repo-wide `kustomize.buildOptions: --enable-alpha-plugins --enable-exec` such repos set failed every kustomize app at drydock's option allowlist, generators or not. Requested by a user (ref: github.com/lehmanju/homecluster).

SOPS files in this pattern keep structure and key names plaintext and encrypt only values, so drydock can render them **natively — no decryption keys, no network, no exec, no new dependencies** — the same philosophy as the existing `--enable-avp-compat` path.

Three slices:

**1. `feat(cli)` — options plumbing.** `--enable-ksops-compat` mirrors `--enable-avp-compat` end to end: CLI flag → requestopts → PluginOptions → RenderOptions, joining both render cache key structs.

**2. `feat(render)` — the core.**
- `--enable-alpha-plugins` / `--enable-exec` are now **accepted** at all three build-option gates (they enable nothing — krusty stays builtins-only; the option-level rejection previously failed even generator-free apps).
- Generator-bearing kustomizations are routed through the prepared-workspace pipeline, and every `generators:` entry — inline or path — is classified three ways: **KSOPS** → emulated under the flag (strip the `sops` block, replace `ENC[...]` values with deterministic identity-derived markers `drydock-ksops-redacted-<12hex>`, valid base64 under `data:`) or an actionable error without it; **builtin** (`apiVersion: builtin`) → left for kustomize, unchanged behavior; **anything else** (exec/container KRM fns, `secretFrom`/`binaryFiles`/`envs`, `behavior`/`needs-hash` annotations) → fails closed with a clear diagnostic. Kustomize never sees an unclassified generator.
- SOPS file referents join the render input digest, boundary validation, and the workspace copy set (path, inline, and cross-directory entries). Value-only rotations render identically by design — placeholders derive from key identity, not ciphertext — documented as "no diff does not mean no change."
- Every substitution surfaces a per-source warning (`kustomize.ksops-compat-substituted`) so a compat render can't be mistaken for decrypted reality.
- **Hardening found during adversarial review:** generated workspace files are now created `O_EXCL` through a shared guard (also applied to the helm generated-file writers). Workspace trees materialize as hard links, and the previous `O_TRUNC` write at a predictable generated path could be made to mutate a planted file in the user's original repo tree through the shared inode. A planted collision now fails loudly, regression-tested.

**3. `feat(pr-action)` — surface.** `Config.EnableKSOPSCompat` in the public Go API, an `enable-ksops-compat` action input (default false) wired to test/diff/image commands, and docs across compatibility/CLI/action/plugin-policy pages.

## Validation (real repositories)

| Probe | Result |
|---|---|
| lehmanju/homecluster (35 apps), before this PR | 13/35 PASS — every failure the option-allowlist error |
| This PR, without the flag | **20/35 PASS** — all generator-free apps recover; the 15 KSOPS apps fail with the actionable diagnostic naming the flag |
| This PR, with `--enable-ksops-compat` | **34/35 PASS** — the one failure is an unrelated upstream OCI chart-ref issue in that repo |
| Structural sops edit, diffed | exactly one `+ NEW_KEY: <redacted-added>` hunk; untouched keys diff unchanged (identity-derived markers doing their job) |
| Ciphertext-only rotation | byte-identical render, as documented |
| home-ops regression (31 apps, no ksops) | 31/31 PASS, unchanged |

## Tests

Guard tests are sabotage-validated (mode-off gate bypass, base64 omission, digest omissions, ciphertext-derived and constant markers, builtin misclassification, write-through guard removal — each temporarily broken to confirm the exact pinning test fails). Includes: mode on/off fixtures, inline and path generators, builtin regression pins, multi-doc/multi-file/multi-generator, boundary escapes, planted-collision write-through regression, structural-vs-rotation digest cases, render-input coverage fixture, cache-key rotation on both layers, and pr-action wiring tests. Full gate: golangci-lint 0 issues, `go test ./...` + race clean, shellcheck/zizmor/actionlint/docs-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
