### PR TITLE
fix(render): ksops-compat placeholder polish and fetch-base test deflake

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -204,8 +204,11 @@ Supported:
   entries are rendered as deterministic placeholder manifests without
   decryption: SOPS-encrypted file structure and key names are preserved; every
   encrypted value is replaced by a deterministic placeholder
-  (`drydock-ksops-redacted-<12hex>` marker). Secret `data:` values are valid
-  base64 of the placeholder. The secret VALUES are never decrypted and no
+  (`drydock-ksops-redacted-<12hex>` marker). Secret `data:`/`binaryData:` and
+  ConfigMap `binaryData:` values are valid base64 of the placeholder;
+  everywhere else — including ConfigMap `data:` — the plain grep-able marker
+  is emitted. The secret
+  VALUES are never decrypted and no
   decryption key, KMS network call, or exec is involved.
   Builtin generator configs (`apiVersion: builtin`) are left for krusty and
   render successfully with or without the flag. Exec transformers, exec

--- a/internal/render/kustomize_build_options.go
+++ b/internal/render/kustomize_build_options.go
@@ -8,8 +8,13 @@ import (
 )
 
 type kustomizeBuildSettings struct {
-	LoadRestrictions   types.LoadRestrictions
-	APIVersions        []string
+	LoadRestrictions types.LoadRestrictions
+	APIVersions      []string
+	// EnableAlphaPlugins and EnableExec are intentionally write-only: drydock
+	// accepts the Argo CD build options so option-bearing repos parse, but the
+	// booleans never reach krusty (which always runs builtins-only) and enable
+	// no execution. They exist to record parsed intent — do not delete as dead
+	// fields.
 	EnableAlphaPlugins bool
 	EnableExec         bool
 }

--- a/internal/render/kustomize_ksops_compat.go
+++ b/internal/render/kustomize_ksops_compat.go
@@ -296,7 +296,12 @@ func substituteKSOPSSopsFile(relPath string, content []byte) ([]byte, error) {
 			return nil, fmt.Errorf("generator option annotation %q is unsupported", annotation)
 		}
 		removeYAMLMappingKey(root, "sops")
