### PR TITLE
feat(source): first-class OCI artifact sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ repository diagnostics, cache inspection, and Go API embedding.
 
 Default commands use native Go renderers and do not shell out to `kubectl`,
 `argocd`, Helm CLI, Kustomize CLI, or repo-server wrappers. Runtime-offline
-does not mean network-disconnected: declared Git, HTTP Helm, OCI Helm, and
-remote Kustomize sources may still be fetched into explicit drydock caches
-unless `--offline` is set.
+does not mean network-disconnected: declared Git, HTTP Helm, OCI Helm, OCI
+artifact, and remote Kustomize sources may still be fetched into explicit
+drydock caches unless `--offline` is set.
 
 **Full documentation:** [sholdee.github.io/drydock](https://sholdee.github.io/drydock/).
 
@@ -261,11 +261,12 @@ inspect locally and in CI:
   rendered app-of-apps/bootstrap children, explicit Kustomize discovery
   entrypoints, AppProjects, and settings objects.
 - **Rendering:** directory, Kustomize, Helm, Jsonnet, single-source and
-  multi-source Applications, Kustomize Helm charts, remote Helm charts, and
-  remote Kustomize sources.
-- **Source acquisition:** declared Git, HTTP Helm, OCI Helm, and remote
-  Kustomize inputs through explicit drydock caches, plus `--repo-map` for
-  adjacent local checkouts.
+  multi-source Applications, Kustomize Helm charts, remote Helm charts,
+  first-class OCI artifact sources (`oci://` + `path:`), and remote Kustomize
+  sources.
+- **Source acquisition:** declared Git, HTTP Helm, OCI Helm, OCI artifact,
+  and remote Kustomize inputs through explicit drydock caches, plus
+  `--repo-map` for adjacent local checkouts.
 - **Diffs and images:** desired-vs-desired manifest and image diffs,
   changed-only selection, default noisy-field filtering, and structured or
   markdown output.

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -189,13 +189,19 @@ Canonical references:
 - `internal/source`
 - `internal/chart`
 - `internal/remote`
+- `internal/ociartifact`
 - `internal/acquisition`
 - `internal/cache`
 - `internal/cacheevent`
 - `docs/design.md`
 
 Repository URL maps are deterministic and preferred over network fetches. Path
-source resolution order is explicit repo map, existing local source path,
+source resolution order is explicit repo map, `oci://` classification (a
+first-class OCI artifact source — `oci://` URL, no `chart:` — acquires from
+the registry and never falls to the local-path, self-repo, or Git branches;
+`oci://` + `chart:` keeps the Helm-chart flow as a recorded divergence from
+strict Argo CD v3.4.5, and `chart:` + `path:` on one `oci://` source is an
+error), existing local source path,
 self-repo resolution (on all render surfaces, a source naming a configured
 remote of the local checkout at `""`/`HEAD`, a diffed ref name during diffs,
 or the repository's default-branch name resolves to the local tree — the
@@ -220,9 +226,12 @@ remote's host and repository name but a different owner. The pr-action's
 symref) so render-test-only configs — which never run fetch-base — still get
 default-branch self-resolution.
 
-`--offline` controls Git, Helm chart, and remote Kustomize network behavior.
-When it is set, source resolution must use local files, repo maps, or existing
-cache entries.
+`--offline` controls Git, Helm chart, OCI artifact, and remote Kustomize
+network behavior. When it is set, source resolution must use local files, repo
+maps, or existing cache entries. Offline OCI artifact resolution is seam-level:
+digests pass through to the digest-keyed image cache, and tags/constraints
+resolve from records written on online resolves; misses carry the literal
+`offline cache miss` contract string that `cacheevent.ActionForError` keys on.
 
 Caches live under user cache roots or explicit cache directories, never inside
 the current or baseline repository tree. Cache lifecycle commands are local

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -122,6 +122,12 @@ Supported:
 - Kustomize, directory, local Helm chart, and chart-only remote Helm sources.
 - HTTP(S) and OCI Helm chart fetching by default for chart-only remote Helm
   sources.
+- First-class Argo CD OCI artifact sources (`repoURL: oci://...` with `path:`
+  and no `chart:`): digest, exact tag, and semver-constraint revisions;
+  extraction with Argo CD repo-server default guards (layer media-type
+  allowlist, single content layer, at most 10 layers, 1G extracted-size cap);
+  digest-keyed image caching with offline tag/constraint records; and cache
+  lifecycle support as source `oci`.
 - Kustomize `helmCharts` rendered through the shared Go-library Helm path.
 - Helm `$ref/...` external value files and file parameters from Git sources.
 - HTTP(S) remote Helm value files through the remote-resource cache.
@@ -134,17 +140,33 @@ Supported:
 - Explicit HTTP(S) Helm bearer/basic auth.
 - Explicit HTTP(S) remote Kustomize bearer/basic auth.
 - Explicit Helm OCI registry config path plumbing.
-- Cache event API/reporting for Git, Helm, and remote Kustomize acquisition,
-  with redacted targets and errors.
-- Local cache lifecycle commands for recognized Git, chart, and remote
-  Kustomize cache layouts; render output entries are not listed, pruned, or
-  deleted.
+- Cache event API/reporting for Git, Helm, OCI artifact, and remote Kustomize
+  acquisition, with redacted targets and errors.
+- Local cache lifecycle commands for recognized Git, chart, OCI artifact, and
+  remote Kustomize cache layouts; render output entries are not listed,
+  pruned, or deleted.
 
 Important boundaries:
 
-- `--offline` disables Git, Helm chart, and remote Kustomize resource network
-  fetching and requires cache hits, repo maps, local files, or local chart
-  availability.
+- `--offline` disables Git, Helm chart, OCI artifact, and remote Kustomize
+  resource network fetching and requires cache hits, repo maps, local files,
+  or local chart availability. Offline OCI artifact renders use digest
+  passthrough plus the digest-keyed image cache; tags and semver constraints
+  resolve from records captured on earlier online runs.
+- Recorded divergence from strict Argo CD v3.4.5: a source combining an
+  `oci://` repository URL with `chart:` (no `path:`) keeps drydock's existing
+  Helm-chart flow instead of upstream's OCI-before-Helm dispatch, because
+  fleets use that shape and the chart flow renders what their clusters run.
+  An `oci://` source setting both `chart:` and `path:` is rejected with a
+  clear unsupported-source-shape error.
+- `$ref` value-file sources are Git-only, matching upstream: an OCI `$ref`
+  source fails with a clear error.
+- Private OCI registries are not yet supported for OCI artifact sources;
+  `--registry-config` credentials apply to OCI Helm chart sources only.
+  Reusing the Helm OCI credential machinery for artifact sources is a
+  recorded follow-up, as are CLI flags for the extraction media-type
+  allowlist and size cap, and an OCI fixture for the Argo CD render parity
+  smoke (which needs an in-cluster registry).
 - `--repo-map` takes precedence over local fallback and network fetching.
 - Top-level `--repo` for Git ref diffs supports local repository paths only.
 - Missing HTTP(S) and OCI Helm chart dependencies declared in `Chart.yaml` are

--- a/docs/design.md
+++ b/docs/design.md
@@ -8,8 +8,8 @@ compares current and baseline desired state for pull request diffs.
 The core design target is runtime-offline analysis: default workflows require
 no running Kubernetes cluster, Argo CD instance, `kubectl`, `argocd`, Helm CLI,
 Kustomize CLI, repo-server, or external render service. Declared Git, HTTP
-Helm, OCI Helm, and remote Kustomize sources may be fetched into explicit
-drydock caches unless `--offline` is set.
+Helm, OCI Helm, OCI artifact, and remote Kustomize sources may be fetched into
+explicit drydock caches unless `--offline` is set.
 
 ## Runtime Boundary
 
@@ -188,6 +188,10 @@ Supported render paths:
 - Local Helm charts.
 - Kustomize `helmCharts` through the shared Helm library path.
 - Remote Helm chart sources from HTTP(S) and OCI repositories.
+- First-class OCI artifact sources (`repoURL: oci://...` with `path:` and no
+  `chart:`): revision resolved to a digest, artifact content pulled into the
+  digest-keyed OCI cache, and the selected `path` rendered through the normal
+  directory, Kustomize, or Helm pipeline.
 - Remote Kustomize HTTP(S) files and Git refs.
 - Discovered Argo CD CMP definitions that normalize to a safe `kustomize
   build` command, interpreted through drydock's native Kustomize renderer.

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,15 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.4.5
+	github.com/argoproj/pkg v0.13.6
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-git/go-git/v5 v5.19.1
+	github.com/google/go-containerregistry v0.20.6
 	github.com/google/go-jsonnet v0.22.0
 	github.com/itchyny/gojq v0.12.19
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v3 v3.0.4
@@ -20,6 +23,7 @@ require (
 	golang.org/x/term v0.45.0
 	helm.sh/helm/v4 v4.2.3
 	k8s.io/apimachinery v0.36.2
+	oras.land/oras-go/v2 v2.6.1
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2
@@ -41,7 +45,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
-	github.com/argoproj/pkg v0.13.6 // indirect
 	github.com/argoproj/pkg/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -119,7 +122,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
@@ -186,7 +188,6 @@ require (
 	k8s.io/kubernetes v1.34.2 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427 // indirect
-	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/controller-runtime v0.24.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=
+github.com/containerd/stargz-snapshotter/estargz v0.16.3/go.mod h1:uyr4BfYfOj3G9WBVE8cOlQmXAbPN9VEQpBBeJIuOipU=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -122,6 +124,10 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsyN9SdInc1A=
+github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
+github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
 github.com/docker/docker-credential-helpers v0.9.5/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
 github.com/docker/go-events v0.0.0-20250808211157-605354379745 h1:yOn6Ze6IbYI/KAw2lw/83ELYvZh6hvsygTVkD0dzMC4=
@@ -265,6 +271,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB31qAwjAohdSTU=
+github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
 github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
 github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
@@ -379,6 +387,7 @@ github.com/minio/minio-go/v7 v7.0.29/go.mod h1:x81+AX5gHSfCSqw7jxRKHvxUXMlE5uKX0
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
@@ -559,6 +568,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
+github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/go-tinylfu v0.2.2 h1:H1eiG6HM36iniK6+21n9LLpzx1G9R3DJa2UjUjbynsI=
 github.com/vmihailenco/go-tinylfu v0.2.2/go.mod h1:CutYi2Q9puTxfcolkliPq4npPuofg9N9t8JVrjzwa3Q=
 github.com/vmihailenco/msgpack/v5 v5.3.4/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=

--- a/internal/acquisition/session.go
+++ b/internal/acquisition/session.go
@@ -355,6 +355,13 @@ func (acquirer cacheSafeOCIArtifactAcquirer) Resolve(ctx context.Context, repoUR
 }
 
 func (acquirer cacheSafeOCIArtifactAcquirer) Extract(ctx context.Context, repoURL, digest string, opts ociartifact.Options) (string, func(), error) {
+	// An empty snapshot root with snapshot reads on would make
+	// snapshotCachePath pass the extraction dir through unchanged, the
+	// delegate release below would delete it, and the deleted path would be
+	// memoized and returned — fail loudly instead.
+	if acquirer.snapshot && strings.TrimSpace(acquirer.snapshotRoot) == "" {
+		return "", nil, fmt.Errorf("oci artifact session snapshot root is empty for %s digest %s", ociartifact.RedactURL(repoURL), digest)
+	}
 	key, keyErr := ociCacheLockKey(repoURL, digest, opts)
 	if keyErr != nil {
 		return acquirer.delegate.Extract(ctx, repoURL, digest, opts)
@@ -371,6 +378,16 @@ func (acquirer cacheSafeOCIArtifactAcquirer) Extract(ctx context.Context, repoUR
 	dir, release, err := acquirer.delegate.Extract(ctx, repoURL, digest, opts)
 	if err != nil || !acquirer.snapshot {
 		return dir, release, err
+	}
+	// Defense in depth ahead of the snapshot copy, which recreates symlinks
+	// verbatim: an extracted tree holding an out-of-bounds symlink never
+	// enters the session area (upstream CheckOutOfBoundsSymlinks parity,
+	// behind the extractor's own tar guards).
+	if err := rejectOutOfBoundsSymlinks(dir); err != nil {
+		if release != nil {
+			release()
+		}
+		return "", nil, fmt.Errorf("oci artifact %s digest %s: %w", ociartifact.RedactURL(repoURL), digest, err)
 	}
 	// Copy into the session snapshot area, then close argo's extraction
 	// closer immediately: the extraction lives under os.TempDir, so the copy
@@ -484,6 +501,51 @@ func absoluteCacheLockKey(prefix, path string) (string, error) {
 		return "", err
 	}
 	return prefix + ":" + filepath.Clean(abs), nil
+}
+
+// rejectOutOfBoundsSymlinks fails when the tree under root contains a symlink
+// that escapes it: absolute targets, or relative targets any traversal step
+// of which leaves root (argo-cd CheckOutOfBoundsSymlinks parity,
+// util/app/path/path.go). Callers run it before a snapshot copy so an escape
+// is never recreated inside the session area.
+func rejectOutOfBoundsSymlinks(root string) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(absRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink == 0 {
+			return nil
+		}
+		target, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return err
+		}
+		if filepath.IsAbs(target) {
+			return fmt.Errorf("out-of-bounds symlink %q -> %q", relPath, target)
+		}
+		// Walk each target component so intermediate ".." escapes are caught
+		// even when the joined path collapses back inside root.
+		currentDir := filepath.Dir(path)
+		for part := range strings.SplitSeq(target, string(os.PathSeparator)) {
+			currentDir = filepath.Join(currentDir, part)
+			rel, err := filepath.Rel(absRoot, currentDir)
+			if err != nil {
+				return err
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				return fmt.Errorf("out-of-bounds symlink %q -> %q", relPath, target)
+			}
+		}
+		return nil
+	})
 }
 
 type snapshotCopyOptions struct {

--- a/internal/acquisition/session.go
+++ b/internal/acquisition/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/filecopy"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/source"
 )
@@ -39,9 +40,11 @@ type TargetLocks struct {
 }
 
 type SnapshotCache struct {
-	mu     sync.Mutex
-	gits   map[string]source.GitResult
-	charts map[string]chart.Result
+	mu          sync.Mutex
+	gits        map[string]source.GitResult
+	charts      map[string]chart.Result
+	ociResolves map[string]string
+	ociExtracts map[string]string
 }
 
 type targetLock struct {
@@ -55,8 +58,10 @@ func NewTargetLocks() *TargetLocks {
 
 func NewSnapshotCache() *SnapshotCache {
 	return &SnapshotCache{
-		gits:   map[string]source.GitResult{},
-		charts: map[string]chart.Result{},
+		gits:        map[string]source.GitResult{},
+		charts:      map[string]chart.Result{},
+		ociResolves: map[string]string{},
+		ociExtracts: map[string]string{},
 	}
 }
 
@@ -94,6 +99,44 @@ func (cache *SnapshotCache) storeGit(key string, result source.GitResult) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 	cache.gits[key] = result
+}
+
+func (cache *SnapshotCache) ociResolve(key string) (string, bool) {
+	if cache == nil {
+		return "", false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	digest, ok := cache.ociResolves[key]
+	return digest, ok
+}
+
+func (cache *SnapshotCache) storeOCIResolve(key, digest string) {
+	if cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.ociResolves[key] = digest
+}
+
+func (cache *SnapshotCache) ociExtract(key string) (string, bool) {
+	if cache == nil {
+		return "", false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	dir, ok := cache.ociExtracts[key]
+	return dir, ok
+}
+
+func (cache *SnapshotCache) storeOCIExtract(key, dir string) {
+	if cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.ociExtracts[key] = dir
 }
 
 func (cache *SnapshotCache) chart(key string) (chart.Result, bool) {
@@ -165,6 +208,28 @@ func (session Session) ChartAcquirer(delegate chart.Acquirer) chart.Acquirer {
 		return delegate
 	}
 	return cacheSafeChartAcquirer{
+		delegate:      delegate,
+		locks:         session.Locks,
+		snapshotRoot:  session.SnapshotRoot,
+		snapshot:      session.SnapshotCacheReads,
+		snapshotCache: session.SnapshotCache,
+	}
+}
+
+// OCIArtifactAcquirer decorates delegate with the session memo required by
+// the render-cache prepare phase: collectSourceIdentities re-invokes source
+// resolution before every render, so without memoization every OCI source
+// would resolve and extract twice with duplicated acquisition events.
+// Extractions are copied into the session snapshot area and released with the
+// session.
+func (session Session) OCIArtifactAcquirer(delegate ociartifact.Acquirer) ociartifact.Acquirer {
+	if delegate == nil {
+		delegate = ociartifact.DefaultAcquirer{}
+	}
+	if session.Locks == nil {
+		return delegate
+	}
+	return cacheSafeOCIArtifactAcquirer{
 		delegate:      delegate,
 		locks:         session.Locks,
 		snapshotRoot:  session.SnapshotRoot,
@@ -263,6 +328,65 @@ func (acquirer cacheSafeChartAcquirer) Acquire(ctx context.Context, request char
 	return result, nil
 }
 
+type cacheSafeOCIArtifactAcquirer struct {
+	delegate      ociartifact.Acquirer
+	locks         *TargetLocks
+	snapshotRoot  string
+	snapshot      bool
+	snapshotCache *SnapshotCache
+}
+
+func (acquirer cacheSafeOCIArtifactAcquirer) Resolve(ctx context.Context, repoURL, revision string, opts ociartifact.Options) (string, error) {
+	key := "oci-resolve:" + ociartifact.NormalizeURL(repoURL) + "\x00" + strings.TrimSpace(revision)
+	unlock := acquirer.locks.lock(key)
+	defer unlock()
+
+	if acquirer.snapshot {
+		if digest, ok := acquirer.snapshotCache.ociResolve(key); ok {
+			return digest, nil
+		}
+	}
+	digest, err := acquirer.delegate.Resolve(ctx, repoURL, revision, opts)
+	if err != nil || !acquirer.snapshot {
+		return digest, err
+	}
+	acquirer.snapshotCache.storeOCIResolve(key, digest)
+	return digest, nil
+}
+
+func (acquirer cacheSafeOCIArtifactAcquirer) Extract(ctx context.Context, repoURL, digest string, opts ociartifact.Options) (string, func(), error) {
+	key, keyErr := ociCacheLockKey(repoURL, digest, opts)
+	if keyErr != nil {
+		return acquirer.delegate.Extract(ctx, repoURL, digest, opts)
+	}
+	unlock := acquirer.locks.lock(key)
+	defer unlock()
+
+	if acquirer.snapshot {
+		if dir, ok := acquirer.snapshotCache.ociExtract(key); ok {
+			return dir, func() {}, nil
+		}
+	}
+
+	dir, release, err := acquirer.delegate.Extract(ctx, repoURL, digest, opts)
+	if err != nil || !acquirer.snapshot {
+		return dir, release, err
+	}
+	// Copy into the session snapshot area, then close argo's extraction
+	// closer immediately: the extraction lives under os.TempDir, so the copy
+	// never renames across the temp boundary (EXDEV) and the snapshot is
+	// released with the session.
+	snapshot, err := snapshotCachePath(acquirer.snapshotRoot, "oci", dir, snapshotCopyOptions{})
+	if release != nil {
+		release()
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	acquirer.snapshotCache.storeOCIExtract(key, snapshot)
+	return snapshot, func() {}, nil
+}
+
 type cacheSafeRemoteAcquirer struct {
 	delegate     remote.Acquirer
 	locks        *TargetLocks
@@ -329,6 +453,14 @@ func chartCacheLockKey(request chart.Request, opts chart.Options) (string, error
 		return "", err
 	}
 	return absoluteCacheLockKey("chart", filepath.Join(cacheDir, string(request.Kind), key))
+}
+
+func ociCacheLockKey(repoURL, digest string, opts ociartifact.Options) (string, error) {
+	cacheDir, err := ociartifact.ResolveCacheDir(opts.CacheDir, opts.ForbiddenRoots)
+	if err != nil {
+		return "", err
+	}
+	return absoluteCacheLockKey("oci", ociartifact.EntryPath(cacheDir, repoURL, digest))
 }
 
 func remoteCacheLockKey(request remote.Request, opts remote.Options) (string, error) {

--- a/internal/acquisition/session_oci_test.go
+++ b/internal/acquisition/session_oci_test.go
@@ -1,0 +1,142 @@
+package acquisition
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/ociartifact"
+)
+
+type fakeOCIAcquirer struct {
+	mu           sync.Mutex
+	resolveCalls int
+	extractCalls int
+	digest       string
+	extractRoot  string
+}
+
+func (a *fakeOCIAcquirer) Resolve(_ context.Context, _, _ string, _ ociartifact.Options) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.resolveCalls++
+	return a.digest, nil
+}
+
+func (a *fakeOCIAcquirer) Extract(_ context.Context, _, _ string, opts ociartifact.Options) (string, func(), error) {
+	a.mu.Lock()
+	a.extractCalls++
+	a.mu.Unlock()
+	dir, err := os.MkdirTemp(a.extractRoot, "extract-*")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "artifact.yaml"), []byte("kind: Fixture\n"), 0o600); err != nil {
+		return "", nil, err
+	}
+	if opts.OnAcquired != nil {
+		opts.OnAcquired(false)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func newOCITestSession(t *testing.T) (Session, string) {
+	t.Helper()
+	snapshotRoot := t.TempDir()
+	return Session{
+		Locks:              NewTargetLocks(),
+		SnapshotRoot:       snapshotRoot,
+		SnapshotCacheReads: true,
+		SnapshotCache:      NewSnapshotCache(),
+	}, snapshotRoot
+}
+
+func TestOCIArtifactAcquirerMemoizesResolveAndExtract(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	fake := &fakeOCIAcquirer{digest: digest, extractRoot: t.TempDir()}
+	session, snapshotRoot := newOCITestSession(t)
+	acquirer := session.OCIArtifactAcquirer(fake)
+	opts := ociartifact.Options{CacheDir: t.TempDir()}
+	repoURL := "oci://registry.example/org/app"
+
+	got, err := acquirer.Resolve(t.Context(), repoURL, "1.2.3", opts)
+	if err != nil || got != digest {
+		t.Fatalf("Resolve() = %q, %v", got, err)
+	}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "1.2.3", opts); err != nil {
+		t.Fatalf("second Resolve() error = %v", err)
+	}
+	if fake.resolveCalls != 1 {
+		t.Fatalf("delegate resolve calls = %d, want 1 (memoized)", fake.resolveCalls)
+	}
+
+	acquired := 0
+	opts.OnAcquired = func(bool) { acquired++ }
+	dir1, release1, err := acquirer.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	dir2, release2, err := acquirer.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("second Extract() error = %v", err)
+	}
+	if fake.extractCalls != 1 {
+		t.Fatalf("delegate extract calls = %d, want 1 (memoized)", fake.extractCalls)
+	}
+	if acquired != 1 {
+		t.Fatalf("OnAcquired calls = %d, want 1 (memo hits must not re-report acquisition)", acquired)
+	}
+	if dir1 != dir2 {
+		t.Fatalf("memoized extract dirs differ: %q vs %q", dir1, dir2)
+	}
+	if !strings.HasPrefix(dir1, snapshotRoot+string(filepath.Separator)) {
+		t.Fatalf("extract dir %q not inside session snapshot root %q", dir1, snapshotRoot)
+	}
+	if _, err := os.Stat(filepath.Join(dir1, "artifact.yaml")); err != nil {
+		t.Fatalf("snapshot content missing: %v", err)
+	}
+	// The session, not per-call releases, owns the snapshot lifetime.
+	release1()
+	release2()
+	if _, err := os.Stat(filepath.Join(dir1, "artifact.yaml")); err != nil {
+		t.Fatalf("snapshot removed by per-call release: %v", err)
+	}
+}
+
+// TestOCIArtifactAcquirerClosesDelegateReleaseAfterSnapshot pins that argo's
+// extraction closer is closed immediately after the snapshot copy: the
+// delegate's temp extraction dir must be gone while the snapshot survives.
+func TestOCIArtifactAcquirerClosesDelegateReleaseAfterSnapshot(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("cd", 32)
+	extractRoot := t.TempDir()
+	fake := &fakeOCIAcquirer{digest: digest, extractRoot: extractRoot}
+	session, _ := newOCITestSession(t)
+	acquirer := session.OCIArtifactAcquirer(fake)
+
+	dir, _, err := acquirer.Extract(t.Context(), "oci://registry.example/org/app", digest, ociartifact.Options{CacheDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	entries, err := os.ReadDir(extractRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("delegate extraction dir not released after snapshot copy: %d entries remain", len(entries))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "artifact.yaml")); err != nil {
+		t.Fatalf("snapshot content missing after delegate release: %v", err)
+	}
+}
+
+func TestOCIArtifactAcquirerPassthroughWithoutLocks(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("ef", 32)
+	fake := &fakeOCIAcquirer{digest: digest, extractRoot: t.TempDir()}
+	acquirer := Session{}.OCIArtifactAcquirer(fake)
+	if _, ok := acquirer.(*fakeOCIAcquirer); !ok {
+		t.Fatalf("lock-less session should return the delegate unchanged, got %T", acquirer)
+	}
+}

--- a/internal/acquisition/session_oci_test.go
+++ b/internal/acquisition/session_oci_test.go
@@ -17,6 +17,9 @@ type fakeOCIAcquirer struct {
 	extractCalls int
 	digest       string
 	extractRoot  string
+	// symlinks are created inside the extraction dir (name -> target) to
+	// exercise the copy-into-session symlink guard.
+	symlinks map[string]string
 }
 
 func (a *fakeOCIAcquirer) Resolve(_ context.Context, _, _ string, _ ociartifact.Options) (string, error) {
@@ -36,6 +39,11 @@ func (a *fakeOCIAcquirer) Extract(_ context.Context, _, _ string, opts ociartifa
 	}
 	if err := os.WriteFile(filepath.Join(dir, "artifact.yaml"), []byte("kind: Fixture\n"), 0o600); err != nil {
 		return "", nil, err
+	}
+	for name, target := range a.symlinks {
+		if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+			return "", nil, err
+		}
 	}
 	if opts.OnAcquired != nil {
 		opts.OnAcquired(false)
@@ -129,6 +137,74 @@ func TestOCIArtifactAcquirerClosesDelegateReleaseAfterSnapshot(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "artifact.yaml")); err != nil {
 		t.Fatalf("snapshot content missing after delegate release: %v", err)
+	}
+}
+
+// TestOCIArtifactAcquirerRejectsOutOfBoundsSymlinks pins the defense-in-depth
+// guard at the copy-into-session step: an extracted tree whose symlinks
+// escape it never enters the session snapshot area.
+func TestOCIArtifactAcquirerRejectsOutOfBoundsSymlinks(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("aa", 32)
+	for name, target := range map[string]string{
+		"absolute-escape": "/etc/passwd",
+		"relative-escape": "../outside.yaml",
+		"nested-escape":   "sub/../../outside.yaml",
+	} {
+		fake := &fakeOCIAcquirer{digest: digest, extractRoot: t.TempDir(), symlinks: map[string]string{name: target}}
+		session, snapshotRoot := newOCITestSession(t)
+		acquirer := session.OCIArtifactAcquirer(fake)
+
+		_, _, err := acquirer.Extract(t.Context(), "oci://registry.example/org/app", digest, ociartifact.Options{CacheDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "out-of-bounds symlink") {
+			t.Fatalf("Extract() error = %v, want out-of-bounds symlink rejection (%s)", err, name)
+		}
+		entries, readErr := os.ReadDir(snapshotRoot)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("rejected extraction reached the session snapshot area (%s)", name)
+		}
+	}
+}
+
+// In-bounds symlinks are legitimate artifact content and survive the copy.
+func TestOCIArtifactAcquirerAllowsInBoundsSymlink(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("bb", 32)
+	fake := &fakeOCIAcquirer{digest: digest, extractRoot: t.TempDir(), symlinks: map[string]string{"link.yaml": "artifact.yaml"}}
+	session, _ := newOCITestSession(t)
+	acquirer := session.OCIArtifactAcquirer(fake)
+
+	dir, _, err := acquirer.Extract(t.Context(), "oci://registry.example/org/app", digest, ociartifact.Options{CacheDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	target, err := os.Readlink(filepath.Join(dir, "link.yaml"))
+	if err != nil || target != "artifact.yaml" {
+		t.Fatalf("in-bounds symlink not preserved in snapshot: %q, %v", target, err)
+	}
+}
+
+// TestOCIArtifactAcquirerRejectsEmptySnapshotRoot pins the snapshot-root
+// guard: with snapshot reads on and no root, snapshotCachePath would pass the
+// extraction dir through unchanged, the delegate release would delete it, and
+// the deleted path would be memoized and returned.
+func TestOCIArtifactAcquirerRejectsEmptySnapshotRoot(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("cc", 32)
+	fake := &fakeOCIAcquirer{digest: digest, extractRoot: t.TempDir()}
+	session := Session{
+		Locks:              NewTargetLocks(),
+		SnapshotCacheReads: true,
+		SnapshotCache:      NewSnapshotCache(),
+	}
+	acquirer := session.OCIArtifactAcquirer(fake)
+
+	_, _, err := acquirer.Extract(t.Context(), "oci://registry.example/org/app", digest, ociartifact.Options{CacheDir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "snapshot root is empty") {
+		t.Fatalf("Extract() error = %v, want empty snapshot root rejection", err)
+	}
+	if fake.extractCalls != 0 {
+		t.Fatalf("delegate extract calls = %d, want 0 (guard fires before the doomed extraction)", fake.extractCalls)
 	}
 }
 

--- a/internal/app/build_session_validation.go
+++ b/internal/app/build_session_validation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sholdee/drydock/internal/chart"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/pathsafety"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/rendercache"
@@ -24,6 +25,9 @@ func validateBuildNetworkOptions(request BuildRequest) error {
 		return err
 	}
 	if _, err := remote.ResolveCacheDir(request.RemoteResourceCacheDir, forbiddenRoots); err != nil {
+		return err
+	}
+	if _, err := ociartifact.ResolveCacheDir(request.OCICacheDir, forbiddenRoots); err != nil {
 		return err
 	}
 	if err := validateBuildRenderCacheRoot(request); err != nil {

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sholdee/drydock/internal/diff"
 	"github.com/sholdee/drydock/internal/gitref"
 	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/rendercache"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
@@ -529,6 +530,9 @@ func validateDiffCacheRoots(request DiffRequest, forbiddenRoots []string) error 
 		return err
 	}
 	if _, err := remote.ResolveCacheDir(request.RemoteResourceCacheDir, forbiddenRoots); err != nil {
+		return err
+	}
+	if _, err := ociartifact.ResolveCacheDir(request.OCICacheDir, forbiddenRoots); err != nil {
 		return err
 	}
 	if err := validateDiffRenderCacheRoot(request); err != nil {

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -981,6 +981,46 @@ func TestDiffAppsRejectsChartCacheInsideEitherRoot(t *testing.T) {
 	}
 }
 
+// Direct pin for the diff-surface validation layer: per-build validation also
+// rejects a contained OCI cache dir, so only a direct call observes that
+// validateDiffCacheRoots itself carries the check (chart-pattern symmetry).
+func TestValidateDiffCacheRootsRejectsOCICacheDir(t *testing.T) {
+	root := t.TempDir()
+	request := DiffRequest{
+		AcquisitionOptions: AcquisitionOptions{
+			OCICacheDir: filepath.Join(root, ".drydock", "oci"),
+		},
+	}
+	err := validateDiffCacheRoots(request, []string{root})
+	if err == nil {
+		t.Fatal("validateDiffCacheRoots() error = nil, want oci cache containment error")
+	}
+	if !strings.Contains(err.Error(), "oci cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+		t.Fatalf("validateDiffCacheRoots() error = %v, want oci cache containment error", err)
+	}
+}
+
+func TestDiffAppsRejectsOCICacheInsideEitherRoot(t *testing.T) {
+	left := t.TempDir()
+	right := t.TempDir()
+
+	for _, root := range []string{left, right} {
+		_, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+			LeftPath:  left,
+			RightPath: right,
+			AcquisitionOptions: AcquisitionOptions{
+				OCICacheDir: filepath.Join(root, ".drydock", "oci"),
+			},
+		})
+		if err == nil {
+			t.Fatal("DiffApps() error = nil, want oci cache containment error")
+		}
+		if !strings.Contains(err.Error(), "oci cache dir") || !strings.Contains(err.Error(), "must not be inside repository root") {
+			t.Fatalf("DiffApps() error = %v, want oci cache containment error", err)
+		}
+	}
+}
+
 func TestDiffAppsRejectsRenderCacheInsideEitherRoot(t *testing.T) {
 	left := t.TempDir()
 	right := t.TempDir()

--- a/internal/app/discovery_frontier.go
+++ b/internal/app/discovery_frontier.go
@@ -149,9 +149,14 @@ func applicationMayRenderDiscoveryObjects(root string, request BuildRequest, dis
 		}
 		// OCI artifact content comes from a registry exactly like chart-only
 		// sources: it never renders local discovery objects, and `path: .`
-		// must not pull the local repository into the discovery frontier.
+		// must not pull the local repository into the discovery frontier. A
+		// repo-mapped oci:// URL is the documented escape hatch, though: the
+		// mapped local tree stands in for the artifact content, so it keeps
+		// frontier eligibility through localDiscoverySourceRoot below.
 		if ociartifact.IsOCIURL(sourcePlan.Source.RepoURL) {
-			continue
+			if _, mapped := mappedRepositoryPath(request, sourcePlan.Source.RepoURL); !mapped {
+				continue
+			}
 		}
 		sourceRoot, ok := localDiscoverySourceRoot(root, request, sourcePlan.Source)
 		if !ok {

--- a/internal/app/discovery_frontier.go
+++ b/internal/app/discovery_frontier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/discovery"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/render"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -144,6 +145,12 @@ func applicationMayRenderDiscoveryObjects(root string, request BuildRequest, dis
 			continue
 		}
 		if sourcePlan.Source.Chart != "" && sourcePlan.Source.Path == "" {
+			continue
+		}
+		// OCI artifact content comes from a registry exactly like chart-only
+		// sources: it never renders local discovery objects, and `path: .`
+		// must not pull the local repository into the discovery frontier.
+		if ociartifact.IsOCIURL(sourcePlan.Source.RepoURL) {
 			continue
 		}
 		sourceRoot, ok := localDiscoverySourceRoot(root, request, sourcePlan.Source)

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/diagnostic"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/pluginpolicy"
@@ -39,6 +40,9 @@ type localProvider struct {
 	remoteResourceForbiddenRoots []string
 	remoteResourceCredentials    remote.Credentials
 	remoteResourceGitCredentials remote.GitCredentials
+	ociArtifactAcquirer          ociartifact.Acquirer
+	ociCacheDir                  string
+	ociForbiddenRoots            []string
 	helmValueFileSchemes         []string
 	helmValueFileSchemesSet      bool
 	helmChartLoadCache           *render.HelmChartLoadCache
@@ -99,6 +103,12 @@ func (p localProvider) RenderSource(ctx context.Context, source render.ResolvedS
 		}
 	}
 	source.RepoRoot = sourceRoot
+	if ociartifact.IsOCIURL(source.RepoURL) && source.Chart == "" && source.Path == "" {
+		// Argo CD renders the extraction root when an OCI source omits path
+		// (apppathutil.Path(ociPath, "") — vendored repository.go:415-418);
+		// "." selects the same root through the local-renderer dispatch below.
+		source.Path = "."
+	}
 	opts.ChartAcquirer = p.acquisition.ChartAcquirer(p.chartAcquirer)
 	opts.ChartCacheDir = p.chartCacheDir
 	opts.OfflineCharts = p.offline

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sholdee/drydock/internal/chart"
 	"github.com/sholdee/drydock/internal/config"
 	"github.com/sholdee/drydock/internal/gitref"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/render"
@@ -25,6 +26,10 @@ func newLocalProvider(ctx context.Context, orchestrator Orchestrator, root strin
 	gitAcquirer := orchestrator.GitAcquirer
 	if gitAcquirer == nil {
 		gitAcquirer = sourcepkg.DefaultGitAcquirer{}
+	}
+	ociAcquirer := orchestrator.OCIArtifactAcquirer
+	if ociAcquirer == nil {
+		ociAcquirer = ociartifact.DefaultAcquirer{}
 	}
 	pluginExecRunner := orchestrator.PluginExecRunner
 	if pluginExecRunner == nil {
@@ -56,6 +61,9 @@ func newLocalProvider(ctx context.Context, orchestrator Orchestrator, root strin
 		remoteResourceForbiddenRoots: forbiddenRoots,
 		remoteResourceCredentials:    request.RemoteResourceCredentials,
 		remoteResourceGitCredentials: request.RemoteResourceGitCredentials,
+		ociArtifactAcquirer:          ociAcquirer,
+		ociCacheDir:                  request.OCICacheDir,
+		ociForbiddenRoots:            forbiddenRoots,
 		helmValueFileSchemes:         settingsHelmValueFileSchemes(settings),
 		helmValueFileSchemesSet:      settings.HelmValuesFileSchemesSet,
 		helmChartLoadCache:           render.NewHelmChartLoadCache(),

--- a/internal/app/local_provider_sources.go
+++ b/internal/app/local_provider_sources.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
@@ -22,6 +23,14 @@ func (p localProvider) resolveSourceRoot(ctx context.Context, source render.Reso
 // the source persistence-ineligible.
 func (p localProvider) resolveSourceRootIdentity(ctx context.Context, source render.ResolvedSource) (string, SourceIdentity, error) {
 	if source.Path == "" && source.Chart != "" {
+		// DELIBERATE DRYDOCK DIVERGENCE from argo-cd v3.4.5: upstream checks
+		// source.IsOCI() before helm handling and ignores source.Chart for
+		// oci:// URLs (repository.go:349-356,384-420), and IsHelmOciRepo only
+		// accepts schemeless OCI helm repos (util/helm/client.go:439-446) —
+		// strict v3.4.5 would error on oci:// + chart. drydock keeps routing
+		// oci:// + chart (no path) through the existing helm-chart flow:
+		// fleets use that shape and it renders what their clusters run
+		// (fleet-validated). Recorded divergence; regression-pinned.
 		return p.repoRoot, chartOnlySourceIdentity(source), nil
 	}
 	if p.sourceResolver != nil {
@@ -30,6 +39,16 @@ func (p localProvider) resolveSourceRootIdentity(ctx context.Context, source ren
 			abs, err := filepath.Abs(mappedPath)
 			return abs, SourceIdentity{}, err
 		}
+	}
+	// OCI classification is total over oci:// spellings and sits AFTER the
+	// repo-map escape hatch (a --repo-map of the oci URL must keep winning)
+	// but BEFORE the path-exists, self-repo, and git-acquisition branches:
+	// `path: .` always exists locally, so falling through would silently
+	// render the local checkout (issue #220's masked failure mode), and
+	// CanonicalGitURLKey strips schemes, so an oci:// URL could otherwise
+	// full-match a git remote in the self-repo branch.
+	if ociartifact.IsOCIURL(source.RepoURL) {
+		return p.resolveClassifiedOCISource(ctx, source)
 	}
 	if source.Path != "" {
 		if exists, err := sourcePathExists(p.repoRoot, source.Path); err != nil {
@@ -112,6 +131,80 @@ func (p localProvider) resolveSourceRootIdentity(ctx context.Context, source ren
 	}, nil
 }
 
+// resolveClassifiedOCISource handles every oci:// source that classification
+// routed away from the local branches: the hybrid chart+path shape errors
+// clearly (never the masked branches), everything else is a first-class OCI
+// artifact source. The chart-only shape never reaches here (it returns before
+// classification).
+func (p localProvider) resolveClassifiedOCISource(ctx context.Context, source render.ResolvedSource) (string, SourceIdentity, error) {
+	if source.Chart != "" {
+		return "", SourceIdentity{}, fmt.Errorf("unsupported source shape: OCI source %s sets both chart %q and path %q; use chart for Helm-chart flow or path for OCI artifact content", ociartifact.RedactURL(source.RepoURL), source.Chart, source.Path)
+	}
+	return p.resolveOCIArtifactSource(ctx, source)
+}
+
+// resolveOCIArtifactSource acquires a first-class OCI artifact source: the
+// revision resolves to a digest, the artifact content extracts into the
+// session snapshot area, and the extraction root becomes the source root.
+func (p localProvider) resolveOCIArtifactSource(ctx context.Context, source render.ResolvedSource) (string, SourceIdentity, error) {
+	acquirer := p.acquisition.OCIArtifactAcquirer(p.ociArtifactAcquirer)
+	acquiredFromCache := (*bool)(nil)
+	opts := ociartifact.Options{
+		CacheDir:       p.ociCacheDir,
+		Offline:        p.offline,
+		ForbiddenRoots: append([]string(nil), p.ociForbiddenRoots...),
+		OnAcquired: func(fromImageCache bool) {
+			acquiredFromCache = &fromImageCache
+		},
+	}
+	digest, err := acquirer.Resolve(ctx, source.RepoURL, source.TargetRevision, opts)
+	if err != nil {
+		return "", SourceIdentity{}, p.recordOCIAcquisitionError(source, err)
+	}
+	root, _, err := acquirer.Extract(ctx, source.RepoURL, digest, opts)
+	if err != nil {
+		return "", SourceIdentity{}, p.recordOCIAcquisitionError(source, err)
+	}
+	// Session-memoized calls skip OnAcquired: only real acquisitions emit an
+	// event, so a two-sided diff at one digest records a single event.
+	if acquiredFromCache != nil {
+		p.recordCacheEvent(cacheevent.NewAcquisitionEvent(cacheevent.AcquisitionEventInput{
+			Source:            cacheevent.SourceOCI,
+			Target:            source.RepoURL,
+			Revision:          digest,
+			RequestedRevision: source.TargetRevision,
+			FromCache:         *acquiredFromCache,
+			Network:           !*acquiredFromCache,
+			Offline:           p.offline,
+		}))
+		p.recordAcquisition(cacheevent.AcquisitionRecord{
+			Kind:              cacheevent.AcquisitionOCI,
+			RequestedRevision: source.TargetRevision,
+			ResolvedRevision:  digest,
+		})
+	}
+	// The resolved digest rides in the same identity field the git flow uses
+	// for commit SHAs (SourceIdentity.Revision, see the git branch above), so
+	// persistent render-cache keys rotate with content, not tag spelling.
+	return root, SourceIdentity{
+		Kind:     sourceIdentityKindOCI,
+		Locator:  ociartifact.RedactURL(source.RepoURL),
+		Revision: digest,
+	}, nil
+}
+
+func (p localProvider) recordOCIAcquisitionError(source render.ResolvedSource, err error) error {
+	acquireError := cacheevent.NewAcquisitionError(cacheevent.AcquisitionEventInput{
+		Source:            cacheevent.SourceOCI,
+		Target:            source.RepoURL,
+		RequestedRevision: source.TargetRevision,
+		Offline:           p.offline,
+		Err:               err,
+	})
+	p.recordCacheEvent(acquireError.Event)
+	return fmt.Errorf("%s", acquireError.RedactedError)
+}
+
 // chartOnlySourceIdentity derives the identity from the spec alone: drydock
 // supports exact chart versions only, so name+version fully determine content
 // per registry contract.
@@ -133,6 +226,13 @@ func (p localProvider) resolveRefRoots(ctx context.Context, refSources map[strin
 	}
 	out := make(map[string]string, len(refSources))
 	for refKey, refSource := range refSources {
+		// Upstream parity: $ref value-file materialization is git-only in
+		// argo-cd v3.4.5 (resolveReferencedSources, repository.go:546-592,
+		// 820-870). Without this gate every ref funnels through
+		// resolveSourceRoot and OCI refs would work by accident.
+		if ociartifact.IsOCIURL(refSource.RepoURL) {
+			return nil, fmt.Errorf("ref root %s: OCI sources cannot be referenced as $ref value sources (unsupported by Argo CD)", refKey)
+		}
 		root, err := p.resolveSourceRoot(ctx, refSource)
 		if err != nil {
 			return nil, fmt.Errorf("ref root %s: %w", refKey, err)

--- a/internal/app/oci_source_test.go
+++ b/internal/app/oci_source_test.go
@@ -1,0 +1,645 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/sholdee/drydock/internal/cacheevent"
+	"github.com/sholdee/drydock/internal/config"
+	"github.com/sholdee/drydock/internal/discovery"
+	"github.com/sholdee/drydock/internal/ociartifact"
+	"github.com/sholdee/drydock/internal/ociartifact/ocitest"
+	"github.com/sholdee/drydock/internal/render"
+	sourcepkg "github.com/sholdee/drydock/internal/source"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// fakeOCIArtifactAcquirer is the unit-test seam fake: it resolves every
+// revision to a fixed digest and extracts fixed files, mirroring the
+// OnAcquired contract of the production acquirer.
+type fakeOCIArtifactAcquirer struct {
+	mu       sync.Mutex
+	digest   string
+	files    map[string]string
+	resolves int
+	extracts int
+}
+
+func (a *fakeOCIArtifactAcquirer) Resolve(_ context.Context, _, _ string, _ ociartifact.Options) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.resolves++
+	return a.digest, nil
+}
+
+func (a *fakeOCIArtifactAcquirer) Extract(_ context.Context, _, _ string, opts ociartifact.Options) (string, func(), error) {
+	a.mu.Lock()
+	a.extracts++
+	a.mu.Unlock()
+	dir, err := os.MkdirTemp("", "drydock-fake-oci-*")
+	if err != nil {
+		return "", nil, err
+	}
+	for name, data := range a.files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return "", nil, err
+		}
+		if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+			return "", nil, err
+		}
+	}
+	if opts.OnAcquired != nil {
+		opts.OnAcquired(false)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func (a *fakeOCIArtifactAcquirer) counts() (int, int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.resolves, a.extracts
+}
+
+func writeOCIApplication(t *testing.T, root, appName, repoURL, sourcePath, revision, extra string) {
+	t.Helper()
+	pathLine := ""
+	if sourcePath != "" {
+		pathLine = "    path: " + sourcePath + "\n"
+	}
+	writeTestFile(t, filepath.Join(root, "apps", appName+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+appName+`
+  namespace: argocd
+spec:
+  source:
+    repoURL: `+repoURL+`
+    targetRevision: "`+revision+`"
+`+pathLine+extra+`  destination:
+    name: in-cluster
+    namespace: default
+`)
+}
+
+func ociEventCount(events []cacheevent.Event) int {
+	count := 0
+	for _, event := range events {
+		if event.Source == cacheevent.SourceOCI {
+			count++
+		}
+	}
+	return count
+}
+
+func ociBuildRequest(t *testing.T, root string) BuildRequest {
+	t.Helper()
+	return BuildRequest{
+		Path: root,
+		AcquisitionOptions: AcquisitionOptions{
+			OCICacheDir:       t.TempDir(),
+			RecordCacheEvents: true,
+		},
+	}
+}
+
+// Issue #220 shape WITHOUT a helm block: the silent-masking mode. Path "."
+// always exists locally, so without total classification the local checkout
+// (including this decoy) would render instead of the artifact content.
+func TestBuildRendersOCIArtifactWithoutHelmBlock(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", reg.RepoURL("charts/demo"), ".", "1.2.3", "")
+	writeTestFile(t, filepath.Join(root, "decoy.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-decoy
+data: {}
+`)
+
+	request := ociBuildRequest(t, root)
+	result, err := Orchestrator{}.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	manifest := assertManifestNamed(t, result.Manifests, "demo-demo")
+	if marker, _, _ := unstructured.NestedString(manifest.Object.Object, "data", "marker"); marker != "oci-artifact-content" {
+		t.Fatalf("marker = %q, want artifact content", marker)
+	}
+	if message, _, _ := unstructured.NestedString(manifest.Object.Object, "data", "message"); message != "from-defaults" {
+		t.Fatalf("message = %q, want chart default", message)
+	}
+	if _, ok := manifestByName(result.Manifests, "local-decoy"); ok {
+		t.Fatal("local checkout content leaked into an OCI artifact render")
+	}
+	if got := ociEventCount(result.CacheEvents); got != 1 {
+		t.Fatalf("oci cache events = %d, want 1: %#v", got, result.CacheEvents)
+	}
+	for _, event := range result.CacheEvents {
+		if event.Source == cacheevent.SourceOCI && event.Action != cacheevent.ActionFetch {
+			t.Fatalf("first online acquisition action = %q, want fetch", event.Action)
+		}
+	}
+}
+
+// Issue #220 shape WITH a helm block: values flow into the artifact chart.
+func TestBuildRendersOCIArtifactWithHelmValues(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", reg.RepoURL("charts/demo"), ".", "1.2.3", `    helm:
+      values: |
+        message: overridden
+`)
+
+	result, err := Orchestrator{}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	manifest := assertManifestNamed(t, result.Manifests, "demo-demo")
+	if message, _, _ := unstructured.NestedString(manifest.Object.Object, "data", "message"); message != "overridden" {
+		t.Fatalf("message = %q, want helm values override", message)
+	}
+}
+
+// Local-path masking pin: the declared path exists in the local checkout with
+// different content; the artifact content must win with zero local reads.
+func TestBuildOCIArtifactIgnoresExistingLocalPath(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "v1", map[string]string{
+		"manifests/demo/cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: artifact-content\ndata: {}\n",
+	})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", reg.RepoURL("manifests/app"), "manifests/demo", "v1", "")
+	writeTestFile(t, filepath.Join(root, "manifests", "demo", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-decoy
+data: {}
+`)
+
+	result, err := Orchestrator{}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "artifact-content")
+	if _, ok := manifestByName(result.Manifests, "local-decoy"); ok {
+		t.Fatal("existing local path masked the OCI artifact source")
+	}
+}
+
+func TestBuildRendersPlainManifestsOCIArtifact(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/plain", "v1", map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: plain-artifact\ndata: {}\n",
+	})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "plain", reg.RepoURL("manifests/plain"), ".", "v1", "")
+
+	result, err := Orchestrator{}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "plain-artifact")
+}
+
+// Classic-shape regression pin: oci:// + chart keeps drydock's existing
+// helm-chart flow (recorded divergence) — the chart acquirer is hit, the
+// artifact acquirer never runs.
+func TestBuildClassicOCIChartShapeUsesChartAcquirer(t *testing.T) {
+	root := t.TempDir()
+	chartRoot := t.TempDir()
+	writeTestChart(t, chartRoot, "demo")
+	writeTestFile(t, filepath.Join(root, "apps", "classic.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: classic
+  namespace: argocd
+spec:
+  source:
+    repoURL: oci://charts.example.test/org
+    targetRevision: 1.2.3
+    chart: demo
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	chartAcquirer := &recordingChartAcquirer{chartDir: filepath.Join(chartRoot, "demo")}
+	artifactAcquirer := &fakeOCIArtifactAcquirer{digest: "sha256:" + strings.Repeat("ab", 32)}
+
+	result, err := Orchestrator{ChartAcquirer: chartAcquirer, OCIArtifactAcquirer: artifactAcquirer}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "classic")
+	if len(chartAcquirer.requests) == 0 {
+		t.Fatal("chart acquirer not hit for oci:// + chart shape")
+	}
+	if resolves, extracts := artifactAcquirer.counts(); resolves != 0 || extracts != 0 {
+		t.Fatalf("artifact acquirer hit for oci:// + chart shape: %d resolves %d extracts", resolves, extracts)
+	}
+}
+
+// The hybrid shape (oci:// + chart + path) errors clearly instead of falling
+// through to the masked branches.
+func TestBuildHybridOCIChartPathShapeFails(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "hybrid.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hybrid
+  namespace: argocd
+spec:
+  source:
+    repoURL: oci://charts.example.test/org
+    targetRevision: 1.2.3
+    chart: demo
+    path: .
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	artifactAcquirer := &fakeOCIArtifactAcquirer{digest: "sha256:" + strings.Repeat("ab", 32)}
+	_, err := Orchestrator{OCIArtifactAcquirer: artifactAcquirer}.Build(context.Background(), ociBuildRequest(t, root))
+	assertBuildErrorContains(t, err, "unsupported source shape")
+	if resolves, extracts := artifactAcquirer.counts(); resolves != 0 || extracts != 0 {
+		t.Fatalf("artifact acquirer hit for hybrid shape: %d resolves %d extracts", resolves, extracts)
+	}
+}
+
+// Offline phase split: online build populates the cache, the registry
+// closes, and a fresh orchestrator must render from cache — while an unseen
+// tag fails with the offline cache miss contract text.
+func TestBuildOCIArtifactOffline(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	root := t.TempDir()
+	repoURL := reg.RepoURL("charts/demo")
+	writeOCIApplication(t, root, "demo", repoURL, ".", "1.2.3", "")
+	ociCacheDir := t.TempDir()
+
+	onlineRequest := BuildRequest{Path: root, AcquisitionOptions: AcquisitionOptions{OCICacheDir: ociCacheDir, RecordCacheEvents: true}}
+	onlineResult, err := Orchestrator{}.Build(context.Background(), onlineRequest)
+	if err != nil {
+		t.Fatalf("online Build() error = %v", err)
+	}
+	onlineManifest := assertManifestNamed(t, onlineResult.Manifests, "demo-demo")
+
+	reg.Server.Close()
+
+	offlineRequest := BuildRequest{Path: root, AcquisitionOptions: AcquisitionOptions{OCICacheDir: ociCacheDir, Offline: true, RecordCacheEvents: true}}
+	offlineResult, err := Orchestrator{}.Build(context.Background(), offlineRequest)
+	if err != nil {
+		t.Fatalf("offline Build() error = %v", err)
+	}
+	offlineManifest := assertManifestNamed(t, offlineResult.Manifests, "demo-demo")
+	if marker, _, _ := unstructured.NestedString(offlineManifest.Object.Object, "data", "marker"); marker != "oci-artifact-content" {
+		t.Fatalf("offline marker = %q, want artifact content", marker)
+	}
+	if onlineName, offlineName := onlineManifest.Object.GetName(), offlineManifest.Object.GetName(); onlineName != offlineName {
+		t.Fatalf("offline render diverged: %q vs %q", onlineName, offlineName)
+	}
+	sawHit := false
+	for _, event := range offlineResult.CacheEvents {
+		if event.Source == cacheevent.SourceOCI && event.Action == cacheevent.ActionHit && event.Offline {
+			sawHit = true
+		}
+	}
+	if !sawHit {
+		t.Fatalf("offline build events missing oci hit: %#v", offlineResult.CacheEvents)
+	}
+
+	// Unseen tag offline: clear offline cache miss error.
+	unseenRoot := t.TempDir()
+	writeOCIApplication(t, unseenRoot, "demo", repoURL, ".", "9.9.9", "")
+	_, err = Orchestrator{}.Build(context.Background(), BuildRequest{Path: unseenRoot, AcquisitionOptions: AcquisitionOptions{OCICacheDir: ociCacheDir, Offline: true}})
+	assertBuildErrorContains(t, err, "offline cache miss")
+}
+
+// Two-sided diff at one digest: the session memo makes the whole diff a
+// single real acquisition (one oci cache event).
+func TestDiffTwoSidedOCISingleAcquisitionEvent(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	repoURL := reg.RepoURL("charts/demo")
+	left := t.TempDir()
+	right := t.TempDir()
+	writeOCIApplication(t, left, "demo", repoURL, ".", "1.2.3", "")
+	writeOCIApplication(t, right, "demo", repoURL, ".", "1.2.3", "")
+
+	result, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:  left,
+		RightPath: right,
+		Unified:   3,
+		AcquisitionOptions: AcquisitionOptions{
+			OCICacheDir:       t.TempDir(),
+			RecordCacheEvents: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	if len(result.Results) != 0 {
+		t.Fatalf("Results = %#v, want none for identical sides", result.Results)
+	}
+	if got := ociEventCount(result.CacheEvents); got != 1 {
+		t.Fatalf("oci cache events = %d, want 1 (session memo): %#v", got, result.CacheEvents)
+	}
+}
+
+// Identity pin 9a: re-pushing the SAME tag with different content is
+// reflected on the next online render (tags re-resolve via network HEAD).
+func TestBuildOCISameTagRepushReflectsNewContent(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "stable", map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: content-v1\ndata: {}\n",
+	})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", reg.RepoURL("manifests/app"), ".", "stable", "")
+	ociCacheDir := t.TempDir()
+	request := BuildRequest{Path: root, AcquisitionOptions: AcquisitionOptions{OCICacheDir: ociCacheDir}}
+
+	first, err := Orchestrator{}.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first Build() error = %v", err)
+	}
+	assertManifestNamed(t, first.Manifests, "content-v1")
+
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "stable", map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: content-v2\ndata: {}\n",
+	})
+	second, err := Orchestrator{}.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	assertManifestNamed(t, second.Manifests, "content-v2")
+	if _, ok := manifestByName(second.Manifests, "content-v1"); ok {
+		t.Fatal("stale tag content served after same-tag re-push")
+	}
+}
+
+// Identity pin 9b: two tags aliasing one digest share a single image-cache
+// entry.
+func TestBuildOCITagAliasesShareImageCacheEntry(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "v1", map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: aliased\ndata: {}\n",
+	})
+	ocitest.TagAlias(t, reg, "manifests/app", "v1", "v1-alias")
+	repoURL := reg.RepoURL("manifests/app")
+	ociCacheDir := t.TempDir()
+
+	for _, revision := range []string{"v1", "v1-alias"} {
+		root := t.TempDir()
+		writeOCIApplication(t, root, "demo", repoURL, ".", revision, "")
+		if _, err := (Orchestrator{}).Build(context.Background(), BuildRequest{Path: root, AcquisitionOptions: AcquisitionOptions{OCICacheDir: ociCacheDir}}); err != nil {
+			t.Fatalf("Build(%s) error = %v", revision, err)
+		}
+	}
+
+	entries, err := os.ReadDir(ociCacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() && len(entry.Name()) == 64 {
+			entryCount++
+		}
+	}
+	if entryCount != 1 {
+		t.Fatalf("image cache entries = %d, want 1 (tags alias one digest)", entryCount)
+	}
+}
+
+// Identity pin 9c (fake-level): the identity derives from the resolved
+// digest, not the revision string.
+func TestOCISourceIdentityDerivesFromDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	fake := &fakeOCIArtifactAcquirer{digest: digest, files: map[string]string{"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata: {}\n"}}
+	root := t.TempDir()
+	request := ociBuildRequest(t, root)
+	recorder := cacheevent.NewRecorder(false)
+	provider, cleanup, err := newLocalProvider(context.Background(), Orchestrator{OCIArtifactAcquirer: fake}, root, config.ArgoSettings{}, request, recorder, "drydock-oci-identity-test-*")
+	if err != nil {
+		t.Fatalf("newLocalProvider() error = %v", err)
+	}
+	defer cleanup()
+
+	identities := make([]SourceIdentity, 0, 2)
+	for _, revision := range []string{"1.2.3", "some-tag"} {
+		_, identity, err := provider.resolveSourceRootIdentity(context.Background(), render.ResolvedSource{
+			RepoURL:        "oci://registry.example/org/app",
+			TargetRevision: revision,
+			Path:           ".",
+		})
+		if err != nil {
+			t.Fatalf("resolveSourceRootIdentity(%s) error = %v", revision, err)
+		}
+		identities = append(identities, identity)
+	}
+	if identities[0] != identities[1] {
+		t.Fatalf("identities differ across revision spellings of one digest: %#v vs %#v", identities[0], identities[1])
+	}
+	if identities[0].Kind != sourceIdentityKindOCI || identities[0].Revision != digest {
+		t.Fatalf("identity = %#v, want kind oci with digest revision", identities[0])
+	}
+}
+
+// Near-miss/self-repo exclusion: an oci:// URL whose scheme-stripped form
+// FULL-matches a git remote of the local checkout must not resolve to the
+// local tree ("demo"), and a fork-shaped oci:// URL (same host and repo name,
+// different owner, "fork") must not emit the near-miss warning.
+func TestBuildOCISourceSkipsSelfRepoAndNearMiss(t *testing.T) {
+	root := t.TempDir()
+	repo, err := git.PlainInit(root, false)
+	if err != nil {
+		t.Fatalf("PlainInit() error = %v", err)
+	}
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{"https://registry.example/org/app"}}); err != nil {
+		t.Fatalf("CreateRemote() error = %v", err)
+	}
+	writeOCIApplication(t, root, "demo", "oci://registry.example/org/app", ".", "1.2.3", "")
+	// Empty targetRevision passes the near-miss revision gate, so only the
+	// oci:// URL guard keeps the fork warning quiet.
+	writeOCIApplication(t, root, "fork", "oci://registry.example/other/app", ".", "", "")
+	fake := &fakeOCIArtifactAcquirer{
+		digest: "sha256:" + strings.Repeat("cd", 32),
+		files:  map[string]string{"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: artifact-content\ndata: {}\n"},
+	}
+
+	result, err := Orchestrator{OCIArtifactAcquirer: fake}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "artifact-content")
+	if _, extracts := fake.counts(); extracts == 0 {
+		t.Fatal("OCI source resolved without the artifact acquirer (self-repo mask)")
+	}
+	for _, diag := range result.Diagnostics {
+		if diag.Code == selfRepoNearMissCode {
+			t.Fatalf("near-miss diagnostic fired for an oci:// URL: %#v", diag)
+		}
+	}
+}
+
+// $ref→OCI is excluded (upstream parity): a helm value file referencing an
+// OCI ref source fails with a clear error.
+func TestBuildOCIRefSourceExcluded(t *testing.T) {
+	root := t.TempDir()
+	writeTestChart(t, root, "chart")
+	writeTestFile(t, filepath.Join(root, "apps", "ref.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ref
+  namespace: argocd
+spec:
+  sources:
+    - repoURL: oci://registry.example/org/values
+      targetRevision: "1.0.0"
+      ref: values
+    - repoURL: https://github.com/example/repo
+      targetRevision: main
+      path: chart
+      helm:
+        valueFiles:
+          - $values/values.yaml
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	fake := &fakeOCIArtifactAcquirer{digest: "sha256:" + strings.Repeat("ef", 32), files: map[string]string{"values.yaml": "message: nope\n"}}
+	_, err := Orchestrator{OCIArtifactAcquirer: fake}.Build(context.Background(), ociBuildRequest(t, root))
+	assertBuildErrorContains(t, err, "$values", "cannot be referenced as $ref value sources")
+}
+
+// repo-map precedence: mapping the oci:// URL to a local path keeps winning
+// over OCI classification (today's only #220 workaround stays intact).
+func TestBuildOCIRepoMapPrecedence(t *testing.T) {
+	root := t.TempDir()
+	mapped := t.TempDir()
+	writeTestFile(t, filepath.Join(mapped, "manifests", "cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mapped-content
+data: {}
+`)
+	writeOCIApplication(t, root, "demo", "oci://registry.example/org/app", "manifests", "1.2.3", "")
+	fake := &fakeOCIArtifactAcquirer{digest: "sha256:" + strings.Repeat("aa", 32)}
+	request := ociBuildRequest(t, root)
+	request.RepoMaps = []sourcepkg.RepoMap{{URL: "oci://registry.example/org/app", Path: mapped}}
+
+	result, err := Orchestrator{OCIArtifactAcquirer: fake}.Build(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "mapped-content")
+	if resolves, extracts := fake.counts(); resolves != 0 || extracts != 0 {
+		t.Fatalf("artifact acquirer hit despite repo-map: %d resolves %d extracts", resolves, extracts)
+	}
+}
+
+// Discovery frontier: OCI sources are skipped exactly like chart-only ones.
+func TestOCISourceSkippedInDiscoveryFrontier(t *testing.T) {
+	root := t.TempDir()
+	// Application manifests at the local path an unclassified `path: .` would
+	// resolve to — the skip must keep them out of the frontier.
+	writeBuildApplication(t, root, "inner", "inner-cm")
+	app := argoappv1.Application{
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "oci://registry.example/org/app",
+				TargetRevision: "1.2.3",
+				Path:           ".",
+			},
+		},
+	}
+	if applicationMayRenderDiscoveryObjects(root, BuildRequest{}, discovery.Result{}, app) {
+		t.Fatal("OCI source entered the discovery frontier")
+	}
+}
+
+// Changed-path selection: an OCI source with `path: .` must not claim every
+// changed path; its changes stay unowned.
+func TestOCISourceDoesNotClaimChangedPaths(t *testing.T) {
+	app := argoappv1.Application{
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "oci://registry.example/org/app",
+				TargetRevision: "1.2.3",
+				Path:           ".",
+				Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values.yaml"}},
+			},
+		},
+	}
+	selected, unowned := SelectChangedApplications([]argoappv1.Application{app}, []string{"manifests/other/cm.yaml"})
+	if len(selected) != 0 {
+		t.Fatalf("selected = %#v, want none", selected)
+	}
+	if len(unowned) != 1 || unowned[0] != "manifests/other/cm.yaml" {
+		t.Fatalf("unowned = %#v, want the changed path", unowned)
+	}
+}
+
+// Extraction lifecycle: the extracted dir is present during render and
+// released with the session; two sides at one digest with different paths do
+// not contaminate each other.
+func TestOCIExtractionLifecycleAndTwoSidedPaths(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "v1", map[string]string{
+		"a/cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: side-a\ndata: {}\n",
+		"b/cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: side-b\ndata: {}\n",
+	})
+	repoURL := reg.RepoURL("manifests/app")
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", repoURL, "a", "v1", "")
+
+	var renderRoots []string
+	orchestrator := Orchestrator{}
+	orchestrator.renderObserver = func(source render.ResolvedSource) {
+		renderRoots = append(renderRoots, source.RepoRoot)
+	}
+	result, err := orchestrator.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	assertManifestNamed(t, result.Manifests, "side-a")
+	if len(renderRoots) == 0 {
+		t.Fatal("render observer captured no source roots")
+	}
+	for _, renderRoot := range renderRoots {
+		if _, err := os.Stat(renderRoot); !os.IsNotExist(err) {
+			t.Fatalf("extraction root %q survived session release: %v", renderRoot, err)
+		}
+	}
+
+	// Two sides, same digest, different paths.
+	left := t.TempDir()
+	right := t.TempDir()
+	writeOCIApplication(t, left, "demo", repoURL, "a", "v1", "")
+	writeOCIApplication(t, right, "demo", repoURL, "b", "v1", "")
+	diffResult, err := Orchestrator{}.DiffApps(context.Background(), DiffRequest{
+		LeftPath:           left,
+		RightPath:          right,
+		Unified:            3,
+		AcquisitionOptions: AcquisitionOptions{OCICacheDir: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v", err)
+	}
+	names := map[string]bool{}
+	for _, diffEntry := range diffResult.Results {
+		names[diffEntry.Resource.Name] = true
+	}
+	if !names["side-a"] || !names["side-b"] {
+		t.Fatalf("diff results = %#v, want side-a and side-b (no cross-side contamination)", diffResult.Results)
+	}
+}

--- a/internal/app/oci_source_test.go
+++ b/internal/app/oci_source_test.go
@@ -275,6 +275,51 @@ spec:
 	}
 }
 
+// Empty-path normalization pin: an OCI Application with NO path line renders
+// the artifact manifests exactly like `path: .` — argo renders the extraction
+// root when an OCI source omits path (vendored repository.go:415-418).
+func TestBuildRendersOCIArtifactWithoutPath(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	root := t.TempDir()
+	writeOCIApplication(t, root, "demo", reg.RepoURL("charts/demo"), "", "1.2.3", "")
+
+	result, err := Orchestrator{}.Build(context.Background(), ociBuildRequest(t, root))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	manifest := assertManifestNamed(t, result.Manifests, "demo-demo")
+	if marker, _, _ := unstructured.NestedString(manifest.Object.Object, "data", "marker"); marker != "oci-artifact-content" {
+		t.Fatalf("marker = %q, want artifact content", marker)
+	}
+}
+
+// The hybrid-shape error text goes through RedactURL: credentials embedded in
+// the repoURL spelling never appear in it.
+func TestBuildHybridOCIShapeErrorRedactsCredentials(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "apps", "hybrid.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hybrid
+  namespace: argocd
+spec:
+  source:
+    repoURL: oci://user:sekret@charts.example.test/org
+    targetRevision: 1.2.3
+    chart: demo
+    path: .
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+	_, err := Orchestrator{}.Build(context.Background(), ociBuildRequest(t, root))
+	assertBuildErrorContains(t, err, "unsupported source shape")
+	if strings.Contains(err.Error(), "sekret") {
+		t.Fatalf("hybrid-shape error leaks URL credentials: %v", err)
+	}
+}
+
 // Offline phase split: online build populates the cache, the registry
 // closes, and a fresh orchestrator must render from cache — while an unseen
 // tag fails with the offline cache miss contract text.
@@ -567,6 +612,35 @@ func TestOCISourceSkippedInDiscoveryFrontier(t *testing.T) {
 	}
 }
 
+// Repo-map escape hatch at the frontier: a repo-mapped oci:// parent renders
+// from the mapped local tree, so it keeps frontier eligibility and discovers
+// child Applications; an unmapped oci:// parent stays skipped.
+func TestOCISourceRepoMappedEntersDiscoveryFrontier(t *testing.T) {
+	root := t.TempDir()
+	// A discovery-relevant file at the local `path: .` keeps the unmapped
+	// assertion honest: without the OCI skip it would enter the frontier.
+	writeBuildApplication(t, root, "decoy", "decoy-cm")
+	mapped := t.TempDir()
+	writeBuildApplication(t, mapped, "child", "child-cm")
+	app := argoappv1.Application{
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "oci://registry.example/org/app",
+				TargetRevision: "1.2.3",
+				Path:           ".",
+			},
+		},
+	}
+	request := BuildRequest{}
+	request.RepoMaps = []sourcepkg.RepoMap{{URL: "oci://registry.example/org/app", Path: mapped}}
+	if !applicationMayRenderDiscoveryObjects(root, request, discovery.Result{}, app) {
+		t.Fatal("repo-mapped OCI parent lost frontier eligibility (its child Applications would be silently dropped)")
+	}
+	if applicationMayRenderDiscoveryObjects(root, BuildRequest{}, discovery.Result{}, app) {
+		t.Fatal("unmapped OCI source entered the discovery frontier")
+	}
+}
+
 // Changed-path selection: an OCI source with `path: .` must not claim every
 // changed path; its changes stay unowned.
 func TestOCISourceDoesNotClaimChangedPaths(t *testing.T) {
@@ -585,6 +659,55 @@ func TestOCISourceDoesNotClaimChangedPaths(t *testing.T) {
 		t.Fatalf("selected = %#v, want none", selected)
 	}
 	if len(unowned) != 1 || unowned[0] != "manifests/other/cm.yaml" {
+		t.Fatalf("unowned = %#v, want the changed path", unowned)
+	}
+}
+
+// Value-file guard pin (local shape): an OCI source's helm value files
+// resolve inside the extracted artifact, so a changed path at the value-file
+// location must stay unowned.
+func TestOCISourceLocalValueFilesDoNotClaimChangedPaths(t *testing.T) {
+	app := argoappv1.Application{
+		Spec: argoappv1.ApplicationSpec{
+			Source: &argoappv1.ApplicationSource{
+				RepoURL:        "oci://registry.example/org/app",
+				TargetRevision: "1.2.3",
+				Path:           "manifests",
+				Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"values.yaml"}},
+			},
+		},
+	}
+	selected, unowned := SelectChangedApplications([]argoappv1.Application{app}, []string{"manifests/values.yaml"})
+	if len(selected) != 0 {
+		t.Fatalf("selected = %#v, want none (OCI value files are artifact content)", selected)
+	}
+	if len(unowned) != 1 || unowned[0] != "manifests/values.yaml" {
+		t.Fatalf("unowned = %#v, want the changed path", unowned)
+	}
+}
+
+// Value-file guard pin ($ref shape): a $ref value file whose ref source is
+// OCI must not claim the changed path either, even when the consuming source
+// shares the repoURL spelling.
+func TestOCIRefValueFilesDoNotClaimChangedPaths(t *testing.T) {
+	app := argoappv1.Application{
+		Spec: argoappv1.ApplicationSpec{
+			Sources: argoappv1.ApplicationSources{
+				{RepoURL: "oci://registry.example/org/app", TargetRevision: "1.2.3", Ref: "values"},
+				{
+					RepoURL:        "oci://registry.example/org/app",
+					TargetRevision: "1.2.3",
+					Path:           "manifests",
+					Helm:           &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"$values/values.yaml"}},
+				},
+			},
+		},
+	}
+	selected, unowned := SelectChangedApplications([]argoappv1.Application{app}, []string{"values.yaml"})
+	if len(selected) != 0 {
+		t.Fatalf("selected = %#v, want none (OCI $ref value files are artifact content)", selected)
+	}
+	if len(unowned) != 1 || unowned[0] != "values.yaml" {
 		t.Fatalf("unowned = %#v, want the changed path", unowned)
 	}
 }

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sholdee/drydock/internal/discovery"
 	"github.com/sholdee/drydock/internal/luahealth"
 	"github.com/sholdee/drydock/internal/manifest"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/plugincontainer"
 	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/project"
@@ -146,6 +147,7 @@ type Orchestrator struct {
 	ChartAcquirer          chart.Acquirer
 	GitAcquirer            sourcepkg.GitAcquirer
 	RemoteResourceAcquirer remote.Acquirer
+	OCIArtifactAcquirer    ociartifact.Acquirer
 	PluginRenderer         render.PluginRenderer
 	PluginExecRunner       pluginexec.Runner
 	PluginContainerRunner  plugincontainer.Runner

--- a/internal/app/render_cache_persistent.go
+++ b/internal/app/render_cache_persistent.go
@@ -37,6 +37,7 @@ const (
 	sourceIdentityKindRoot           = "root"
 	sourceIdentityKindGit            = "git"
 	sourceIdentityKindChart          = "chart"
+	sourceIdentityKindOCI            = "oci"
 	sourceIdentityKindLocalInputs    = "local-inputs"
 	sourceIdentityKindWorktreeInputs = "worktree-inputs"
 )
@@ -1277,6 +1278,9 @@ func acquisitionsPinStable(records []cacheevent.AcquisitionRecord) bool {
 		switch record.Kind {
 		case cacheevent.AcquisitionGit:
 			// Git source revisions are already key inputs.
+		case cacheevent.AcquisitionOCI:
+			// The resolved digest is already a key input
+			// (SourceIdentity.Revision), so moved tags rotate the key.
 		case cacheevent.AcquisitionChart:
 			if strings.TrimSpace(record.RequestedRevision) == "" {
 				return false

--- a/internal/app/request_options.go
+++ b/internal/app/request_options.go
@@ -33,6 +33,7 @@ type AcquisitionOptions struct {
 	RemoteResourceForbiddenRoots []string
 	RemoteResourceCredentials    remote.Credentials
 	RemoteResourceGitCredentials remote.GitCredentials
+	OCICacheDir                  string
 	RecordCacheEvents            bool
 }
 

--- a/internal/app/select.go
+++ b/internal/app/select.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
 
@@ -128,6 +129,9 @@ func refHelmValueFileInputPath(source argoappv1.ApplicationSource, refs map[stri
 	if !ok {
 		return "", false
 	}
+	if ociartifact.IsOCIURL(refSource.RepoURL) {
+		return "", false
+	}
 	if sourcepkg.NormalizeURL(refSource.RepoURL) != sourcepkg.NormalizeURL(source.RepoURL) {
 		return "", false
 	}
@@ -135,6 +139,9 @@ func refHelmValueFileInputPath(source argoappv1.ApplicationSource, refs map[stri
 }
 
 func localHelmValueFileInputPath(source argoappv1.ApplicationSource, valueFile string) (string, bool) {
+	if ociartifact.IsOCIURL(source.RepoURL) {
+		return "", false
+	}
 	if source.Path == "" {
 		return "", false
 	}
@@ -161,6 +168,13 @@ func splitHelmValueFileRef(valueFile string) (string, string, bool) {
 }
 
 func localSourcePath(source argoappv1.ApplicationSource) (string, bool) {
+	// An OCI source's path selects within the extracted artifact, never the
+	// local repository — treating `path: .` as local would intersect EVERY
+	// changed path. OCI sources re-render when the Application manifest
+	// changes, not on arbitrary repository changes.
+	if ociartifact.IsOCIURL(source.RepoURL) {
+		return "", false
+	}
 	if source.Path != "" {
 		return normalizeSelectPath(source.Path), true
 	}

--- a/internal/app/self_repo.go
+++ b/internal/app/self_repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sholdee/drydock/internal/diagnostic"
 	"github.com/sholdee/drydock/internal/gitref"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/render"
 	sourcepkg "github.com/sholdee/drydock/internal/source"
 )
@@ -157,6 +158,12 @@ func (p localProvider) selfRepoNearMissDiagnostics(source render.ResolvedSource,
 func (p localProvider) selfRepoNearMissDiagnostic(source render.ResolvedSource) (diagnostic.Diagnostic, bool) {
 	repoURL := strings.TrimSpace(source.RepoURL)
 	if repoURL == "" {
+		return diagnostic.Diagnostic{}, false
+	}
+	// OCI sources never resolve to the local checkout (classification runs
+	// before the self-repo branch), so a scheme-stripped oci:// URL matching
+	// a git remote's host and repo name is not a fork near-miss.
+	if ociartifact.IsOCIURL(repoURL) {
 		return diagnostic.Diagnostic{}, false
 	}
 	rev := strings.TrimSpace(source.TargetRevision)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,6 +19,11 @@ const (
 	SourceChart  Source = "chart"
 	SourceRemote Source = "remote"
 	SourceRender Source = "render"
+	// SourceOCI is the first-class OCI artifact image cache. The name does not
+	// collide with the chart cache's "oci" repository kind: Source and Kind are
+	// distinct fields on entries and metadata, and chart "oci" only appears as
+	// a Kind under SourceChart (listChartEntries below).
+	SourceOCI Source = "oci"
 )
 
 type Options struct {
@@ -26,6 +31,7 @@ type Options struct {
 	ChartCacheDir  string
 	RemoteCacheDir string
 	RenderCacheDir string
+	OCICacheDir    string
 	Sources        []Source
 	ForbiddenRoots []string
 }
@@ -103,6 +109,13 @@ func List(opts Options) ([]Entry, error) {
 			return nil, err
 		}
 		entries = append(entries, remoteEntries...)
+	}
+	if enabled[SourceOCI] {
+		ociEntries, err := listSimpleEntries(SourceOCI, "image", opts.OCICacheDir, opts.ForbiddenRoots)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, ociEntries...)
 	}
 	if enabled[SourceRender] {
 		renderEntries, err := listRenderEntries(opts.RenderCacheDir, opts.ForbiddenRoots)
@@ -570,6 +583,7 @@ func enabledSources(sources []Source) map[Source]bool {
 		out[SourceChart] = true
 		out[SourceRemote] = true
 		out[SourceRender] = true
+		out[SourceOCI] = true
 		return out
 	}
 	for _, source := range sources {

--- a/internal/cache/layout.go
+++ b/internal/cache/layout.go
@@ -18,6 +18,10 @@ func RemoteEntryPath(root, key string) string {
 	return filepath.Join(root, key)
 }
 
+func OCIEntryPath(root, key string) string {
+	return filepath.Join(root, key)
+}
+
 func RemoteHTTPFilePath(root, key string) string {
 	return filepath.Join(RemoteEntryPath(root, key), "resource.yaml")
 }

--- a/internal/cache/oci_test.go
+++ b/internal/cache/oci_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func seedOCITestEntry(t *testing.T, root, key string) string {
+	t.Helper()
+	entry := OCIEntryPath(root, key)
+	if err := os.MkdirAll(entry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entry, "image.tar"), []byte("tar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteMetadata(entry, Metadata{
+		Source:   SourceOCI,
+		Kind:     "image",
+		Key:      key,
+		Target:   "oci://registry.example/org/app",
+		Revision: "sha256:" + strings.Repeat("ab", 32),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+// TestListIncludesOCIEntriesByDefault pins SourceOCI membership in the
+// default enabled-source set and the entry shape (source oci, kind image).
+func TestListIncludesOCIEntriesByDefault(t *testing.T) {
+	root := t.TempDir()
+	key := strings.Repeat("a", 64)
+	seedOCITestEntry(t, root, key)
+	// Non-entry names (offline tag records) are ignored by the lister.
+	if err := os.MkdirAll(filepath.Join(root, "tags"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := List(Options{OCICacheDir: root})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1: %#v", len(entries), entries)
+	}
+	entry := entries[0]
+	if entry.Source != SourceOCI || entry.Kind != "image" || entry.Key != key {
+		t.Fatalf("entry = %+v, want oci/image/%s", entry, key)
+	}
+	if entry.Legacy || entry.Metadata == nil {
+		t.Fatalf("entry = %+v, want metadata-backed", entry)
+	}
+}

--- a/internal/cacheevent/acquisition.go
+++ b/internal/cacheevent/acquisition.go
@@ -12,6 +12,7 @@ const (
 	AcquisitionChart      AcquisitionKind = "chart"
 	AcquisitionRemoteGit  AcquisitionKind = "remote-git"
 	AcquisitionRemoteHTTP AcquisitionKind = "remote-http"
+	AcquisitionOCI        AcquisitionKind = "oci"
 )
 
 // AcquisitionRecord retains the pre-collapse requested and resolved revisions

--- a/internal/cacheevent/cacheevent.go
+++ b/internal/cacheevent/cacheevent.go
@@ -16,6 +16,7 @@ const (
 	SourceChart  Source = "chart"
 	SourceRemote Source = "remote"
 	SourceRender Source = "render"
+	SourceOCI    Source = "oci"
 )
 
 type Action string

--- a/internal/cacheevent/oci_test.go
+++ b/internal/cacheevent/oci_test.go
@@ -1,0 +1,44 @@
+package cacheevent
+
+import "testing"
+
+// TestRecordRoundTripsOCITargets pins that the git-oriented target redaction
+// passes oci:// URLs through unchanged (RedactGitRepoURL parses them as
+// scheme+host URLs and only strips userinfo/query/fragment).
+func TestRecordRoundTripsOCITargets(t *testing.T) {
+	recorder := NewRecorder(true)
+	recorder.Record(Event{
+		Source:   SourceOCI,
+		Action:   ActionFetch,
+		Target:   "oci://ghcr.io/org/app",
+		Revision: "sha256:abc",
+	})
+	events := recorder.Events()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].Target != "oci://ghcr.io/org/app" {
+		t.Fatalf("Target = %q, want oci URL unchanged", events[0].Target)
+	}
+}
+
+// TestActionForErrorOCIOfflineMiss pins the "offline cache miss" text
+// contract the OCI acquirer errors rely on for ActionMiss.
+func TestActionForErrorOCIOfflineMiss(t *testing.T) {
+	result := NewAcquisitionError(AcquisitionEventInput{
+		Source:            SourceOCI,
+		Target:            "oci://ghcr.io/org/app",
+		RequestedRevision: "1.2.3",
+		Offline:           true,
+		Err:               errOffline{},
+	})
+	if result.Event.Action != ActionMiss {
+		t.Fatalf("Action = %q, want miss", result.Event.Action)
+	}
+}
+
+type errOffline struct{}
+
+func (errOffline) Error() string {
+	return `offline cache miss for OCI artifact oci://ghcr.io/org/app revision "1.2.3"`
+}

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sholdee/drydock/internal/cache"
 	"github.com/sholdee/drydock/internal/chart"
 	cliformat "github.com/sholdee/drydock/internal/format"
+	"github.com/sholdee/drydock/internal/ociartifact"
 	"github.com/sholdee/drydock/internal/remote"
 	"github.com/sholdee/drydock/internal/rendercache"
 	"github.com/sholdee/drydock/internal/source"
@@ -23,6 +24,7 @@ type cacheFlags struct {
 	chartCacheDir      string
 	remoteCacheDir     string
 	renderCacheDir     string
+	ociCacheDir        string
 	renderCacheMaxSize quantityFlag
 	maxSize            quantityFlag
 	source             string
@@ -67,6 +69,7 @@ func newCacheCommand() *cobra.Command {
 				cache.SourceChart:  opts.ChartCacheDir,
 				cache.SourceRemote: opts.RemoteCacheDir,
 				cache.SourceRender: opts.RenderCacheDir,
+				cache.SourceOCI:    opts.OCICacheDir,
 			})
 		},
 	}
@@ -166,10 +169,11 @@ func bindCacheRootFlags(cmd *cobra.Command, flags *cacheFlags) {
 	cmd.Flags().StringVar(&flags.chartCacheDir, "chart-cache-dir", flags.chartCacheDir, "directory for cached Helm charts")
 	cmd.Flags().StringVar(&flags.remoteCacheDir, "remote-cache-dir", flags.remoteCacheDir, "directory for cached remote Kustomize resources")
 	cmd.Flags().StringVar(&flags.renderCacheDir, "render-cache-dir", flags.renderCacheDir, "directory for persisted Application render outputs")
+	cmd.Flags().StringVar(&flags.ociCacheDir, "oci-cache-dir", flags.ociCacheDir, "directory for cached OCI artifact sources")
 }
 
 func bindCacheSourceFlag(cmd *cobra.Command, flags *cacheFlags) {
-	cmd.Flags().StringVar(&flags.source, "source", flags.source, "cache source to select: git, chart, remote, or render")
+	cmd.Flags().StringVar(&flags.source, "source", flags.source, "cache source to select: git, chart, remote, render, or oci")
 }
 
 func bindCacheOperationFlags(cmd *cobra.Command, flags *cacheFlags) {
@@ -196,6 +200,7 @@ func cacheListOptions(flags cacheFlags) (cache.Options, error) {
 		ChartCacheDir:  roots[cache.SourceChart],
 		RemoteCacheDir: roots[cache.SourceRemote],
 		RenderCacheDir: roots[cache.SourceRender],
+		OCICacheDir:    roots[cache.SourceOCI],
 		Sources:        sources,
 		ForbiddenRoots: forbiddenRoots,
 	}, nil
@@ -270,11 +275,20 @@ func cacheRoots(flags cacheFlags) (map[cache.Source]string, error) {
 			return nil, err
 		}
 	}
+	ociCacheDir := flags.ociCacheDir
+	if ociCacheDir == "" {
+		var err error
+		ociCacheDir, err = ociartifact.DefaultCacheDir()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return map[cache.Source]string{
 		cache.SourceGit:    gitCacheDir,
 		cache.SourceChart:  chartCacheDir,
 		cache.SourceRemote: remoteCacheDir,
 		cache.SourceRender: renderCacheDir,
+		cache.SourceOCI:    ociCacheDir,
 	}, nil
 }
 
@@ -300,10 +314,10 @@ func parseCacheSources(raw string) ([]cache.Source, error) {
 	}
 	source := cache.Source(raw)
 	switch source {
-	case cache.SourceGit, cache.SourceChart, cache.SourceRemote, cache.SourceRender:
+	case cache.SourceGit, cache.SourceChart, cache.SourceRemote, cache.SourceRender, cache.SourceOCI:
 		return []cache.Source{source}, nil
 	default:
-		return nil, fmt.Errorf("unsupported cache source %q: valid sources are git, chart, remote, render", raw)
+		return nil, fmt.Errorf("unsupported cache source %q: valid sources are git, chart, remote, render, oci", raw)
 	}
 }
 
@@ -331,6 +345,7 @@ func renderCachePaths(cmd *cobra.Command, roots map[cache.Source]string) error {
 		{"source": string(cache.SourceChart), "path": roots[cache.SourceChart]},
 		{"source": string(cache.SourceRemote), "path": roots[cache.SourceRemote]},
 		{"source": string(cache.SourceRender), "path": roots[cache.SourceRender]},
+		{"source": string(cache.SourceOCI), "path": roots[cache.SourceOCI]},
 	})
 }
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -45,6 +45,7 @@ type commonFlags struct {
 	registryConfig           string
 	refreshRemotes           bool
 	remoteCacheDir           string
+	ociCacheDir              string
 	remoteUsername           string
 	remotePassword           string
 	remoteBearerToken        string
@@ -135,6 +136,7 @@ func bindAcquisitionCacheFlags(cmd *cobra.Command, flags *commonFlags) {
 	cmd.Flags().StringVar(&flags.chartCacheDir, "chart-cache-dir", flags.chartCacheDir, "directory for cached Helm charts")
 	cmd.Flags().StringVar(&flags.gitCacheDir, "git-cache-dir", flags.gitCacheDir, "directory for cached Git repositories")
 	cmd.Flags().BoolVar(&flags.refreshGit, "refresh-git", flags.refreshGit, "fetch cached Git repositories before rendering")
+	cmd.Flags().StringVar(&flags.ociCacheDir, "oci-cache-dir", flags.ociCacheDir, "directory for cached OCI artifact sources")
 }
 
 func bindAuthFlags(cmd *cobra.Command, flags *commonFlags) {
@@ -349,6 +351,7 @@ func requestOptionsFromFlags(flags commonFlags, repoMaps []source.RepoMap) reque
 		RemoteResourceCacheDir:         flags.remoteCacheDir,
 		RemoteResourceCredentials:      flags.remoteCredentials(),
 		RemoteResourceGitCredentials:   flags.remoteGitCredentials(),
+		OCICacheDir:                    flags.ociCacheDir,
 		EnableAVPCompat:                flags.enableAVPCompat,
 		EnableKSOPSCompat:              flags.enableKSOPSCompat,
 		EnablePlugins:                  flags.enablePlugins,

--- a/internal/cli/oci_cache_test.go
+++ b/internal/cli/oci_cache_test.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sholdee/drydock/internal/cache"
+	"github.com/sholdee/drydock/internal/ociartifact"
+	"github.com/sholdee/drydock/internal/ociartifact/ocitest"
+)
+
+func runCacheCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs(args)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func seedOCICacheEntry(t *testing.T, ociCacheDir, repoURL, digest string, updatedAt time.Time) string {
+	t.Helper()
+	entry := ociartifact.EntryPath(ociCacheDir, repoURL, digest)
+	writeCacheEntry(t, filepath.Join(entry, "image.tar"))
+	if err := cache.WriteMetadata(entry, cache.Metadata{
+		Source:    cache.SourceOCI,
+		Kind:      ociartifact.EntryKind,
+		Key:       filepath.Base(entry),
+		Target:    ociartifact.RedactURL(repoURL),
+		Revision:  digest,
+		CreatedAt: updatedAt,
+		UpdatedAt: updatedAt,
+	}); err != nil {
+		t.Fatalf("WriteMetadata() error = %v", err)
+	}
+	return entry
+}
+
+func TestParseCacheSourcesOCI(t *testing.T) {
+	sources, err := parseCacheSources("oci")
+	if err != nil {
+		t.Fatalf("parseCacheSources(oci) error = %v", err)
+	}
+	if len(sources) != 1 || sources[0] != cache.SourceOCI {
+		t.Fatalf("parseCacheSources(oci) = %v, want [oci]", sources)
+	}
+	_, err = parseCacheSources("bogus")
+	if err == nil || !strings.Contains(err.Error(), "oci") {
+		t.Fatalf("parseCacheSources(bogus) error = %v, want message naming oci", err)
+	}
+}
+
+func TestCacheRootsOCIDefault(t *testing.T) {
+	wantDefault, err := ociartifact.DefaultCacheDir()
+	if err != nil {
+		t.Fatalf("ociartifact.DefaultCacheDir() error = %v", err)
+	}
+	flags := defaultCacheFlags()
+	roots, err := cacheRoots(flags)
+	if err != nil {
+		t.Fatalf("cacheRoots() error = %v", err)
+	}
+	if roots[cache.SourceOCI] != wantDefault {
+		t.Fatalf("cacheRoots()[oci] = %q, want %q", roots[cache.SourceOCI], wantDefault)
+	}
+
+	override := t.TempDir()
+	flags.ociCacheDir = override
+	roots, err = cacheRoots(flags)
+	if err != nil {
+		t.Fatalf("cacheRoots(override) error = %v", err)
+	}
+	if roots[cache.SourceOCI] != override {
+		t.Fatalf("cacheRoots(override)[oci] = %q, want %q", roots[cache.SourceOCI], override)
+	}
+}
+
+func TestCachePathIncludesOCIRow(t *testing.T) {
+	ociCacheDir := t.TempDir()
+	got, err := runCacheCLI(t,
+		"cache", "path",
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(got, "oci") || !strings.Contains(got, ociCacheDir) {
+		t.Fatalf("cache path output missing oci row %q:\n%s", ociCacheDir, got)
+	}
+}
+
+// TestCacheListOCIEntriesFromRealAcquirer lists entries written by the
+// production acquirer against the hermetic registry.
+func TestCacheListOCIEntriesFromRealAcquirer(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "v1", map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: listed\ndata: {}\n",
+	})
+	repoURL := reg.RepoURL("manifests/app")
+	ociCacheDir := t.TempDir()
+	_, release, err := (ociartifact.DefaultAcquirer{}).Extract(t.Context(), repoURL, digest, ociartifact.Options{CacheDir: ociCacheDir})
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	release()
+
+	got, err := runCacheCLI(t,
+		"cache", "list",
+		"--source", "oci",
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+		"-o", "json",
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var entries []cache.Entry
+	if err := json.Unmarshal([]byte(got), &entries); err != nil {
+		t.Fatalf("unmarshal cache list output: %v\n%s", err, got)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1: %s", len(entries), got)
+	}
+	entry := entries[0]
+	if entry.Source != cache.SourceOCI || entry.Kind != ociartifact.EntryKind {
+		t.Fatalf("entry = %+v, want source oci kind image", entry)
+	}
+	if entry.Legacy {
+		t.Fatalf("entry = %+v, want metadata-backed (not legacy)", entry)
+	}
+	if entry.Metadata == nil || entry.Metadata.Revision != digest {
+		t.Fatalf("entry metadata = %+v, want revision %q", entry.Metadata, digest)
+	}
+}
+
+// TestCachePruneDefaultSourcesIncludesOCI pins the enabledSources default:
+// a prune without --source must select stale OCI entries.
+func TestCachePruneDefaultSourcesIncludesOCI(t *testing.T) {
+	ociCacheDir := t.TempDir()
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	entry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", digest, time.Now().Add(-48*time.Hour))
+
+	_, err := runCacheCLI(t,
+		"cache", "prune",
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+		"--older-than", "24h",
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Stat(entry); !os.IsNotExist(err) {
+		t.Fatalf("stale oci entry survived default-source prune: %v", err)
+	}
+}
+
+// TestCachePruneExplicitOCISource prunes through --source oci and pins that
+// the offline tag records directory is not treated as a prunable entry.
+func TestCachePruneExplicitOCISource(t *testing.T) {
+	ociCacheDir := t.TempDir()
+	oldDigest := "sha256:" + strings.Repeat("ab", 32)
+	freshDigest := "sha256:" + strings.Repeat("cd", 32)
+	oldEntry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", oldDigest, time.Now().Add(-48*time.Hour))
+	freshEntry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", freshDigest, time.Now())
+	recordsDir := filepath.Join(ociCacheDir, "tags")
+	writeCLITestFile(t, filepath.Join(recordsDir, "record.json"), `{"digests":{"v1":"`+oldDigest+`"}}`)
+
+	got, err := runCacheCLI(t,
+		"cache", "prune",
+		"--source", "oci",
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+		"--older-than", "24h",
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(got, "removed 1 cache entries") {
+		t.Fatalf("stdout = %q, want one removal", got)
+	}
+	if _, err := os.Stat(oldEntry); !os.IsNotExist(err) {
+		t.Fatalf("stale oci entry survived --source oci prune: %v", err)
+	}
+	if _, err := os.Stat(freshEntry); err != nil {
+		t.Fatalf("fresh oci entry removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(recordsDir, "record.json")); err != nil {
+		t.Fatalf("offline tag records removed by prune: %v", err)
+	}
+}
+
+// TestCachePruneMaxSizeEvictsLRUOCIEntries drives the size phase over OCI
+// entries: the least-recently-used entry goes first.
+func TestCachePruneMaxSizeEvictsLRUOCIEntries(t *testing.T) {
+	ociCacheDir := t.TempDir()
+	oldDigest := "sha256:" + strings.Repeat("ab", 32)
+	freshDigest := "sha256:" + strings.Repeat("cd", 32)
+	oldEntry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", oldDigest, time.Now().Add(-48*time.Hour))
+	freshEntry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", freshDigest, time.Now())
+	// Make the LRU entry dominate the total so a 2000-byte cap evicts exactly
+	// it (entry sizes include metadata.json).
+	if err := os.WriteFile(filepath.Join(oldEntry, "image.tar"), bytes.Repeat([]byte("x"), 4096), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runCacheCLI(t,
+		"cache", "prune",
+		"--source", "oci",
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+		"--max-size", "2000",
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Stat(oldEntry); !os.IsNotExist(err) {
+		t.Fatalf("LRU oci entry survived --max-size prune: %v", err)
+	}
+	if _, err := os.Stat(freshEntry); err != nil {
+		t.Fatalf("most-recent oci entry evicted before LRU: %v", err)
+	}
+}
+
+func TestCacheDeleteOCIEntryByKey(t *testing.T) {
+	ociCacheDir := t.TempDir()
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	entry := seedOCICacheEntry(t, ociCacheDir, "oci://registry.example/org/app", digest, time.Now())
+
+	_, err := runCacheCLI(t,
+		"cache", "delete",
+		"--source", "oci",
+		"--key", filepath.Base(entry),
+		"--git-cache-dir", t.TempDir(),
+		"--chart-cache-dir", t.TempDir(),
+		"--remote-cache-dir", t.TempDir(),
+		"--render-cache-dir", t.TempDir(),
+		"--oci-cache-dir", ociCacheDir,
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Stat(entry); !os.IsNotExist(err) {
+		t.Fatalf("oci entry survived delete: %v", err)
+	}
+}

--- a/internal/cli/oci_source_test.go
+++ b/internal/cli/oci_source_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/ociartifact/ocitest"
+)
+
+// writeOCIAppForCLI writes an Application sourcing an OCI artifact from the
+// hermetic registry.
+func writeOCIAppForCLI(t *testing.T, root, appName, repoURL, sourcePath, revision string) {
+	t.Helper()
+	writeCLITestFile(t, filepath.Join(root, "apps", appName+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+appName+`
+  namespace: argocd
+spec:
+  source:
+    repoURL: `+repoURL+`
+    targetRevision: "`+revision+`"
+    path: `+sourcePath+`
+  destination:
+    name: in-cluster
+    namespace: default
+`)
+}
+
+func pushCLIChartArtifact(t *testing.T, reg *ocitest.Registry, repoName, tag, marker string) {
+	t.Helper()
+	ocitest.PushPlainManifestsArtifact(t, reg, repoName, tag, map[string]string{
+		"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + marker + "\ndata: {}\n",
+	})
+}
+
+// CLI integration against the hermetic registry through the REAL acquirer
+// wrapper (no injected fakes): the nil-EventHandlers panic class would
+// surface on any of these paths.
+func TestCLIGetTestBuildOCISource(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	pushCLIChartArtifact(t, reg, "manifests/app", "v1", "cli-artifact-content")
+	root := t.TempDir()
+	writeOCIAppForCLI(t, root, "demo", reg.RepoURL("manifests/app"), ".", "v1")
+	ociCacheDir := t.TempDir()
+
+	getResult := runCLI(t, "get", "apps", "--path", root, "--oci-cache-dir", ociCacheDir)
+	assertStdoutContainsAll(t, getResult, "demo")
+
+	testResult := runCLI(t, "test", "apps", "--path", root, "--oci-cache-dir", ociCacheDir)
+	assertStdoutContainsAll(t, testResult, "demo", "PASS")
+
+	buildResult := runCLI(t, "build", "apps", "--path", root, "--oci-cache-dir", ociCacheDir)
+	assertStdoutContainsAll(t, buildResult, "cli-artifact-content")
+}
+
+func TestCLIDiffOCISourceBothSidesAndOneSided(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	pushCLIChartArtifact(t, reg, "manifests/app", "v1", "artifact-v1")
+	pushCLIChartArtifact(t, reg, "manifests/app", "v2", "artifact-v2")
+	repoURL := reg.RepoURL("manifests/app")
+	ociCacheDir := t.TempDir()
+
+	// Both sides at different tags: the diff reflects artifact content change.
+	left := t.TempDir()
+	right := t.TempDir()
+	writeOCIAppForCLI(t, left, "demo", repoURL, ".", "v1")
+	writeOCIAppForCLI(t, right, "demo", repoURL, ".", "v2")
+	diffResult := runCLI(t, "diff", "apps", "--path-orig", left, "--path", right, "--oci-cache-dir", ociCacheDir, "--exit-code=false")
+	assertStdoutContainsAll(t, diffResult, "artifact-v1", "artifact-v2")
+
+	// One-sided: the app exists only on the right side (added).
+	emptyLeft := t.TempDir()
+	writeCLITestFile(t, filepath.Join(emptyLeft, ".keep"), "")
+	oneSided := runCLI(t, "diff", "apps", "--path-orig", emptyLeft, "--path", right, "--oci-cache-dir", ociCacheDir, "--exit-code=false")
+	assertStdoutContainsAll(t, oneSided, "artifact-v2")
+}

--- a/internal/ociartifact/ociartifact.go
+++ b/internal/ociartifact/ociartifact.go
@@ -16,8 +16,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
+	utilio "github.com/argoproj/argo-cd/v3/util/io"
 	"github.com/argoproj/argo-cd/v3/util/oci"
 	"github.com/argoproj/argo-cd/v3/util/versions"
 	"github.com/argoproj/pkg/sync"
@@ -29,8 +31,11 @@ import (
 // entries (source "oci", kind "image").
 const EntryKind = "image"
 
-// imageTarName is the per-entry tar file the argo client os.Create()s
-// (util/oci/client.go:521-530 createTarFile via saveCompressedImageToPath).
+// imageTarName is the committed per-entry tar file. The argo client
+// os.Create()s whatever path the TempPaths seam hands it (util/oci/client.go
+// :521-530 createTarFile via saveCompressedImageToPath), so fresh fetches are
+// staged at stagingImageTarPath and renamed here only after a fully
+// successful Extract — a committed image.tar is always a complete tar.
 const imageTarName = "image.tar"
 
 // Options carries per-call acquisition inputs, mirroring chart.Options.
@@ -118,9 +123,16 @@ func IsDigest(revision string) bool {
 	return digestPattern.MatchString(strings.TrimSpace(revision))
 }
 
-// RedactURL returns the URL form safe for errors and cache events.
+// RedactURL returns the URL form safe for errors and cache events: URL
+// userinfo is dropped (mirroring remote.RedactURL), so credentials embedded
+// in a repoURL spelling never reach error text or cache metadata.
 func RedactURL(repoURL string) string {
-	return "oci://" + NormalizeURL(repoURL)
+	parsed, err := url.Parse("oci://" + NormalizeURL(repoURL))
+	if err != nil {
+		return "[invalid-url]"
+	}
+	parsed.User = nil
+	return parsed.String()
 }
 
 func DefaultCacheDir() (string, error) {
@@ -173,11 +185,22 @@ func ImageTarPath(entryPath string) string {
 	return filepath.Join(entryPath, imageTarName)
 }
 
+// stagingImageTarPath is where the argo client writes a fresh fetch before
+// extractAttempt commits it. The name is deterministic, so the client's
+// per-path lock still serializes concurrent fetches of one entry.
+func stagingImageTarPath(entryPath string) string {
+	return filepath.Join(entryPath, "."+imageTarName+".partial")
+}
+
 // entryTempPaths adapts the drydock OCI cache layout to the argo client's
 // TempPaths seam. The client keys paths on the JSON document
 // {"url":…,"version":…} (util/oci/client.go:339-345 getCachedPath); the
-// adapter maps that key deterministically to <entry>/image.tar with the entry
-// directory pre-created so the client's os.Create succeeds.
+// adapter maps that key deterministically to the entry's committed
+// <entry>/image.tar when one exists, and to the entry's staging path
+// otherwise, with the entry directory pre-created so the client's os.Create
+// succeeds. Handing out the staging path is what makes the committed tar
+// atomic: the client fetches into it and extractAttempt renames it into place
+// only after a fully successful Extract.
 type entryTempPaths struct {
 	root string
 }
@@ -196,7 +219,16 @@ func (p entryTempPaths) GetPath(key string) (string, error) {
 	if err := os.MkdirAll(entry, 0o755); err != nil {
 		return "", err
 	}
-	return ImageTarPath(entry), nil
+	final := ImageTarPath(entry)
+	if _, err := os.Stat(final); err == nil {
+		return final, nil
+	}
+	// No committed tar: hand out the staging path, clearing any partial an
+	// interrupted earlier run left behind so the client's existence check
+	// never mistakes it for a complete tar.
+	staging := stagingImageTarPath(entry)
+	_ = os.Remove(staging)
+	return staging, nil
 }
 
 func (p entryTempPaths) GetPathIfExists(key string) string {
@@ -262,10 +294,11 @@ func (a DefaultAcquirer) newClient(repoURL string, cacheDir string) (oci.Client,
 
 // Resolve resolves revision to a digest. Digest-pinned revisions pass through
 // without network. Online, resolution mirrors argo-cd v3.4.5
-// util/oci/client.go:384-407: an exact revision resolves via a registry HEAD;
-// a semver constraint resolves MaxVersion over the tag list and then the
-// winning tag via HEAD. Offline, resolution is seam-level from records
-// captured on earlier online runs; the argo client is never constructed.
+// util/oci/client.go:384-407 exactly: the literal revision resolves first via
+// a registry HEAD, and only when that fails does a constraint-shaped revision
+// fall back to MaxVersion over the tag list. Offline, resolution is
+// seam-level from records captured on earlier online runs, in the same
+// exact-first order; the argo client is never constructed.
 func (a DefaultAcquirer) Resolve(ctx context.Context, repoURL, revision string, opts Options) (string, error) {
 	revision = strings.TrimSpace(revision)
 	if IsDigest(revision) {
@@ -286,29 +319,39 @@ func (a DefaultAcquirer) Resolve(ctx context.Context, repoURL, revision string, 
 }
 
 func resolveOnline(ctx context.Context, client oci.Client, cacheDir, repoURL, revision string) (string, error) {
+	// Match the argo-cd v3.4.5 resolution order exactly: ResolveRevision
+	// resolves the literal revision first and only falls back to MaxVersion
+	// over the tag list when the exact lookup fails and the revision parses
+	// as a semver constraint (util/oci/client.go:384-407 resolveRevision).
+	// Dispatching on IsConstraint before the exact lookup would resolve a
+	// literal constraint-shaped tag like "1.x" to the constraint winner
+	// instead of the tag's own digest.
+	digest, err := client.ResolveRevision(ctx, revision, true)
+	if err != nil {
+		return "", fmt.Errorf("resolve OCI artifact %s revision %q: %w", RedactURL(repoURL), revision, err)
+	}
 	if !versions.IsConstraint(revision) {
-		digest, err := client.ResolveRevision(ctx, revision, true)
-		if err != nil {
-			return "", fmt.Errorf("resolve OCI artifact %s revision %q: %w", RedactURL(repoURL), revision, err)
-		}
-		// Overwritten on every online resolve: tags never go stale, at the
-		// accepted cost of dropping older recorded tags.
-		writeTagRecord(cacheDir, repoURL, tagRecord{Digests: map[string]string{revision: digest}})
+		updateTagRecord(cacheDir, repoURL, nil, false, map[string]string{revision: digest})
 		return digest, nil
 	}
-	tags, err := client.GetTags(ctx, true)
-	if err != nil {
-		return "", fmt.Errorf("resolve OCI artifact %s constraint %q: %w", RedactURL(repoURL), revision, err)
+	// Constraint-shaped revisions also refresh the recorded tag list so other
+	// constraints keep resolving offline through MaxVersion. When the digest
+	// came from the constraint fallback (the literal revision is not a tag),
+	// it is recorded under the winning version too, so offline MaxVersion
+	// lookups land on it.
+	if tags, tagsErr := client.GetTags(ctx, true); tagsErr == nil {
+		digests := map[string]string{revision: digest}
+		if !slices.Contains(tags, revision) {
+			if version, versionErr := versions.MaxVersion(revision, tags); versionErr == nil {
+				digests[version] = digest
+			}
+		}
+		updateTagRecord(cacheDir, repoURL, tags, true, digests)
+		return digest, nil
 	}
-	version, err := versions.MaxVersion(revision, tags)
-	if err != nil {
-		return "", fmt.Errorf("resolve OCI artifact %s constraint %q: %w", RedactURL(repoURL), revision, err)
-	}
-	digest, err := client.ResolveRevision(ctx, version, true)
-	if err != nil {
-		return "", fmt.Errorf("resolve OCI artifact %s revision %q: %w", RedactURL(repoURL), version, err)
-	}
-	writeTagRecord(cacheDir, repoURL, tagRecord{Tags: tags, Digests: map[string]string{version: digest}})
+	// A failed tag-list fetch after a successful resolve records the digest
+	// alone: resolution itself already succeeded.
+	updateTagRecord(cacheDir, repoURL, nil, false, map[string]string{revision: digest})
 	return digest, nil
 }
 
@@ -317,10 +360,12 @@ func resolveOffline(cacheDir, repoURL, revision string) (string, error) {
 	if !ok {
 		return "", offlineResolveMiss(repoURL, revision)
 	}
+	// Exact-first mirrors the online resolution order: a digest recorded for
+	// the literal revision wins even when the revision parses as a constraint.
+	if digest, ok := record.Digests[revision]; ok {
+		return digest, nil
+	}
 	if !versions.IsConstraint(revision) {
-		if digest, ok := record.Digests[revision]; ok {
-			return digest, nil
-		}
 		return "", offlineResolveMiss(repoURL, revision)
 	}
 	version, err := versions.MaxVersion(revision, record.Tags)
@@ -340,10 +385,13 @@ func offlineResolveMiss(repoURL, revision string) error {
 	return fmt.Errorf("offline cache miss for OCI artifact %s revision %q", RedactURL(repoURL), revision)
 }
 
-// Extract materializes the artifact content for digest. With the image tar
-// cached, the argo client extracts locally without network; offline without a
-// cached tar it fails with the offline cache miss contract error instead of
-// letting the client reach the registry.
+// Extract materializes the artifact content for digest. With a committed
+// image tar cached, the argo client extracts locally without network; offline
+// without a cached tar it fails with the offline cache miss contract error
+// instead of letting the client reach the registry. Online, a cached tar that
+// fails to extract (truncated by an interrupted earlier run or corrupted
+// externally) is deleted and re-fetched once, so a bad tar never poisons
+// every future run.
 func (a DefaultAcquirer) Extract(ctx context.Context, repoURL, digest string, opts Options) (string, func(), error) {
 	cacheDir, err := ResolveCacheDir(opts.CacheDir, opts.ForbiddenRoots)
 	if err != nil {
@@ -361,11 +409,14 @@ func (a DefaultAcquirer) Extract(ctx context.Context, repoURL, digest string, op
 	if err != nil {
 		return "", nil, err
 	}
-	dir, closer, err := client.Extract(ctx, digest)
+	dir, closer, err := extractAttempt(ctx, client, entry, digest)
+	if err != nil && fromImageCache && !opts.Offline {
+		// Self-heal: drop the unusable cached tar and re-fetch once.
+		_ = os.Remove(ImageTarPath(entry))
+		fromImageCache = false
+		dir, closer, err = extractAttempt(ctx, client, entry, digest)
+	}
 	if err != nil {
-		if dir != "" {
-			_ = os.RemoveAll(dir)
-		}
 		return "", nil, fmt.Errorf("extract OCI artifact %s digest %s: %w", RedactURL(repoURL), digest, err)
 	}
 	writeEntryMetadata(entry, repoURL, digest)
@@ -378,6 +429,28 @@ func (a DefaultAcquirer) Extract(ctx context.Context, repoURL, digest string, op
 		}
 	}
 	return dir, release, nil
+}
+
+// extractAttempt runs one client extraction and commits the staged tar on
+// success: fresh fetches land at the staging path (entryTempPaths.GetPath)
+// and only the rename after a fully successful Extract publishes image.tar,
+// so a crash or failure can never leave a partial committed tar. Failed
+// attempts discard their partial along with the error-path extraction dir.
+func extractAttempt(ctx context.Context, client oci.Client, entry, digest string) (string, utilio.Closer, error) {
+	dir, closer, err := client.Extract(ctx, digest)
+	staging := stagingImageTarPath(entry)
+	if err != nil {
+		if dir != "" {
+			_ = os.RemoveAll(dir)
+		}
+		_ = os.Remove(staging)
+		return "", nil, err
+	}
+	if _, statErr := os.Stat(staging); statErr == nil {
+		// Best-effort commit: a failed rename only costs a re-fetch next run.
+		_ = os.Rename(staging, ImageTarPath(entry))
+	}
+	return dir, closer, nil
 }
 
 // writeEntryMetadata satisfies the cache lister contract (64-hex entry dir

--- a/internal/ociartifact/ociartifact.go
+++ b/internal/ociartifact/ociartifact.go
@@ -1,0 +1,394 @@
+// Package ociartifact acquires first-class Argo CD OCI artifact sources
+// (repoURL "oci://…" without chart:) by wrapping the vendored Argo CD OCI
+// client. Revision resolution and extraction guards follow argo-cd v3.4.5
+// util/oci/client.go; the image cache is a drydock-owned layout under the OCI
+// cache root so `drydock cache` can list and prune it.
+package ociartifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/argoproj/argo-cd/v3/util/oci"
+	"github.com/argoproj/argo-cd/v3/util/versions"
+	"github.com/argoproj/pkg/sync"
+	"github.com/sholdee/drydock/internal/cache"
+	"github.com/sholdee/drydock/internal/pathsafety"
+)
+
+// EntryKind is the cache metadata kind recorded for OCI artifact image
+// entries (source "oci", kind "image").
+const EntryKind = "image"
+
+// imageTarName is the per-entry tar file the argo client os.Create()s
+// (util/oci/client.go:521-530 createTarFile via saveCompressedImageToPath).
+const imageTarName = "image.tar"
+
+// Options carries per-call acquisition inputs, mirroring chart.Options.
+type Options struct {
+	CacheDir       string
+	Offline        bool
+	ForbiddenRoots []string
+	// OnAcquired is invoked by the production acquirer exactly once per real
+	// (non-memoized) successful Extract, with fromImageCache reporting whether
+	// the image tar was already cached before the call. Session memo hits never
+	// invoke it, which is what makes single-acquisition event assertions
+	// memo-sensitive. Fakes should call it when simulating an extraction.
+	OnAcquired func(fromImageCache bool)
+}
+
+// Acquirer is the OCI artifact acquisition seam. Resolve turns a tag, semver
+// constraint, or digest into a concrete digest; Extract materializes the
+// artifact content for that digest into a directory and returns a release
+// callback for it.
+type Acquirer interface {
+	Resolve(ctx context.Context, repoURL, revision string, opts Options) (string, error)
+	Extract(ctx context.Context, repoURL, digest string, opts Options) (string, func(), error)
+}
+
+// DefaultAcquirer wraps util/oci.NewClientWithLock. Every exported method of
+// the argo client calls its embedded EventHandlers unconditionally and
+// NewClientWithLock installs no defaults (util/oci/client.go:232,244,357,
+// 373,410), so no-op handlers are mandatory. WithIndexCache is deliberately
+// not used: upstream SetOCITags stores the empty read buffer
+// (util/oci/client.go:450-452), so the tags cache never functions.
+type DefaultAcquirer struct{}
+
+// ociKeyLock is the drydock-supplied KeyLock serializing per-path image cache
+// writes inside the argo client (extract locks on the cached tar path).
+var ociKeyLock = sync.NewKeyLock()
+
+// defaultLayerMediaTypes mirrors the Argo CD repo-server default for
+// --oci-layer-media-types (vendored argo-cd v3.4.5
+// cmd/argocd-repo-server/commands/argocd_repo_server.go:267).
+func defaultLayerMediaTypes() []string {
+	return []string{
+		"application/vnd.oci.image.layer.v1.tar",
+		"application/vnd.oci.image.layer.v1.tar+gzip",
+		"application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+	}
+}
+
+// defaultManifestMaxExtractedSize mirrors the Argo CD repo-server default for
+// --oci-manifest-max-extracted-size, "1G" (vendored argo-cd v3.4.5
+// cmd/argocd-repo-server/commands/argocd_repo_server.go:262);
+// resource.ParseQuantity("1G").ToDec().Value() is 10^9 bytes.
+const defaultManifestMaxExtractedSize = int64(1_000_000_000)
+
+// IsOCIURL reports whether repoURL names an OCI registry source. It is total
+// over oci:// spellings: surrounding whitespace and scheme casing do not
+// change classification, so no spelling can fall through to the local
+// path-exists or git-acquisition branches. Argo CD matches the exact
+// lowercase prefix (v1alpha1 types.go:317-319); accepting case variants only
+// widens classification, never re-routes a URL argo would treat as OCI.
+func IsOCIURL(repoURL string) bool {
+	trimmed := strings.TrimSpace(repoURL)
+	if len(trimmed) < len("oci://") {
+		return false
+	}
+	return strings.EqualFold(trimmed[:len("oci://")], "oci://")
+}
+
+// NormalizeURL canonicalizes an OCI repository URL for cache keys and
+// records: whitespace and trailing slashes trimmed, scheme dropped (the argo
+// client keys its cache on the schemeless repo path, util/oci/client.go:125).
+func NormalizeURL(repoURL string) string {
+	trimmed := strings.TrimSpace(repoURL)
+	if IsOCIURL(trimmed) {
+		trimmed = trimmed[len("oci://"):]
+	}
+	return strings.TrimRight(trimmed, "/")
+}
+
+// digestPattern matches OCI digest references (algorithm:hex, lowercase hex
+// per the OCI image spec digest grammar).
+var digestPattern = regexp.MustCompile(`^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[0-9a-f]{32,}$`)
+
+// IsDigest reports whether revision is a digest-pinned reference.
+func IsDigest(revision string) bool {
+	return digestPattern.MatchString(strings.TrimSpace(revision))
+}
+
+// RedactURL returns the URL form safe for errors and cache events.
+func RedactURL(repoURL string) string {
+	return "oci://" + NormalizeURL(repoURL)
+}
+
+func DefaultCacheDir() (string, error) {
+	root, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "drydock", "oci"), nil
+}
+
+// ResolveCacheDir follows the chart cache-dir validation pattern
+// (chart.ResolveCacheDir): default under the user cache dir, absolute, and
+// never inside a protected root.
+func ResolveCacheDir(cacheDir string, forbiddenRoots []string) (string, error) {
+	if cacheDir == "" {
+		defaultDir, err := DefaultCacheDir()
+		if err != nil {
+			return "", err
+		}
+		cacheDir = defaultDir
+	}
+	absCacheDir, err := filepath.Abs(cacheDir)
+	if err != nil {
+		return "", err
+	}
+	absCacheDir = filepath.Clean(absCacheDir)
+	inside, matchedRoot, err := pathsafety.IsInsideAny(absCacheDir, forbiddenRoots)
+	if err != nil {
+		return "", err
+	}
+	if inside {
+		return "", fmt.Errorf("oci cache dir %q must not be inside repository root %q", absCacheDir, matchedRoot)
+	}
+	return absCacheDir, nil
+}
+
+// EntryKey derives the 64-hex cache entry key from (url, version).
+func EntryKey(repoURL, version string) string {
+	sum := sha256.Sum256([]byte(NormalizeURL(repoURL) + "\x00" + strings.TrimSpace(version)))
+	return hex.EncodeToString(sum[:])
+}
+
+// EntryPath returns the cache entry directory for (url, version).
+func EntryPath(cacheDir, repoURL, version string) string {
+	return cache.OCIEntryPath(cacheDir, EntryKey(repoURL, version))
+}
+
+// ImageTarPath returns the cached image tar location inside an entry.
+func ImageTarPath(entryPath string) string {
+	return filepath.Join(entryPath, imageTarName)
+}
+
+// entryTempPaths adapts the drydock OCI cache layout to the argo client's
+// TempPaths seam. The client keys paths on the JSON document
+// {"url":…,"version":…} (util/oci/client.go:339-345 getCachedPath); the
+// adapter maps that key deterministically to <entry>/image.tar with the entry
+// directory pre-created so the client's os.Create succeeds.
+type entryTempPaths struct {
+	root string
+}
+
+func (p entryTempPaths) Add(string, string) {}
+
+func (p entryTempPaths) GetPath(key string) (string, error) {
+	var parsed struct {
+		URL     string `json:"url"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(key), &parsed); err != nil {
+		return "", fmt.Errorf("unexpected oci cache path key: %w", err)
+	}
+	entry := EntryPath(p.root, parsed.URL, parsed.Version)
+	if err := os.MkdirAll(entry, 0o755); err != nil {
+		return "", err
+	}
+	return ImageTarPath(entry), nil
+}
+
+func (p entryTempPaths) GetPathIfExists(key string) string {
+	path, err := p.GetPath(key)
+	if err != nil {
+		return ""
+	}
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+func (p entryTempPaths) GetPaths() map[string]string {
+	return map[string]string{}
+}
+
+// noopEventHandlers fills every EventHandlers field: the argo client invokes
+// them unconditionally on each exported method, so leaving any nil panics
+// (util/oci/client.go:232,244,357,373,410).
+func noopEventHandlers() oci.EventHandlers {
+	handler := func(string) func() { return func() {} }
+	failHandler := func(string) func(string) { return func(string) {} }
+	return oci.EventHandlers{
+		OnExtract:             handler,
+		OnResolveRevision:     handler,
+		OnDigestMetadata:      handler,
+		OnTestRepo:            handler,
+		OnGetTags:             handler,
+		OnExtractFail:         failHandler,
+		OnResolveRevisionFail: failHandler,
+		OnDigestMetadataFail:  failHandler,
+		OnTestRepoFail:        handler,
+		OnGetTagsFail:         handler,
+	}
+}
+
+// isLoopbackURL reports whether the registry host is loopback. Loopback
+// registries use plain HTTP (the Docker localhost convention), which keeps
+// hermetic httptest registries and local development registries working
+// without a global insecure switch; non-loopback hosts always use TLS.
+func isLoopbackURL(repoURL string) bool {
+	parsed, err := url.Parse("oci://" + NormalizeURL(repoURL))
+	if err != nil {
+		return false
+	}
+	host := parsed.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (a DefaultAcquirer) newClient(repoURL string, cacheDir string) (oci.Client, error) {
+	creds := oci.Creds{InsecureHTTPOnly: isLoopbackURL(repoURL)}
+	return oci.NewClientWithLock("oci://"+NormalizeURL(repoURL), creds, ociKeyLock, "", "", defaultLayerMediaTypes(),
+		oci.WithEventHandlers(noopEventHandlers()),
+		oci.WithImagePaths(entryTempPaths{root: cacheDir}),
+		oci.WithManifestMaxExtractedSize(defaultManifestMaxExtractedSize),
+	)
+}
+
+// Resolve resolves revision to a digest. Digest-pinned revisions pass through
+// without network. Online, resolution mirrors argo-cd v3.4.5
+// util/oci/client.go:384-407: an exact revision resolves via a registry HEAD;
+// a semver constraint resolves MaxVersion over the tag list and then the
+// winning tag via HEAD. Offline, resolution is seam-level from records
+// captured on earlier online runs; the argo client is never constructed.
+func (a DefaultAcquirer) Resolve(ctx context.Context, repoURL, revision string, opts Options) (string, error) {
+	revision = strings.TrimSpace(revision)
+	if IsDigest(revision) {
+		return revision, nil
+	}
+	cacheDir, err := ResolveCacheDir(opts.CacheDir, opts.ForbiddenRoots)
+	if err != nil {
+		return "", err
+	}
+	if opts.Offline {
+		return resolveOffline(cacheDir, repoURL, revision)
+	}
+	client, err := a.newClient(repoURL, cacheDir)
+	if err != nil {
+		return "", err
+	}
+	return resolveOnline(ctx, client, cacheDir, repoURL, revision)
+}
+
+func resolveOnline(ctx context.Context, client oci.Client, cacheDir, repoURL, revision string) (string, error) {
+	if !versions.IsConstraint(revision) {
+		digest, err := client.ResolveRevision(ctx, revision, true)
+		if err != nil {
+			return "", fmt.Errorf("resolve OCI artifact %s revision %q: %w", RedactURL(repoURL), revision, err)
+		}
+		// Overwritten on every online resolve: tags never go stale, at the
+		// accepted cost of dropping older recorded tags.
+		writeTagRecord(cacheDir, repoURL, tagRecord{Digests: map[string]string{revision: digest}})
+		return digest, nil
+	}
+	tags, err := client.GetTags(ctx, true)
+	if err != nil {
+		return "", fmt.Errorf("resolve OCI artifact %s constraint %q: %w", RedactURL(repoURL), revision, err)
+	}
+	version, err := versions.MaxVersion(revision, tags)
+	if err != nil {
+		return "", fmt.Errorf("resolve OCI artifact %s constraint %q: %w", RedactURL(repoURL), revision, err)
+	}
+	digest, err := client.ResolveRevision(ctx, version, true)
+	if err != nil {
+		return "", fmt.Errorf("resolve OCI artifact %s revision %q: %w", RedactURL(repoURL), version, err)
+	}
+	writeTagRecord(cacheDir, repoURL, tagRecord{Tags: tags, Digests: map[string]string{version: digest}})
+	return digest, nil
+}
+
+func resolveOffline(cacheDir, repoURL, revision string) (string, error) {
+	record, ok := readTagRecord(cacheDir, repoURL)
+	if !ok {
+		return "", offlineResolveMiss(repoURL, revision)
+	}
+	if !versions.IsConstraint(revision) {
+		if digest, ok := record.Digests[revision]; ok {
+			return digest, nil
+		}
+		return "", offlineResolveMiss(repoURL, revision)
+	}
+	version, err := versions.MaxVersion(revision, record.Tags)
+	if err != nil {
+		return "", offlineResolveMiss(repoURL, revision)
+	}
+	if digest, ok := record.Digests[version]; ok {
+		return digest, nil
+	}
+	return "", offlineResolveMiss(repoURL, revision)
+}
+
+// offlineResolveMiss carries the literal "offline cache miss" contract string
+// that cacheevent.ActionForError keys on for ActionMiss
+// (internal/cacheevent/cacheevent.go:127-132).
+func offlineResolveMiss(repoURL, revision string) error {
+	return fmt.Errorf("offline cache miss for OCI artifact %s revision %q", RedactURL(repoURL), revision)
+}
+
+// Extract materializes the artifact content for digest. With the image tar
+// cached, the argo client extracts locally without network; offline without a
+// cached tar it fails with the offline cache miss contract error instead of
+// letting the client reach the registry.
+func (a DefaultAcquirer) Extract(ctx context.Context, repoURL, digest string, opts Options) (string, func(), error) {
+	cacheDir, err := ResolveCacheDir(opts.CacheDir, opts.ForbiddenRoots)
+	if err != nil {
+		return "", nil, err
+	}
+	entry := EntryPath(cacheDir, repoURL, digest)
+	fromImageCache := false
+	if info, err := os.Stat(ImageTarPath(entry)); err == nil && info.Mode().IsRegular() {
+		fromImageCache = true
+	}
+	if opts.Offline && !fromImageCache {
+		return "", nil, fmt.Errorf("offline cache miss for OCI artifact %s digest %s", RedactURL(repoURL), digest)
+	}
+	client, err := a.newClient(repoURL, cacheDir)
+	if err != nil {
+		return "", nil, err
+	}
+	dir, closer, err := client.Extract(ctx, digest)
+	if err != nil {
+		if dir != "" {
+			_ = os.RemoveAll(dir)
+		}
+		return "", nil, fmt.Errorf("extract OCI artifact %s digest %s: %w", RedactURL(repoURL), digest, err)
+	}
+	writeEntryMetadata(entry, repoURL, digest)
+	if opts.OnAcquired != nil {
+		opts.OnAcquired(fromImageCache)
+	}
+	release := func() {
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
+	return dir, release, nil
+}
+
+// writeEntryMetadata satisfies the cache lister contract (64-hex entry dir
+// plus metadata.json, internal/cache/cache.go:384,411) and refreshes
+// UpdatedAt so LRU pruning tracks last use.
+func writeEntryMetadata(entryPath, repoURL, digest string) {
+	_ = cache.WriteMetadata(entryPath, cache.Metadata{
+		Source:   cache.SourceOCI,
+		Kind:     EntryKind,
+		Key:      filepath.Base(entryPath),
+		Target:   RedactURL(repoURL),
+		Revision: digest,
+	})
+}

--- a/internal/ociartifact/ociartifact_test.go
+++ b/internal/ociartifact/ociartifact_test.go
@@ -94,25 +94,35 @@ func TestEntryTempPathsAdapterMapsClientKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	entry := EntryPath(root, "oci://127.0.0.1:5000/org/app", "sha256:"+strings.Repeat("ab", 32))
 	got, err := adapter.GetPath(string(key))
 	if err != nil {
 		t.Fatalf("GetPath() error = %v", err)
 	}
-	want := ImageTarPath(EntryPath(root, "oci://127.0.0.1:5000/org/app", "sha256:"+strings.Repeat("ab", 32)))
-	if got != want {
-		t.Fatalf("GetPath() = %q, want %q", got, want)
+	// No committed tar yet: the client must be handed the staging path (and
+	// never a leftover partial), so a fetch write cannot land at image.tar
+	// directly.
+	if want := stagingImageTarPath(entry); got != want {
+		t.Fatalf("GetPath() = %q, want staging path %q before a committed tar", got, want)
 	}
-	if info, err := os.Stat(filepath.Dir(got)); err != nil || !info.IsDir() {
+	if info, err := os.Stat(entry); err != nil || !info.IsDir() {
 		t.Fatalf("entry dir not pre-created: %v", err)
 	}
 	if adapter.GetPathIfExists(string(key)) != "" {
-		t.Fatal("GetPathIfExists() should be empty before the tar exists")
+		t.Fatal("GetPathIfExists() should be empty before the tar is committed")
 	}
-	if err := os.WriteFile(got, []byte("tar"), 0o600); err != nil {
+	if err := os.WriteFile(ImageTarPath(entry), []byte("tar"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if adapter.GetPathIfExists(string(key)) != want {
-		t.Fatal("GetPathIfExists() should return the tar path once present")
+	got, err = adapter.GetPath(string(key))
+	if err != nil {
+		t.Fatalf("GetPath() error = %v", err)
+	}
+	if want := ImageTarPath(entry); got != want {
+		t.Fatalf("GetPath() = %q, want committed tar %q once present", got, want)
+	}
+	if adapter.GetPathIfExists(string(key)) != ImageTarPath(entry) {
+		t.Fatal("GetPathIfExists() should return the tar path once committed")
 	}
 }
 
@@ -346,6 +356,224 @@ func TestOfflineFirstRunFails(t *testing.T) {
 		t.Fatal("first-run offline Resolve should fail")
 	} else if !strings.Contains(err.Error(), "offline cache miss") {
 		t.Fatalf("first-run offline Resolve error = %q, want offline cache miss contract text", err)
+	}
+}
+
+// TestExtractSelfHealsCorruptCachedImageTar pins the self-heal contract: a
+// pre-existing truncated/corrupt image.tar must not poison online runs — the
+// tar is dropped and re-fetched once, and the healed tar serves offline runs.
+func TestExtractSelfHealsCorruptCachedImageTar(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushHelmChartArtifact(t, reg, "charts/heal", "1.2.3", ocitest.HelmChartSpec{Name: "heal", Version: "1.2.3"})
+	repoURL := reg.RepoURL("charts/heal")
+	opts := Options{CacheDir: t.TempDir()}
+	entry := EntryPath(opts.CacheDir, repoURL, digest)
+	if err := os.MkdirAll(entry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ImageTarPath(entry), []byte("truncated-tar-write"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fromCache := true
+	opts.OnAcquired = func(fromImageCache bool) { fromCache = fromImageCache }
+	dir, release, err := DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("online Extract() with corrupt cached tar error = %v, want self-heal re-fetch", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+		t.Fatalf("self-healed extract content missing: %v", err)
+	}
+	release()
+	if fromCache {
+		t.Fatal("OnAcquired reported fromImageCache = true for a self-heal re-fetch")
+	}
+
+	// The healed tar is committed: offline extraction now works.
+	reg.Server.Close()
+	opts.OnAcquired = nil
+	opts.Offline = true
+	dir, release, err = DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("offline Extract() after self-heal error = %v", err)
+	}
+	defer release()
+	if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+		t.Fatalf("offline extract content missing after self-heal: %v", err)
+	}
+}
+
+// Offline, a corrupt cached tar cannot re-fetch: the error must be clear and
+// the tar must be left in place for a later online run to heal.
+func TestOfflineExtractCorruptCachedImageTarFails(t *testing.T) {
+	repoURL := "oci://127.0.0.1:1/none/app"
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	opts := Options{CacheDir: t.TempDir(), Offline: true}
+	entry := EntryPath(opts.CacheDir, repoURL, digest)
+	if err := os.MkdirAll(entry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ImageTarPath(entry), []byte("truncated-tar-write"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err == nil {
+		t.Fatal("offline Extract() with corrupt cached tar should fail")
+	}
+	if !strings.Contains(err.Error(), "extract OCI artifact "+RedactURL(repoURL)) {
+		t.Fatalf("offline Extract() error = %q, want clear extract error naming the artifact", err)
+	}
+	if _, statErr := os.Stat(ImageTarPath(entry)); statErr != nil {
+		t.Fatalf("offline failure must leave the cached tar for a later online heal: %v", statErr)
+	}
+}
+
+// TestExtractFailureDoesNotCommitImageTar pins tar-write atomicity: an
+// extraction that fails after the client fetched and saved the image (corrupt
+// content layer) must leave neither a committed image.tar nor a staged
+// partial behind.
+func TestExtractFailureDoesNotCommitImageTar(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushCorruptContentLayerArtifact(t, reg, "corrupt/app", "v1")
+	repoURL := reg.RepoURL("corrupt/app")
+	opts := Options{CacheDir: t.TempDir()}
+	entry := EntryPath(opts.CacheDir, repoURL, digest)
+
+	if _, _, err := (DefaultAcquirer{}).Extract(t.Context(), repoURL, digest, opts); err == nil {
+		t.Fatal("Extract() of a corrupt content layer should fail")
+	}
+	if _, err := os.Stat(ImageTarPath(entry)); !os.IsNotExist(err) {
+		t.Fatalf("failed extraction committed image.tar: %v", err)
+	}
+	if _, err := os.Stat(stagingImageTarPath(entry)); !os.IsNotExist(err) {
+		t.Fatalf("failed extraction left a staged partial behind: %v", err)
+	}
+}
+
+// TestOfflineRecordsAccumulateAcrossTags pins record merging: different tags
+// of one repository resolved online in one run (two apps pinning different
+// tags) must all resolve offline, and the recorded tag list must survive
+// later exact-tag resolves so other constraints still resolve via MaxVersion.
+func TestOfflineRecordsAccumulateAcrossTags(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	firstDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/multi", "1.0.0", ocitest.HelmChartSpec{Version: "1.0.0"})
+	secondDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/multi", "2.0.0", ocitest.HelmChartSpec{Version: "2.0.0"})
+	repoURL := reg.RepoURL("charts/multi")
+	opts := Options{CacheDir: t.TempDir()}
+	acquirer := DefaultAcquirer{}
+
+	// Order matters: the constraint resolve records the tag list, then two
+	// exact resolves follow — whole-record overwrites would drop both the
+	// first tag's digest and the tag list.
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "~1.0", opts); err != nil {
+		t.Fatalf("online Resolve(~1.0) error = %v", err)
+	}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "1.0.0", opts); err != nil {
+		t.Fatalf("online Resolve(1.0.0) error = %v", err)
+	}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "2.0.0", opts); err != nil {
+		t.Fatalf("online Resolve(2.0.0) error = %v", err)
+	}
+
+	reg.Server.Close()
+	opts.Offline = true
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "1.0.0", opts); err != nil || digest != firstDigest {
+		t.Fatalf("offline Resolve(1.0.0) = %q, %v; want %q (sibling tag record dropped)", digest, err, firstDigest)
+	}
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "2.0.0", opts); err != nil || digest != secondDigest {
+		t.Fatalf("offline Resolve(2.0.0) = %q, %v; want %q", digest, err, secondDigest)
+	}
+	// "^2.0" was never resolved online: it needs the preserved tag list plus
+	// the merged winner digest.
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "^2.0", opts); err != nil || digest != secondDigest {
+		t.Fatalf("offline Resolve(^2.0) = %q, %v; want %q (tag list dropped by a later exact resolve)", digest, err, secondDigest)
+	}
+}
+
+// TestResolveLiteralConstraintShapedTag pins argo-cd v3.4.5 resolution order:
+// a literal tag that parses as a semver constraint ("1.x") resolves to its
+// own digest via the exact lookup, never to the constraint's MaxVersion
+// winner — online and offline.
+func TestResolveLiteralConstraintShapedTag(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	literalDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/literal", "1.x", ocitest.HelmChartSpec{Version: "1.0.0"})
+	winnerDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/literal", "1.9.9", ocitest.HelmChartSpec{Version: "1.9.9"})
+	if literalDigest == winnerDigest {
+		t.Fatal("fixture digests must differ")
+	}
+	repoURL := reg.RepoURL("charts/literal")
+	opts := Options{CacheDir: t.TempDir()}
+	acquirer := DefaultAcquirer{}
+
+	digest, err := acquirer.Resolve(t.Context(), repoURL, "1.x", opts)
+	if err != nil {
+		t.Fatalf("Resolve(1.x) error = %v", err)
+	}
+	if digest != literalDigest {
+		t.Fatalf("Resolve(1.x) = %q, want the literal tag's digest %q, not MaxVersion winner %q", digest, literalDigest, winnerDigest)
+	}
+
+	reg.Server.Close()
+	opts.Offline = true
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "1.x", opts); err != nil || digest != literalDigest {
+		t.Fatalf("offline Resolve(1.x) = %q, %v; want exact-first record hit %q", digest, err, literalDigest)
+	}
+}
+
+// TestRedactURLStripsUserinfo pins credential redaction (remote.RedactURL
+// parity): userinfo never survives into error/cache-event URL forms.
+func TestRedactURLStripsUserinfo(t *testing.T) {
+	for _, testCase := range []struct{ input, want string }{
+		{"oci://user:secret@ghcr.io/org/app", "oci://ghcr.io/org/app"},
+		{"oci://token@ghcr.io/org/app", "oci://ghcr.io/org/app"},
+		{"oci://ghcr.io/org/app", "oci://ghcr.io/org/app"},
+	} {
+		if got := RedactURL(testCase.input); got != testCase.want {
+			t.Fatalf("RedactURL(%q) = %q, want %q", testCase.input, got, testCase.want)
+		}
+	}
+}
+
+// Cache metadata goes through RedactURL: credentials embedded in a repoURL
+// spelling never land in metadata.json.
+func TestEntryMetadataTargetRedactsUserinfo(t *testing.T) {
+	entry := filepath.Join(t.TempDir(), strings.Repeat("ab", 32))
+	if err := os.MkdirAll(entry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:" + strings.Repeat("cd", 32)
+	writeEntryMetadata(entry, "oci://user:secret@ghcr.io/org/app", digest)
+	metadata, err := cache.ReadMetadata(entry, cache.SourceOCI, EntryKind, filepath.Base(entry))
+	if err != nil || metadata == nil {
+		t.Fatalf("metadata = %v, %v; want valid metadata", metadata, err)
+	}
+	if strings.Contains(metadata.Target, "secret") || strings.Contains(metadata.Target, "user") {
+		t.Fatalf("metadata target %q leaks URL userinfo", metadata.Target)
+	}
+	if metadata.Target != "oci://ghcr.io/org/app" {
+		t.Fatalf("metadata target = %q, want redacted URL", metadata.Target)
+	}
+}
+
+// TestIsLoopbackURLPlainHTTPBoundary pins the plain-HTTP boundary: loopback
+// registries (the Docker localhost convention, hermetic fixtures) use plain
+// HTTP; every other host — including private-range IPs — stays TLS-only.
+func TestIsLoopbackURLPlainHTTPBoundary(t *testing.T) {
+	for _, testCase := range []struct {
+		url  string
+		want bool
+	}{
+		{"oci://localhost/org/app", true},
+		{"oci://localhost:5000/org/app", true},
+		{"oci://127.0.0.1:5000/org/app", true},
+		{"oci://[::1]:5000/org/app", true},
+		{"oci://ghcr.io/org/app", false},
+		{"oci://10.0.0.1:5000/org/app", false},
+	} {
+		if got := isLoopbackURL(testCase.url); got != testCase.want {
+			t.Fatalf("isLoopbackURL(%q) = %v, want %v", testCase.url, got, testCase.want)
+		}
 	}
 }
 

--- a/internal/ociartifact/ociartifact_test.go
+++ b/internal/ociartifact/ociartifact_test.go
@@ -1,0 +1,368 @@
+package ociartifact
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sholdee/drydock/internal/cache"
+	"github.com/sholdee/drydock/internal/ociartifact/ocitest"
+)
+
+func TestIsOCIURLTotalOverSpellings(t *testing.T) {
+	for _, url := range []string{
+		"oci://ghcr.io/org/app",
+		"OCI://ghcr.io/org/app",
+		"Oci://ghcr.io/org/app",
+		"  oci://ghcr.io/org/app  ",
+	} {
+		if !IsOCIURL(url) {
+			t.Fatalf("IsOCIURL(%q) = false, want true", url)
+		}
+	}
+	for _, url := range []string{
+		"https://ghcr.io/org/app",
+		"ghcr.io/org/app",
+		"git@github.com:org/app.git",
+		"",
+		"oci:/ghcr.io/org/app",
+	} {
+		if IsOCIURL(url) {
+			t.Fatalf("IsOCIURL(%q) = true, want false", url)
+		}
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	for _, testCase := range []struct{ input, want string }{
+		{"oci://ghcr.io/org/app", "ghcr.io/org/app"},
+		{"OCI://ghcr.io/org/app/", "ghcr.io/org/app"},
+		{"  oci://ghcr.io/org/app ", "ghcr.io/org/app"},
+		{"ghcr.io/org/app", "ghcr.io/org/app"},
+	} {
+		if got := NormalizeURL(testCase.input); got != testCase.want {
+			t.Fatalf("NormalizeURL(%q) = %q, want %q", testCase.input, got, testCase.want)
+		}
+	}
+}
+
+func TestIsDigest(t *testing.T) {
+	if !IsDigest("sha256:" + strings.Repeat("ab", 32)) {
+		t.Fatal("sha256 digest not recognized")
+	}
+	if !IsDigest("sha512:" + strings.Repeat("cd", 64)) {
+		t.Fatal("sha512 digest not recognized")
+	}
+	for _, revision := range []string{"1.2.3", "latest", "sha256:XYZ", "", "~1.2"} {
+		if IsDigest(revision) {
+			t.Fatalf("IsDigest(%q) = true, want false", revision)
+		}
+	}
+}
+
+// TestDefaultsMatchArgoRepoServer pins the adopted Argo CD repo-server
+// defaults: --oci-layer-media-types (argocd_repo_server.go:267) and
+// --oci-manifest-max-extracted-size "1G" (argocd_repo_server.go:262).
+func TestDefaultsMatchArgoRepoServer(t *testing.T) {
+	want := []string{
+		"application/vnd.oci.image.layer.v1.tar",
+		"application/vnd.oci.image.layer.v1.tar+gzip",
+		"application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+	}
+	got := defaultLayerMediaTypes()
+	if len(got) != len(want) {
+		t.Fatalf("defaultLayerMediaTypes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("defaultLayerMediaTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if defaultManifestMaxExtractedSize != 1_000_000_000 {
+		t.Fatalf("defaultManifestMaxExtractedSize = %d, want 1G (10^9)", defaultManifestMaxExtractedSize)
+	}
+}
+
+func TestEntryTempPathsAdapterMapsClientKeys(t *testing.T) {
+	root := t.TempDir()
+	adapter := entryTempPaths{root: root}
+	// The argo client keys cache paths on this JSON document
+	// (util/oci/client.go:339-345 getCachedPath).
+	key, err := json.Marshal(map[string]string{"url": "127.0.0.1:5000/org/app", "version": "sha256:" + strings.Repeat("ab", 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := adapter.GetPath(string(key))
+	if err != nil {
+		t.Fatalf("GetPath() error = %v", err)
+	}
+	want := ImageTarPath(EntryPath(root, "oci://127.0.0.1:5000/org/app", "sha256:"+strings.Repeat("ab", 32)))
+	if got != want {
+		t.Fatalf("GetPath() = %q, want %q", got, want)
+	}
+	if info, err := os.Stat(filepath.Dir(got)); err != nil || !info.IsDir() {
+		t.Fatalf("entry dir not pre-created: %v", err)
+	}
+	if adapter.GetPathIfExists(string(key)) != "" {
+		t.Fatal("GetPathIfExists() should be empty before the tar exists")
+	}
+	if err := os.WriteFile(got, []byte("tar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.GetPathIfExists(string(key)) != want {
+		t.Fatal("GetPathIfExists() should return the tar path once present")
+	}
+}
+
+func TestEntryKeyIsCacheKeyShaped(t *testing.T) {
+	key := EntryKey("oci://ghcr.io/org/app", "sha256:"+strings.Repeat("ab", 32))
+	if len(key) != 64 {
+		t.Fatalf("EntryKey length = %d, want 64", len(key))
+	}
+	if key != EntryKey("OCI://ghcr.io/org/app/", "sha256:"+strings.Repeat("ab", 32)) {
+		t.Fatal("EntryKey must be spelling-stable across oci:// URL variants")
+	}
+}
+
+// TestResolveAndExtractRealWrapper exercises the production argo-client
+// wrapper end-to-end against the hermetic registry. The nil-EventHandlers
+// panic class is invisible to fakes, so this coverage is mandatory.
+func TestResolveAndExtractRealWrapper(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	pushedDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/demo", "1.2.3", ocitest.HelmChartSpec{Name: "demo", Version: "1.2.3"})
+	repoURL := reg.RepoURL("charts/demo")
+	opts := Options{CacheDir: t.TempDir()}
+	acquirer := DefaultAcquirer{}
+
+	digest, err := acquirer.Resolve(t.Context(), repoURL, "1.2.3", opts)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if digest != pushedDigest {
+		t.Fatalf("Resolve() = %q, want %q", digest, pushedDigest)
+	}
+
+	acquiredCalls := 0
+	fromCache := false
+	opts.OnAcquired = func(fromImageCache bool) {
+		acquiredCalls++
+		fromCache = fromImageCache
+	}
+	dir, release, err := acquirer.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	defer release()
+	if acquiredCalls != 1 || fromCache {
+		t.Fatalf("OnAcquired calls = %d fromCache = %v, want 1 false", acquiredCalls, fromCache)
+	}
+	// The helm chart tgz holds exactly one top-level chart dir whose contents
+	// land at the extraction root, so `path: .` lands on the chart root.
+	if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+		t.Fatalf("Chart.yaml not at extraction root: %v", err)
+	}
+
+	entry := EntryPath(opts.CacheDir, repoURL, digest)
+	if _, err := os.Stat(ImageTarPath(entry)); err != nil {
+		t.Fatalf("image tar not cached: %v", err)
+	}
+	metadata, err := cache.ReadMetadata(entry, cache.SourceOCI, EntryKind, filepath.Base(entry))
+	if err != nil || metadata == nil {
+		t.Fatalf("entry metadata = %v, %v; want valid metadata", metadata, err)
+	}
+	if metadata.Revision != digest {
+		t.Fatalf("metadata revision = %q, want %q", metadata.Revision, digest)
+	}
+
+	// Second extract: image-cache hit.
+	dir2, release2, err := acquirer.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("second Extract() error = %v", err)
+	}
+	defer release2()
+	if acquiredCalls != 2 || !fromCache {
+		t.Fatalf("second Extract OnAcquired calls = %d fromCache = %v, want 2 true", acquiredCalls, fromCache)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, "Chart.yaml")); err != nil {
+		t.Fatalf("cached-extract Chart.yaml missing: %v", err)
+	}
+}
+
+func TestExtractReleaseRemovesExtractionDir(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushPlainManifestsArtifact(t, reg, "manifests/app", "v1", map[string]string{
+		"configmap.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: plain\n",
+	})
+	repoURL := reg.RepoURL("manifests/app")
+	opts := Options{CacheDir: t.TempDir()}
+	dir, release, err := DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "configmap.yaml")); err != nil {
+		t.Fatalf("plain manifest missing at extraction root: %v", err)
+	}
+	release()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("release did not remove extraction dir: %v", err)
+	}
+}
+
+func TestResolveSemverConstraint(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/semver", "1.2.3", ocitest.HelmChartSpec{Version: "1.2.3"})
+	want := ocitest.PushHelmChartArtifact(t, reg, "charts/semver", "1.2.4", ocitest.HelmChartSpec{Version: "1.2.4"})
+	ocitest.PushHelmChartArtifact(t, reg, "charts/semver", "2.0.0", ocitest.HelmChartSpec{Version: "2.0.0"})
+	// Build-metadata tags are pushed with "_" and converted back to "+"
+	// during tag listing (util/oci/client.go:440-444); MaxVersion must parse
+	// them without failing the whole constraint.
+	ocitest.PushHelmChartArtifact(t, reg, "charts/semver", "1.1.0_build.7", ocitest.HelmChartSpec{Version: "1.1.0"})
+	repoURL := reg.RepoURL("charts/semver")
+	opts := Options{CacheDir: t.TempDir()}
+
+	digest, err := DefaultAcquirer{}.Resolve(t.Context(), repoURL, "~1.2", opts)
+	if err != nil {
+		t.Fatalf("Resolve(~1.2) error = %v", err)
+	}
+	if digest != want {
+		t.Fatalf("Resolve(~1.2) = %q, want %q (1.2.4)", digest, want)
+	}
+}
+
+func TestResolveMissingTagFails(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	ocitest.PushHelmChartArtifact(t, reg, "charts/missing", "1.0.0", ocitest.HelmChartSpec{})
+	repoURL := reg.RepoURL("charts/missing")
+	opts := Options{CacheDir: t.TempDir()}
+
+	if _, err := (DefaultAcquirer{}).Resolve(t.Context(), repoURL, "9.9.9", opts); err == nil {
+		t.Fatal("Resolve(missing tag) should fail")
+	} else if !strings.Contains(err.Error(), "9.9.9") {
+		t.Fatalf("Resolve(missing tag) error %q should name the revision", err)
+	}
+}
+
+func TestExtractRejectsDisallowedMediaType(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushDisallowedMediaTypeArtifact(t, reg, "blocked/app", "v1")
+	repoURL := reg.RepoURL("blocked/app")
+	opts := Options{CacheDir: t.TempDir()}
+
+	_, _, err := DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err == nil {
+		t.Fatal("Extract() should reject disallowed media types")
+	}
+	if !strings.Contains(err.Error(), "not in the list of allowed media types") {
+		t.Fatalf("Extract() error = %q, want allowlist rejection", err)
+	}
+}
+
+func TestExtractRejectsMultipleContentLayers(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	digest := ocitest.PushMultiContentLayerArtifact(t, reg, "multi/app", "v1")
+	repoURL := reg.RepoURL("multi/app")
+	opts := Options{CacheDir: t.TempDir()}
+
+	_, _, err := DefaultAcquirer{}.Extract(t.Context(), repoURL, digest, opts)
+	if err == nil {
+		t.Fatal("Extract() should reject multiple content layers")
+	}
+	if !strings.Contains(err.Error(), "expected only a single oci content layer") {
+		t.Fatalf("Extract() error = %q, want single-content-layer rejection", err)
+	}
+}
+
+// TestOfflineResolution phase-splits online and offline: the online phase
+// populates records and the image cache, then the registry is closed (network
+// refused) and a fresh acquirer value must serve digests, recorded tags, and
+// recorded constraints from disk.
+func TestOfflineResolution(t *testing.T) {
+	reg := ocitest.StartRegistry(t)
+	tagDigest := ocitest.PushHelmChartArtifact(t, reg, "charts/offline", "1.2.3", ocitest.HelmChartSpec{Version: "1.2.3"})
+	repoURL := reg.RepoURL("charts/offline")
+	cacheDir := t.TempDir()
+	online := Options{CacheDir: cacheDir}
+
+	acquirer := DefaultAcquirer{}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "1.2.3", online); err != nil {
+		t.Fatalf("online Resolve(tag) error = %v", err)
+	}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "~1.2", online); err != nil {
+		t.Fatalf("online Resolve(constraint) error = %v", err)
+	}
+	if _, release, err := acquirer.Extract(t.Context(), repoURL, tagDigest, online); err != nil {
+		t.Fatalf("online Extract() error = %v", err)
+	} else {
+		release()
+	}
+
+	// Network refused from here on.
+	reg.Server.Close()
+	offline := Options{CacheDir: cacheDir, Offline: true}
+	offlineAcquirer := DefaultAcquirer{}
+
+	assertOfflineResolves(t, offlineAcquirer, repoURL, tagDigest, offline)
+
+	dir, release, err := offlineAcquirer.Extract(t.Context(), repoURL, tagDigest, offline)
+	if err != nil {
+		t.Fatalf("offline Extract(cached digest) error = %v", err)
+	}
+	defer release()
+	if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+		t.Fatalf("offline extract content missing: %v", err)
+	}
+
+	missingDigest := "sha256:" + strings.Repeat("12", 32)
+	if _, _, err := offlineAcquirer.Extract(t.Context(), repoURL, missingDigest, offline); err == nil {
+		t.Fatal("offline Extract(uncached digest) should fail")
+	} else if !strings.Contains(err.Error(), "offline cache miss") {
+		t.Fatalf("offline Extract(uncached digest) error = %q, want offline cache miss contract text", err)
+	}
+}
+
+func assertOfflineResolves(t *testing.T, acquirer DefaultAcquirer, repoURL, tagDigest string, offline Options) {
+	t.Helper()
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, tagDigest, offline); err != nil || digest != tagDigest {
+		t.Fatalf("offline Resolve(digest) = %q, %v; want passthrough", digest, err)
+	}
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "1.2.3", offline); err != nil || digest != tagDigest {
+		t.Fatalf("offline Resolve(recorded tag) = %q, %v; want %q", digest, err, tagDigest)
+	}
+	if digest, err := acquirer.Resolve(t.Context(), repoURL, "~1.2", offline); err != nil || digest != tagDigest {
+		t.Fatalf("offline Resolve(recorded constraint) = %q, %v; want %q", digest, err, tagDigest)
+	}
+	if _, err := acquirer.Resolve(t.Context(), repoURL, "4.5.6", offline); err == nil {
+		t.Fatal("offline Resolve(unseen tag) should fail")
+	} else if !strings.Contains(err.Error(), "offline cache miss") {
+		t.Fatalf("offline Resolve(unseen tag) error = %q, want offline cache miss contract text", err)
+	}
+}
+
+func TestOfflineFirstRunFails(t *testing.T) {
+	opts := Options{CacheDir: t.TempDir(), Offline: true}
+	if _, err := (DefaultAcquirer{}).Resolve(t.Context(), "oci://127.0.0.1:1/none/app", "1.0.0", opts); err == nil {
+		t.Fatal("first-run offline Resolve should fail")
+	} else if !strings.Contains(err.Error(), "offline cache miss") {
+		t.Fatalf("first-run offline Resolve error = %q, want offline cache miss contract text", err)
+	}
+}
+
+// TestRecordsPathOutsideEntryContract pins that offline records live outside
+// the 64-hex entry namespace, so the cache lister never reports them.
+func TestRecordsPathOutsideEntryContract(t *testing.T) {
+	cacheDir := t.TempDir()
+	writeTagRecord(cacheDir, "oci://ghcr.io/org/app", tagRecord{Digests: map[string]string{"v1": "sha256:" + strings.Repeat("ab", 32)}})
+	entries, err := cache.List(cache.Options{OCICacheDir: cacheDir, Sources: []cache.Source{cache.SourceOCI}})
+	if err != nil {
+		t.Fatalf("cache.List() error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("cache.List() = %d entries, want 0 (records are not entries)", len(entries))
+	}
+	record, ok := readTagRecord(cacheDir, "oci://ghcr.io/org/app")
+	if !ok || record.Digests["v1"] == "" {
+		t.Fatalf("record round-trip failed: %v %v", record, ok)
+	}
+}

--- a/internal/ociartifact/ocitest/ocitest.go
+++ b/internal/ociartifact/ocitest/ocitest.go
@@ -123,6 +123,14 @@ func PushDisallowedMediaTypeArtifact(t *testing.T, reg *Registry, repoName, tag 
 	return pushArtifact(t, reg, repoName, tag, plainConfigType, []layerSpec{{mediaType: "application/vnd.drydock.test.blocked.tar+gzip", data: tgz}})
 }
 
+// PushCorruptContentLayerArtifact pushes an artifact whose single allowlisted
+// content layer is not valid gzip: fetch and image-tar save succeed, layer
+// extraction fails — the shape that exercises post-save failure handling.
+func PushCorruptContentLayerArtifact(t *testing.T, reg *Registry, repoName, tag string) string {
+	t.Helper()
+	return pushArtifact(t, reg, repoName, tag, plainConfigType, []layerSpec{{mediaType: plainLayerMediaType, data: []byte("not-a-gzip-stream")}})
+}
+
 // PushMultiContentLayerArtifact pushes an artifact with two allowlisted
 // content layers, violating the exactly-one-content-layer guard.
 func PushMultiContentLayerArtifact(t *testing.T, reg *Registry, repoName, tag string) string {

--- a/internal/ociartifact/ocitest/ocitest.go
+++ b/internal/ociartifact/ocitest/ocitest.go
@@ -1,0 +1,238 @@
+// Package ocitest provides hermetic OCI registry fixtures for drydock tests:
+// an httptest-mounted distribution server plus artifact push helpers shaped
+// like the artifacts the Argo CD OCI client consumes (helm chart artifacts,
+// plain-manifest artifacts, and guard-violating variants). Test-only.
+package ocitest
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"maps"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+const (
+	helmConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
+	helmLayerMediaType  = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+	plainLayerMediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+	plainConfigType     = "application/vnd.oci.empty.v1+json"
+)
+
+// Registry is a hermetic OCI distribution registry on a loopback port.
+type Registry struct {
+	Server *httptest.Server
+	Host   string
+}
+
+// StartRegistry starts an in-process distribution registry. It is closed with
+// the test.
+func StartRegistry(t *testing.T) *Registry {
+	t.Helper()
+	server := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(server.Close)
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse registry URL %q: %v", server.URL, err)
+	}
+	return &Registry{Server: server, Host: parsed.Host}
+}
+
+// RepoURL returns the oci:// URL for a repository on this registry.
+func (r *Registry) RepoURL(name string) string {
+	return "oci://" + r.Host + "/" + name
+}
+
+type layerSpec struct {
+	mediaType string
+	data      []byte
+}
+
+// HelmChartSpec describes a helm chart artifact fixture. Files are relative
+// to the chart directory; Chart.yaml, values.yaml, and a marker template are
+// generated unless overridden.
+type HelmChartSpec struct {
+	Name    string
+	Version string
+	Files   map[string]string
+}
+
+func (spec HelmChartSpec) files() map[string]string {
+	name := spec.Name
+	if name == "" {
+		name = "demo"
+	}
+	version := spec.Version
+	if version == "" {
+		version = "1.0.0"
+	}
+	files := map[string]string{
+		"Chart.yaml":  "apiVersion: v2\nname: " + name + "\nversion: " + version + "\n",
+		"values.yaml": "message: from-defaults\n",
+		"templates/configmap.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n" +
+			"  name: {{ .Release.Name }}-demo\ndata:\n" +
+			"  message: {{ .Values.message | quote }}\n" +
+			"  marker: oci-artifact-content\n",
+	}
+	maps.Copy(files, spec.Files)
+	return files
+}
+
+// PushHelmChartArtifact pushes a helm chart artifact (helm config media type,
+// single helm content layer whose tgz holds exactly one top-level chart
+// directory — what makes `path: .` land on the chart root) and returns the
+// manifest digest.
+func PushHelmChartArtifact(t *testing.T, reg *Registry, repoName, tag string, spec HelmChartSpec) string {
+	t.Helper()
+	name := spec.Name
+	if name == "" {
+		name = "demo"
+	}
+	tgz := buildTgz(t, name+"/", spec.files())
+	return pushArtifact(t, reg, repoName, tag, helmConfigMediaType, []layerSpec{{mediaType: helmLayerMediaType, data: tgz}})
+}
+
+// PushPlainManifestsArtifact pushes a generic single-content-layer artifact
+// whose tgz entries land at the extraction root.
+func PushPlainManifestsArtifact(t *testing.T, reg *Registry, repoName, tag string, files map[string]string) string {
+	t.Helper()
+	tgz := buildTgz(t, "", files)
+	return pushArtifact(t, reg, repoName, tag, plainConfigType, []layerSpec{{mediaType: plainLayerMediaType, data: tgz}})
+}
+
+// PushDisallowedMediaTypeArtifact pushes an artifact whose content layer uses
+// a tar-suffixed media type outside the allowlist.
+func PushDisallowedMediaTypeArtifact(t *testing.T, reg *Registry, repoName, tag string) string {
+	t.Helper()
+	tgz := buildTgz(t, "", map[string]string{"payload.yaml": "kind: Nope\n"})
+	return pushArtifact(t, reg, repoName, tag, plainConfigType, []layerSpec{{mediaType: "application/vnd.drydock.test.blocked.tar+gzip", data: tgz}})
+}
+
+// PushMultiContentLayerArtifact pushes an artifact with two allowlisted
+// content layers, violating the exactly-one-content-layer guard.
+func PushMultiContentLayerArtifact(t *testing.T, reg *Registry, repoName, tag string) string {
+	t.Helper()
+	first := buildTgz(t, "", map[string]string{"first.yaml": "kind: First\n"})
+	second := buildTgz(t, "", map[string]string{"second.yaml": "kind: Second\n"})
+	return pushArtifact(t, reg, repoName, tag, plainConfigType, []layerSpec{
+		{mediaType: plainLayerMediaType, data: first},
+		{mediaType: plainLayerMediaType, data: second},
+	})
+}
+
+// TagAlias tags an already-pushed reference (tag or digest) with another tag,
+// aliasing both to one manifest digest.
+func TagAlias(t *testing.T, reg *Registry, repoName, existingRef, newTag string) {
+	t.Helper()
+	repo := remoteRepo(t, reg, repoName)
+	if _, err := oras.Tag(t.Context(), repo, existingRef, newTag); err != nil {
+		t.Fatalf("tag %s as %s: %v", existingRef, newTag, err)
+	}
+}
+
+func remoteRepo(t *testing.T, reg *Registry, repoName string) *remote.Repository {
+	t.Helper()
+	repo, err := remote.NewRepository(reg.Host + "/" + repoName)
+	if err != nil {
+		t.Fatalf("new repository %s/%s: %v", reg.Host, repoName, err)
+	}
+	repo.PlainHTTP = true
+	return repo
+}
+
+func pushArtifact(t *testing.T, reg *Registry, repoName, tag, configMediaType string, layers []layerSpec) string {
+	t.Helper()
+	ctx := t.Context()
+	store := memory.New()
+
+	configBytes := []byte("{}")
+	configDesc := content.NewDescriptorFromBytes(configMediaType, configBytes)
+	pushBlob(t, ctx, store, configDesc, configBytes)
+
+	layerDescs := make([]imagev1.Descriptor, 0, len(layers))
+	for _, layer := range layers {
+		desc := content.NewDescriptorFromBytes(layer.mediaType, layer.data)
+		pushBlob(t, ctx, store, desc, layer.data)
+		layerDescs = append(layerDescs, desc)
+	}
+
+	manifest := imagev1.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: imagev1.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    layerDescs,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(imagev1.MediaTypeImageManifest, manifestBytes)
+	pushBlob(t, ctx, store, manifestDesc, manifestBytes)
+	if err := store.Tag(ctx, manifestDesc, tag); err != nil {
+		t.Fatalf("tag manifest %s: %v", tag, err)
+	}
+
+	repo := remoteRepo(t, reg, repoName)
+	if _, err := oras.Copy(ctx, store, tag, repo, tag, oras.DefaultCopyOptions); err != nil {
+		t.Fatalf("push artifact %s/%s:%s: %v", reg.Host, repoName, tag, err)
+	}
+	return manifestDesc.Digest.String()
+}
+
+func pushBlob(t *testing.T, ctx context.Context, store *memory.Store, desc imagev1.Descriptor, data []byte) {
+	t.Helper()
+	if err := store.Push(ctx, desc, bytes.NewReader(data)); err != nil {
+		t.Fatalf("push blob %s: %v", desc.MediaType, err)
+	}
+}
+
+// buildTgz builds a deterministic tgz whose entries are prefixed with prefix
+// (use "name/" for helm charts' single top-level chart directory, "" for
+// root-level plain manifests).
+func buildTgz(t *testing.T, prefix string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if prefix != "" {
+		if err := tw.WriteHeader(&tar.Header{Name: prefix, Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+			t.Fatalf("write tar dir header: %v", err)
+		}
+	}
+	for _, name := range names {
+		data := []byte(files[name])
+		if err := tw.WriteHeader(&tar.Header{Name: prefix + name, Mode: 0o644, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatalf("write tar header %s: %v", name, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("write tar data %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/ociartifact/records.go
+++ b/internal/ociartifact/records.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 )
@@ -16,8 +17,9 @@ import (
 const recordsDirName = "tags"
 
 // tagRecord is one repository's offline resolution record: the tag list from
-// the last online constraint resolve plus the tag→digest pairs resolved
-// online. Each online resolve overwrites the whole record.
+// the last online tag-list fetch plus the revision→digest pairs resolved
+// online. Digest entries merge across resolves; the tag list is replaced
+// whole on each fresh fetch (see updateTagRecord).
 type tagRecord struct {
 	Tags    []string          `json:"tags,omitempty"`
 	Digests map[string]string `json:"digests,omitempty"`
@@ -38,6 +40,27 @@ func readTagRecord(cacheDir, repoURL string) (tagRecord, bool) {
 		return tagRecord{}, false
 	}
 	return record, true
+}
+
+// updateTagRecord read-merge-writes one repository's record under the package
+// key lock: digest entries accumulate across resolves (two Applications
+// pinning different tags of one repository must both resolve offline after
+// one online run), while the tag list is replaced only when this resolve
+// fetched a fresh list. The lock serializes in-process resolves of one
+// repository; cross-process merges stay best-effort like every record write.
+func updateTagRecord(cacheDir, repoURL string, freshTags []string, replaceTags bool, digests map[string]string) {
+	path := tagRecordPath(cacheDir, repoURL)
+	ociKeyLock.Lock(path)
+	defer ociKeyLock.Unlock(path)
+	record, _ := readTagRecord(cacheDir, repoURL)
+	if record.Digests == nil {
+		record.Digests = make(map[string]string, len(digests))
+	}
+	maps.Copy(record.Digests, digests)
+	if replaceTags {
+		record.Tags = freshTags
+	}
+	writeTagRecord(cacheDir, repoURL, record)
 }
 
 // writeTagRecord is best-effort: a failed record write only degrades a later

--- a/internal/ociartifact/records.go
+++ b/internal/ociartifact/records.go
@@ -1,0 +1,69 @@
+package ociartifact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// recordsDirName holds per-repository tag records captured on successful
+// online resolves so tags and semver constraints resolve under --offline.
+// "tags" is not a 64-hex cache key, so the cache entry listers skip the
+// directory (internal/cache/cache.go:384,581-591 isCacheKey) and prune never
+// selects it.
+const recordsDirName = "tags"
+
+// tagRecord is one repository's offline resolution record: the tag list from
+// the last online constraint resolve plus the tag→digest pairs resolved
+// online. Each online resolve overwrites the whole record.
+type tagRecord struct {
+	Tags    []string          `json:"tags,omitempty"`
+	Digests map[string]string `json:"digests,omitempty"`
+}
+
+func tagRecordPath(cacheDir, repoURL string) string {
+	sum := sha256.Sum256([]byte(NormalizeURL(repoURL)))
+	return filepath.Join(cacheDir, recordsDirName, hex.EncodeToString(sum[:])+".json")
+}
+
+func readTagRecord(cacheDir, repoURL string) (tagRecord, bool) {
+	data, err := os.ReadFile(tagRecordPath(cacheDir, repoURL))
+	if err != nil {
+		return tagRecord{}, false
+	}
+	var record tagRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return tagRecord{}, false
+	}
+	return record, true
+}
+
+// writeTagRecord is best-effort: a failed record write only degrades a later
+// offline run to the offline-cache-miss error. The write is atomic
+// (temp+rename) so concurrent resolves never expose partial records.
+func writeTagRecord(cacheDir, repoURL string, record tagRecord) {
+	path := tagRecordPath(cacheDir, repoURL)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		return
+	}
+	_ = os.Rename(tmpName, path)
+}

--- a/internal/requestopts/options.go
+++ b/internal/requestopts/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	RemoteResourceForbiddenRoots   []string
 	RemoteResourceCredentials      remote.Credentials
 	RemoteResourceGitCredentials   remote.GitCredentials
+	OCICacheDir                    string
 	EnableAVPCompat                bool
 	EnableKSOPSCompat              bool
 	EnablePlugins                  bool
@@ -150,6 +151,7 @@ func (options Options) acquisitionOptions() app.AcquisitionOptions {
 		RemoteResourceForbiddenRoots: append([]string(nil), options.RemoteResourceForbiddenRoots...),
 		RemoteResourceCredentials:    options.RemoteResourceCredentials,
 		RemoteResourceGitCredentials: options.RemoteResourceGitCredentials,
+		OCICacheDir:                  options.OCICacheDir,
 		RecordCacheEvents:            options.RecordCacheEvents,
 	}
 }

--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -109,6 +109,8 @@ type Config struct {
 	// RemoteResourceCredentials supplies credentials for remote Kustomize HTTP
 	// resources.
 	RemoteResourceCredentials RemoteResourceCredentials
+	// OCICacheDir overrides the OCI artifact source cache root.
+	OCICacheDir string
 	// EnableAVPCompat forces argocd-vault-plugin placeholder redaction for
 	// native-rendered sources. Explicit argocd-vault-plugin sources use native
 	// compatibility by default.
@@ -329,6 +331,7 @@ func (client *Client) requestOptions() requestopts.Options {
 		RemoteResourceForbiddenRoots:   append([]string(nil), client.config.RemoteResourceForbiddenRoots...),
 		RemoteResourceCredentials:      remoteResourceCredentialsToInternal(client.config.RemoteResourceCredentials),
 		RemoteResourceGitCredentials:   gitCredentialsToRemoteInternal(client.config.GitCredentials),
+		OCICacheDir:                    client.config.OCICacheDir,
 		EnableAVPCompat:                client.config.EnableAVPCompat,
 		EnableKSOPSCompat:              client.config.EnableKSOPSCompat,
 		EnablePlugins:                  client.config.EnablePlugins,

--- a/pr-action/prune.sh
+++ b/pr-action/prune.sh
@@ -22,6 +22,7 @@ prune_output="$(
     --chart-cache-dir "${cache_path}/charts" \
     --remote-cache-dir "${cache_path}/remotes" \
     --render-cache-dir "${cache_path}/renders" \
+    --oci-cache-dir "${cache_path}/oci" \
     -o json \
     2>"${stderr_tmp}"
 )" || prune_exit=$?

--- a/pr-action/prune_test.go
+++ b/pr-action/prune_test.go
@@ -70,6 +70,7 @@ printf '{"removedCount":3,"sizeEvictedBytes":1048576,"totalSizeBytes":2097152}\n
 		"--chart-cache-dir " + cachePath + "/charts",
 		"--remote-cache-dir " + cachePath + "/remotes",
 		"--render-cache-dir " + cachePath + "/renders",
+		"--oci-cache-dir " + cachePath + "/oci",
 		"-o json",
 	} {
 		if !strings.Contains(args, want) {

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -275,7 +275,7 @@ work_dir="${DRYDOCK_ACTION_WORK_DIR}"
 mkdir -p "${work_dir}"
 cache_path="${DRYDOCK_CACHE_PATH:-}"
 if [[ -n "${cache_path}" ]]; then
-  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes" "${cache_path}/plugin" "${cache_path}/renders"
+  mkdir -p "${cache_path}/git" "${cache_path}/charts" "${cache_path}/remotes" "${cache_path}/plugin" "${cache_path}/renders" "${cache_path}/oci"
 fi
 diff_html_artifact_name="${DRYDOCK_DIFF_HTML_ARTIFACT_NAME:-}"
 if [[ -z "${diff_html_artifact_name}" ]]; then
@@ -337,6 +337,7 @@ if [[ -n "${cache_path}" ]]; then
     "--remote-cache-dir" "${cache_path}/remotes"
     "--plugin-cache-dir" "${cache_path}/plugin"
     "--render-cache-dir" "${cache_path}/renders"
+    "--oci-cache-dir" "${cache_path}/oci"
   )
 fi
 append_bool_flag common_args "${DRYDOCK_INPUT_SKIP_SECRETS}" "--skip-secrets"

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -428,6 +428,7 @@ func TestRunPassesCacheDirsToEveryInvocationWhenCachePathSet(t *testing.T) {
 	}
 	wantPlugin := "--plugin-cache-dir " + filepath.Join(cachePath, "plugin")
 	wantRender := "--render-cache-dir " + filepath.Join(cachePath, "renders")
+	wantOCI := "--oci-cache-dir " + filepath.Join(cachePath, "oci")
 	for _, line := range lines {
 		if !strings.Contains(line, wantPlugin) {
 			t.Fatalf("drydock invocation missing plugin cache dir %q:\n%s", wantPlugin, line)
@@ -435,8 +436,11 @@ func TestRunPassesCacheDirsToEveryInvocationWhenCachePathSet(t *testing.T) {
 		if !strings.Contains(line, wantRender) {
 			t.Fatalf("drydock invocation missing render cache dir %q:\n%s", wantRender, line)
 		}
+		if !strings.Contains(line, wantOCI) {
+			t.Fatalf("drydock invocation missing oci cache dir %q:\n%s", wantOCI, line)
+		}
 	}
-	for _, name := range []string{"git", "charts", "remotes", "plugin", "renders"} {
+	for _, name := range []string{"git", "charts", "remotes", "plugin", "renders", "oci"} {
 		path := filepath.Join(cachePath, name)
 		info, err := os.Stat(path)
 		if err != nil {
@@ -471,6 +475,9 @@ func TestRunOmitsPluginCacheDirWhenCachePathEmpty(t *testing.T) {
 		}
 		if strings.Contains(line, "--render-cache-dir") {
 			t.Fatalf("drydock invocation included render cache dir with empty DRYDOCK_CACHE_PATH:\n%s", line)
+		}
+		if strings.Contains(line, "--oci-cache-dir") {
+			t.Fatalf("drydock invocation included oci cache dir with empty DRYDOCK_CACHE_PATH:\n%s", line)
 		}
 	}
 }

--- a/site/content/compatibility/_index.md
+++ b/site/content/compatibility/_index.md
@@ -26,7 +26,7 @@ which boundaries are intentionally runtime-offline.
 | --- | --- | --- | --- |
 | Applications | Native | Direct `Application` manifests, single-source and multi-source apps, rendered app-of-apps discovery. | No live application-controller state or sync behavior. |
 | ApplicationSets | Native and supported with input | Git directories, Git files, list, matrix, merge, template overrides, `templatePatch`, and fixture-backed provider generators. | No live Kubernetes, SCM, pull-request, cloud, or plugin provider API calls. |
-| Sources | Native and supported with input | Local paths, Git cache/fetch, `--repo-map`, HTTP(S) Helm, OCI Helm, remote Kustomize, external Helm value files, and cache lifecycle commands. | `--offline` requires local files, repo maps, or cache hits. Ambient Git helpers and Helm registry config are not read. |
+| Sources | Native and supported with input | Local paths, Git cache/fetch, `--repo-map`, HTTP(S) Helm, OCI Helm, OCI artifact sources, remote Kustomize, external Helm value files, and cache lifecycle commands. | `--offline` requires local files, repo maps, or cache hits. Ambient Git helpers and Helm registry config are not read. Private OCI registries are not yet supported for OCI artifact sources. |
 | Rendering | Native | Directory, Kustomize, Helm, Jsonnet, Kustomize Helm charts, Argo CD tracking metadata, namespace normalization, and custom health Lua validation. | No `kubectl`, `argocd`, Helm CLI, Kustomize CLI, repo-server wrapper, or live API defaulting. |
 | Plugins | Supported with input | Native safe Kustomize CMP compatibility, argocd-vault-plugin placeholder compatibility, in-process public API renderers, trusted exec or container policy with `--enable-plugins`, and `bootstrap.entrypoints` for plugin-rendered app discovery. | No default sidecar plugin execution, ambient plugin loading, or plugin credential injection. |
 | Diffs and images | Native | Desired-vs-desired manifest diffs, Git ref diffs, ignored-field normalization, markdown diff previews, and image extraction from PodSpecs and exact `image` keys. | No live managed-fields prediction, server-side diff, or arbitrary string image scanning. |
@@ -42,6 +42,7 @@ which boundaries are intentionally runtime-offline.
 | App-of-apps or bootstrap manifests | Let recursive rendered fleet discovery find rendered Applications, use `--discover-kustomize PATH` for explicit Kustomize entrypoints, or use trusted PluginPolicy `bootstrap.entrypoints` when bootstrap apps are plugin-rendered. |
 | Multi-source Applications | Use normal commands; add `--repo-map URL=PATH` when external Git sources are already checked out locally. |
 | Remote Helm or OCI charts | Let drydock fetch into its chart cache, or pre-populate the cache and use `--offline`. |
+| First-class OCI artifact sources (`oci://` + `path:`) | Use normal commands; drydock resolves the tag or constraint to a digest and renders the artifact content. Warm the cache online before `--offline` runs. |
 | Private Git, Helm, or remote Kustomize sources | Pass explicit auth flags or local repo maps. drydock does not read ambient credential helpers. |
 | Kustomize with Helm charts | Use the native renderer. `kustomize.buildOptions: --enable-helm` is honored without shelling out to Kustomize. |
 | Config management plugins | Prefer native compatibility paths. Use trusted plugin policy plus `--enable-plugins` only when exec or container command simulation is truly needed. |
@@ -70,9 +71,9 @@ See [ApplicationSet support](/docs/applicationsets/) and
 ### Sources and rendering
 
 drydock renders directory, Kustomize, Helm, and Jsonnet sources through native
-Go paths. It can fetch declared Git, HTTP(S) Helm, OCI Helm, and remote
-Kustomize resources into explicit caches. `--offline` turns those source
-network fetches into cache/local-only requirements.
+Go paths. It can fetch declared Git, HTTP(S) Helm, OCI Helm, OCI artifact,
+and remote Kustomize resources into explicit caches. `--offline` turns those
+source network fetches into cache/local-only requirements.
 
 Rendering intentionally does not call live Argo CD, Kubernetes, `kubectl`,
 `argocd`, Helm CLI, or Kustomize CLI. That keeps local and CI analysis fast,

--- a/site/content/concepts/how-it-works.md
+++ b/site/content/concepts/how-it-works.md
@@ -29,9 +29,16 @@ selection, or rendered fleet discovery.
 ## Source Resolution
 
 Application sources resolve from repo maps, local paths, declared Git sources,
-Helm chart sources, remote Kustomize resources, and drydock caches. Default
-runs may fetch declared Git, HTTP Helm, OCI Helm, and remote Kustomize inputs
-into explicit caches. `--offline` makes those source lookups cache-only.
+Helm chart sources, OCI artifact sources, remote Kustomize resources, and
+drydock caches. Default runs may fetch declared Git, HTTP Helm, OCI Helm, OCI
+artifact, and remote Kustomize inputs into explicit caches. `--offline` makes
+those source lookups cache-only.
+
+First-class OCI artifact sources (`repoURL: oci://...` with `path:` and no
+`chart:`) are classified before local-path resolution: their revision resolves
+to a digest, the artifact content is pulled and extracted, and the selected
+`path` renders through the normal pipeline. `--repo-map` of the `oci://` URL
+still takes precedence.
 
 ## Rendering
 

--- a/site/content/concepts/runtime-offline.md
+++ b/site/content/concepts/runtime-offline.md
@@ -8,8 +8,8 @@ It renders desired state from repository contents, explicit mappings, and
 drydock caches.
 
 Runtime-offline does not mean every source network request is disabled.
-Declared Git, HTTP Helm, OCI Helm, and remote Kustomize sources can still be
-fetched into explicit caches unless `--offline` is set.
+Declared Git, HTTP Helm, OCI Helm, OCI artifact, and remote Kustomize sources
+can still be fetched into explicit caches unless `--offline` is set.
 
 ## Runtime Boundary
 
@@ -43,6 +43,28 @@ drydock diff apps --path . --path-orig ../baseline --offline
 
 With `--offline`, source resolution must use local files, `--repo-map`, or
 existing cache entries.
+
+## OCI Artifact Sources Offline
+
+OCI artifact sources have revision-dependent offline behavior:
+
+- **Digest-pinned revisions** (`sha256:...`) pass through with no resolution
+  network call and render from the cached image for that digest.
+- **Tags and semver constraints** resolve from records that online runs write
+  into the OCI cache on every successful resolve: the tag-to-digest pairs it
+  resolved and, for constraints, the registry tag list. A recorded tag or a
+  constraint satisfiable from the recorded tag list renders offline; anything
+  not yet recorded fails.
+
+A revision that cannot be resolved offline — or a digest whose image was
+never pulled — fails with an `offline cache miss` error. The remediation is
+one online run of the same render against the same cache directory
+(`--oci-cache-dir` if overridden), which populates both the image cache and
+the tag records, then re-run with `--offline`.
+
+Because online runs always re-resolve tags against the registry and overwrite
+the records, offline tag resolution reflects the most recent online run —
+there is no staleness window to manage and no refresh flag.
 
 For the complete support boundary, see [Compatibility](/compatibility/) and
 [Argo CD Render Parity](/concepts/argocd-render-parity/).

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -5,22 +5,27 @@ aliases:
 ---
 
 drydock renders from local files and explicit source caches. It may fetch
-declared Git, HTTP Helm, OCI Helm, and remote Kustomize inputs unless
-`--offline` is set. It does not read ambient Git credential helpers, ambient
-Helm registry config, or live Argo CD repository state.
+declared Git, HTTP Helm, OCI Helm, OCI artifact, and remote Kustomize inputs
+unless `--offline` is set. It does not read ambient Git credential helpers,
+ambient Helm registry config, or live Argo CD repository state.
 
 ## Resolution Order
 
 For repository sources, drydock resolves deterministically:
 
 1. Explicit `--repo-map URL=PATH`.
-2. Existing local source path under the selected repository tree.
-3. A source naming the local checkout — a configured remote of the selected
+2. `oci://` source classification. An `oci://` repository URL without `chart:`
+   is a first-class [OCI artifact source](#oci-artifact-sources) and is
+   acquired from the registry — it never falls through to a local source path
+   or Git acquisition, even when its `path:` (commonly `.`) exists in the
+   local tree.
+3. Existing local source path under the selected repository tree.
+4. A source naming the local checkout — a configured remote of the selected
    repository — at `""`/`HEAD`, a diffed ref name (during diffs), or the
    repository's default-branch name resolves to the local tree (during diffs,
    the active side tree). Full-commit-SHA revisions still acquire remotely.
-4. Declared Git cache or fetch behavior for unmapped external repositories.
-5. Clear failure.
+5. Declared Git cache or fetch behavior for unmapped external repositories.
+6. Clear failure.
 
 `--repo-map` wins over local fallback and network fetching. Use it for adjacent
 local checkouts or CI jobs that prepare dependencies explicitly:
@@ -90,6 +95,14 @@ Chart-only HTTP(S) and OCI Helm sources may be fetched into the chart cache
 unless `--offline` is set. Local Helm chart sources render from the repository
 tree.
 
+A source combining an `oci://` repository URL with `chart:` (and no `path:`)
+keeps drydock's existing Helm-chart flow. This is a deliberate, recorded
+divergence from strict Argo CD v3.4.5, which dispatches `oci://` URLs to its
+OCI handling before Helm handling and would reject that shape — fleets use it,
+and rendering the chart matches what their clusters run. An `oci://` source
+that sets both `chart:` and `path:` fails with a clear
+`unsupported source shape` error instead of falling into either flow.
+
 Drydock resolves missing HTTP(S) and OCI chart dependencies declared in
 `Chart.yaml` through its native chart cache. With `--offline`, cache hits are
 allowed but network fetches are disabled. The source checkout is not mutated,
@@ -111,6 +124,92 @@ the repository index and to chart archive URLs on the same host. When
 `passCredentials` is true, drydock also forwards them to cross-host chart
 archive URLs returned by the repository index. It does not enable ambient
 credential discovery.
+
+## OCI Artifact Sources
+
+Argo CD first-class OCI sources — `repoURL: oci://registry/repo`, a `path:`
+into the artifact content, and no `chart:` — are supported on every render
+surface. drydock resolves the revision to a digest, pulls the artifact from
+the registry, extracts its content, and renders the selected `path` with the
+normal directory, Kustomize, or Helm pipeline:
+
+```yaml
+source:
+  repoURL: oci://ghcr.io/example/config-artifact
+  targetRevision: 1.2.3
+  path: .
+```
+
+Classification is total over `oci://` URLs: an OCI source never resolves to a
+local source path, the self-repository branch, or Git acquisition, even when
+`path: .` exists in the local tree. Explicit `--repo-map` of the `oci://` URL
+still wins and renders the mapped local path instead of fetching.
+
+### Revisions
+
+`targetRevision` accepts:
+
+- A digest (`sha256:...`), used as-is with no resolution network call.
+- An exact tag, resolved to a digest via a registry HEAD request.
+- A semver constraint (for example `1.x`), resolved to the highest matching
+  tag from the registry tag list, then to that tag's digest.
+
+Matching Argo CD repo-server freshness semantics, online runs always
+re-resolve tags and constraints against the registry, so a re-pushed tag is
+reflected on the next online render; only the image content itself is served
+from the cache when its digest is already present. There is no `--refresh-oci`
+flag because nothing tag-shaped can go stale between online runs.
+
+### Extraction Guards
+
+Artifact extraction enforces the Argo CD repo-server defaults: at most 10
+layers, exactly one content layer, a layer media-type allowlist
+(`application/vnd.oci.image.layer.v1.tar`,
+`application/vnd.oci.image.layer.v1.tar+gzip`,
+`application/vnd.cncf.helm.chart.content.v1.tar+gzip`), and a 1G
+maximum extracted size. These limits are not yet configurable from the CLI.
+
+### Cache Layout
+
+OCI artifacts cache under `<user cache dir>/drydock/oci` (override with
+`--oci-cache-dir PATH`). Each entry is keyed by repository URL and digest and
+holds the pulled image tar plus metadata; `cache list` reports the entries as
+source `oci`, kind `image`, and `cache prune`/`cache delete` manage them like
+every other source cache (`--source oci` scopes to them). The cache root also
+holds a `tags/` records directory used for offline tag resolution; it is not
+an entry, so lifecycle commands list and prune around it.
+
+### Offline Behavior
+
+Under `--offline`:
+
+- Digest-pinned revisions pass through without resolution and render from the
+  cached image; a digest whose image was never pulled fails with an
+  `offline cache miss` error.
+- Tags and semver constraints resolve from records captured on earlier
+  successful online runs against the same cache directory. A tag or
+  constraint that no online run has resolved fails with an
+  `offline cache miss` error.
+
+The remediation for an offline cache miss is one online run of the same
+command (or any render covering the same source) to populate the image cache
+and tag records, then re-run with `--offline`.
+
+### Boundaries
+
+- `oci://` + `chart:` keeps the Helm-chart flow (see
+  [Helm Sources](#helm-sources)); `chart:` + `path:` on one `oci://` source
+  is an error.
+- OCI sources cannot be `$ref` value-file sources. Argo CD materializes
+  referenced sources from Git only, and drydock fails such refs with a clear
+  error instead of accidentally supporting them.
+- Changed-only diff selection treats OCI sources like chart-only Helm
+  sources: they re-render when the Application manifest changes, not on
+  arbitrary repository changes, and they never render discovery objects.
+- Private registries requiring authentication are not yet supported for OCI
+  artifact sources; `--registry-config` applies to OCI Helm chart sources
+  only. Loopback registries (localhost) use plain HTTP for local development
+  and testing; all other hosts use TLS.
 
 ## Kustomize Sources
 
@@ -183,7 +282,7 @@ drydock test apps --path . --offline
 
 | Flag | Behavior |
 | --- | --- |
-| `--offline` | Disable Git, Helm chart, and remote Kustomize network fetching. |
+| `--offline` | Disable Git, Helm chart, OCI artifact, and remote Kustomize network fetching. |
 | `--repo-map URL=PATH` | Map a source repository URL to a local checkout. |
 | `--refresh-git` | Fetch cached Git repositories and bypass persisted render outputs for those inputs. |
 | `--git-cache-dir PATH` | Override the default Git repository cache root. |
@@ -191,6 +290,7 @@ drydock test apps --path . --offline
 | `--chart-cache-dir PATH` | Override the default chart cache root. |
 | `--refresh-remotes` | Refresh cached remote Kustomize resources and bypass persisted render outputs for those inputs. |
 | `--remote-cache-dir PATH` | Override the default remote-resource cache root. |
+| `--oci-cache-dir PATH` | Override the default OCI artifact cache root. |
 | `--render-cache` | Reuse persisted Application render outputs across runs (default on). |
 | `--render-cache-dir PATH` | Override the default render-output cache root. |
 | `--render-cache-max-size QUANTITY` | Size cap before LRU eviction (default `512Mi`). |
@@ -198,7 +298,7 @@ drydock test apps --path . --offline
 | `--plugin-cache-dir PATH` | Runtime override for policy-managed container plugin cache mounts. |
 | `--registry-config PATH` | Supply the only Helm OCI registry credentials. |
 
-Render-time Git, chart, and remote-resource caches must stay outside the
+Render-time Git, chart, OCI artifact, and remote-resource caches must stay outside the
 current repository tree, compared repository trees, repo-map roots, and their
 symlink-resolved equivalents. Drydock validates these roots before cache reads,
 fetches, or writes so a repository cannot double as its own mutable source
@@ -220,8 +320,8 @@ output entries via `--source render` and `--render-cache-dir`. During prune,
 when render entries are in scope (either because `--source render` is set or
 because no `--source` filter is used), `cache prune` additionally enforces the
 render cache size cap and removes stale orphaned temp files. A `--source
-git`, `--source chart`, or `--source remote` prune scopes only to that source
-and skips the render sweep entirely.
+git`, `--source chart`, `--source remote`, or `--source oci` prune scopes only
+to that source and skips the render sweep entirely.
 
 > **Warning:** The render cache size cap is a runtime flag (`--render-cache-max-size`)
 > that `cache prune` cannot discover automatically. If your builds use a custom
@@ -364,8 +464,9 @@ They do not:
 - retry failed network or authentication acquisitions
 
 `cache prune` and `cache delete` operate only on recognized drydock Git,
-chart, remote-resource, and render output cache entry roots. They do not
-manage plugin cache mount roots selected with `--plugin-cache-dir`.
+chart, remote-resource, OCI artifact, and render output cache entry roots.
+They do not manage plugin cache mount roots selected with
+`--plugin-cache-dir`.
 
 Cache lifecycle commands reject cache roots that resolve inside the current
 working directory, selected repository roots, Git repository trees, or

--- a/site/content/cookbook/source-access.md
+++ b/site/content/cookbook/source-access.md
@@ -17,6 +17,30 @@ at `HEAD` or its default-branch name resolves to the local tree automatically
 on all render surfaces. Keep `--repo-map` for forks, commit-SHA pins, and runs
 from a subdirectory of the checkout.
 
+## Render OCI Artifact Sources
+
+```yaml
+source:
+  repoURL: oci://ghcr.io/example/config-artifact
+  targetRevision: 1.2.3
+  path: .
+```
+
+First-class OCI artifact sources render with normal commands — no extra flags:
+
+```bash
+drydock test apps --path .
+drydock build apps --path . --oci-cache-dir /var/cache/drydock-oci
+```
+
+The revision may be a digest (`sha256:...`), an exact tag, or a semver
+constraint such as `1.x`. Tags re-resolve against the registry on every online
+run, so a re-pushed tag is picked up automatically; pin a digest when the
+render must not move. For `--offline` runs, warm the cache with one online run
+first — digests render from the cached image, and tags or constraints resolve
+from records captured online. Private registries requiring authentication are
+not yet supported for OCI artifact sources.
+
 ## Prove Cache-Only Runs
 
 ```bash

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -24,9 +24,9 @@ For task-oriented examples, start with [Getting started](/getting-started/),
 | Check plugin policy readiness | `drydock plugin-policy doctor --path .` |
 
 All render-backed commands are runtime-offline: they do not contact live Argo
-CD or Kubernetes. Declared Git, HTTP Helm, OCI Helm, and remote Kustomize
-sources may still be fetched into explicit drydock caches unless `--offline`
-is set.
+CD or Kubernetes. Declared Git, HTTP Helm, OCI Helm, OCI artifact, and remote
+Kustomize sources may still be fetched into explicit drydock caches unless
+`--offline` is set.
 
 ## Discovery Commands
 
@@ -138,9 +138,20 @@ statuses, diagnostics, cache events, and structured output.
 
 Rendering supports directory sources, directory Jsonnet, Kustomize sources,
 local Helm charts, Kustomize `helmCharts`, remote Kustomize HTTP(S) files and
-Git refs, and Argo CD chart-only remote Helm sources. Path-based Git sources
-use the local `--path` tree when the source path exists there. Use
-`--repo-map URL=PATH` to force a source repository URL to a local checkout.
+Git refs, Argo CD chart-only remote Helm sources, and first-class OCI
+artifact sources (`repoURL: oci://...` with `path:` and no `chart:`).
+Path-based Git sources use the local `--path` tree when the source path
+exists there. Use `--repo-map URL=PATH` to force a source repository URL to a
+local checkout.
+
+OCI artifact sources resolve digest, exact-tag, or semver-constraint
+revisions against the registry, cache the pulled image under the OCI cache
+root (`--oci-cache-dir PATH` overrides it), and render the extracted content
+at the source `path`. An `oci://` source with `chart:` and no `path:` keeps
+the Helm-chart flow; setting both `chart:` and `path:` is an error, and OCI
+sources cannot be `$ref` value-file sources. See
+[Source acquisition](/concepts/source-acquisition/#oci-artifact-sources) for
+revision, cache, and offline details.
 
 Capability-gated charts can render optional resources only when a Kubernetes
 version or API version is available. drydock derives a default Kubernetes
@@ -388,13 +399,18 @@ Print resolved cache roots:
 drydock cache path
 ```
 
-List recognized Git, chart, remote Kustomize, and render output cache
-entries:
+List recognized Git, chart, remote Kustomize, OCI artifact, and render output
+cache entries:
 
 ```bash
 drydock cache list
 drydock cache list --source chart -o json
+drydock cache list --source oci -o json
 ```
+
+`--source` accepts `git`, `chart`, `remote`, `render`, or `oci`. OCI artifact
+entries list with source `oci` and kind `image`, keyed by repository URL and
+resolved digest.
 
 Report stale entries without deleting them:
 
@@ -416,8 +432,9 @@ Dry-runs never require confirmation and leave cache files in place.
 Cache lifecycle commands are local filesystem operations only. They do not
 render Applications, clone or fetch Git repositories, fetch Helm charts, fetch
 remote Kustomize resources, or read credential flags. They operate only on
-recognized drydock Git, chart, remote-resource, and render output cache entry
-roots and reject cache roots that resolve inside the current working
+recognized drydock Git, chart, remote-resource, OCI artifact, and render
+output cache entry roots and reject cache roots that resolve inside the
+current working
 directory, selected repository roots, Git repository trees, or
 symlink-resolved equivalents. Render output entries are selected with
 `--source render` and `--render-cache-dir`; plugin cache mount roots remain

--- a/site/content/reference/go-api.md
+++ b/site/content/reference/go-api.md
@@ -24,8 +24,12 @@ For exported types, functions, and field-level comments, use the maintained
 
 Package-level `Render`, `ListApplications`, `DiffApplications`, and
 `DiffImages` functions use the same default network and cache behavior as the
-CLI. Declared Git, chart, and remote Kustomize inputs may be fetched unless
-the request is configured for offline/cache-only behavior.
+CLI. Declared Git, chart, OCI artifact, and remote Kustomize inputs may be
+fetched unless the request is configured for offline/cache-only behavior.
+
+`Config.OCICacheDir` overrides the OCI artifact source cache root, mirroring
+the CLI `--oci-cache-dir` flag. Like the other cache roots, it must resolve
+outside current and baseline repository trees.
 
 `NewClient` accepts public Git, chart, remote-resource, and plugin renderer
 interfaces so tests and embedding callers can provide deterministic fakes

--- a/site/content/troubleshooting/_index.md
+++ b/site/content/troubleshooting/_index.md
@@ -68,8 +68,8 @@ manifest instead; ignoring it hides it from every discovery-based command.
 ## Symptom: Render Fails In CI But Works Locally
 
 Confirm whether CI has the same source access and caches. Default runs may
-fetch declared Git, Helm, OCI Helm, and remote Kustomize sources into drydock
-caches. `--offline` disables those source network fetches and requires local
+fetch declared Git, Helm, OCI Helm, OCI artifact, and remote Kustomize
+sources into drydock caches. `--offline` disables those source network fetches and requires local
 files, repo maps, or existing cache entries.
 
 ```bash
@@ -114,6 +114,37 @@ Two remediations:
 The flip side of local resolution: a self-repository source `path` that was
 deleted locally fails path-not-found even though the remote tip still has it —
 the local tree is the desired state.
+
+## Symptom: OCI Source Renders The Local Checkout Or Fails With `load helm chart .`
+
+A first-class OCI artifact source — `repoURL: oci://...` with `path:` and no
+`chart:` — has two historical failure modes on older drydock releases, which
+did not classify `oci://` URLs:
+
+- With a `helm:` block, the render failed with an error like
+  `load helm chart .`, because the local repository root was treated as the
+  chart directory.
+- Without a `helm:` block, the run silently succeeded but rendered the LOCAL
+  checkout as plain manifests (`path: .` always exists locally), not the
+  artifact content.
+
+Upgrade drydock: current releases classify every `oci://` source before local
+path resolution, resolve the revision to a digest, and render the pulled
+artifact content. If you added `--repo-map` of the `oci://` URL as a
+workaround, it still wins over registry acquisition — remove it when you want
+the artifact fetched, keep it when a local checkout of the content should be
+rendered instead.
+
+Related shapes on current releases:
+
+- `oci://` + `chart:` (no `path:`) keeps the Helm-chart flow (recorded
+  divergence from strict Argo CD v3.4.5).
+- `oci://` + `chart:` + `path:` fails with `unsupported source shape`.
+- An OCI URL as a `$ref` value-file source fails clearly; Argo CD supports
+  Git-only `$ref` sources.
+- An `offline cache miss` error under `--offline` means the digest, tag, or
+  constraint was never resolved online against this cache directory — run
+  once without `--offline` to warm the image cache and tag records.
 
 ## Symptom: Changed-Only Falls Back To All Apps
 

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -218,9 +218,9 @@ artifacts.
 
 Binary caching is separate from drydock repository caches. Binary cache entries
 contain only the released `drydock` archive and are keyed by release checksum.
-The PR action cache root contains fetched Git, Helm, and remote Kustomize
-sources, policy-managed plugin cache mounts, and persisted render outputs for
-the repository under test.
+The PR action cache root contains fetched Git, Helm, OCI artifact, and remote
+Kustomize sources, policy-managed plugin cache mounts, and persisted render
+outputs for the repository under test.
 
 Dirty-worktree render output reuse uses the existing render cache behavior. No
 new PR action input is required.
@@ -238,11 +238,19 @@ plugin cache material. They also skip PR comments by default. Set
 runs is acceptable for that repository. Cache save remains disabled for fork
 PRs.
 
+The action wires each source cache to its own subdirectory of the cache root:
+`${cache-path}/git`, `${cache-path}/charts`, `${cache-path}/remotes`, and
+`${cache-path}/oci` (passed to drydock as `--oci-cache-dir`). OCI artifact
+image entries are digest-keyed and can be large — one entry per pulled
+artifact version — so repositories with many OCI artifact sources should
+budget cache size accordingly (`cache-prune-max-size` bounds the local-mode
+cache, and the same subdirectories are covered by the action's prune step).
+
 When trusted container plugins are enabled, policy-managed plugin cache mounts
 live under the PR action cache root as `${cache-path}/plugin`. Persisted render
 outputs live under `${cache-path}/renders`. Both are restored or saved with the
 same action cache entry. `drydock cache` lifecycle commands manage Git,
-chart, remote-resource, and render output cache entry roots (use
+chart, remote-resource, OCI artifact, and render output cache entry roots (use
 `--render-cache-dir ${cache-path}/renders` to target the action's persisted
 renders); they do not manage plugin cache mount roots.
 

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -245,6 +245,9 @@ image entries are digest-keyed and can be large — one entry per pulled
 artifact version — so repositories with many OCI artifact sources should
 budget cache size accordingly (`cache-prune-max-size` bounds the local-mode
 cache, and the same subdirectories are covered by the action's prune step).
+Note the upgrade coupling: action refs that pass `--oci-cache-dir` require a
+drydock binary that understands it, so a workflow pinning `version` to a
+pre-0.2.7 release must pin a matching pre-0.2.7 action ref.
 
 When trusted container plugins are enabled, policy-managed plugin cache mounts
 live under the PR action cache root as `${cache-path}/plugin`. Persisted render


### PR DESCRIPTION
Fixes #220

## Problem

Argo CD's first-class OCI source form (`repoURL: oci://…` + `path:`, no `chart:` field) was unsupported — and masked. The path-exists fallback in source resolution silently rendered the **local checkout** at the source's path: with a `helm:` block that produced the reported `load helm chart .` error, and without one it produced an exit-0 render of local repo files as the app's manifests (the worse mode: green checks over phantom content).

## Design

Native support mirroring the vendored Argo CD v3.4.5 repo-server, importing Argo's own `util/oci` client (ORAS-based) rather than reimplementing it:

- **Classification is total over `oci://` spellings** and runs before path-exists/self-repo/git resolution — the silent local-render mode is structurally dead (pinned by tests either way). Explicit `--repo-map` of an `oci://` URL still wins, so the previous workaround keeps working, including at the discovery frontier for app-of-apps parents.
- **Revision resolution** matches upstream exactly: exact tag first (a literal `1.x` tag resolves to its own digest, as live Argo does), semver-constraint fallback via MaxVersion over registry tags.
- **Extraction** goes through upstream's guards (≤10 layers, single content layer, media-type allowlist identical to the repo-server default, max-extracted-size, helm-chart vs generic-content handling) plus out-of-bounds-symlink rejection at the copy-into-session step. Extractions are session-scoped and memoized (one acquisition per digest per run, both diff sides shared).
- **Cache**: a new `oci` cache source under `--oci-cache-dir` — atomic staged image commits with online self-heal for corrupt cached tars, digest-keyed render-cache identity, full participation in `cache prune` (age/LRU/`--max-size`) and the pr-action cache-dir wiring.
- **Offline**: digest-pinned revisions resolve directly from the image cache; tags and semver constraints resolve from records captured on online runs (merge-on-write, so multi-tag repos survive); anything unseen fails with a clear `offline cache miss` error.
- **Recorded divergence**: `oci://` + `chart:` keeps drydock's existing helm-chart flow. Strict upstream first-class OCI would reject that namespace-URL shape, but real fleets use it and drydock's output matches what their clusters run — pinned by fleet regression and documented.
- **Upstream-parity exclusions**: `$ref`→OCI value sources are rejected with a clear error (git-only upstream); appset generators unaffected; hybrid `chart:`+`path:` shapes error explicitly instead of falling into masked branches.

## Validation

- 40+ new hermetic tests against an in-process distribution registry (`go-containerregistry`, test-only — verified absent from the shipped binary), including the real vendored-client wrapper end-to-end (which caught that the client nil-panics without event handlers), corrupt-cache self-heal, offline phase-splits with acquirer reconstruction, media-type/layer-guard rejection, and same-tag-repush cache-identity pins.
- Two adversarial review rounds on the plan and one on the implementation (three lenses + security), plus 17 plan sabotages and 3 auditor-devised ones run empirically; a judged fix round addressed 4 blocking findings (atomic cache writes + self-heal, frontier repo-map gate, lossy offline records, empty-path pin) and 8 adopted advisories, each fix verified by watching its pin test fail against the regressed form.
- Oracles against the real registry: the issue's exact spec shape (`oci://ghcr.io/argoproj/argo-helm/argo-cd`) renders the chart with and without a `helm:` block, semver `7.7.x` resolves, offline-from-cache output is byte-identical with a clear error on a cold cache, and `cache prune --max-size` sweeps OCI entries.
- Fleet regression: homecluster (including its `oci://`+`chart:` grafana shape — the divergence pin) and home-ops render byte-identically across old/new binaries; the discover-ignore and appset-scoping repro fixtures and a clean-clone PR-957 ref-diff are all unchanged.

Recorded follow-ups: private-registry credentials (reusing the helm-OCI creds machinery), media-type/max-size flags, and an argocd-parity-smoke OCI fixture (needs an in-cluster registry).