### PR TITLE
chore(renovate): ignore argoproj/pkg — version tracks vendored argo-cd

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,14 @@
   minimumReleaseAge: '3 days',
   internalChecksFilter: 'strict',
   ignorePaths: ['testdata/**'],
-  ignoreDeps: ['github.com/argoproj/argo-cd/gitops-engine'],
+  // argoproj/pkg's version must track the vendored argo-cd util/oci KeyLock
+  // signature (v0 today; v0 is frozen upstream, and MVS + gomodTidy track it
+  // upward automatically at argo-cd bumps). The v0→v2 migration happens only
+  // inside an argo-cd upgrade that changes the signature.
+  ignoreDeps: [
+    'github.com/argoproj/argo-cd/gitops-engine',
+    'github.com/argoproj/pkg',
+  ],
   postUpdateOptions: ['gomodTidy'],
   postUpgradeTasks: {
     commands: ['go run ./scripts/sync-argocd-gitops-engine.go'],


### PR DESCRIPTION
Closes the loop on renovate PR #224, which failed CI structurally: the proposed `argoproj/pkg` v0→v2 major swaps the require line, but drydock's only use of the module is the `sync.KeyLock` handed to the vendored argo-cd `util/oci.NewClientWithLock`, whose v3.4.5 signature is pinned to the **v0** type. The import must stay v0, `pkg/v2` is already in the graph as an indirect dep of argo-cd itself, so `go mod tidy` demotes renovate's new require to indirect and `mod-tidy-check` correctly fails.

This is the same argo-cd-derived dependency class the config already expresses for gitops-engine, so `argoproj/pkg` joins `ignoreDeps` with a comment explaining the coupling. Nothing is forfeited: v0 is frozen upstream (development moved to v2), MVS + the existing `gomodTidy` post-update option track the v0 line upward automatically if a future argo-cd bump requires a newer v0, and the eventual v0→v2 migration can only happen inside an argo-cd upgrade that changes the `util/oci` signature — a hand-managed change regardless. No sync-helper extension needed (it's an ordinary require, not a replace pin).

Validated with the CI validator (`renovate-config-validator --strict`): config valid. #224 can be closed after this merges (renovate will not re-open it).