-		substituteEncryptedYAMLValues(root, relPath, docIndex, nil, false)
+		// base64 applies only where Kubernetes requires it: Secret
+		// data:/binaryData: and ConfigMap binaryData: (ConfigMap data: values
+		// are plain strings — a base64'd marker there would be valid but not
+		// grep-able).
+		kind := yamlMappingString(root, "kind")
+		substituteEncryptedYAMLValues(root, relPath, docIndex, nil, kind, false)
 		data, err := goyaml.Marshal(doc)
 		if err != nil {
 			return nil, fmt.Errorf("encode placeholder manifest: %w", err)
@@ -313,35 +318,54 @@ func substituteKSOPSSopsFile(relPath string, content []byte) ([]byte, error) {
 
 // substituteEncryptedYAMLValues replaces every string leaf beginning with
 // ENC[ — sops repositories vary encrypted_regex, so replacement is by value
-// prefix, not by field name. Leaves under a data: map are base64-encoded
-// (kustomize and downstream consumers expect valid base64 there); everywhere
-// else the plain grep-able marker is emitted.
-func substituteEncryptedYAMLValues(node *goyaml.Node, relPath string, docIndex int, path []string, underData bool) {
+// prefix, not by field name. Leaves under a Secret's data: or binaryData: map
+// are base64-encoded (Kubernetes requires valid base64 there); everywhere
+// else — including ConfigMap data: — the plain grep-able marker is emitted.
+func substituteEncryptedYAMLValues(node *goyaml.Node, relPath string, docIndex int, path []string, kind string, underB64 bool) {
 	switch node.Kind {
 	case goyaml.DocumentNode:
 		for _, child := range node.Content {
-			substituteEncryptedYAMLValues(child, relPath, docIndex, path, underData)
+			substituteEncryptedYAMLValues(child, relPath, docIndex, path, kind, underB64)
 		}
 	case goyaml.MappingNode:
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := node.Content[i].Value
-			substituteEncryptedYAMLValues(node.Content[i+1], relPath, docIndex, append(path, key), underData || key == "data")
+			childB64 := underB64 || ksopsBase64Eligible(kind, path, key)
+			substituteEncryptedYAMLValues(node.Content[i+1], relPath, docIndex, append(path, key), kind, childB64)
 		}
 	case goyaml.SequenceNode:
 		for i, child := range node.Content {
-			substituteEncryptedYAMLValues(child, relPath, docIndex, append(path, strconv.Itoa(i)), underData)
+			substituteEncryptedYAMLValues(child, relPath, docIndex, append(path, strconv.Itoa(i)), kind, underB64)
 		}
 	case goyaml.ScalarNode:
 		if node.Tag != "!!str" || !strings.HasPrefix(node.Value, ksopsEncryptedValuePrefix) {
 			return
 		}
 		marker := ksopsRedactedValue(relPath, docIndex, strings.Join(path, "."))
-		if underData {
+		if underB64 {
 			marker = base64.StdEncoding.EncodeToString([]byte(marker))
 		}
 		node.SetString(marker)
 	case goyaml.AliasNode:
 		// Alias targets are rewritten at their anchor definition.
+	}
+}
+
+// ksopsBase64Eligible reports whether values under a top-level mapping key
+// must be base64-encoded: Secret data: and binaryData:, and ConfigMap
+// binaryData: (Kubernetes requires valid base64 there); everywhere else the
+// plain marker stays grep-able.
+func ksopsBase64Eligible(kind string, path []string, key string) bool {
+	if len(path) != 0 {
+		return false
+	}
+	switch kind {
+	case "Secret":
+		return key == "data" || key == "binaryData"
+	case "ConfigMap":
+		return key == "binaryData"
+	default:
+		return false
 	}
 }
 

--- a/internal/render/kustomize_ksops_compat_test.go
+++ b/internal/render/kustomize_ksops_compat_test.go
@@ -866,3 +866,161 @@ func TestKustomizeKSOPSCompatRenderDoesNotMutateOriginalTree(t *testing.T) {
 		}
 	}
 }
+
+// TestKustomizeKSOPSCompatConfigMapDataStaysPlain pins the kind-gated base64
+// rule: ConfigMap data: values are plain strings in Kubernetes, so the
+// placeholder stays the grep-able plain marker (only Secret data:/binaryData:
+// are base64-encoded).
+func TestKustomizeKSOPSCompatConfigMapDataStaysPlain(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: cm-generator
+files:
+  - ./config.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "config.sops.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: demo-config
+data:
+    SETTING: ENC[AES256_GCM,data:cmCipher,iv:x,tag:y,type:str]
+sops:
+    encrypted_regex: ^(data)$
+    version: 3.10.2
+`)
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	cm := manifestNamed(t, manifests, "ConfigMap", "demo-config")
+	data, _, _ := unstructured.NestedStringMap(cm.Object, "data")
+	value := data["SETTING"]
+	if !strings.HasPrefix(value, "drydock-ksops-redacted-") {
+		t.Fatalf("ConfigMap data.SETTING = %q, want plain drydock-ksops-redacted- marker (not base64)", value)
+	}
+}
+
+// TestKustomizeKSOPSCompatSecretBinaryDataIsBase64 pins base64 encoding under
+// Secret binaryData: (Kubernetes requires valid base64 there, like data:).
+func TestKustomizeKSOPSCompatSecretBinaryDataIsBase64(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: bin-generator
+files:
+  - ./binary.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "binary.sops.yaml"), `apiVersion: v1
+kind: Secret
+metadata:
+    name: demo-binary
+binaryData:
+    CERT: ENC[AES256_GCM,data:binCipher,iv:x,tag:y,type:str]
+sops:
+    encrypted_regex: ^(binaryData)$
+    version: 3.10.2
+`)
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	secret := manifestNamed(t, manifests, "Secret", "demo-binary")
+	binaryData, _, _ := unstructured.NestedStringMap(secret.Object, "binaryData")
+	decoded, err := base64.StdEncoding.DecodeString(binaryData["CERT"])
+	if err != nil {
+		t.Fatalf("binaryData.CERT = %q, want valid base64: %v", binaryData["CERT"], err)
+	}
+	if !strings.HasPrefix(string(decoded), "drydock-ksops-redacted-") {
+		t.Fatalf("binaryData.CERT decodes to %q, want drydock-ksops-redacted- marker", decoded)
+	}
+}
+
+// TestKustomizeKSOPSCompatDuplicateFileAcrossGeneratorsFailsInKustomize pins
+// why per-write substitution counting equals unique-file counting: the same
+// sops file referenced by two generators produces duplicate resource IDs,
+// which kustomize accumulation rejects — the render fails before any
+// substituted-count diagnostic could over-count.
+func TestKustomizeKSOPSCompatDuplicateFileAcrossGeneratorsFailsInKustomize(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./generator-a.yaml
+  - ./generator-b.yaml
+`)
+	for _, name := range []string{"generator-a.yaml", "generator-b.yaml"} {
+		writeFile(t, filepath.Join(root, "apps", "demo", name), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: `+name+`
+files:
+  - ./shared-secret.sops.yaml
+`)
+	}
+	writeFile(t, filepath.Join(root, "apps", "demo", "shared-secret.sops.yaml"), ksopsTestSopsSecret("shared-secret", "TOKEN", "sharedCipher"))
+
+	_, _, err := renderKSOPSFixture(t, root, true)
+	if err == nil {
+		t.Fatalf("Render() error = nil, want kustomize duplicate-id rejection")
+	}
+	if !strings.Contains(err.Error(), "already registered id") {
+		t.Fatalf("Render() error = %v, want already-registered-id accumulation error", err)
+	}
+}
+
+// TestKustomizeKSOPSCompatNestedDataKeyStaysPlain pins the top-level
+// restriction in ksopsBase64Eligible: a nested data: key (e.g. inside a CRD
+// spec) does not trigger base64 — only a Secret's top-level data:/binaryData:
+// (and ConfigMap binaryData:) do.
+func TestKustomizeKSOPSCompatNestedDataKeyStaysPlain(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "apps", "demo", "kustomization.yaml"), `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - ./secret-generator.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "secret-generator.yaml"), `apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: crd-generator
+files:
+  - ./custom.sops.yaml
+`)
+	writeFile(t, filepath.Join(root, "apps", "demo", "custom.sops.yaml"), `apiVersion: example.com/v1
+kind: Widget
+metadata:
+    name: demo-widget
+spec:
+    data:
+        NESTED: ENC[AES256_GCM,data:nestedCipher,iv:x,tag:y,type:str]
+sops:
+    encrypted_regex: ^(NESTED)$
+    version: 3.10.2
+`)
+	manifests, _, err := renderKSOPSFixture(t, root, true)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	widget := manifestNamed(t, manifests, "Widget", "demo-widget")
+	value, _, _ := unstructured.NestedString(widget.Object, "spec", "data", "NESTED")
+	if !strings.HasPrefix(value, "drydock-ksops-redacted-") {
+		t.Fatalf("spec.data.NESTED = %q, want plain drydock-ksops-redacted- marker (nested data: must not base64)", value)
+	}
+}

