### PR TITLE
fix(render): resolve self-repo sources to the local tree on render surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,11 @@ when the user-facing task requires it.
   action Lua remains metadata-only/deferred.
 - Adding provider generator network/API access. Provider-backed ApplicationSet
   generators are fixture-backed offline.
-- Expecting self-referential diff sources to fetch remotely. During diffs,
-  sources naming the repository under diff at `HEAD`, a diffed ref name, or the repository's default-branch name
-  resolve to the active side tree; commit-SHA pins still fetch.
+- Expecting self-referential sources to fetch remotely. On all render
+  surfaces, sources naming the local checkout at `HEAD`, a diffed ref name
+  (diffs only), or the repository's default-branch name (remote HEAD symref
+  only — no fallback guessing) resolve to the local tree; commit-SHA pins
+  still fetch. Working-tree edits therefore flow into self-`$repo` values.
 - Trusting old audit or report claims without checking the current code.
 
 ## Task Routing

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -196,15 +196,29 @@ Canonical references:
 
 Repository URL maps are deterministic and preferred over network fetches. Path
 source resolution order is explicit repo map, existing local source path,
-diff-scoped self-repo resolution (during diffs, a source naming the repository
-under diff at `""`/`HEAD`, a diffed ref name, or the repository's
-default-branch name resolves to the active side tree; full-commit-SHA
-revisions still acquire remotely), declared Git
-cache/fetch behavior, then clear failure. Diff commands also rewrite
-`--repo-map` entries pointing at the diffed checkout to each side's tree and
-warn once per URL per side (`source.self-repo-near-miss`) for fork-shaped
-URLs that match a diffed remote's host and repository name but a different
-owner.
+self-repo resolution (on all render surfaces, a source naming a configured
+remote of the local checkout at `""`/`HEAD`, a diffed ref name during diffs,
+or the repository's default-branch name resolves to the local tree — the
+active side tree during diffs; full-commit-SHA revisions still acquire
+remotely), declared Git cache/fetch behavior, then clear failure.
+Default-branch names are read from remote HEAD symrefs only — symref-or-nothing,
+no `init.defaultBranch` or checked-out-HEAD fallback, and the symref target
+name is read unresolved (a dangling symref still yields the branch name).
+Build/list surfaces populate the self-repo refs in exactly two orchestrator
+leaves (`ListApplications` and `Build`), guarded so diff sides carrying
+pre-populated refs are never re-detected. Detection opens the Git repository
+at the given path without walking up, so `--path <subdir>` runs get no
+self-resolution (documented; use the checkout root or `--repo-map`).
+Consequent behavior: dirty working-tree edits flow into self-`$repo` values on
+renders, and a locally deleted `path` fails path-not-found even when the
+remote tip still has it. Diff commands also rewrite `--repo-map` entries
+pointing at the diffed checkout to each side's tree and warn once per URL per
+provider (`source.self-repo-near-miss`) for fork-shaped URLs that match a
+remote's host and repository name but a different owner. The pr-action's
+`run.sh` records the pull request's base branch as `refs/remotes/origin/HEAD`
+(`ensure_origin_head_symref`, tolerant and never overwriting an existing
+symref) so render-test-only configs — which never run fetch-base — still get
+default-branch self-resolution.
 
 `--offline` controls Git, Helm chart, and remote Kustomize network behavior.
 When it is set, source resolution must use local files, repo maps, or existing

--- a/docs/design.md
+++ b/docs/design.md
@@ -155,10 +155,18 @@ Repository resolution and cache behavior are documented in
 - PR diff roots are authoritative for mapped repositories. During diffs, a
   `--repo-map` entry pointing at the checkout under diff is rewritten to each
   side's tree so one mapped worktree never serves both sides.
