### PR TITLE
feat(discovery): add --discover-ignore globs for pre-decode exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Application. Use repeatable `--changed-only-include` and
 `--changed-only-ignore` globs when CI should ignore known non-GitOps paths
 before changed-only ownership is evaluated.
 
+Use repeatable `--discover-ignore` repository-relative globs to exclude
+non-deployable YAML, such as unrendered chart templates, from repository
+discovery before decoding. This is separate from `--changed-only-ignore`:
+discover-ignore removes files from discovery itself, while changed-only-ignore
+only filters changed-path selection for diffs.
+
 You can also compare against committed Git refs without creating a baseline
 worktree:
 

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -148,6 +148,15 @@ Discovery scans YAML files by GVK. Keep scans generic; do not hard-code a
 specific user's repository layout. Default scans skip symlinks and tolerate
 unrelated YAML. Explicit app manifest paths reject symlinked components.
 
+`--discover-ignore` globs (repository-relative, doublestar semantics shared
+with `--changed-only-ignore` via `internal/change`) remove matching files from
+top-level repository discovery before any decode, including explicit app
+manifest paths. They must not filter ApplicationSet Git generator file
+matching, Helm value files, Kustomize inputs, changed-path selection, or
+rendered-tier discovery. Fatal discovery decode errors append a
+`--discover-ignore` remediation hint at the discovery call sites, not inside
+`internal/manifest`.
+
 Supported ApplicationSet generators are local and deterministic. The supported
 set includes Git directories, Git files, list, matrix, merge, and explicit
 fixture-backed provider generators. Preserve Go-template behavior such as

--- a/docs/design.md
+++ b/docs/design.md
@@ -112,6 +112,16 @@ AppProjects, repository metadata, and cluster Secret metadata. Generated and
 direct Applications share the same downstream planning, rendering, test, and
 diff path.
 
+Repeatable `--discover-ignore` repository-relative globs (same doublestar
+semantics as `--changed-only-ignore`) exclude matching files from this scan
+before decoding, including files named by explicit app manifest paths. The
+flag scopes to top-level repository discovery only; it does not filter
+ApplicationSet Git generator file matching, Helm value files, Kustomize
+inputs, changed-path selection, or rendered fleet discovery. Fatal discovery
+decode errors carry a remediation hint naming the flag. Undecodable candidate
+files still fail loudly by default so corrupted real manifests are not
+silently skipped.
+
 ApplicationSet support is deterministic and local. Git, list, matrix, merge,
 and fixture-backed provider generators are documented in
 `site/content/docs/applicationsets.md`.

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -491,6 +491,7 @@ func (request DiffRequest) buildAcquisitionOptions(forbiddenRoots []string) Acqu
 
 func cloneDiscoveryOptions(input DiscoveryOptions) DiscoveryOptions {
 	input.DiscoverKustomizePaths = append([]string(nil), input.DiscoverKustomizePaths...)
+	input.DiscoverIgnoreGlobs = append([]string(nil), input.DiscoverIgnoreGlobs...)
 	return input
 }
 

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -31,7 +31,7 @@ func (o Orchestrator) discoverRepository(ctx context.Context, root string, reque
 	request.discoveryPathMemo = &sync.Map{}
 	request.appsetGenerationMemo = &sync.Map{}
 
-	discovered, err := discovery.Scan(root, discovery.Options{})
+	discovered, err := discovery.Scan(root, discovery.Options{IgnoreGlobs: request.DiscoverIgnoreGlobs})
 	if err != nil {
 		return discovery.Result{}, nil, nil, renderCache, "", err
 	}

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -582,6 +582,118 @@ func TestListApplicationsRejectsUnsafeDiscoverKustomizePath(t *testing.T) {
 	}
 }
 