--- a/internal/render/kustomize_workspace.go
+++ b/internal/render/kustomize_workspace.go
@@ -12,13 +12,18 @@ import (
 )
 
 type kustomizeWorkspace struct {
-	originalRepoRoot      string
-	tempRepoRoot          string
-	sourceRoot            string
-	opts                  RenderOptions
-	visited               map[string]struct{}
-	nextGraphIndex        int
-	nextPathIndex         int
+	originalRepoRoot string
+	tempRepoRoot     string
+	sourceRoot       string
+	opts             RenderOptions
+	visited          map[string]struct{}
+	nextGraphIndex   int
+	nextPathIndex    int
+	// ksopsSubstitutedFiles counts sops files substituted by ksops-compat
+	// emulation. Per-write counting equals unique-file counting: the same
+	// sops file referenced by two generators (or twice in one files: list)
+	// emits duplicate resource IDs, which kustomize accumulation rejects
+	// before any diagnostic is surfaced.
 	ksopsSubstitutedFiles int
 }
 

--- a/pr-action/fetch_base_test.go
+++ b/pr-action/fetch_base_test.go
@@ -159,6 +159,12 @@ func TestFetchBaseResolvesMergeBaseForDivergedShallowClone(t *testing.T) {
 			"-c", "user.name=drydock test",
 			"-c", "init.defaultBranch=main",
 			"-c", "protocol.file.allow=always",
+			// Disable background maintenance: a detached auto-gc can still be
+			// writing .git/objects when t.TempDir cleanup runs (flaky
+			// "directory not empty" failures on CI).
+			"-c", "gc.auto=0",
+			"-c", "gc.autoDetach=false",
+			"-c", "maintenance.auto=false",
 		}, args...)
 		cmd := exec.Command("git", full...)
 		cmd.Dir = dir