-- During diffs, a source naming the repository under diff at `""`/`HEAD`, a
-  diffed ref name, or the repository's default-branch name (from a remote
-  HEAD symref) resolves to the active side tree; full-commit-SHA revisions
-  still acquire remotely. Fork-shaped near misses (same host and repository
+- On all render surfaces, a source naming the local checkout at `""`/`HEAD`,
+  a diffed ref name (diffs only), or the repository's default-branch name
+  resolves to the local tree — during diffs, the active side tree.
+  Full-commit-SHA revisions, tags, and unrelated branches still acquire
+  remotely. Default-branch names come from remote HEAD symrefs only
+  (symref-or-nothing; no `init.defaultBranch` or checked-out-HEAD fallback).
+  Consequences: uncommitted working-tree edits flow into self-`$repo` value
+  files on build/test surfaces, and a self-repository source whose `path`
+  exists on the remote tip but was deleted locally fails path-not-found
+  instead of rendering remote content. Detection does not walk up from a
+  `--path` subdirectory to the enclosing `.git`; run from the checkout root
+  or use `--repo-map`. Fork-shaped near misses (same host and repository
   name, different owner) warn with `source.self-repo-near-miss` and keep
   remote acquisition; the warning is advisory only and exempt from `--strict`
   escalation and failure.

--- a/internal/app/build_ref_sources_test.go
+++ b/internal/app/build_ref_sources_test.go
@@ -1,0 +1,615 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/diagnostic"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Build/list-surface self-repo resolution suite (issue #206 follow-up):
+// sources naming the local checkout's own repository at ""/HEAD or a
+// symref-derived default-branch name resolve to the local tree on render
+// surfaces, exactly like the #207 diff behavior. Fixture conventions follow
+// diff_ref_sources_test.go: real git repositories with configured remotes and
+// remote-HEAD symrefs, plus counting acquirer fakes.
+
+func setSelfRepoRemoteHeadSymref(t *testing.T, repo *git.Repository, remoteName, branch string) {
+	t.Helper()
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName("refs/remotes/"+remoteName+"/HEAD"),
+		plumbing.ReferenceName("refs/remotes/"+remoteName+"/"+branch),
+	)); err != nil {
+		t.Fatalf("SetReference(%s/HEAD) error = %v", remoteName, err)
+	}
+}
+
+func buildConfigMapValue(t *testing.T, result BuildResult, name string) string {
+	t.Helper()
+	for _, renderedManifest := range result.Manifests {
+		if renderedManifest.Object == nil || renderedManifest.Object.GetKind() != "ConfigMap" || renderedManifest.Object.GetName() != name {
+			continue
+		}
+		value, _, err := unstructured.NestedString(renderedManifest.Object.Object, "data", "value")
+		if err != nil {
+			t.Fatalf("NestedString(data.value) error = %v", err)
+		}
+		return value
+	}
+	t.Fatalf("no ConfigMap %q in result manifests: %#v", name, result.Manifests)
+	return ""
+}
+
+// writeSelfRepoAppOfAppsFixture writes a parent Application whose local helm
+// chart source consumes a $repo value file from the repository's own URL at
+// the default-branch NAME and templates a child Application. The child's name
+// exists ONLY in the local tree's value file, so listing surfaces can only
+// discover it when the $repo ref resolves locally (frontier discovery
+// swallows render errors, so a broken ref silently drops the child).
+func writeSelfRepoAppOfAppsFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, "apps", "parent.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: parent
+  namespace: argocd
+spec:
+  sources:
+    - repoURL: `+selfRepoSpecURL+`
+      targetRevision: "main"
+      ref: repo
+    - repoURL: `+selfRepoSpecURL+`
+      targetRevision: HEAD
+      path: bootstrap-chart
+      helm:
+        valueFiles:
+          - $repo/values/parent.yaml
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "Chart.yaml"), `apiVersion: v2
+name: bootstrap
+version: 0.1.0
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "values.yaml"), `childName: default-child
+`)
+	writeTestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "child.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.childName }}
+  namespace: argocd
+spec:
+  source:
+    repoURL: `+selfRepoSpecURL+`
+    targetRevision: HEAD
+    path: manifests/child
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "values", "parent.yaml"), `childName: local-only-child
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", "child", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: child-config
+  namespace: default
+data:
+  value: child
+`)
+}
+
+// Test 1 — LIST-surface pin (app-of-apps): the child Application exists only
+// in the local tree's $repo value file, so its presence in ListApplications
+// output proves the discovery providers received the self-repo refs.
+func TestListApplicationsSelfRepoRefAppOfAppsDiscoversLocalOnlyChild(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeSelfRepoAppOfAppsFixture(t, root)
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer: gitAcquirer,
+	}).ListApplications(context.Background(), BuildRequest{
+		Path:               root,
+		AcquisitionOptions: AcquisitionOptions{RecordCacheEvents: true},
+	})
+	if err != nil {
+		t.Fatalf("ListApplications() error = %v", err)
+	}
+	names := make([]string, 0, len(result.Applications))
+	for _, application := range result.Applications {
+		names = append(names, application.Name)
+	}
+	if !slices.Contains(names, "local-only-child") {
+		t.Fatalf("Applications = %#v, want the $repo-values-driven child discovered from the local tree", names)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+	if !hasCacheEvent(result.CacheEvents, "git", "local", "github.com/example/repo") {
+		t.Fatalf("CacheEvents = %#v, want local git event for the self-mapped $repo ref", result.CacheEvents)
+	}
+	for _, event := range result.CacheEvents {
+		if event.Source == cacheevent.SourceGit && strings.Contains(event.Target, "github.com/example/repo") && event.Action != cacheevent.ActionLocal {
+			t.Fatalf("unexpected non-local git event for the self URL during discovery: %#v", event)
+		}
+	}
+}
+
+// Test 2 — BUILD-surface repro shape (orchestrator-level direct Build, per
+// the review verdict: a CLI-level shape could be masked by list-phase
+// render-cache reuse): a $repo values ref at the symref-derived
+// default-branch name renders from the local tree with an ActionLocal event.
+func TestBuildSelfRepoRefDefaultBranchValuesRenderLocally(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "main", "from-local-tree")
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{
+		Path:               root,
+		AcquisitionOptions: AcquisitionOptions{RecordCacheEvents: true},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-local-tree" {
+		t.Fatalf("rendered value = %q, want from-local-tree", got)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+	if !hasCacheEvent(result.CacheEvents, "git", "local", "github.com/example/repo") {
+		t.Fatalf("CacheEvents = %#v, want local git event for the self-mapped $repo ref", result.CacheEvents)
+	}
+}
+
+// Test 3 — symref gate on a render surface: only the remote-HEAD symref may
+// contribute default-branch names. A wrapper hallucinating from
+// init.defaultBranch or the checked-out HEAD fails cases (b) and (d).
+func TestBuildSelfRepoDefaultBranchSymrefGate(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		symrefTarget   string // "" = no symref
+		targetRevision string
+		checkoutBranch string // branch to check out before building; "" = stay put
+		wantAcquired   bool
+	}{
+		{name: "symref names the spec branch: resolves locally", symrefTarget: "main", targetRevision: "main"},
+		{name: "no symref: acquires remotely (symref-or-nothing)", targetRevision: "main", wantAcquired: true},
+		{name: "symref names a different branch: acquires remotely", symrefTarget: "prod", targetRevision: "main", wantAcquired: true},
+		{name: "checked-out non-default branch name: acquires remotely", symrefTarget: "main", targetRevision: "feature", checkoutBranch: "feature", wantAcquired: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+			if tt.symrefTarget != "" {
+				setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", tt.symrefTarget)
+			}
+			writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, tt.targetRevision, "from-local-tree")
+			commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+			if tt.checkoutBranch != "" {
+				checkoutDiffGitBranch(t, fixture.wt, tt.checkoutBranch)
+			}
+
+			gitAcquirer := &countingGitAcquirer{err: errors.New("self ref must not be acquired")}
+			if tt.wantAcquired {
+				fetchedRoot := t.TempDir()
+				writeSelfRepoRefValuesFile(t, fetchedRoot, "demo", "from-remote")
+				gitAcquirer = &countingGitAcquirer{path: fetchedRoot, revision: "7777777777777777777777777777777777777777"}
+			}
+			result, err := (Orchestrator{
+				GitAcquirer:   gitAcquirer,
+				ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+			}).Build(context.Background(), BuildRequest{Path: root})
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if tt.wantAcquired {
+				if got := gitAcquirer.calls(); got != 1 {
+					t.Fatalf("git acquire calls = %d, want 1: %#v", got, gitAcquirer.requests)
+				}
+				if got := buildConfigMapValue(t, result, "demo"); got != "from-remote" {
+					t.Fatalf("rendered value = %q, want from-remote", got)
+				}
+				return
+			}
+			if got := gitAcquirer.calls(); got != 0 {
+				t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+			}
+			if got := buildConfigMapValue(t, result, "demo"); got != "from-local-tree" {
+				t.Fatalf("rendered value = %q, want from-local-tree", got)
+			}
+		})
+	}
+}
+
+// Test 4 — revision gate on a render surface: ""/HEAD resolve locally; pinned
+// commit SHAs and unrelated branches keep acquiring, and the acquired content
+// (not the local tree) is what renders.
+func TestBuildSelfRepoRevisionGate(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		targetRevision string
+		wantAcquired   bool
+	}{
+		{name: "empty revision resolves locally", targetRevision: ""},
+		{name: "HEAD resolves locally", targetRevision: "HEAD"},
+		{name: "pinned SHA acquires remotely", targetRevision: "1111111111111111111111111111111111111111", wantAcquired: true},
+		{name: "unrelated branch acquires remotely", targetRevision: "release-1.x", wantAcquired: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+			writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, tt.targetRevision, "from-local-tree")
+			commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+			gitAcquirer := &countingGitAcquirer{err: errors.New("self ref must not be acquired")}
+			if tt.wantAcquired {
+				fetchedRoot := t.TempDir()
+				writeSelfRepoRefValuesFile(t, fetchedRoot, "demo", "from-remote")
+				gitAcquirer = &countingGitAcquirer{path: fetchedRoot, revision: "8888888888888888888888888888888888888888"}
+			}
+			result, err := (Orchestrator{
+				GitAcquirer:   gitAcquirer,
+				ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+			}).Build(context.Background(), BuildRequest{Path: root})
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			wantCalls, wantValue := 0, "from-local-tree"
+			if tt.wantAcquired {
+				wantCalls, wantValue = 1, "from-remote"
+			}
+			if got := gitAcquirer.calls(); got != wantCalls {
+				t.Fatalf("git acquire calls = %d, want %d: %#v", got, wantCalls, gitAcquirer.requests)
+			}
+			if got := buildConfigMapValue(t, result, "demo"); got != wantValue {
+				t.Fatalf("rendered value = %q, want %q", got, wantValue)
+			}
+		})
+	}
+}
+
+// Test 5 — OFFLINE render surface: self refs resolve before any acquirer, so
+// --offline renders instead of failing with an offline cache miss.
+func TestBuildSelfRepoRefRendersOffline(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "main", "from-local-tree")
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	result, err := (Orchestrator{
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{
+		Path: root,
+		AcquisitionOptions: AcquisitionOptions{
+			Offline:     true,
+			GitCacheDir: t.TempDir(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-local-tree" {
+		t.Fatalf("rendered value = %q, want from-local-tree", got)
+	}
+}
+
+// Test 6a — NO-CLOBBER, ref-diff side shape: a .git-less root (as diff-side
+// snapshots are) with pre-populated selfRepo refs must keep them. Unconditional
+// re-detection would find no remotes, wipe the refs, and acquire.
+func TestBuildPrepopulatedSelfRepoRefsPreservedOnGitlessRoot(t *testing.T) {
+	root := t.TempDir() // .git-less: models a materialized ref-diff side snapshot
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "sidebranch", "from-snapshot")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("prepopulated self ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{
+		Path: root,
+		selfRepo: selfRepoRefs{
+			urlKeys:   []string{sourcepkg.CanonicalGitURLKey(selfRepoRemoteURL)},
+			revisions: []string{"sidebranch"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-snapshot" {
+		t.Fatalf("rendered value = %q, want from-snapshot", got)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+}
+
+// Test 6b — NO-CLOBBER, path-diff shape: both side checkouts carry a matching
+// remote, but the revision gate name ("sidebranch") is known only from the
+// LEFT checkout's HEAD symref. The per-side builds must preserve the
+// diff-detected refs: wrongful re-detection on the right side would drop
+// "sidebranch" (no symref there) and acquire instead of using the side tree.
+func TestDiffPathSelfRepoBothSidesWithRemotesPreserveDiffDetectedRefs(t *testing.T) {
+	right := t.TempDir()
+	rightRepo, rightWt := initDiffGitRepo(t, right)
+	if _, err := rightRepo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{selfRepoRemoteURL}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	writeSelfRepoRefValuesApp(t, right, "demo", selfRepoSpecURL, "sidebranch", "old")
+	commitDiffGitRepo(t, rightRepo, rightWt, "baseline")
+
+	left := t.TempDir()
+	leftRepo, leftWt := initDiffGitRepo(t, left)
+	if _, err := leftRepo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{selfRepoRemoteURL}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	setSelfRepoRemoteHeadSymref(t, leftRepo, "origin", "sidebranch")
+	writeSelfRepoRefValuesApp(t, left, "demo", selfRepoSpecURL, "sidebranch", "old")
+	commitDiffGitRepo(t, leftRepo, leftWt, "baseline")
+
+	writeSelfRepoRefValuesFile(t, right, "demo", "new")
+	commitDiffGitRepo(t, rightRepo, rightWt, "new values")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).DiffApps(context.Background(), DiffRequest{
+		LeftPath:         left,
+		RightPath:        right,
+		Unified:          3,
+		ExecutionOptions: ExecutionOptions{Parallelism: 1},
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	assertSingleDiffContains(t, result, "-  value: old", "+  value: new")
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+}
+
+// Test 7 — REPO-MAP precedence: MappedPath resolution precedes the self-repo
+// gate, so an explicit --repo-map wins even when the URL is a self reference.
+// The mapped directory carries DIFFERENT content than the local tree because
+// <url>=<local tree> could not discriminate the two resolutions.
+func TestBuildSelfRepoRepoMapPrecedesSelfResolution(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "main", "from-local-tree")
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	mapped := t.TempDir()
+	writeSelfRepoRefValuesFile(t, mapped, "demo", "from-repo-map")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("mapped repository must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{
+		Path: root,
+		AcquisitionOptions: AcquisitionOptions{
+			RecordCacheEvents: true,
+			RepoMaps:          []sourcepkg.RepoMap{{URL: selfRepoRemoteURL, Path: mapped}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-repo-map" {
+		t.Fatalf("rendered value = %q, want from-repo-map", got)
+	}
+	if !hasCacheEvent(result.CacheEvents, "git", "mapped", "github.com/example/repo") {
+		t.Fatalf("CacheEvents = %#v, want mapped git event for the repo-mapped self URL", result.CacheEvents)
+	}
+	if hasCacheEvent(result.CacheEvents, "git", "local", "github.com/example/repo") {
+		t.Fatalf("CacheEvents = %#v, want no local git event when a repo-map covers the URL", result.CacheEvents)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+}
+
+// Test 8 — NEAR-MISS on a render surface: fork-shaped URLs warn with the
+// surface-neutral wording, still acquire remotely, and stay strict-exempt.
+// The post-dedupe user-visible count is asserted deliberately: on a
+// single-tree build one provider chain emits once per URL across both apps.
+func TestBuildSelfRepoForkNearMissSurfaceNeutralWarning(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		strict bool
+	}{
+		{name: "default"},
+		{name: "strict still succeeds", strict: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root, _ := initSelfRepoDiffGitRepo(t, "https://github.com/me/repo.git")
+			writeSelfRepoRefValuesApp(t, root, "demo", "https://github.com/upstream/repo", "HEAD", "unused")
+			writeSelfRepoRefValuesApp(t, root, "second", "https://github.com/upstream/repo", "HEAD", "unused")
+
+			fetchedRoot := t.TempDir()
+			writeSelfRepoRefValuesFile(t, fetchedRoot, "demo", "from-remote")
+			writeSelfRepoRefValuesFile(t, fetchedRoot, "second", "from-remote")
+			gitAcquirer := &countingGitAcquirer{path: fetchedRoot, revision: "9999999999999999999999999999999999999999"}
+			result, err := (Orchestrator{
+				GitAcquirer:   gitAcquirer,
+				ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+			}).Build(context.Background(), BuildRequest{
+				Path:   root,
+				Strict: tt.strict,
+			})
+			if err != nil {
+				t.Fatalf("Build() error = %v (near-miss must stay strict-exempt)", err)
+			}
+			var nearMisses []diagnostic.Diagnostic
+			for _, diag := range result.Diagnostics {
+				if diag.Code == selfRepoNearMissCode {
+					nearMisses = append(nearMisses, diag)
+				}
+			}
+			if len(nearMisses) != 1 {
+				t.Fatalf("near-miss diagnostics = %d, want exactly 1 post-dedupe across two apps: %#v", len(nearMisses), result.Diagnostics)
+			}
+			diag := nearMisses[0]
+			if diag.Severity != diagnostic.SeverityWarning {
+				t.Fatalf("near-miss severity = %s, want warning: %#v", diag.Severity, diag)
+			}
+			for _, fragment := range []string{
+				"https://github.com/upstream/repo",
+				"github.com/me/repo",
+				"--repo-map",
+				"resembles a remote of the local checkout",
+				"may not reflect the local tree",
+			} {
+				if !strings.Contains(diag.Message, fragment) {
+					t.Fatalf("near-miss message = %q, want fragment %q", diag.Message, fragment)
+				}
+			}
+			for _, forbidden := range []string{"under diff", "diff side"} {
+				if strings.Contains(diag.Message, forbidden) {
+					t.Fatalf("near-miss message = %q, must not carry diff-only wording %q", diag.Message, forbidden)
+				}
+			}
+			if got := gitAcquirer.calls(); got != 1 {
+				t.Fatalf("git acquire calls = %d, want 1 (remote acquisition still attempted): %#v", got, gitAcquirer.requests)
+			}
+		})
+	}
+}
+
+// Test 9 — DIRTY-WORKTREE persistent-cache pin: an uncommitted edit to a
+// self-$repo value file between two cache-enabled builds must reflect in the
+// second build (never serve the stale cached render).
+func TestBuildSelfRepoDirtyWorktreeEditReflectedWithPersistentCache(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "main", "one")
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	request := BuildRequest{
+		Path: root,
+		RenderCacheOptions: RenderCacheOptions{
+			RenderCacheEnabled: true,
+			RenderCacheDir:     t.TempDir(),
+			EngineFingerprint:  testEngineFingerprint(),
+		},
+	}
+	orchestrator := Orchestrator{
+		GitAcquirer:   &countingGitAcquirer{err: errors.New("self-repo ref must not be acquired")},
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}
+	first, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, first, "demo"); got != "one" {
+		t.Fatalf("first rendered value = %q, want one", got)
+	}
+
+	writeSelfRepoRefValuesFile(t, root, "demo", "two") // uncommitted: dirty worktree
+
+	second, err := orchestrator.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, second, "demo"); got != "two" {
+		t.Fatalf("second rendered value = %q, want the dirty-worktree edit (two), not a stale cached render", got)
+	}
+}
+
+// Test 10 — GREEN-TO-RED pin: a self-URL source whose Path was deleted
+// locally but still exists on the remote tip now fails path-not-found instead
+// of silently rendering acquired content — correct desired-state semantics,
+// documented as a behavior change.
+func TestBuildSelfRepoLocallyMissingPathFailsInsteadOfAcquiring(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	writeTestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  source:
+    repoURL: `+selfRepoSpecURL+`
+    targetRevision: main
+    path: manifests/removed
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	// The remote tip still has the path; previously it rendered via acquisition.
+	fetchedRoot := t.TempDir()
+	writeTestFile(t, filepath.Join(fetchedRoot, "manifests", "removed", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: removed
+  namespace: default
+data:
+  value: remote-only
+`)
+	gitAcquirer := &countingGitAcquirer{path: fetchedRoot, revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	result, err := (Orchestrator{GitAcquirer: gitAcquirer}).Build(context.Background(), BuildRequest{Path: root})
+	if err == nil {
+		t.Fatalf("Build() error = nil, want path-not-found failure for the locally deleted path: %#v", result.Manifests)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0 (self URL must resolve locally): %#v", got, gitAcquirer.requests)
+	}
+	failed := false
+	for _, status := range result.Statuses {
+		if status.Status == ApplicationStatusFail && strings.Contains(status.Message, "manifests/removed") {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Fatalf("Statuses = %#v, want a FAIL naming manifests/removed", result.Statuses)
+	}
+}
+
+// Test 11 — SUBDIR limitation pin: gitref helpers open the repository at the
+// given --path without DetectDotGit walk-up, so a subdirectory path gets no
+// self-resolution and the source acquires — the documented behavior (run from
+// the checkout root or use --repo-map).
+func TestBuildSelfRepoSubdirPathGetsNoSelfResolution(t *testing.T) {
+	root, fixture := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
+	setSelfRepoRemoteHeadSymref(t, fixture.repo, "origin", "main")
+	deploy := filepath.Join(root, "deploy")
+	writeSelfRepoRefValuesApp(t, deploy, "demo", selfRepoSpecURL, "main", "from-local-tree")
+	commitDiffGitRepo(t, fixture.repo, fixture.wt, "baseline")
+
+	fetchedRoot := t.TempDir()
+	writeSelfRepoRefValuesFile(t, fetchedRoot, "demo", "from-remote")
+	gitAcquirer := &countingGitAcquirer{path: fetchedRoot, revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{Path: deploy})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := gitAcquirer.calls(); got != 1 {
+		t.Fatalf("git acquire calls = %d, want 1 (subdir paths do not self-resolve): %#v", got, gitAcquirer.requests)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-remote" {
+		t.Fatalf("rendered value = %q, want from-remote", got)
+	}
+}

--- a/internal/app/build_ref_sources_test.go
+++ b/internal/app/build_ref_sources_test.go
@@ -340,6 +340,64 @@ func TestBuildPrepopulatedSelfRepoRefsPreservedOnGitlessRoot(t *testing.T) {
 	}
 }
 