+func TestListApplicationsDiscoverIgnoreDoesNotFilterGitFilesGeneratorParams(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "params", "demo", "config.yaml"), `team: platform
+`)
+	writeTestFile(t, filepath.Join(root, "appsets", "generated.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: generated
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://github.com/example/repo.git
+        revision: HEAD
+        files:
+          - path: params/*/config.yaml
+  template:
+    metadata:
+      name: '{{.path.basename}}'
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo.git
+        path: '{{.path.path}}'
+        targetRevision: HEAD
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{.path.basename}}'
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path: root,
+		DiscoveryOptions: DiscoveryOptions{
+			// The generator param file matches the ignore glob; discover-ignore
+			// scopes to repository discovery only and must not filter appset git
+			// generator file matching.
+			DiscoverIgnoreGlobs: []string{"params/**"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	for _, app := range result.Applications {
+		if app.Name == "demo" {
+			return
+		}
+	}
+	t.Fatalf("Applications = %#v, want generated demo from ignored param file", result.Applications)
+}
+
+func TestListApplicationsDiscoverIgnoreDoesNotFilterExplicitRenderedKustomize(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "application.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: apps/raw
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "base", "kustomization.yaml"), `resources:
+  - application.yaml
+`)
+	writeTestFile(t, filepath.Join(root, "argocd", "overlays", "prod", "kustomization.yaml"), `resources:
+  - ../../base
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: demo
+    patch: |-
+      - op: replace
+        path: /spec/source/path
+        value: apps/rendered
+`)
+
+	result, err := Orchestrator{}.ListApplications(context.Background(), BuildRequest{
+		Path: root,
+		DiscoveryOptions: DiscoveryOptions{
+			DiscoverKustomizePaths: []string{filepath.Join("argocd", "overlays", "prod")},
+			// Every static file matches the ignore glob; rendered-tier discovery
+			// (ScanObjects with synthetic display paths under argocd/) must be
+			// unaffected.
+			DiscoverIgnoreGlobs: []string{"argocd/**"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %#v, want one rendered Application", result.Applications)
+	}
+	if got := result.Applications[0].Spec.Source.Path; got != "apps/rendered" {
+		t.Fatalf("Application source path = %q, want rendered path", got)
+	}
+	// The static duplicate was ignored, so the rendered Application must not
+	// produce a duplicate discovery warning.
+	if diag, ok := diagnosticByCategory(result.Diagnostics, "discovery"); ok && strings.Contains(diag.Message, "duplicate Application") {
+		t.Fatalf("Diagnostics = %#v, want no duplicate discovery warning", result.Diagnostics)
+	}
+}
+
 func TestListApplicationsWarnsWhenApplicationSetGeneratesZeroApplications(t *testing.T) {
 	root := t.TempDir()
 	writeZeroApplicationSet(t, root)

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -16,6 +16,7 @@ type DiscoveryOptions struct {
 	MaxDiscoveryDepth      int
 	MaxDiscoveryDepthSet   bool
 	DiscoverKustomizePaths []string
+	DiscoverIgnoreGlobs    []string
 }
 
 type AcquisitionOptions struct {

--- a/internal/change/filter.go
+++ b/internal/change/filter.go
@@ -25,15 +25,45 @@ type FilterResult struct {
 }
 
 func NewPathFilter(config PathFilterConfig) (PathFilter, error) {
-	includes, err := normalizePatterns(config.Includes, "include")
+	includes, err := normalizePatterns(config.Includes, "changed-only include")
 	if err != nil {
 		return PathFilter{}, err
 	}
-	ignores, err := normalizePatterns(config.Ignores, "ignore")
+	ignores, err := normalizePatterns(config.Ignores, "changed-only ignore")
 	if err != nil {
 		return PathFilter{}, err
 	}
 	return PathFilter{includes: includes, ignores: ignores}, nil
+}
+
+// IgnoreMatcher reports whether repository-relative paths match a validated
+// set of ignore globs, using the same normalization and doublestar semantics
+// as PathFilter. The zero value matches nothing.
+type IgnoreMatcher struct {
+	patterns []string
+}
+
+// NewIgnoreMatcher validates globs and returns a matcher. Validation errors
+// name the flag given by label (for example "discover-ignore").
+func NewIgnoreMatcher(globs []string, label string) (IgnoreMatcher, error) {
+	patterns, err := normalizePatterns(globs, label)
+	if err != nil {
+		return IgnoreMatcher{}, err
+	}
+	return IgnoreMatcher{patterns: patterns}, nil
+}
+
+func (matcher IgnoreMatcher) Matches(inputPath string) bool {
+	if len(matcher.patterns) == 0 {
+		return false
+	}
+	normalized := normalizeFilterPath(inputPath)
+	for _, pattern := range matcher.patterns {
+		if doublestar.MatchUnvalidated(pattern, normalized) {
+			return true
+		}
+	}
+	return false
 }
 
 func (filter PathFilter) Apply(paths []string) FilterResult {
@@ -79,10 +109,10 @@ func normalizePatterns(patterns []string, label string) ([]string, error) {
 	for _, pattern := range patterns {
 		normalized := normalizeFilterPath(pattern)
 		if normalized == "" {
-			return nil, fmt.Errorf("changed-only %s glob must not be blank", label)
+			return nil, fmt.Errorf("%s glob must not be blank", label)
 		}
 		if !doublestar.ValidatePattern(normalized) {
-			return nil, fmt.Errorf("changed-only %s glob %q is invalid", label, pattern)
+			return nil, fmt.Errorf("%s glob %q is invalid", label, pattern)
 		}
 		out = append(out, normalized)
 	}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -26,6 +26,7 @@ type commonFlags struct {
 	maxDiscoveryDepth        int
 	maxDiscoveryDepthSet     bool
 	discoverKustomize        []string
+	discoverIgnore           []string
 	repoMaps                 []string
 	offline                  bool
 	refreshCharts            bool
@@ -124,6 +125,7 @@ func bindPathDiscoveryFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVar(&flags.discoveryMode, "discovery-mode", flags.discoveryMode, "Application discovery mode: fleet or static")
 	cmd.Flags().IntVar(&flags.maxDiscoveryDepth, "max-discovery-depth", flags.maxDiscoveryDepth, "maximum recursive rendered Application discovery depth")
 	cmd.Flags().StringArrayVar(&flags.discoverKustomize, "discover-kustomize", flags.discoverKustomize, "additional local Kustomize path to render for Argo CD Application discovery")
+	cmd.Flags().StringArrayVar(&flags.discoverIgnore, "discover-ignore", flags.discoverIgnore, "repository-relative glob excluded from discovery before decoding")
 	cmd.Flags().StringArrayVar(&flags.repoMaps, "repo-map", flags.repoMaps, "repository URL mapping in from=to form")
 }
 
@@ -325,6 +327,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		MaxDiscoveryDepth:              flags.maxDiscoveryDepth,
 		MaxDiscoveryDepthSet:           flags.maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), flags.discoverKustomize...),
+		DiscoverIgnores:                append([]string(nil), flags.discoverIgnore...),
 		ChangedOnly:                    &flags.changedOnly,
 		ChangedOnlyIncludes:            append([]string(nil), flags.changedOnlyIncludes...),
 		ChangedOnlyIgnores:             append([]string(nil), flags.changedOnlyIgnores...),

--- a/internal/cli/discovery_flags_test.go
+++ b/internal/cli/discovery_flags_test.go
@@ -1,6 +1,118 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const cliDiscoverIgnoreHint = "(use --discover-ignore to exclude non-deployable manifests from discovery)"
+
+// Scaffolding template that passes discovery's content sniff but fails typed
+// decoding: requeueAfterSeconds is a string placeholder where int64 is expected.
+func cliUndecodableScaffold(placeholder string) string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: scaffold
+spec:
+  generators:
+    - pullRequest:
+        requeueAfterSeconds: ` + placeholder + `
+`
+}
+
+func executeCLIExpectingError(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want error\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func TestTestAppsDiscoverIgnoreExcludesUndecodableCandidates(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "stable")
+	writeCLITestFile(t, filepath.Join(root, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE"))
+
+	_, _, err := executeCLIExpectingError(t, "test", "apps", "--path", root, "--offline")
+	if !strings.Contains(err.Error(), cliDiscoverIgnoreHint) {
+		t.Fatalf("Execute() error = %v, want remediation hint %q", err, cliDiscoverIgnoreHint)
+	}
+
+	result := runCLI(t, "test", "apps", "--path", root, "--offline", "--discover-ignore", "templates/**")
+	assertStdoutContainsAll(t, result, "PASS argocd/demo")
+}
+
+func TestDiffAppsDiscoverIgnoreExcludesUndecodableCandidates(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleAppForCLI(t, left, "old")
+	writeSimpleAppForCLI(t, right, "new")
+	writeCLITestFile(t, filepath.Join(left, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE"))
+	writeCLITestFile(t, filepath.Join(right, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE"))
+
+	_, _, err := executeCLIExpectingError(t, "diff", "apps", "--path-orig", left, "--path", right, "--exit-code=false")
+	if !strings.Contains(err.Error(), cliDiscoverIgnoreHint) {
+		t.Fatalf("Execute() error = %v, want remediation hint %q", err, cliDiscoverIgnoreHint)
+	}
+
+	result := runCLI(t, "diff", "apps", "--path-orig", left, "--path", right, "--exit-code=false", "--discover-ignore", "templates/**")
+	assertStdoutContainsAll(t, result, "Application: argocd/demo", "-  value: old", "+  value: new")
+}
+
+func TestDiffAppsRefDiffPropagatesDiscoverIgnoreToBothSides(t *testing.T) {
+	root := t.TempDir()
+	repo, wt := initCLIGitRepo(t, root)
+	writeSimpleAppForCLI(t, root, "baseline")
+	// The undecodable candidate is committed on BOTH refs so a one-side
+	// propagation drop of the ignore globs fails the command.
+	writeCLITestFile(t, filepath.Join(root, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE"))
+	commitCLIGitRepo(t, repo, wt, "baseline")
+	checkoutCLIGitBranch(t, wt, "feature")
+	writeSimpleAppForCLI(t, root, "feature")
+	commitCLIGitRepo(t, repo, wt, "feature")
+
+	_, _, err := executeCLIExpectingError(t, "diff", "apps", "--repo", root, "--ref-orig", "master", "--ref", "feature", "--exit-code=false")
+	if !strings.Contains(err.Error(), cliDiscoverIgnoreHint) {
+		t.Fatalf("Execute() error = %v, want remediation hint %q", err, cliDiscoverIgnoreHint)
+	}
+
+	result := runCLI(t, "diff", "apps", "--repo", root, "--ref-orig", "master", "--ref", "feature", "--exit-code=false", "--discover-ignore", "templates/**")
+	assertStdoutContainsAll(t, result, "-  value: baseline", "+  value: feature")
+}
+
+func TestDiffAppsDiscoverIgnoreKeepsStrictChangedOnlyIndependent(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writeSimpleAppForCLI(t, left, "old")
+	writeSimpleAppForCLI(t, right, "new")
+	writeCLITestFile(t, filepath.Join(left, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE"))
+	writeCLITestFile(t, filepath.Join(right, "templates", "scaffold.yaml"), cliUndecodableScaffold("$PR_REQUEUE_CHANGED"))
+
+	// A discover-ignored file that changes still surfaces as an unowned changed
+	// path under --strict-changed-only; the flag families are independent.
+	_, stderr, _ := executeCLIExpectingError(t, "diff", "apps", "--path-orig", left, "--path", right,
+		"--strict-changed-only", "--discover-ignore", "templates/**")
+	for _, want := range []string{"error changed-only:", "templates/scaffold.yaml"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+
+	result := runCLI(t, "diff", "apps", "--path-orig", left, "--path", right, "--exit-code=false",
+		"--strict-changed-only", "--discover-ignore", "templates/**", "--changed-only-ignore", "templates/**")
+	assertStdoutContainsAll(t, result, "Application: argocd/demo", "-  value: old", "+  value: new")
+}
 
 func TestMaxDiscoveryDepthFlagDistinguishesDefaultFromExplicitZero(t *testing.T) {
 	recorder := &recordingCLIOrchestrator{}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -8,12 +8,16 @@ import (
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/change"
 	"github.com/sholdee/drydock/internal/manifest"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Options struct {
 	AppManifestPaths []string
+	// IgnoreGlobs removes matching repository-relative files from discovery
+	// before any decode, including explicit AppManifestPaths scans.
+	IgnoreGlobs []string
 }
 
 type SourceTier int
@@ -68,6 +72,10 @@ type Result struct {
 
 func Scan(root string, opts Options) (Result, error) {
 	var result Result
+	ignore, err := change.NewIgnoreMatcher(opts.IgnoreGlobs, "discover-ignore")
+	if err != nil {
+		return result, err
+	}
 	roots := opts.AppManifestPaths
 	explicit := len(roots) > 0
 	if !explicit {
@@ -85,7 +93,7 @@ func Scan(root string, opts Options) (Result, error) {
 				return result, err
 			}
 		}
-		if err := scanPath(root, start, explicit, seen, &result); err != nil {
+		if err := scanPath(root, start, explicit, ignore, seen, &result); err != nil {
 			return result, err
 		}
 	}
@@ -105,7 +113,7 @@ func ScanObjects(path string, objects []*unstructured.Unstructured) (Result, err
 	return result, nil
 }
 
-func scanPath(root, start string, explicit bool, seen map[string]struct{}, result *Result) error {
+func scanPath(root, start string, explicit bool, ignore change.IgnoreMatcher, seen map[string]struct{}, result *Result) error {
 	info, err := os.Lstat(start)
 	if err != nil {
 		return err
@@ -124,7 +132,7 @@ func scanPath(root, start string, explicit bool, seen map[string]struct{}, resul
 		if !isYAML(start) {
 			return nil
 		}
-		return scanYAMLFileOnce(root, start, explicit, seen, result)
+		return scanYAMLFileOnce(root, start, explicit, ignore, seen, result)
 	}
 
 	return filepath.WalkDir(start, func(path string, entry os.DirEntry, err error) error {
@@ -143,14 +151,19 @@ func scanPath(root, start string, explicit bool, seen map[string]struct{}, resul
 		if !isYAML(path) {
 			return nil
 		}
-		return scanYAMLFileOnce(root, path, explicit, seen, result)
+		return scanYAMLFileOnce(root, path, explicit, ignore, seen, result)
 	})
 }
 
-func scanYAMLFileOnce(root, path string, explicit bool, seen map[string]struct{}, result *Result) error {
+func scanYAMLFileOnce(root, path string, explicit bool, ignore change.IgnoreMatcher, seen map[string]struct{}, result *Result) error {
 	rel, err := relativePath(root, path)
 	if err != nil {
 		return err
+	}
+	// ignore wins everywhere, including explicit AppManifestPaths scans, and
+	// runs before any decode work.
+	if ignore.Matches(filepath.ToSlash(rel)) {
+		return nil
 	}
 	if _, ok := seen[rel]; ok {
 		return nil
@@ -171,6 +184,8 @@ func scanYAMLFileOnce(root, path string, explicit bool, seen map[string]struct{}
 	return scanYAMLFile(path, rel, result)
 }
 
+const discoverIgnoreHint = "(use --discover-ignore to exclude non-deployable manifests from discovery)"
+
 func scanYAMLFile(path, rel string, result *Result) error {
 	file, err := os.Open(path)
 	if err != nil {
@@ -180,11 +195,11 @@ func scanYAMLFile(path, rel string, result *Result) error {
 
 	docs, err := manifest.DecodeDocuments(path, file)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w %s", err, discoverIgnoreHint)
 	}
 	for _, doc := range docs {
 		if err := scanDocument(rel, doc.Index, doc.Object, false, result); err != nil {
-			return err
+			return fmt.Errorf("%w %s", err, discoverIgnoreHint)
 		}
 	}
 	return nil

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -590,6 +590,165 @@ metadata:
 	}
 }
 
+const discoverIgnoreHintText = "(use --discover-ignore to exclude non-deployable manifests from discovery)"
+
+// Scaffolding template with a typed decode failure: requeueAfterSeconds is a
+// string placeholder where the ApplicationSet API expects int64.
+const typedDecodeScaffold = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: scaffold
+spec:
+  generators:
+    - pullRequest:
+        requeueAfterSeconds: $PR_REQUEUE
+`
+
+// Scaffolding template that passes the content sniff but is invalid raw YAML
+// (template braces outside a Helm chart).
+const rawYAMLScaffold = `{{- if .Values.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.name }}
+{{- end }}
+`
+
+func TestScanFailsUndecodableCandidatesWithDiscoverIgnoreHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantText string
+	}{
+		{name: "typed decode error", content: typedDecodeScaffold, wantText: "decode ApplicationSet"},
+		{name: "invalid raw YAML", content: rawYAMLScaffold, wantText: "decode YAML document failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustCopy(t, filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml"), filepath.Join(root, "apps", "app.yaml"))
+			mustWriteFile(t, filepath.Join(root, "templates", "scaffold.yaml"), tt.content)
+
+			_, err := Scan(root, Options{})
+			if err == nil {
+				t.Fatal("Scan() error = nil, want undecodable candidate error")
+			}
+			if !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("Scan() error = %v, want %q", err, tt.wantText)
+			}
+			if !strings.Contains(err.Error(), discoverIgnoreHintText) {
+				t.Fatalf("Scan() error = %v, want remediation hint %q", err, discoverIgnoreHintText)
+			}
+		})
+	}
+}
+
+func TestScanIgnoreGlobsSkipUndecodableCandidatesBeforeDecode(t *testing.T) {
+	root := t.TempDir()
+	mustCopy(t, filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml"), filepath.Join(root, "apps", "app.yaml"))
+	mustWriteFile(t, filepath.Join(root, "templates", "appset-scaffold.yaml"), typedDecodeScaffold)
+	mustWriteFile(t, filepath.Join(root, "templates", "raw-scaffold.yaml"), rawYAMLScaffold)
+
+	result, err := Scan(root, Options{IgnoreGlobs: []string{"templates/**"}})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %#v, want one", result.Applications)
+	}
+	if result.Applications[0].Path != filepath.Join("apps", "app.yaml") {
+		t.Fatalf("Path = %s", result.Applications[0].Path)
+	}
+	if len(result.ApplicationSets) != 0 {
+		t.Fatalf("ApplicationSets = %#v, want ignored scaffolding excluded", result.ApplicationSets)
+	}
+}
+
+func TestScanIgnoreGlobForms(t *testing.T) {
+	tests := []struct {
+		name string
+		glob string
+	}{
+		{name: "exact path", glob: "templates/scaffold.tmpl.yaml"},
+		{name: "directory doublestar", glob: "templates/**"},
+		{name: "extension doublestar", glob: "**/*.tmpl.yaml"},
+		{name: "dot-slash prefix normalized", glob: "./templates/**"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustCopy(t, filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml"), filepath.Join(root, "apps", "app.yaml"))
+			mustWriteFile(t, filepath.Join(root, "templates", "scaffold.tmpl.yaml"), typedDecodeScaffold)
+
+			result, err := Scan(root, Options{IgnoreGlobs: []string{tt.glob}})
+			if err != nil {
+				t.Fatalf("Scan() error = %v", err)
+			}
+			if len(result.Applications) != 1 {
+				t.Fatalf("Applications = %#v, want one", result.Applications)
+			}
+		})
+	}
+}
+
+func TestScanNonMatchingIgnoreGlobChangesNothing(t *testing.T) {
+	root := t.TempDir()
+	mustCopy(t, filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml"), filepath.Join(root, "apps", "app.yaml"))
+
+	result, err := Scan(root, Options{IgnoreGlobs: []string{"other/**"}})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %#v, want one", result.Applications)
+	}
+}
+
+func TestScanRejectsInvalidAndBlankIgnoreGlobs(t *testing.T) {
+	tests := []struct {
+		name     string
+		glob     string
+		wantText string
+	}{
+		{name: "invalid glob", glob: "templates/[", wantText: `discover-ignore glob "templates/[" is invalid`},
+		{name: "blank glob", glob: "  ", wantText: "discover-ignore glob must not be blank"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustCopy(t, filepath.Join("..", "..", "testdata", "applications", "direct-app.yaml"), filepath.Join(root, "apps", "app.yaml"))
+
+			_, err := Scan(root, Options{IgnoreGlobs: []string{tt.glob}})
+			if err == nil {
+				t.Fatal("Scan() error = nil, want glob validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("Scan() error = %v, want %q", err, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestScanIgnoreGlobsWinOverExplicitAppManifestPaths(t *testing.T) {
+	root := t.TempDir()
+	scaffold := filepath.Join("templates", "scaffold.yaml")
+	mustWriteFile(t, filepath.Join(root, scaffold), typedDecodeScaffold)
+
+	result, err := Scan(root, Options{
+		AppManifestPaths: []string{scaffold},
+		IgnoreGlobs:      []string{"templates/**"},
+	})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.Applications) != 0 || len(result.ApplicationSets) != 0 {
+		t.Fatalf("result = %#v, want ignored explicit path excluded", result)
+	}
+}
+
 func TestExplicitPathFailsMalformedYAML(t *testing.T) {
 	root := t.TempDir()
 	malformed := filepath.Join("apps", "bad-app.yaml")

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -24,6 +24,7 @@ type Options struct {
 	MaxDiscoveryDepth              int
 	MaxDiscoveryDepthSet           bool
 	DiscoverKustomizePaths         []string
+	DiscoverIgnores                []string
 	ChangedOnly                    *bool
 	ChangedOnlyIncludes            []string
 	ChangedOnlyIgnores             []string
@@ -130,6 +131,7 @@ func (options Options) discoveryOptions() app.DiscoveryOptions {
 		MaxDiscoveryDepth:      options.MaxDiscoveryDepth,
 		MaxDiscoveryDepthSet:   options.MaxDiscoveryDepthSet,
 		DiscoverKustomizePaths: append([]string(nil), options.DiscoverKustomizePaths...),
+		DiscoverIgnoreGlobs:    append([]string(nil), options.DiscoverIgnores...),
 	}
 }
 

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -67,6 +67,9 @@ type Config struct {
 	// DiscoverKustomizePaths adds explicit Kustomize entrypoints to rendered
 	// bootstrap discovery.
 	DiscoverKustomizePaths []string
+	// DiscoverIgnores removes repository-relative glob matches from repository
+	// discovery before decoding, including explicit path scans.
+	DiscoverIgnores []string
 	// Strict promotes supported diagnostics that are warnings by default to
 	// operation errors.
 	Strict bool
@@ -303,6 +306,7 @@ func (client *Client) requestOptions() requestopts.Options {
 		MaxDiscoveryDepth:              maxDiscoveryDepth,
 		MaxDiscoveryDepthSet:           maxDiscoveryDepthSet,
 		DiscoverKustomizePaths:         append([]string(nil), client.config.DiscoverKustomizePaths...),
+		DiscoverIgnores:                append([]string(nil), client.config.DiscoverIgnores...),
 		ChangedOnly:                    client.config.ChangedOnly,
 		ChangedOnlyIncludes:            append([]string(nil), client.config.ChangedOnlyIncludes...),
 		ChangedOnlyIgnores:             append([]string(nil), client.config.ChangedOnlyIgnores...),

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -22,6 +22,41 @@ func TestRenderApplications(t *testing.T) {
 	}
 }
 
+func TestRenderDiscoverIgnoresExcludeUndecodableCandidates(t *testing.T) {
+	root := t.TempDir()
+	writeAPIAppTree(t, root, "demo", configMapBody("demo", "v1"))
+	// Scaffolding template that passes discovery's content sniff but fails
+	// typed decoding: requeueAfterSeconds expects int64.
+	writeAPIFile(t, filepath.Join(root, "templates", "scaffold.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: scaffold
+spec:
+  generators:
+    - pullRequest:
+        requeueAfterSeconds: $PR_REQUEUE
+`)
+
+	_, err := Render(context.Background(), Config{Path: root})
+	if err == nil {
+		t.Fatal("Render() error = nil, want undecodable candidate error")
+	}
+	if want := "(use --discover-ignore to exclude non-deployable manifests from discovery)"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("Render() error = %v, want remediation hint %q", err, want)
+	}
+
+	result, err := Render(context.Background(), Config{Path: root, DiscoverIgnores: []string{"templates/**"}})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("Applications = %d, want 1", len(result.Applications))
+	}
+	if len(result.Manifests) != 1 {
+		t.Fatalf("Manifests = %d, want 1", len(result.Manifests))
+	}
+}
+
 func TestRenderAVPCompatibilityReplacesPlaceholders(t *testing.T) {
 	root := t.TempDir()
 	writeAPIAppTree(t, root, "demo", `apiVersion: v1

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -108,6 +108,9 @@ inputs:
   discover-kustomize:
     description: Newline-delimited local Kustomize paths to render for Argo CD Application discovery.
     required: false
+  discover-ignore:
+    description: Newline-delimited repository-relative glob patterns excluded from discovery before decoding.
+    required: false
   repo-map:
     description: Newline-delimited repository URL mappings in URL=PATH form.
     required: false
@@ -443,6 +446,7 @@ runs:
         DRYDOCK_INPUT_COMMENT_MODE: ${{ inputs.comment-mode }}
         DRYDOCK_INPUT_DIFF_MAX_BYTES: ${{ inputs.diff-max-bytes }}
         DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY: ${{ inputs.disable-plugin-policy }}
+        DRYDOCK_INPUT_DISCOVER_IGNORE: ${{ inputs.discover-ignore }}
         DRYDOCK_INPUT_DISCOVER_KUSTOMIZE: ${{ inputs.discover-kustomize }}
         DRYDOCK_INPUT_ENABLE_AVP_COMPAT: ${{ inputs.enable-avp-compat }}
         DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT: ${{ inputs.enable-ksops-compat }}

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -207,6 +207,31 @@ func TestActionKSOPSCompatInputDeclaredAndWiredToRunStep(t *testing.T) {
 	}
 }
 
+func TestActionDiscoverIgnoreInputDeclaredAndWiredToRunStep(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	// Input must be declared.
+	if !strings.Contains(actionYAML, "discover-ignore:") {
+		t.Fatalf("action.yml missing discover-ignore input declaration")
+	}
+
+	// Run step must wire the env var.
+	runIdx := strings.Index(actionYAML, "- name: Run drydock\n")
+	if runIdx == -1 {
+		t.Fatalf("action.yml missing 'Run drydock' step")
+	}
+	nextStep := strings.Index(actionYAML[runIdx+1:], "\n    - name: ")
+	var runBlock string
+	if nextStep == -1 {
+		runBlock = actionYAML[runIdx:]
+	} else {
+		runBlock = actionYAML[runIdx : runIdx+1+nextStep]
+	}
+	if !strings.Contains(runBlock, "DRYDOCK_INPUT_DISCOVER_IGNORE: ${{ inputs.discover-ignore }}") {
+		t.Fatalf("Run step env block missing DRYDOCK_INPUT_DISCOVER_IGNORE wiring:\n%s", runBlock)
+	}
+}
+
 func TestActionNoPinnedActionRefsInPruneStep(t *testing.T) {
 	actionYAML := loadActionYAML(t)
 

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -329,6 +329,7 @@ append_value_flag common_args "${DRYDOCK_INPUT_PLUGIN_POLICY_REF}" "--plugin-pol
 append_value_flag common_args "${DRYDOCK_INPUT_PLUGIN_POLICY_REPO}" "--plugin-policy-repo"
 append_value_flag common_args "${DRYDOCK_INPUT_KUBE_VERSION}" "--kube-version"
 append_lines common_args "${DRYDOCK_INPUT_DISCOVER_KUSTOMIZE}" "--discover-kustomize"
+append_lines common_args "${DRYDOCK_INPUT_DISCOVER_IGNORE}" "--discover-ignore"
 append_lines common_args "${DRYDOCK_INPUT_REPO_MAP}" "--repo-map"
 append_lines common_args "${DRYDOCK_INPUT_API_VERSIONS}" "--api-versions"
 if [[ -n "${DRYDOCK_INPUT_CHANGED_ONLY}" ]]; then

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -362,6 +362,50 @@ func TestRunPassesChangedOnlyPathFiltersOnlyToDiffCommands(t *testing.T) {
 	}
 }
 
+func TestRunPassesDiscoverIgnoreToAllCommands(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode:    "both",
+		diffOutput:     true,
+		imageOutput:    true,
+		runTest:        true,
+		discoverIgnore: "templates/**\nscaffold/*.yaml",
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	lines := strings.Split(strings.TrimSpace(args), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, "--discover-ignore templates/**") ||
+			!strings.Contains(line, "--discover-ignore scaffold/*.yaml") {
+			t.Fatalf("drydock invocation missing discover-ignore globs:\n%s", line)
+		}
+	}
+}
+
+func TestRunOmitsDiscoverIgnoreWhenInputUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode: "both",
+		diffOutput:  true,
+		imageOutput: true,
+		runTest:     true,
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	if strings.Contains(args, "--discover-ignore") {
+		t.Fatalf("drydock invocations = %q, want no --discover-ignore flag when input unset", args)
+	}
+}
+
 func TestRunPassesCacheDirsToEveryInvocationWhenCachePathSet(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -678,6 +722,7 @@ type commentScenario struct {
 	extraImageArgs                  string
 	changedOnlyInclude              string
 	changedOnlyIgnore               string
+	discoverIgnore                  string
 	omitDiffHTMLArtifactNameFromEnv bool
 	cachePath                       string
 }
@@ -700,6 +745,7 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 		"DRYDOCK_INPUT_EXTRA_IMAGE_DIFF_ARGS="+scenario.extraImageArgs,
 		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE="+scenario.changedOnlyInclude,
 		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE="+scenario.changedOnlyIgnore,
+		"DRYDOCK_INPUT_DISCOVER_IGNORE="+scenario.discoverIgnore,
 		"DRYDOCK_INPUT_RUN_DIFF=true",
 		"DRYDOCK_INPUT_RUN_IMAGE_DIFF="+boolString(!scenario.skipImageDiff),
 		"DRYDOCK_INPUT_RUN_TEST="+boolString(scenario.runTest),
@@ -1034,6 +1080,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_INPUT_COMMENT_MODE=none",
 		"DRYDOCK_INPUT_DIFF_MAX_BYTES=60000",
 		"DRYDOCK_INPUT_DISABLE_PLUGIN_POLICY=false",
+		"DRYDOCK_INPUT_DISCOVER_IGNORE=",
 		"DRYDOCK_INPUT_DISCOVER_KUSTOMIZE=",
 		"DRYDOCK_INPUT_ENABLE_AVP_COMPAT=false",
 		"DRYDOCK_INPUT_ENABLE_KSOPS_COMPAT=false",

--- a/site/content/concepts/changed-only.md
+++ b/site/content/concepts/changed-only.md
@@ -48,6 +48,30 @@ diff instead of rendering the fleet.
 `diff app` selects one requested Application directly and does not use
 changed-only Git path filtering.
 
+## Changed-Only Ignore vs Discover Ignore
+
+`--changed-only-ignore` and `--discover-ignore` share glob syntax but act at
+different stages. `--changed-only-ignore` filters which changed paths are
+considered for changed-only ownership; the files themselves are still
+discovered and decoded. `--discover-ignore` removes matching files from
+repository discovery before decoding, on every command that discovers
+Applications.
+
+The two flag families stay independent under `--strict-changed-only`: a
+discover-ignored file that changes still surfaces as an unowned changed path
+unless it is also `--changed-only-ignore`d. Repositories that commit
+non-deployable YAML usually want the same glob in both flags:
+
+```bash
+drydock diff apps \
+  --repo . \
+  --ref HEAD \
+  --ref-orig main \
+  --strict-changed-only \
+  --discover-ignore 'templates/**' \
+  --changed-only-ignore 'templates/**'
+```
+
 ## Mental Model
 
 Changed-only behavior is Argo Application-aware. Shared resources from

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -20,6 +20,12 @@ Supported ApplicationSet generators expand offline from local files, lists,
 matrix and merge combinations, or explicit provider fixtures. Unsupported
 generators produce diagnostics instead of guessing.
 
+Repeatable `--discover-ignore` repository-relative globs exclude matching
+files from this repository scan before decoding, including files named by
+explicit app manifest paths. The flag does not filter ApplicationSet Git
+generator file matching, Helm value files, Kustomize inputs, changed-path
+selection, or rendered fleet discovery.
+
 ## Source Resolution
 
 Application sources resolve from repo maps, local paths, declared Git sources,

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -82,6 +82,22 @@ The path is relative to `--path`, must not escape through `..`, and must not
 include symlinked path components. Explicitly rendered Kustomize objects take
 precedence over committed duplicates with the same identity.
 
+For repositories that also commit non-deployable YAML, such as unrendered
+chart templates that fail strict decoding, exclude those files from discovery
+with repeatable `--discover-ignore` globs:
+
+```bash
+drydock get apps --path . --discover-ignore 'templates/**'
+drydock test apps --path . --discover-ignore 'charts/**/templates/**'
+```
+
+Patterns are repository-relative, slash-normalized doublestar globs with the
+same syntax as `--changed-only-ignore`. Matching happens before any decoding,
+and ignored files are skipped even when named by explicit app manifest paths.
+The flag only affects top-level repository discovery of static manifests; it
+does not filter ApplicationSet Git generator file matching, Helm value files,
+Kustomize inputs, changed-path selection, or rendered fleet discovery.
+
 For generated ApplicationSet behavior, see [ApplicationSets](/docs/applicationsets/).
 For repository shapes, see [Repository topologies](/concepts/topologies/).
 

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -41,6 +41,30 @@ In one-sided diffs, the failing side's zero desired Applications appear as
 additions or deletions, while the live controller would abort reconciliation
 without pruning.
 
+## Symptom: Discovery Fails Decoding Non-Deployable YAML
+
+Discovery errors that end with
+`(use --discover-ignore to exclude non-deployable manifests from discovery)`
+mean the scan found YAML it could not decode, such as unrendered chart
+templates or scaffolding committed alongside real Argo CD objects:
+
+```text
+templates/scaffold.yaml: decode ApplicationSet: json: cannot unmarshal string
+into Go struct field ... of type int64 (use --discover-ignore to exclude
+non-deployable manifests from discovery)
+```
+
+If the file is not deployable Argo CD intent, exclude it from discovery with a
+repository-relative glob:
+
+```bash
+drydock test apps --path . --discover-ignore 'templates/**'
+```
+
+Matching files are skipped before decoding, even when named by explicit app
+manifest paths. If the failing file is a real Application manifest, fix the
+manifest instead; ignoring it hides it from every discovery-based command.
+
 ## Symptom: Render Fails In CI But Works Locally
 
 Confirm whether CI has the same source access and caches. Default runs may

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -159,6 +159,14 @@ non-GitOps paths from forcing a full-fleet changed-only fallback. Keep them
 narrow; ignored paths cannot trigger Application renders. They do not affect
 `test apps`.
 
+`discover-ignore` is different: its newline-delimited globs exclude matching
+files from repository discovery before decoding, and it applies to `test apps`
+as well as both diff steps. Use it when the repository commits non-deployable
+YAML, such as unrendered chart templates, that fails strict discovery decoding.
+With `strict-changed-only`, a discover-ignored file that changes still counts
+as an unowned changed path unless it is also listed in `changed-only-ignore`;
+repositories usually want the same globs in both inputs.
+
 Use markdown output directly when building a custom workflow, or let
 `pr-action` produce the comment:
 
@@ -361,6 +369,7 @@ Newline-delimited inputs are passed as repeated drydock flags:
 - `changed-only-include`
 - `changed-only-ignore`
 - `discover-kustomize`
+- `discover-ignore`
 - `repo-map`
 - `cache-restore-keys`
 - `extra-test-args`
@@ -439,6 +448,7 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | `changed-only-ignore` | unset | Newline-delimited repository-relative globs ignored by changed-only selection. |
 | `show-ignored-fields` | `false` | Show drydock default ignored diff fields. |
 | `discover-kustomize` | unset | Newline-delimited local Kustomize paths to render during Application discovery. |
+| `discover-ignore` | unset | Newline-delimited repository-relative glob patterns excluded from discovery before decoding. Applies to test, diff, and image diff steps. |
 | `repo-map` | unset | Newline-delimited repository URL mappings in `URL=PATH` form. |
 | `kube-version` | unset | Kubernetes version for rendering capabilities. Overrides per-app `kubeVersion`. |
 | `api-versions` | unset | Newline-delimited additional Kubernetes API versions for capability-gated rendering, unioned with per-app `apiVersions`. Accepts `group/version` or `group/version/Kind` form. |

--- a/site/content/workflows/local-diffs.md
+++ b/site/content/workflows/local-diffs.md
@@ -42,6 +42,8 @@ uncommitted changes, against committed `main`. `--repo . --ref feature
 - `--strict-changed-only` fails if changed-file ownership is incomplete.
 - `--changed-only-include 'apps/**'` considers only matching changed paths.
 - `--changed-only-ignore '.github/**'` removes matching paths before ownership.
+- `--discover-ignore 'templates/**'` excludes matching files from discovery
+  before decoding.
 - `--skip-secrets` omits Secret resources from output and diffs.
 - `--skip-crds` omits CRDs from output and diffs.
 - `--show-ignored-fields` shows drydock default ignored metadata fields.


### PR DESCRIPTION
Fixes #211

## Problem

Discovery decodes every candidate YAML in the tree (the candidate check is a content sniff), and a decode failure is fatal to the whole scan. Repos that keep non-deployable templated Application/ApplicationSet YAML in-tree — envsubst scaffolding with `$VAR` placeholders, unrendered chart templates — cannot render or diff at all, and there was no exclusion surface: `--changed-only-ignore` filters selection after discovery has already decoded.

## Fix

New repeatable `--discover-ignore <glob>` (repo-relative, doublestar, identical semantics to `--changed-only-ignore` via a shared matcher in `internal/change`) removes matching files from repository discovery before any decode. Honored by get/test/diag/diff and build; wired through the public `pkg/drydock` config as `DiscoverIgnores`; new pr-action input `discover-ignore` feeds `test apps` and both diff invocations. Ignore wins over explicit app-manifest paths. Scope is deliberately narrow: appset git-generator file matching, helm values, kustomize inputs, changed-path selection, and rendered-tier discovery are all unaffected (each pinned by a test).

Both fatal decode shapes (typed decode errors and raw-YAML failures that pass the candidate sniff) now end with a remediation hint naming the flag. The issue's alternative — skip-and-warn on undecodable candidates by default — was deliberately not taken: a PR that corrupts a real Application manifest must keep failing loudly.

With the flag unset there is no behavior change beyond the hint suffix on already-fatal errors; the empty-matcher hot path is zero-allocation (verified with `testing.AllocsPerRun`) and discovery benchmarks are unchanged within noise.

## Validation

- 13 new tests across discovery, app, cli, requestopts, pkg/drydock, and pr-action, including: pre-decode ordering, both hint sites independently, ref-diff propagation to both sides (undecodable candidate committed on both refs), all three binary invocations receiving the action input, an action.yml input/env contract test, glob validation errors naming the flag, and `--strict-changed-only` independence.
- 13 empirical sabotage checks: 11 caught by exactly the predicted tests; the remaining 2 were verified to be behaviorally equivalent mutants (defensive slice copy; platform-redundant path normalization), not coverage gaps.
- Issue repro fixture (templated appset with `$PR_REQUEUE`/`$GITHUB_ORG` placeholders plus a raw-YAML template-braces variant): fails with the hint without the flag, renders cleanly with `--discover-ignore 'templates/**'`.
- Fleet regression with the flag unset: homecluster (34 PASS) and home-ops (31 PASS) renders byte-identical to main; lehmanju/homecluster PR 957 diff byte-identical.

Docs updated: README, CLI reference, github-actions workflow (input table + newline-delimited list), changed-only concepts (selection-vs-discovery contrast), how-it-works, troubleshooting (hint-keyed entry), agent-reference, design.