@@ -216,9 +222,17 @@ func TestFetchBaseResolvesMergeBaseForDivergedShallowClone(t *testing.T) {
 		"DRYDOCK_PR_BASE_REF=main",
 		"GITHUB_OUTPUT="+outputPath,
 		"GITHUB_SERVER_URL=https://github.com",
-		"GIT_CONFIG_COUNT=1",
+		// gc.auto/autoDetach/maintenance.auto: keep git from detaching
+		// background maintenance that races t.TempDir cleanup.
+		"GIT_CONFIG_COUNT=4",
 		"GIT_CONFIG_KEY_0=protocol.file.allow",
 		"GIT_CONFIG_VALUE_0=always",
+		"GIT_CONFIG_KEY_1=gc.auto",
+		"GIT_CONFIG_VALUE_1=0",
+		"GIT_CONFIG_KEY_2=gc.autoDetach",
+		"GIT_CONFIG_VALUE_2=false",
+		"GIT_CONFIG_KEY_3=maintenance.auto",
+		"GIT_CONFIG_VALUE_3=false",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("fetch-base.sh failed: %v\n%s", err, out)
@@ -386,6 +400,12 @@ func TestFetchBaseForceUpdatesStaleRemoteTrackingRef(t *testing.T) {
 			"-c", "user.name=drydock test",
 			"-c", "init.defaultBranch=main",
 			"-c", "protocol.file.allow=always",
+			// Disable background maintenance: a detached auto-gc can still be
+			// writing .git/objects when t.TempDir cleanup runs (flaky
+			// "directory not empty" failures on CI).
+			"-c", "gc.auto=0",
+			"-c", "gc.autoDetach=false",
+			"-c", "maintenance.auto=false",
 		}, args...)
 		cmd := exec.Command("git", full...)
 		cmd.Dir = dir