+// The guard must key on urlKeys, not revisions: a ref diff whose --ref names
+// are commit SHAs (filtered from revisions) on a checkout without an
+// origin/HEAD symref hands each side urlKeys-only refs. Re-detecting on the
+// .git-less snapshot root would wipe them and send this HEAD-revision self
+// source to the remote — a #207 regression in the actions/checkout shape.
+func TestBuildPrepopulatedURLKeysOnlySelfRepoRefsPreservedOnGitlessRoot(t *testing.T) {
+	root := t.TempDir() // .git-less: models a materialized ref-diff side snapshot
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "HEAD", "from-snapshot")
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("prepopulated self ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{
+		Path: root,
+		selfRepo: selfRepoRefs{
+			urlKeys: []string{sourcepkg.CanonicalGitURLKey(selfRepoRemoteURL)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-snapshot" {
+		t.Fatalf("rendered value = %q, want from-snapshot", got)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+}
+
+// pkg/drydock passes Config.Path verbatim and the CLI's "--path ." default
+// only shields the CLI, so ensureBuildSelfRepoRefs' Path==""→"." fallback is
+// the only thing keeping empty-Path public-API builds self-resolved.
+func TestBuildEmptyPathDefaultsToCwdAndSelfResolves(t *testing.T) {
+	root := t.TempDir()
+	repo, _ := initDiffGitRepo(t, root)
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{selfRepoRemoteURL}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "HEAD", "from-local-tree")
+	t.Chdir(root)
+
+	gitAcquirer := &countingGitAcquirer{err: errors.New("self ref must not be acquired")}
+	result, err := (Orchestrator{
+		GitAcquirer:   gitAcquirer,
+		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
+	}).Build(context.Background(), BuildRequest{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got := buildConfigMapValue(t, result, "demo"); got != "from-local-tree" {
+		t.Fatalf("rendered value = %q, want from-local-tree", got)
+	}
+	if got := gitAcquirer.calls(); got != 0 {
+		t.Fatalf("git acquire calls = %d, want 0: %#v", got, gitAcquirer.requests)
+	}
+}
+
 // Test 6b — NO-CLOBBER, path-diff shape: both side checkouts carry a matching
 // remote, but the revision gate name ("sidebranch") is known only from the
 // LEFT checkout's HEAD symref. The per-side builds must preserve the

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -66,10 +66,13 @@ type localProvider struct {
 	// for hand-built providers). Aliases the run-scoped handle memo — treat
 	// as read-only; never sort, append to, or mutate it in place.
 	rootDirtyPaths []string
-	// selfRepoURLKeys holds the canonical remote URLs of the repository under
-	// diff; nil outside diffs. selfRepoRevisions holds the diffed ref names
-	// that self-map (beyond ""/HEAD). selfRepoNearMissOnce dedupes fork
-	// near-miss warnings; nil when keys are empty. All three are write-once in
+	// selfRepoURLKeys holds the canonical remote URLs of the local repository
+	// under analysis — populated by diff entry points and, on build/list
+	// surfaces, by ensureBuildSelfRepoRefs; nil for non-git roots or roots
+	// without remotes. selfRepoRevisions holds the symbolic revision names
+	// that self-map beyond ""/HEAD (diffed ref names plus symref-derived
+	// default-branch names). selfRepoNearMissOnce dedupes fork near-miss
+	// warnings; nil when keys are empty. All three are write-once in
 	// newLocalProvider (single-threaded, before any render goroutine starts)
 	// and read-only thereafter — no locking needed.
 	selfRepoURLKeys      map[string]struct{}

--- a/internal/app/local_provider_sources.go
+++ b/internal/app/local_provider_sources.go
@@ -40,13 +40,16 @@ func (p localProvider) resolveSourceRootIdentity(ctx context.Context, source ren
 		}
 	}
 	if p.isSelfRepoRef(source.RepoURL, source.TargetRevision) {
-		// The source names the repository under diff at a revision tracking the
-		// diffed tree. Resolve to this side's root: never consult the git
-		// acquirer, whose snapshot-memo and persistent-cache keys are side-blind
-		// (URL+revision string). rootIdentity is side-scoped (Revision =
-		// per-side rootRevision), so the app stays persistent-render-cache
-		// eligible with per-side keys — also fixing the side-blind identity for
-		// pure ref-only sources.
+		// The source names the local repository at a revision tracking this
+		// tree — the tree drydock is pointed at IS the desired state (#207
+		// rationale, extended from diffs to all render surfaces). Resolve to
+		// this provider's root: never consult the git acquirer, whose
+		// snapshot-memo and persistent-cache keys are blind to which local
+		// tree is rendering (URL+revision string). rootIdentity is
+		// root-scoped (per-side rootRevision on diffs, worktree state on
+		// builds), so the app stays persistent-render-cache eligible with
+		// tree-accurate keys — also fixing the tree-blind identity for pure
+		// ref-only sources.
 		p.recordCacheEvent(cacheevent.Event{Source: cacheevent.SourceGit, Action: cacheevent.ActionLocal, Target: source.RepoURL, Revision: source.TargetRevision})
 		return p.repoRoot, p.rootIdentity, nil
 	}

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -155,6 +155,29 @@ type Orchestrator struct {
 	renderObserver func(render.ResolvedSource)
 }
 
+// ensureBuildSelfRepoRefs populates request.selfRepo for single-tree
+// build/list surfaces so sources naming the local checkout's own repository
+// at ""/HEAD or a symref-derived default-branch name resolve to the local
+// tree (the #207 diff behavior extended to render surfaces). It runs in
+// exactly the two leaves every caller reaches — ListApplications and Build —
+// never at delegating entries. Populating only when urlKeys is empty is THE
+// diff-path protection: per-side diff builds re-enter these leaves carrying
+// refs cloned from the diff request, and re-detection here would replace
+// them with side-local remotes. The inert edge — empty urlKeys with
+// non-empty revisions re-detects to zero — is harmless because isSelfRepoRef
+// short-circuits on empty urlKeys.
+func ensureBuildSelfRepoRefs(request BuildRequest) BuildRequest {
+	if len(request.selfRepo.urlKeys) > 0 {
+		return request
+	}
+	root := request.Path
+	if root == "" {
+		root = "."
+	}
+	request.selfRepo = detectBuildSelfRepoRefs(root)
+	return request
+}
+
 func ensureSnapshotSession(request BuildRequest) (BuildRequest, func(), error) {
 	if request.snapshotSession != nil {
 		return request, func() {}, nil
@@ -199,6 +222,7 @@ func (o Orchestrator) ListApplications(ctx context.Context, request BuildRequest
 	defer func() {
 		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
 	}()
+	request = ensureBuildSelfRepoRefs(request)
 
 	if err := request.ProjectDiagnosticsMode.Validate(); err != nil {
 		return BuildResult{}, err
@@ -324,6 +348,7 @@ func (o Orchestrator) Build(ctx context.Context, request BuildRequest) (result B
 	defer func() {
 		result.CacheEvents = append(result.CacheEvents, releaseRenderCache()...)
 	}()
+	request = ensureBuildSelfRepoRefs(request)
 
 	session, err := newBuildSession(o, request)
 	if err != nil {
@@ -919,10 +944,10 @@ func normalizeDiagnostics(diags []diagnostic.Diagnostic, strict, forceWarning bo
 // strictExemptDiagnostic reports whether a diagnostic is advisory-only:
 // --strict must neither escalate its severity nor fail the application on it.
 // The self-repo near-miss is a --repo-map remediation hint whose primary
-// audience is fork-topology checkouts running strict CI diffs — escalating it
-// would convert exactly those working diffs into hard failures. Rendering
-// stays unchanged when the hint fires (remote acquisition still happens), so
-// there is nothing for --strict to protect against.
+// audience is fork-topology checkouts running strict CI renders and diffs —
+// escalating it would convert exactly those working runs into hard failures.
+// Rendering stays unchanged when the hint fires (remote acquisition still
+// happens), so there is nothing for --strict to protect against.
 func strictExemptDiagnostic(diag diagnostic.Diagnostic) bool {
 	return diag.Code == selfRepoNearMissCode
 }

--- a/internal/app/self_map_remote.go
+++ b/internal/app/self_map_remote.go
@@ -7,9 +7,10 @@ import (
 )
 
 // selfMapRemote wraps the remote acquirer so self-referential kustomize git
-// bases (git::<ownURL>//dir?ref=HEAD) resolve to the active diff side root
-// instead of the shared remote worktree. Returns the delegate unchanged when
-// no self keys are configured — provably dead outside diffs.
+// bases (git::<ownURL>//dir?ref=HEAD) resolve to the active local root (the
+// diff side or the build checkout) instead of the shared remote worktree.
+// Returns the delegate unchanged when no self keys are configured — provably
+// dead for non-git roots and roots without matching remotes.
 func (p localProvider) selfMapRemote(delegate remote.Acquirer) remote.Acquirer {
 	if len(p.selfRepoURLKeys) == 0 {
 		return delegate
@@ -26,14 +27,14 @@ func (a selfMapRemoteAcquirer) Acquire(ctx context.Context, request remote.Reque
 	if request.Kind == remote.RequestGitRepo && a.p.isSelfRepoRef(request.RepoURL, request.Revision) {
 		// Truthful result: FromCache=true makes recordRemoteCacheEvent emit
 		// Network=false and Action=hit — no phantom fetch. Revision carries
-		// the side snapshot SHA when known. Pin-stability is unchanged:
+		// the root's revision SHA when known. Pin-stability is unchanged:
 		// acquisitionsPinStable gates RemoteGit on RequestedRevision, which
 		// stays symbolic, so such apps remain persistent-cache-ineligible
 		// exactly as today.
 		return remote.Result{
 			Path:      a.p.repoRoot,
 			URL:       request.URL,
-			Revision:  a.p.rootIdentity.Revision, // side SHA; may be "" for path diffs
+			Revision:  a.p.rootIdentity.Revision, // root SHA; may be "" when unknown
 			FromCache: true,
 			Release:   func() {}, // idempotent no-op; side root is command-lifetime, read-only
 		}, nil

--- a/internal/app/self_repo.go
+++ b/internal/app/self_repo.go
@@ -14,34 +14,37 @@ import (
 // selfRepoNearMissCode identifies the fork near-miss remediation hint. The
 // code is strict-exempt: normalizeDiagnostics and diagnosticFailure both skip
 // it under --strict (see strictExemptDiagnostic), so the warning stays a
-// warning and never fails the diff.
+// warning and never fails the run.
 const selfRepoNearMissCode = "source.self-repo-near-miss"
 
-// selfRepoRefs identifies "the repository under diff" for source resolution.
-// Populated ONLY by diff entry points; zero value disables everything.
+// selfRepoRefs identifies "the local repository under analysis" for source
+// resolution. Diff entry points populate it from the diff request and side
+// paths; ensureBuildSelfRepoRefs populates it for single-tree build/list
+// surfaces. The zero value disables everything.
 type selfRepoRefs struct {
-	urlKeys   []string // CanonicalGitURLKey of every remote URL of the diffed repo
-	revisions []string // symbolic revisions beyond ""/HEAD that track the diffed
-	// tree: the trimmed --ref and --ref-orig names (non-SHA)
+	urlKeys   []string // CanonicalGitURLKey of every remote URL of the local repo
+	revisions []string // symbolic revisions beyond ""/HEAD that track the local
+	// tree(s): the trimmed --ref/--ref-orig names on diffs plus the
+	// default-branch names read from remote HEAD symrefs (non-SHA)
 }
 
-// detectSelfRepoRefs identifies the repository under diff from the union of
-// the diff repo path and both side paths: ref diffs materialize .git-less
-// snapshots so the side paths contribute nil, while path diffs point at real
-// checkouts whose remotes all contribute. No all-or-nothing fallback — a
-// matching remote on either side is enough.
-func detectSelfRepoRefs(request DiffRequest, repoPath string) selfRepoRefs {
-	urls := gitref.RemoteURLs(repoPath)
-	urls = append(urls, gitref.RemoteURLs(request.LeftPath)...)
-	urls = append(urls, gitref.RemoteURLs(request.RightPath)...)
-	// The repo's default-branch NAME tracks the diffed tree exactly like a
-	// --ref/--ref-orig name does: a spec pinned to "main" diffed across any
-	// two trees of this repository should read the side trees (the post-merge
-	// argument), and a mixed remote-tree render would be less coherent. Real
-	// repos commonly write targetRevision: main rather than HEAD.
-	branchNames := gitref.DefaultBranchNames(repoPath)
-	branchNames = append(branchNames, gitref.DefaultBranchNames(request.LeftPath)...)
-	branchNames = append(branchNames, gitref.DefaultBranchNames(request.RightPath)...)
+// detectSelfRepoRefsFromPaths is the shared detector core: the union of every
+// path's configured remotes identifies the repository (non-git paths
+// contribute nothing), and extraRevisions plus every path's default-branch
+// names form the symbolic revisions. The default-branch NAME tracks the local
+// tree exactly like a --ref/--ref-orig name does: a spec pinned to "main"
+// should read the tree drydock is pointed at (the #207 post-merge argument),
+// and real repos commonly write targetRevision: main rather than HEAD. The
+// names come from remote HEAD symrefs ONLY — no fallback guessing:
+// init.defaultBranch or the checked-out HEAD would wrongly treat a PR branch
+// itself as the default branch.
+func detectSelfRepoRefsFromPaths(paths, extraRevisions []string) selfRepoRefs {
+	urls := make([]string, 0, len(paths))
+	branchNames := make([]string, 0, len(paths))
+	for _, path := range paths {
+		urls = append(urls, gitref.RemoteURLs(path)...)
+		branchNames = append(branchNames, gitref.DefaultBranchNames(path)...)
+	}
 	var refs selfRepoRefs
 	seenKeys := map[string]struct{}{}
 	for _, url := range urls {
@@ -56,7 +59,7 @@ func detectSelfRepoRefs(request DiffRequest, repoPath string) selfRepoRefs {
 		refs.urlKeys = append(refs.urlKeys, key)
 	}
 	seenRevisions := map[string]struct{}{}
-	for _, revision := range append([]string{request.Ref, request.RefOrig}, branchNames...) {
+	for _, revision := range append(append([]string(nil), extraRevisions...), branchNames...) {
 		revision = strings.TrimSpace(revision)
 		if revision == "" || sourcepkg.IsDefaultRevision(revision) || sourcepkg.IsCommitSHA(revision) {
 			continue
@@ -70,8 +73,27 @@ func detectSelfRepoRefs(request DiffRequest, repoPath string) selfRepoRefs {
 	return refs
 }
 
-// clone deep-copies both slices so concurrent diff sides never share mutable
-// state through their BuildRequests.
+// detectSelfRepoRefs identifies the repository under diff from the union of
+// the diff repo path and both side paths: ref diffs materialize .git-less
+// snapshots so the side paths contribute nil, while path diffs point at real
+// checkouts whose remotes all contribute. No all-or-nothing fallback — a
+// matching remote on either side is enough.
+func detectSelfRepoRefs(request DiffRequest, repoPath string) selfRepoRefs {
+	return detectSelfRepoRefsFromPaths(
+		[]string{repoPath, request.LeftPath, request.RightPath},
+		[]string{request.Ref, request.RefOrig},
+	)
+}
+
+// detectBuildSelfRepoRefs identifies the local checkout for single-tree
+// build/list surfaces. Revisions come from the checkout's remote HEAD
+// symrefs only — symref-or-nothing, exactly like the diff side.
+func detectBuildSelfRepoRefs(path string) selfRepoRefs {
+	return detectSelfRepoRefsFromPaths([]string{path}, nil)
+}
+
+// clone deep-copies both slices so concurrent consumers (diff sides in
+// particular) never share mutable state through their BuildRequests.
 func (r selfRepoRefs) clone() selfRepoRefs {
 	return selfRepoRefs{
 		urlKeys:   append([]string(nil), r.urlKeys...),
@@ -79,9 +101,10 @@ func (r selfRepoRefs) clone() selfRepoRefs {
 	}
 }
 
-// isSelfRepoRef reports whether the source names the repository under diff at
-// a revision tracking the diffed tree. Pinned commit SHAs always acquire;
-// tags and branches not named by --ref/--ref-orig always acquire.
+// isSelfRepoRef reports whether the source names the local repository at a
+// revision tracking its tree ("", HEAD, a diffed ref name, or a
+// symref-derived default-branch name). Pinned commit SHAs always acquire;
+// tags and branches beyond the tracked revisions always acquire.
 func (p localProvider) isSelfRepoRef(repoURL, revision string) bool {
 	if len(p.selfRepoURLKeys) == 0 {
 		return false
@@ -102,12 +125,12 @@ func (p localProvider) isSelfRepoRef(repoURL, revision string) bool {
 	return ok
 }
 
-// selfRepoNearMissDiagnostics warns when a source resembles the repository
-// under diff — same host and trailing repo segment as one of its remotes but
+// selfRepoNearMissDiagnostics warns when a source resembles the local
+// repository — same host and trailing repo segment as one of its remotes but
 // a different full canonical key (classic fork topology) — while the revision
 // gate would have passed and no explicit --repo-map covers the URL. The
 // previously silent survival mode is now loud. Warnings dedupe once per URL
-// per side via selfRepoNearMissOnce.
+// per provider via selfRepoNearMissOnce.
 func (p localProvider) selfRepoNearMissDiagnostics(source render.ResolvedSource, refSources map[string]render.ResolvedSource) []diagnostic.Diagnostic {
 	if len(p.selfRepoURLKeys) == 0 || p.selfRepoNearMissOnce == nil {
 		return nil
@@ -182,7 +205,7 @@ func (p localProvider) selfRepoNearMissDiagnostic(source render.ResolvedSource) 
 		Code:     selfRepoNearMissCode,
 		Severity: diagnostic.SeverityWarning,
 		Category: "source",
-		Message:  fmt.Sprintf("source repository %q resembles the repository under diff (remote %q) but matches none of its configured remotes; $ref value files are fetched from the remote repository and may not reflect this diff side — add --repo-map <url>=<path> if these are the same repository", sourcepkg.RedactURL(repoURL), matched),
+		Message:  fmt.Sprintf("source repository %q resembles a remote of the local checkout (remote %q) but matches none of its configured remotes; $ref value files are fetched from the remote repository and may not reflect the local tree — add --repo-map <url>=<path> if these are the same repository", sourcepkg.RedactURL(repoURL), matched),
 	}, true
 }
 

--- a/internal/app/self_repo_test.go
+++ b/internal/app/self_repo_test.go
@@ -227,24 +227,6 @@ func TestSelfMapRemoteEmptyKeysReturnsDelegateUnchanged(t *testing.T) {
 	}
 }
 
-// Single-side control: Build never populates selfRepo, so a self-URL ref
-// source still acquires remotely even when the build root's own remotes match
-// the spec URL — the inertness pin for build/test/pkg/drydock.
-func TestBuildSelfRepoURLRefSourceStillAcquiresOutsideDiffs(t *testing.T) {
-	root, _ := initSelfRepoDiffGitRepo(t, selfRepoRemoteURL)
-	writeSelfRepoRefValuesApp(t, root, "demo", selfRepoSpecURL, "HEAD", "from-current-root")
-
-	fetchedRoot := t.TempDir()
-	writeSelfRepoRefValuesFile(t, fetchedRoot, "demo", "from-remote")
-	gitAcquirer := &countingGitAcquirer{path: fetchedRoot, revision: "6666666666666666666666666666666666666666"}
-	_, err := (Orchestrator{
-		GitAcquirer:   gitAcquirer,
-		ChartAcquirer: newSelfRepoValueChartAcquirer(t),
-	}).Build(context.Background(), BuildRequest{Path: root})
-	if err != nil {
-		t.Fatalf("Build() error = %v", err)
-	}
-	if got := gitAcquirer.calls(); got != 1 {
-		t.Fatalf("git acquire calls = %d, want 1 (self mapping must stay dead outside diffs): %#v", got, gitAcquirer.requests)
-	}
-}
+// The former single-side inertness pin (Build never populates selfRepo) was
+// deliberately removed: build/list surfaces now populate selfRepo via
+// ensureBuildSelfRepoRefs. Its replacements live in build_ref_sources_test.go.

--- a/internal/cli/self_repo_source_test.go
+++ b/internal/cli/self_repo_source_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/sholdee/drydock/internal/app"
+)
+
+// initSelfRepoCLICheckout creates a checkout whose origin remote names the
+// repository the specs reference and whose origin/HEAD symref names "main" —
+// the state actions/checkout plus the pr-action symref write leave behind.
+func initSelfRepoCLICheckout(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	repo, err := git.PlainInit(root, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/example/repo.git"}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName("refs/remotes/origin/HEAD"),
+		plumbing.ReferenceName("refs/remotes/origin/main"),
+	)); err != nil {
+		t.Fatalf("SetReference(origin/HEAD) error = %v", err)
+	}
+	return root
+}
+
+// writeSelfRepoCLIFixture writes the issue #206 repro shape: a parent
+// Application whose local helm chart source consumes a $repo value file from
+// the repository's own URL at the default-branch NAME, templating a child
+// Application whose name exists only in the local tree's value file.
+func writeSelfRepoCLIFixture(t *testing.T, root string) {
+	t.Helper()
+	writeCLITestFile(t, filepath.Join(root, "apps", "parent.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: parent
+  namespace: argocd
+spec:
+  sources:
+    - repoURL: https://github.com/example/repo
+      targetRevision: "main"
+      ref: repo
+    - repoURL: https://github.com/example/repo
+      targetRevision: HEAD
+      path: bootstrap-chart
+      helm:
+        valueFiles:
+          - $repo/values/parent.yaml
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeCLITestFile(t, filepath.Join(root, "bootstrap-chart", "Chart.yaml"), `apiVersion: v2
+name: bootstrap
+version: 0.1.0
+`)
+	writeCLITestFile(t, filepath.Join(root, "bootstrap-chart", "values.yaml"), `childName: default-child
+`)
+	writeCLITestFile(t, filepath.Join(root, "bootstrap-chart", "templates", "child.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.childName }}
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: manifests/child
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeCLITestFile(t, filepath.Join(root, "values", "parent.yaml"), `childName: local-only-child
+`)
+	writeCLITestFile(t, filepath.Join(root, "manifests", "child", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: child-config
+  namespace: default
+data:
+  value: child
+`)
+}
+
+// test apps must pass on the repro-shaped checkout WITHOUT --repo-map: the
+// self-referential $repo values ref resolves to the local tree.
+func TestTestAppsResolvesSelfRepoRefsWithoutRepoMap(t *testing.T) {
+	root := initSelfRepoCLICheckout(t)
+	writeSelfRepoCLIFixture(t, root)
+
+	gitAcquirer := &recordingCLIGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: app.Orchestrator{GitAcquirer: gitAcquirer},
+	}, "test", "apps", "--path", root)
+	assertStdoutContainsAll(t, result, "parent", "local-only-child", "PASS")
+	assertStdoutExcludesAll(t, result, "FAIL")
+	if len(gitAcquirer.requests) != 0 {
+		t.Fatalf("git acquire requests = %#v, want none", gitAcquirer.requests)
+	}
+}
+
+// get apps must list the child Application discovered through the local
+// $repo values WITHOUT --repo-map.
+func TestGetAppsListsSelfRepoAppOfAppsChildWithoutRepoMap(t *testing.T) {
+	root := initSelfRepoCLICheckout(t)
+	writeSelfRepoCLIFixture(t, root)
+
+	gitAcquirer := &recordingCLIGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result := runCLIWithDependencies(t, Dependencies{
+		Orchestrator: app.Orchestrator{GitAcquirer: gitAcquirer},
+	}, "get", "apps", "--path", root)
+	assertStdoutContainsAll(t, result, "parent", "local-only-child")
+	if len(gitAcquirer.requests) != 0 {
+		t.Fatalf("git acquire requests = %#v, want none", gitAcquirer.requests)
+	}
+}

--- a/internal/gitref/remotes_test.go
+++ b/internal/gitref/remotes_test.go
@@ -102,6 +102,40 @@ func TestDefaultBranchNamesReadsRemoteHEADSymrefs(t *testing.T) {
 	}
 }
 
+// A DANGLING symref must still yield the branch name: pr-action render-only
+// mode writes refs/remotes/origin/HEAD without fetching the base branch, so
+// the symref target ref does not exist. DefaultBranchNames reads the target
+// NAME unresolved — resolving the symref would silently drop it.
+func TestDefaultBranchNamesDanglingSymrefStillReturnsBranchName(t *testing.T) {
+	repoPath := t.TempDir()
+	repo, err := git.PlainInit(repoPath, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/me/repo.git"},
+	}); err != nil {
+		t.Fatalf("CreateRemote(origin) error = %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName("refs/remotes/origin/HEAD"),
+		plumbing.ReferenceName("refs/remotes/origin/main"),
+	)); err != nil {
+		t.Fatalf("SetReference(origin/HEAD) error = %v", err)
+	}
+	// Fixture guard: the symref target must NOT resolve, or this test would
+	// silently degrade into the plain symref case.
+	if _, err := repo.Reference(plumbing.ReferenceName("refs/remotes/origin/HEAD"), true); err == nil {
+		t.Fatal("fixture error: origin/HEAD resolved; the symref is not dangling")
+	}
+
+	names := DefaultBranchNames(repoPath)
+	if !reflect.DeepEqual(names, []string{"main"}) {
+		t.Fatalf("DefaultBranchNames() = %#v, want [main] from the dangling symref", names)
+	}
+}
+
 func TestDefaultBranchNamesWithoutSymrefReturnsNil(t *testing.T) {
 	repoPath := t.TempDir()
 	repo, err := git.PlainInit(repoPath, false)

--- a/pkg/drydock/drydock_self_repo_test.go
+++ b/pkg/drydock/drydock_self_repo_test.go
@@ -1,0 +1,87 @@
+package drydock
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// Public-API mapping pin: self-repo resolution needs no new Config surface —
+// the internal build/list leaves populate it from the checkout at Path, so a
+// $repo values ref naming the checkout's own repository at the symref-derived
+// default-branch name renders from the local tree through Render as well.
+func TestRenderSelfRepoRefResolvesToLocalTree(t *testing.T) {
+	root := t.TempDir()
+	repo, err := git.PlainInit(root, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://github.com/example/repo.git"}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName("refs/remotes/origin/HEAD"),
+		plumbing.ReferenceName("refs/remotes/origin/main"),
+	)); err != nil {
+		t.Fatalf("SetReference(origin/HEAD) error = %v", err)
+	}
+	writeAPIFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  sources:
+    - repoURL: https://github.com/example/repo
+      targetRevision: "main"
+      ref: repo
+    - repoURL: https://github.com/example/repo
+      targetRevision: HEAD
+      path: chart
+      helm:
+        valueFiles:
+          - $repo/values/demo.yaml
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeAPIFile(t, filepath.Join(root, "chart", "Chart.yaml"), `apiVersion: v2
+name: demo
+version: 0.1.0
+`)
+	writeAPIFile(t, filepath.Join(root, "chart", "values.yaml"), `value: default
+`)
+	writeAPIFile(t, filepath.Join(root, "chart", "templates", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  value: {{ .Values.value | quote }}
+`)
+	writeAPIFile(t, filepath.Join(root, "values", "demo.yaml"), `value: from-local-tree
+`)
+
+	gitAcquirer := &recordingGitAcquirer{err: errors.New("self-repo ref must not be acquired")}
+	result, err := Render(context.Background(), Config{Path: root, GitAcquirer: gitAcquirer})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	if len(result.Manifests) != 1 {
+		t.Fatalf("Manifests = %d, want 1", len(result.Manifests))
+	}
+	data, ok := result.Manifests[0].Object["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("Object[data] = %#v, want map", result.Manifests[0].Object["data"])
+	}
+	if got := data["value"]; got != "from-local-tree" {
+		t.Fatalf("rendered value = %#v, want from-local-tree", got)
+	}
+	if len(gitAcquirer.requests) != 0 {
+		t.Fatalf("git acquire requests = %#v, want none", gitAcquirer.requests)
+	}
+}

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -439,6 +439,7 @@ runs:
         DRYDOCK_DIFF_HTML_ARTIFACT_NAME: ${{ steps.prepare.outputs.diff-html-artifact-name }}
         DRYDOCK_IMAGE_ARTIFACT_NAME: ${{ steps.prepare.outputs.image-artifact-name }}
         DRYDOCK_INPUT_API_VERSIONS: ${{ inputs.api-versions }}
+        DRYDOCK_INPUT_BASE_REF: ${{ inputs.base-ref }}
         DRYDOCK_INPUT_CHANGED_ONLY: ${{ inputs.changed-only }}
         DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE: ${{ inputs.changed-only-include }}
         DRYDOCK_INPUT_CHANGED_ONLY_IGNORE: ${{ inputs.changed-only-ignore }}
@@ -476,6 +477,7 @@ runs:
         DRYDOCK_INPUT_STRICT: ${{ inputs.strict }}
         DRYDOCK_INPUT_STRICT_CHANGED_ONLY: ${{ inputs.strict-changed-only }}
         DRYDOCK_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload-artifacts }}
+        DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: '"${GITHUB_ACTION_PATH}/run.sh"'
 
     - name: Save drydock render cache

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -232,6 +232,33 @@ func TestActionDiscoverIgnoreInputDeclaredAndWiredToRunStep(t *testing.T) {
 	}
 }
 
+// The Run step needs the base ref even when fetch-base is skipped
+// (render-test-only configs): run.sh writes the origin/HEAD symref from these
+// env vars so drydock's self-repo resolution works in ALL modes.
+func TestActionRunStepWiresBaseRefEnvForSymrefWrite(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	runIdx := strings.Index(actionYAML, "- name: Run drydock\n")
+	if runIdx == -1 {
+		t.Fatalf("action.yml missing 'Run drydock' step")
+	}
+	nextStep := strings.Index(actionYAML[runIdx+1:], "\n    - name: ")
+	var runBlock string
+	if nextStep == -1 {
+		runBlock = actionYAML[runIdx:]
+	} else {
+		runBlock = actionYAML[runIdx : runIdx+1+nextStep]
+	}
+	for _, want := range []string{
+		"DRYDOCK_INPUT_BASE_REF: ${{ inputs.base-ref }}",
+		"DRYDOCK_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}",
+	} {
+		if !strings.Contains(runBlock, want) {
+			t.Fatalf("Run step env block missing %q:\n%s", want, runBlock)
+		}
+	}
+}
+
 func TestActionNoPinnedActionRefsInPruneStep(t *testing.T) {
 	actionYAML := loadActionYAML(t)
 

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -304,6 +304,31 @@ base_compare_ref="${DRYDOCK_BASE_COMPARE_REF:-}"
 drydock_bin="${DRYDOCK_BIN:-drydock}"
 run_url="$(workflow_run_url)"
 
+# Record the base branch as origin's HEAD symref when no earlier step has:
+# drydock's self-repo resolution reads refs/remotes/origin/HEAD to learn the
+# default-branch NAME, and render-test-only configs never run fetch-base (the
+# only other writer, gated on the diff inputs). Offline and tolerant:
+# symbolic-ref writes without validating that the target exists — required
+# because render-only mode never fetches the base branch, and drydock reads
+# the symref target name UNRESOLVED, so a dangling symref still yields the
+# branch name. An already-set origin/HEAD (fetch-base, a full clone) is never
+# overwritten.
+ensure_origin_head_symref() {
+  local base_ref="${DRYDOCK_INPUT_BASE_REF:-}"
+  if [[ -z "${base_ref}" ]]; then
+    base_ref="${DRYDOCK_PR_BASE_REF:-}"
+  fi
+  if [[ -z "${base_ref}" ]]; then
+    return 0
+  fi
+  git check-ref-format --branch "${base_ref}" >/dev/null 2>&1 || return 0
+  if git symbolic-ref -q refs/remotes/origin/HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+  git symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/${base_ref}" >/dev/null 2>&1 || true
+}
+ensure_origin_head_symref
+
 common_args=()
 if [[ -n "${cache_path}" ]]; then
   common_args+=(

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -1049,6 +1049,8 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_DIFF_ARTIFACT_NAME",
 		"DRYDOCK_DIFF_HTML_ARTIFACT_NAME",
 		"DRYDOCK_IMAGE_ARTIFACT_NAME",
+		"DRYDOCK_INPUT_BASE_REF",
+		"DRYDOCK_PR_BASE_REF",
 		"GITHUB_OUTPUT",
 		"GITHUB_REPOSITORY",
 		"GITHUB_RUN_ATTEMPT",
@@ -1073,6 +1075,8 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_DIFF_HTML_ARTIFACT_NAME=diff.html",
 		"DRYDOCK_IMAGE_ARTIFACT_NAME=images",
 		"DRYDOCK_INPUT_API_VERSIONS=",
+		"DRYDOCK_INPUT_BASE_REF=",
+		"DRYDOCK_PR_BASE_REF=",
 		"DRYDOCK_INPUT_CHANGED_ONLY=",
 		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE=",
 		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE=",
@@ -1129,5 +1133,113 @@ func writeExecutable(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// symrefProbeDrydock records the origin/HEAD symref target as observed at
+// drydock-invocation time, pinning that run.sh writes the symref BEFORE the
+// binary runs (not merely at some point during the step).
+const symrefProbeDrydock = `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+if symref="$(git symbolic-ref -q refs/remotes/origin/HEAD)"; then
+  printf '%s\n' "${symref}" > "${DRYDOCK_ACTION_WORK_DIR}/symref-at-invocation.txt"
+else
+  printf 'unset\n' > "${DRYDOCK_ACTION_WORK_DIR}/symref-at-invocation.txt"
+fi
+`
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func runGitOriginHeadSymref(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "symbolic-ref", "-q", "refs/remotes/origin/HEAD")
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		return "" // unset
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// The symref write must be available in ALL modes whenever a base ref is
+// known: render-test-only configs (diff inputs false) never run fetch-base,
+// which was previously the only origin/HEAD writer. The write is offline and
+// tolerant — the target may dangle because render-only mode never fetches the
+// base branch (drydock reads the symref target name unresolved).
+func TestRunEnsuresOriginHeadSymrefForRenderTestOnlyMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	runShPath, err := filepath.Abs("run.sh")
+	if err != nil {
+		t.Fatalf("Abs(run.sh): %v", err)
+	}
+
+	for _, tt := range []struct {
+		name         string
+		inputBaseRef string
+		prBaseRef    string
+		existing     string // pre-set origin/HEAD target branch; "" = unset
+		wantSymref   string // expected origin/HEAD target after run; "" = unset
+	}{
+		{name: "render-only PR event writes dangling symref", prBaseRef: "main", wantSymref: "refs/remotes/origin/main"},
+		{name: "explicit base-ref input wins over PR event ref", inputBaseRef: "release", prBaseRef: "main", wantSymref: "refs/remotes/origin/release"},
+		{name: "existing symref is never overwritten", prBaseRef: "main", existing: "other", wantSymref: "refs/remotes/origin/other"},
+		{name: "no base ref leaves origin/HEAD unset", wantSymref: ""},
+		{name: "invalid base ref is skipped", prBaseRef: "bad..ref", wantSymref: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			writeExecutable(t, filepath.Join(tmp, "drydock"), symrefProbeDrydock)
+			repo := filepath.Join(tmp, "checkout")
+			runGit(t, tmp, "init", "--quiet", repo)
+			runGit(t, repo, "remote", "add", "origin", "https://github.com/example/repo.git")
+			if tt.existing != "" {
+				runGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+tt.existing)
+			}
+
+			workDir := filepath.Join(tmp, "work")
+			outputPath := filepath.Join(tmp, "github-output")
+			env := append(defaultRunEnv(tmp, workDir, outputPath),
+				"DRYDOCK_INPUT_RUN_TEST=true",
+			)
+			if tt.inputBaseRef != "" {
+				env = setEnv(env, "DRYDOCK_INPUT_BASE_REF", tt.inputBaseRef)
+			}
+			if tt.prBaseRef != "" {
+				env = setEnv(env, "DRYDOCK_PR_BASE_REF", tt.prBaseRef)
+			}
+
+			cmd := exec.Command("bash", runShPath)
+			cmd.Dir = repo
+			cmd.Env = env
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("run.sh failed: %v\n%s", err, out)
+			}
+
+			if got := runGitOriginHeadSymref(t, repo); got != tt.wantSymref {
+				t.Fatalf("origin/HEAD symref = %q, want %q", got, tt.wantSymref)
+			}
+			probe := strings.TrimSpace(readFile(t, filepath.Join(workDir, "symref-at-invocation.txt")))
+			wantProbe := tt.wantSymref
+			if wantProbe == "" {
+				wantProbe = "unset"
+			}
+			if probe != wantProbe {
+				t.Fatalf("symref at drydock invocation = %q, want %q", probe, wantProbe)
+			}
+		})
 	}
 }

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -56,7 +56,8 @@ remote HEAD symref still acquire remotely.
 Default-branch names come from remote HEAD symrefs only
 (`refs/remotes/<remote>/HEAD` — set by `git clone`; recreate it with
 `git remote set-head origin -a` after a bare `git init`/fetch checkout; the
-pr-action records the pull request's base branch there in all modes). There is
+pr-action records the pull request's base branch there whenever a base ref is
+known — pull-request events or an explicit `base-ref` input). There is
 no fallback guessing: without a symref, a source pinned to the default-branch
 name acquires remotely, because `init.defaultBranch` or the checked-out HEAD
 could wrongly treat a feature branch as the default.

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -15,9 +15,10 @@ For repository sources, drydock resolves deterministically:
 
 1. Explicit `--repo-map URL=PATH`.
 2. Existing local source path under the selected repository tree.
-3. During diffs, a source naming the repository under diff at `""`/`HEAD`, a
-   diffed ref name, or the repository's default-branch name resolves to the
-   active side tree (full-commit-SHA revisions still acquire remotely).
+3. A source naming the local checkout — a configured remote of the selected
+   repository — at `""`/`HEAD`, a diffed ref name (during diffs), or the
+   repository's default-branch name resolves to the local tree (during diffs,
+   the active side tree). Full-commit-SHA revisions still acquire remotely.
 4. Declared Git cache or fetch behavior for unmapped external repositories.
 5. Clear failure.
 
@@ -32,27 +33,55 @@ drydock test apps --path . \
 For mapped pull-request repositories, `--path` and `--path-orig` are
 authoritative source roots and override declared revisions.
 
-During `diff` commands, drydock detects when a source `repoURL` matches one of
-the configured remotes of the repository under diff. At `""`/`HEAD`, at the
-literal `--ref`/`--ref-orig` names, or at the repository's default-branch name
-(read from each remote's HEAD symref, `refs/remotes/<remote>/HEAD` — set by
-`git clone`; the pr-action's fetch-base step records the pull request's base
-branch there on CI checkouts), such sources resolve to the active side tree
-with no Git cache read or network fetch — including under `--offline`.
-Full-commit-SHA revisions, tags, and branches not named by the diff or a
-remote HEAD symref still acquire remotely. A `--repo-map` entry whose path is the checkout under diff
-is rewritten per side for ref diffs, so a single mapped path never serves one
-worktree to both sides. For path diffs of exported trees (no `.git` anywhere),
-detection finds no remotes; provide per-invocation side-correct maps rather
-than one static self-map. When a source merely resembles the diffed repository
-(same host and repository name, different owner — a fork layout), drydock
-emits a `source.self-repo-near-miss` warning and keeps remote acquisition; add
-`--repo-map URL=PATH` if they are the same repository. The warning is advisory
-only: `--strict` neither escalates it nor fails the diff on it.
+Self-references — sources naming the checkout's own repository at `HEAD` or
+its default-branch name — resolve to the local tree automatically on all
+surfaces, so they need no `--repo-map` entry. Keep `--repo-map` for forks,
+commit-SHA pins, and runs from a subdirectory of the checkout.
 
 Ref-only sources are allowed and render no manifests. `$ref/...` Helm value
 files and file parameters resolve from the referenced source root, not from its
 `path`.
+
+### Self-Repository Sources
+
+On every render surface — `get`, `build`, `test`, `diag`, and both sides of
+`diff` — drydock detects when a source `repoURL` matches one of the configured
+remotes of the local checkout. At `""`/`HEAD`, at the literal
+`--ref`/`--ref-orig` names (diffs only), or at the repository's default-branch
+name, such sources resolve to the local tree — the active side tree during
+diffs — with no Git cache read or network fetch, including under `--offline`.
+Full-commit-SHA revisions, tags, and branches not named by the diff or a
+remote HEAD symref still acquire remotely.
+
+Default-branch names come from remote HEAD symrefs only
+(`refs/remotes/<remote>/HEAD` — set by `git clone`; recreate it with
+`git remote set-head origin -a` after a bare `git init`/fetch checkout; the
+pr-action records the pull request's base branch there in all modes). There is
+no fallback guessing: without a symref, a source pinned to the default-branch
+name acquires remotely, because `init.defaultBranch` or the checked-out HEAD
+could wrongly treat a feature branch as the default.
+
+Because self-repository sources read the local tree, uncommitted working-tree
+edits flow into self-`$repo` value files on render surfaces, exactly as they do
+for the primary source path. The converse also holds: a self-repository source
+whose `path` was deleted locally but still exists on the remote tip fails with
+path-not-found instead of silently rendering stale remote content — the tree
+drydock is pointed at is the desired state.
+
+Detection opens the Git repository at the selected `--path`/`--repo` exactly;
+it does not walk up to a parent `.git`. Running `test apps --path <subdir>`
+from inside a checkout gets no self-resolution — run from the checkout root,
+or add `--repo-map`.
+
+A `--repo-map` entry whose path is the checkout under diff
+is rewritten per side for ref diffs, so a single mapped path never serves one
+worktree to both sides. For path diffs of exported trees (no `.git` anywhere),
+detection finds no remotes; provide per-invocation side-correct maps rather
+than one static self-map. When a source merely resembles the local checkout
+(same host and repository name, different owner — a fork layout), drydock
+emits a `source.self-repo-near-miss` warning and keeps remote acquisition; add
+`--repo-map URL=PATH` if they are the same repository. The warning is advisory
+only: `--strict` neither escalates it nor fails the run on it.
 
 ## Helm Sources
 

--- a/site/content/cookbook/source-access.md
+++ b/site/content/cookbook/source-access.md
@@ -12,6 +12,11 @@ drydock test apps --path . \
 Use `--repo-map` when CI or a developer workstation already checked out a
 source repository.
 
+Self-references need no mapping: a source naming the checkout's own repository
+at `HEAD` or its default-branch name resolves to the local tree automatically
+on all render surfaces. Keep `--repo-map` for forks, commit-SHA pins, and runs
+from a subdirectory of the checkout.
+
 ## Prove Cache-Only Runs
 
 ```bash

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -80,6 +80,40 @@ drydock diag --path . --cache-events
 `--cache-events` renders Applications so source-acquisition events match the
 rendering path.
 
+## Symptom: Self-Repo Values Render From The Remote / Values ENOENT On Renders
+
+A source whose `repoURL` is the checkout's own repository — commonly a
+ref-only `$repo` source supplying Helm value files — should resolve to the
+local tree on every render surface (`get`, `build`, `test`, `diag`, and both
+diff sides). If such a source instead fetches remotely, renders miss files
+that exist only locally (for example, a pull request's new values file fails
+with a not-found error, or edits are silently ignored).
+
+Two remediations:
+
+1. Upgrade drydock (older releases resolved self-repository sources only
+   during diffs) and make sure `refs/remotes/origin/HEAD` exists so drydock
+   can learn the default-branch name — `git clone` sets it, and the pr-action
+   records the pull request's base branch there in all modes. For bare
+   `actions/checkout`-style checkouts outside the pr-action, run:
+
+   ```bash
+   git remote set-head origin -a
+   ```
+
+   Without that symref, sources pinned to the default-branch name acquire
+   remotely — drydock never guesses the default branch from
+   `init.defaultBranch` or the checked-out HEAD.
+
+2. Use `--repo-map URL=PATH` when detection cannot apply: fork-shaped URLs
+   (watch for the `source.self-repo-near-miss` warning), commit-SHA pins, or
+   runs from a subdirectory of the checkout (`--path <subdir>` does not walk
+   up to the enclosing `.git`).
+
+The flip side of local resolution: a self-repository source `path` that was
+deleted locally fails path-not-found even though the remote tip still has it —
+the local tree is the desired state.
+
 ## Symptom: Changed-Only Falls Back To All Apps
 
 Multi-Application diffs use changed-only selection by default. If a changed

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -94,7 +94,8 @@ Two remediations:
 1. Upgrade drydock (older releases resolved self-repository sources only
    during diffs) and make sure `refs/remotes/origin/HEAD` exists so drydock
    can learn the default-branch name — `git clone` sets it, and the pr-action
-   records the pull request's base branch there in all modes. For bare
+   records the pull request's base branch there whenever a base ref is known
+   (pull-request events, or an explicit `base-ref` input). For bare
    `actions/checkout`-style checkouts outside the pr-action, run:
 
    ```bash

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -427,7 +427,7 @@ passes them as arguments without `eval`, but they still change drydock behavior.
 | --- | --- | --- |
 | `checkout` | `true` | Check out the pull request head before running drydock. |
 | `fetch-depth` | `1` | Fetch depth for checkout. |
-| `path` | `.` | Repository path to inspect for render tests. |
+| `path` | `.` | Repository path to inspect for render tests. Self-repository source resolution reads the checkout's git metadata, so pointing this at a subdirectory disables it — keep the checkout root and scope work with `changed-only-include`, or add `repo-map`. |
 | `repo` | `.` | Local Git repository path used for ref-based diffs. |
 | `base-ref` | PR base branch | Baseline branch name for diff commands. Required outside pull request events when diff steps run. |
 | `head-ref` | `HEAD` after checkout | Current Git ref for diff commands. |


### PR DESCRIPTION
Closes #206 (follow-up: the Render Test half)

## Problem

#207 (v0.2.4) resolved self-repository sources to the per-side trees **during diffs only**. The pr-action runs Render Test (`test apps --path .`) before the diff, and on that surface a `$repo` source naming the repo's own URL at `main`/`HEAD` still acquired from the actual remote — so a PR adding a new app kept failing with the values-file ENOENT and the job stayed red even after the diff fix. Reproduced byte-for-byte against lehmanju/homecluster PR 957.

## Fix

The #207 machinery (canonical-URL matching, SHA/tag/branch gating, default-branch symref detection, near-miss fork warning) is extended to single-tree surfaces. `BuildRequest` already carried the refs and the provider wiring was already request-agnostic; the change populates them for non-diff entries:

- One helper called in exactly the two orchestrator leaves every caller reaches (`ListApplications`, `Build`), guarded so per-side diff builds keep their diff-derived refs — the guard is the sole protection on the diff hot path and is pinned against both the wipe and the wrong-field mutants.
- Build-shaped detection is symref-or-nothing: default-branch names come only from `refs/remotes/<remote>/HEAD` (no guessing from `init.defaultBranch` or the checked-out HEAD, which would wrongly treat a PR branch as default). Pinned SHAs, tags, and unrelated branches still acquire.
- The pr-action now writes the `origin/HEAD` symref offline in **all** modes whenever a base ref is known (previously only the diff-gated fetch-base step set it, which would have left render-test-only configs silently unfixed). `git symbolic-ref` tolerates a dangling target — render-only mode never fetches the base branch, and the reader takes the target *name* unresolved.
- The near-miss warning wording is now surface-neutral; explicit `repo-map` keeps precedence (lehmanju's current workaround continues to work unchanged, as does the parity smoke).

Documented behavior changes: uncommitted working-tree edits now flow into self-`$repo` values on renders; a self-referenced path deleted locally but present on the remote tip now fails (correct desired-state semantics, previously masked by acquisition); `--path <subdirectory>` disables detection (documented limitation).

## Validation

- 13 new tests + 2 sabotage-audit hardening pins across app/gitref/cli/pkg/pr-action, including the app-of-apps list-surface pin, the four-case symref gate table, both no-clobber shapes, dirty-worktree render-cache freshness, repo-map precedence with discriminating content, and run.sh symref behavior executed against throwaway git fixtures.
- 14 empirical sabotage checks run independently of the implementer; the 2 initially-surviving mutants were verified as real regression shapes and are now pinned (guard field, empty-Path default).
- Oracles: PR 957 render test goes exit 2 → exit 0 / 35 PASS with no repo-map, and identically with the repo-map workaround; action-shaped `diff apps` output byte-identical to the v0.2.4 replay; `diff images` clean; render-only mode with a dangling symref renders 35/35; home-ops (no self-references) byte-identical across old/new binaries; the discover-ignore and appset-scoping repro fixtures unchanged.
- Bonus proof from the fleet control: the old binary failed fresh homecluster main via a stale cached remote snapshot — the new binary reads the local tree and is immune to that staleness class.