@@ -453,9 +473,17 @@ func TestFetchBaseForceUpdatesStaleRemoteTrackingRef(t *testing.T) {
 		"DRYDOCK_PR_BASE_REF=main",
 		"GITHUB_OUTPUT="+outputPath,
 		"GITHUB_SERVER_URL=https://github.com",
-		"GIT_CONFIG_COUNT=1",
+		// gc.auto/autoDetach/maintenance.auto: keep git from detaching
+		// background maintenance that races t.TempDir cleanup.
+		"GIT_CONFIG_COUNT=4",
 		"GIT_CONFIG_KEY_0=protocol.file.allow",
 		"GIT_CONFIG_VALUE_0=always",
+		"GIT_CONFIG_KEY_1=gc.auto",
+		"GIT_CONFIG_VALUE_1=0",
+		"GIT_CONFIG_KEY_2=gc.autoDetach",
+		"GIT_CONFIG_VALUE_2=false",
+		"GIT_CONFIG_KEY_3=maintenance.auto",
+		"GIT_CONFIG_VALUE_3=false",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("fetch-base.sh failed against a stale shallow remote-tracking ref: %v\n%s", err, out)

--- a/site/content/docs/plugin-policy/engines.md
+++ b/site/content/docs/plugin-policy/engines.md
@@ -24,7 +24,8 @@ manifest has `metadata.annotations["avp.kubernetes.io/path"]`; inline
 `ksops-compat` renders the source with drydock's native Kustomize renderer and
 replaces `apiVersion: viaduct.ai/v1 / kind: ksops` kustomize generator entries
 with deterministic placeholder manifests. Encrypted values become
-`drydock-ksops-redacted-<12hex>` markers (base64-encoded in `data:` fields).
+`drydock-ksops-redacted-<12hex>` markers (base64-encoded in Secret
+`data:`/`binaryData:` and ConfigMap `binaryData:` fields; plain elsewhere).
 No decryption key, KMS network call, or exec is involved. Enable the mode
 globally with `--enable-ksops-compat` (CLI) or `enable-ksops-compat: true`
 (GitHub Action). Builtin generator configs render normally without this flag.

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -158,8 +158,9 @@ Repositories using [KSOPS](https://github.com/viaduct-ai/kustomize-sops) can
 use `--enable-ksops-compat` to render `apiVersion: viaduct.ai/v1 / kind: ksops`
 kustomize generators as deterministic placeholder manifests without decryption.
 Secret structure and key names are preserved; encrypted values are replaced by
-a deterministic placeholder (`drydock-ksops-redacted-<12hex>`), with `data:`
-values encoded as valid base64. No decryption key, network call, or exec is
+a deterministic placeholder (`drydock-ksops-redacted-<12hex>`), with Secret
+`data:`/`binaryData:` and ConfigMap `binaryData:` values encoded as valid
+base64 (plain elsewhere). No decryption key, network call, or exec is
 involved. Pair with `--skip-secrets` to suppress placeholder Secrets from diff
 output.
 


### PR DESCRIPTION
## What

Follow-up polish to #204 before v0.2.3 cuts, plus a CI deflake. Three changes:

**1. Kind-gated base64 for placeholders.** Placeholders are now base64-encoded only where Kubernetes actually requires valid base64 — Secret `data:`/`binaryData:` and ConfigMap `binaryData:` — and stay the plain grep-able `drydock-ksops-redacted-<12hex>` marker everywhere else. This fixes two edges of the initial implementation: any `data:` key at any depth was base64'd (a sops-encrypted ConfigMap `data:` or a nested `data:` in a custom resource got unreadable placeholders), and Secret `binaryData:` was left plain (invalid by schema). Marker identity is unchanged; three new pin tests (ConfigMap-plain, Secret-binaryData-base64, nested-data-plain), the kind gate sabotage-validated. Docs updated to match. Behavior-change safe: ksops-compat is unreleased (no tag contains #204).

**2. Counter reasoning pinned instead of phantom dedupe.** Investigating the "substituted-file count could double-count a shared sops file" review note showed the scenario is unreachable: duplicate sops files across generators emit duplicate resource IDs, which kustomize accumulation rejects before any diagnostic surfaces (KSOPS behaves identically live). Documented on the counter + a test pinning the rejection. Also documented the intentionally write-only `EnableAlphaPlugins`/`EnableExec` settings booleans so a future dead-field cleanup doesn't erase the rationale.

**3. fetch-base test deflake.** `TestFetchBaseResolvesMergeBaseForDivergedShallowClone` intermittently failed CI with `TempDir RemoveAll cleanup: … directory not empty` — git's detached background maintenance (post-fetch `gc --auto`) was still writing `.git/objects` when test cleanup ran. Fixed by disabling auto-maintenance (`gc.auto=0`, `gc.autoDetach=false`, `maintenance.auto=false`) at all four git-env sites in the test; `-c` flags propagate to child gits (covering the upstream repo's receive-pack too) and unknown keys are ignored by older gits.

## Verification

golangci-lint 0 issues, full `go test ./...` green, `go test -count=5 -run TestFetchBase` 35/35, markdownlint clean on changed docs. Independently reviewed (adversarial pass verified the git-maintenance semantics version-by-version, the kustomize accumulation-before-transformers ordering, and that both new pin tests fail analytically under a reverted gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)