### PR TITLE
chore: handle unchecked errors and collapse duplicated merge/record logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Inspect your Argo CD fleet without getting wet
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/sholdee/drydock)](https://goreportcard.com/report/github.com/sholdee/drydock)
+[![CodeFactor](https://www.codefactor.io/repository/github/sholdee/drydock/badge)](https://www.codefactor.io/repository/github/sholdee/drydock)
 [![CI](https://github.com/sholdee/drydock/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sholdee/drydock/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/sholdee/drydock)](go.mod)

--- a/internal/app/discovery_merge.go
+++ b/internal/app/discovery_merge.go
@@ -24,21 +24,32 @@ func mergeDiscoveryResultsWithDiagnostics(base, overlay discovery.Result) (disco
 	return out, diags
 }
 
-func mergeApplications(base, overlay []discovery.ApplicationFile) ([]discovery.ApplicationFile, []diagnostic.Diagnostic) {
-	out := append([]discovery.ApplicationFile(nil), base...)
+// mergeDiscoveryItems merges overlay into base, resolving key collisions via
+// the tier-priority conflict rules. kind is per-item because settings
+// candidates carry their object kind in the item itself.
+func mergeDiscoveryItems[T any](
+	base, overlay []T,
+	key func(T) string,
+	kind func(T) string,
+	same func(T, T) bool,
+	source func(T) (discovery.SourceTier, string, int),
+) ([]T, []diagnostic.Diagnostic) {
+	out := append([]T(nil), base...)
 	indexes := make(map[string]int, len(out))
 	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
 	for i, item := range out {
-		addDiscoveryIndex(indexes, looseIndexes, applicationDiscoveryKey(item.Application), i)
+		addDiscoveryIndex(indexes, looseIndexes, key(item), i)
 	}
 	var diags []diagnostic.Diagnostic
 	for _, item := range overlay {
-		key := applicationDiscoveryKey(item.Application)
-		if index, ok := indexes[key]; ok {
-			if sameApplicationDiscoveryObject(out[index], item) {
+		itemKey := key(item)
+		incomingTier, incomingPath, incomingDocument := source(item)
+		if index, ok := indexes[itemKey]; ok {
+			if same(out[index], item) {
 				continue
 			}
-			replacement, diag := resolveDiscoveryConflict("Application", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+			existingTier, existingPath, existingDocument := source(out[index])
+			replacement, diag := resolveDiscoveryConflict(kind(item), itemKey, existingTier, existingPath, existingDocument, incomingTier, incomingPath, incomingDocument)
 			if diag != nil {
 				diags = append(diags, *diag)
 			}
@@ -47,8 +58,9 @@ func mergeApplications(base, overlay []discovery.ApplicationFile) ([]discovery.A
 			}
 			continue
 		}
-		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
-			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("Application", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
+		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, itemKey); ok {
+			existingTier, existingPath, existingDocument := source(out[index])
+			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict(kind(item), existingKey, itemKey, existingTier, existingPath, existingDocument, incomingTier, incomingPath, incomingDocument)
 			if diag != nil {
 				diags = append(diags, *diag)
 			}
@@ -56,140 +68,54 @@ func mergeApplications(base, overlay []discovery.ApplicationFile) ([]discovery.A
 				delete(indexes, existingKey)
 				removeDiscoveryLooseIndex(looseIndexes, existingKey)
 				out[index] = item
-				addDiscoveryIndex(indexes, looseIndexes, key, index)
+				addDiscoveryIndex(indexes, looseIndexes, itemKey, index)
 			}
 			continue
 		}
-		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
+		addDiscoveryIndex(indexes, looseIndexes, itemKey, len(out))
 		out = append(out, item)
 	}
 	return out, diags
+}
+
+func mergeApplications(base, overlay []discovery.ApplicationFile) ([]discovery.ApplicationFile, []diagnostic.Diagnostic) {
+	return mergeDiscoveryItems(base, overlay,
+		func(item discovery.ApplicationFile) string { return applicationDiscoveryKey(item.Application) },
+		func(discovery.ApplicationFile) string { return "Application" },
+		sameApplicationDiscoveryObject,
+		func(item discovery.ApplicationFile) (discovery.SourceTier, string, int) {
+			return item.Tier, item.Path, item.DocumentIndex
+		})
 }
 
 func mergeApplicationSets(base, overlay []discovery.ApplicationSetFile) ([]discovery.ApplicationSetFile, []diagnostic.Diagnostic) {
-	out := append([]discovery.ApplicationSetFile(nil), base...)
-	indexes := make(map[string]int, len(out))
-	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
-	for i, item := range out {
-		addDiscoveryIndex(indexes, looseIndexes, applicationSetDiscoveryKey(item.ApplicationSet), i)
-	}
-	var diags []diagnostic.Diagnostic
-	for _, item := range overlay {
-		key := applicationSetDiscoveryKey(item.ApplicationSet)
-		if index, ok := indexes[key]; ok {
-			if sameApplicationSetDiscoveryObject(out[index], item) {
-				continue
-			}
-			replacement, diag := resolveDiscoveryConflict("ApplicationSet", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				out[index] = item
-			}
-			continue
-		}
-		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
-			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("ApplicationSet", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				delete(indexes, existingKey)
-				removeDiscoveryLooseIndex(looseIndexes, existingKey)
-				out[index] = item
-				addDiscoveryIndex(indexes, looseIndexes, key, index)
-			}
-			continue
-		}
-		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
-		out = append(out, item)
-	}
-	return out, diags
+	return mergeDiscoveryItems(base, overlay,
+		func(item discovery.ApplicationSetFile) string { return applicationSetDiscoveryKey(item.ApplicationSet) },
+		func(discovery.ApplicationSetFile) string { return "ApplicationSet" },
+		sameApplicationSetDiscoveryObject,
+		func(item discovery.ApplicationSetFile) (discovery.SourceTier, string, int) {
+			return item.Tier, item.Path, item.DocumentIndex
+		})
 }
 
 func mergeProjects(base, overlay []discovery.ProjectFile) ([]discovery.ProjectFile, []diagnostic.Diagnostic) {
-	out := append([]discovery.ProjectFile(nil), base...)
-	indexes := make(map[string]int, len(out))
-	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
-	for i, item := range out {
-		addDiscoveryIndex(indexes, looseIndexes, projectDiscoveryKey(item.Project), i)
-	}
-	var diags []diagnostic.Diagnostic
-	for _, item := range overlay {
-		key := projectDiscoveryKey(item.Project)
-		if index, ok := indexes[key]; ok {
-			if sameProjectDiscoveryObject(out[index], item) {
-				continue
-			}
-			replacement, diag := resolveDiscoveryConflict("AppProject", key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				out[index] = item
-			}
-			continue
-		}
-		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
-			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict("AppProject", existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				delete(indexes, existingKey)
-				removeDiscoveryLooseIndex(looseIndexes, existingKey)
-				out[index] = item
-				addDiscoveryIndex(indexes, looseIndexes, key, index)
-			}
-			continue
-		}
-		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
-		out = append(out, item)
-	}
-	return out, diags
+	return mergeDiscoveryItems(base, overlay,
+		func(item discovery.ProjectFile) string { return projectDiscoveryKey(item.Project) },
+		func(discovery.ProjectFile) string { return "AppProject" },
+		sameProjectDiscoveryObject,
+		func(item discovery.ProjectFile) (discovery.SourceTier, string, int) {
+			return item.Tier, item.Path, item.DocumentIndex
+		})
 }
 
 func mergeSettingsCandidates(base, overlay []discovery.SettingsCandidate) ([]discovery.SettingsCandidate, []diagnostic.Diagnostic) {
-	out := append([]discovery.SettingsCandidate(nil), base...)
-	indexes := make(map[string]int, len(out))
-	looseIndexes := make(map[string]discoveryLooseIndex, len(out))
-	for i, item := range out {
-		addDiscoveryIndex(indexes, looseIndexes, settingsDiscoveryKey(item), i)
-	}
-	var diags []diagnostic.Diagnostic
-	for _, item := range overlay {
-		key := settingsDiscoveryKey(item)
-		if index, ok := indexes[key]; ok {
-			if sameSettingsDiscoveryObject(out[index], item) {
-				continue
-			}
-			replacement, diag := resolveDiscoveryConflict(settingsObjectKind(item.Kind), key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				out[index] = item
-			}
-			continue
-		}
-		if index, existingKey, ok := namespaceDefaultedConflict(indexes, looseIndexes, key); ok {
-			replacement, diag := resolveNamespaceDefaultedDiscoveryConflict(settingsObjectKind(item.Kind), existingKey, key, out[index].Tier, out[index].Path, out[index].DocumentIndex, item.Tier, item.Path, item.DocumentIndex)
-			if diag != nil {
-				diags = append(diags, *diag)
-			}
-			if replacement {
-				delete(indexes, existingKey)
-				removeDiscoveryLooseIndex(looseIndexes, existingKey)
-				out[index] = item
-				addDiscoveryIndex(indexes, looseIndexes, key, index)
-			}
-			continue
-		}
-		addDiscoveryIndex(indexes, looseIndexes, key, len(out))
-		out = append(out, item)
-	}
-	return out, diags
+	return mergeDiscoveryItems(base, overlay,
+		settingsDiscoveryKey,
+		func(item discovery.SettingsCandidate) string { return settingsObjectKind(item.Kind) },
+		sameSettingsDiscoveryObject,
+		func(item discovery.SettingsCandidate) (discovery.SourceTier, string, int) {
+			return item.Tier, item.Path, item.DocumentIndex
+		})
 }
 
 type discoveryLooseIndex struct {

--- a/internal/cache/metadata.go
+++ b/internal/cache/metadata.go
@@ -100,7 +100,7 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return err

--- a/internal/change/detect.go
+++ b/internal/change/detect.go
@@ -151,12 +151,12 @@ func regularFilesChanged(basePath, currentPath string, baseInfo, currentInfo fs.
 	if err != nil {
 		return false, err
 	}
-	defer base.Close()
+	defer func() { _ = base.Close() }()
 	current, err := os.Open(currentPath)
 	if err != nil {
 		return false, err
 	}
-	defer current.Close()
+	defer func() { _ = current.Close() }()
 	equal, err := streamcmp.Equal(base, current)
 	if err != nil {
 		return false, err

--- a/internal/chart/repository.go
+++ b/internal/chart/repository.go
@@ -80,7 +80,7 @@ func (acquirer DefaultAcquirer) Acquire(ctx context.Context, request Request, op
 	if err != nil {
 		return Result{}, fmt.Errorf("create temporary chart cache %s: %w", keyParent, err)
 	}
-	defer os.RemoveAll(tmpKeyDir)
+	defer func() { _ = os.RemoveAll(tmpKeyDir) }()
 
 	tmpChartDir := filepath.Join(tmpKeyDir, request.Name)
 	if err := extractChartArchive(bytes.NewReader(archive), tmpChartDir, request.Name); err != nil {

--- a/internal/chart/repository_archive.go
+++ b/internal/chart/repository_archive.go
@@ -18,7 +18,7 @@ func extractChartArchive(r io.Reader, dest, chartName string) error {
 	if err != nil {
 		return fmt.Errorf("open chart archive gzip: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	tr := tar.NewReader(gz)
 	for {
@@ -114,7 +114,7 @@ func chartArchiveContainsNamedChart(r io.Reader, name string) bool {
 	if err != nil {
 		return false
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 	tr := tar.NewReader(gz)
 	want := path.Join(name, "Chart.yaml")
 	for {

--- a/internal/chart/repository_http.go
+++ b/internal/chart/repository_http.go
@@ -43,7 +43,7 @@ func (acquirer DefaultAcquirer) fetchHTTPChart(ctx context.Context, request Requ
 	if err != nil {
 		return nil, fmt.Errorf("fetch chart repository index %s: %s", redactedIndexURL, redactedChartCredentialError(redactedFetchError(err, indexURL, false), credentials))
 	}
-	defer indexResponse.Body.Close()
+	defer func() { _ = indexResponse.Body.Close() }()
 	if indexResponse.StatusCode == http.StatusUnauthorized || indexResponse.StatusCode == http.StatusForbidden {
 		return nil, fmt.Errorf("fetch chart repository index %s: HTTP %s", redactedIndexURL, indexResponse.Status)
 	}
@@ -71,7 +71,7 @@ func (acquirer DefaultAcquirer) fetchHTTPChart(ctx context.Context, request Requ
 	if err != nil {
 		return nil, fmt.Errorf("fetch chart archive %s: %s", redactedChartURL, redactedChartCredentialError(redactedFetchError(err, chartURL, true), credentials))
 	}
-	defer archiveResponse.Body.Close()
+	defer func() { _ = archiveResponse.Body.Close() }()
 	if archiveResponse.StatusCode == http.StatusUnauthorized || archiveResponse.StatusCode == http.StatusForbidden {
 		return nil, fmt.Errorf("fetch chart archive %s: HTTP %s", redactedChartURL, archiveResponse.Status)
 	}

--- a/internal/chart/repository_oci.go
+++ b/internal/chart/repository_oci.go
@@ -83,7 +83,7 @@ func (puller HelmOCIPuller) Pull(ctx context.Context, request Request, opts Opti
 	if err != nil {
 		return nil, fmt.Errorf("create temporary OCI chart directory: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	registryConfig := strings.TrimSpace(opts.Credentials.RegistryConfig)
 	if registryConfig == "" {

--- a/internal/chart/repository_test.go
+++ b/internal/chart/repository_test.go
@@ -31,7 +31,7 @@ func TestDefaultAcquirerFetchesHTTPChartAndCachesIt(t *testing.T) {
 		switch r.URL.Path {
 		case "/index.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
-			fmt.Fprintf(w, `apiVersion: v1
+			_, _ = fmt.Fprintf(w, `apiVersion: v1
 entries:
   demo:
     - version: 1.2.3
@@ -95,7 +95,7 @@ func TestDefaultAcquirerWritesChartMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.yaml":
-			fmt.Fprintf(w, `apiVersion: v1
+			_, _ = fmt.Fprintf(w, `apiVersion: v1
 entries:
   demo:
     - version: 1.2.3
@@ -139,7 +139,7 @@ func TestDefaultAcquirerWritesChartMetadataOnCacheHit(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.yaml":
-			fmt.Fprintf(w, `apiVersion: v1
+			_, _ = fmt.Fprintf(w, `apiVersion: v1
 entries:
   demo:
     - version: 1.2.3
@@ -316,7 +316,7 @@ func TestDefaultAcquirerUsesExactSemverChartVersion(t *testing.T) {
 		switch r.URL.Path {
 		case "/index.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
-			fmt.Fprint(w, `apiVersion: v1
+			_, _ = fmt.Fprint(w, `apiVersion: v1
 entries:
   demo:
     - version: 1.2.10
@@ -357,7 +357,7 @@ func TestDefaultAcquirerAcceptsLeadingVSemverChartVersion(t *testing.T) {
 		switch r.URL.Path {
 		case "/index.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
-			fmt.Fprint(w, `apiVersion: v1
+			_, _ = fmt.Fprint(w, `apiVersion: v1
 entries:
   demo:
     - version: 1.2.3
@@ -1151,7 +1151,7 @@ func writeIndex(t *testing.T, w http.ResponseWriter, chartURL string) {
 func writeIndexFor(t *testing.T, w http.ResponseWriter, chartName, chartURL string) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/yaml")
-	fmt.Fprintf(w, `apiVersion: v1
+	_, _ = fmt.Fprintf(w, `apiVersion: v1
 entries:
   %q:
     - version: 1.2.3

--- a/internal/cli/plugin_policy.go
+++ b/internal/cli/plugin_policy.go
@@ -476,7 +476,7 @@ func atomicWritePluginPolicyFile(target string, data []byte) error {
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return err

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -320,7 +320,7 @@ func decodeYAMLDocumentAt(path string, documentIndex int, out any) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	decoder := yaml.NewDecoder(file)
 	for index := 0; ; index++ {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -191,7 +191,7 @@ func scanYAMLFile(path, rel string, result *Result) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	docs, err := manifest.DecodeDocuments(path, file)
 	if err != nil {

--- a/internal/filecopy/filecopy.go
+++ b/internal/filecopy/filecopy.go
@@ -22,14 +22,14 @@ func CopyRegularFile(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	tmp, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".tmp-")
 	if err != nil {
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := io.Copy(tmp, in); err != nil {
 		_ = tmp.Close()
 		return err

--- a/internal/gitref/changes.go
+++ b/internal/gitref/changes.go
@@ -280,7 +280,7 @@ func regularWorktreeFileChanged(path string, file *object.File) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer worktreeFile.Close()
+	defer func() { _ = worktreeFile.Close() }()
 	hasher := plumbing.NewHasher(plumbing.BlobObject, info.Size())
 	if _, err := io.Copy(hasher, worktreeFile); err != nil {
 		return false, err

--- a/internal/gitref/snapshot.go
+++ b/internal/gitref/snapshot.go
@@ -215,7 +215,7 @@ func writeSnapshotFile(target string, file *object.File) error {
 	if err != nil {
 		return err
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	mode := os.FileMode(0o644)
 	if file.Mode == filemode.Executable {

--- a/internal/ociartifact/records.go
+++ b/internal/ociartifact/records.go
@@ -80,7 +80,7 @@ func writeTagRecord(cacheDir, repoURL string, record tagRecord) {
 		return
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return

--- a/internal/pluginonboarding/sidecar.go
+++ b/internal/pluginonboarding/sidecar.go
@@ -54,7 +54,7 @@ func sidecarCandidatesFromFile(root, path string) ([]SidecarCandidate, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	data, err := io.ReadAll(file)
 	if err != nil {

--- a/internal/remote/http.go
+++ b/internal/remote/http.go
@@ -94,7 +94,7 @@ func (acquirer DefaultAcquirer) fetch(ctx context.Context, normalizedURL string,
 	if err != nil {
 		return nil, fmt.Errorf("fetch remote resource %s: %s", RedactURL(normalizedURL), redactFetchError(err, normalizedURL, credentials))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch remote resource %s: HTTP %s", RedactURL(normalizedURL), resp.Status)
 	}
@@ -124,7 +124,7 @@ func publishCacheFile(path string, data []byte) error {
 		return fmt.Errorf("create temporary remote resource cache file: %w", err)
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return err

--- a/internal/render/helm_dependencies.go
+++ b/internal/render/helm_dependencies.go
@@ -60,11 +60,11 @@ func prepareHelmDependencyWorkspace(ctx context.Context, chartPath, chartSourceP
 			Credentials:     opts.ChartCredentials,
 		})
 		if err != nil {
-			recordHelmDependencyChartCacheEvent(opts, request, err, chart.Result{})
+			recordChartCacheEvent(opts, request, err, chart.Result{})
 			cleanup()
 			return nil, nil, fmt.Errorf("acquire helm chart dependency %s: %s", request.Name, redactKustomizeChartAcquireError(err, request.Repository, opts.ChartCredentials))
 		}
-		recordHelmDependencyChartCacheEvent(opts, request, nil, result)
+		recordChartCacheEvent(opts, request, nil, result)
 
 		dst, err := replaceHelmDependencyChartTargets(tempChartPath, request.Name)
 		if err != nil {
@@ -325,7 +325,7 @@ func helmChartVersion(chrt helmchart.Charter) string {
 	return chart.Metadata.Version
 }
 
-func recordHelmDependencyChartCacheEvent(opts RenderOptions, request chart.Request, acquireErr error, acquired chart.Result) {
+func recordChartCacheEvent(opts RenderOptions, request chart.Request, acquireErr error, acquired chart.Result) {
 	if acquireErr == nil && opts.AcquisitionCollector != nil {
 		opts.AcquisitionCollector.Record(cacheevent.AcquisitionRecord{
 			Kind:              cacheevent.AcquisitionChart,

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -273,10 +273,10 @@ func resolveKustomizeHelmChart(ctx context.Context, tempRepoRoot, tempSourceRoot
 		Credentials:    opts.ChartCredentials,
 	})
 	if err != nil {
-		recordKustomizeChartCacheEvent(opts, request, err, chart.Result{})
+		recordChartCacheEvent(opts, request, err, chart.Result{})
 		return "", fmt.Errorf("acquire kustomize helm chart %s: %s", helmChart.Name, redactKustomizeChartAcquireError(err, request.Repository, opts.ChartCredentials))
 	}
-	recordKustomizeChartCacheEvent(opts, request, nil, result)
+	recordChartCacheEvent(opts, request, nil, result)
 
 	chartRel := filepath.ToSlash(filepath.Join(".drydock", "charts", generatedName))
 	chartDst, err := generatedKustomizeWorkspacePath(tempRepoRoot, chartRel)
@@ -287,36 +287,6 @@ func resolveKustomizeHelmChart(ctx context.Context, tempRepoRoot, tempSourceRoot
 		return "", fmt.Errorf("copy acquired helm chart %s: %w", helmChart.Name, err)
 	}
 	return chartRel, nil
-}
-
-func recordKustomizeChartCacheEvent(opts RenderOptions, request chart.Request, acquireErr error, acquired chart.Result) {
-	if acquireErr == nil && opts.AcquisitionCollector != nil {
-		opts.AcquisitionCollector.Record(cacheevent.AcquisitionRecord{
-			Kind:              cacheevent.AcquisitionChart,
-			RequestedRevision: request.Version,
-			ResolvedRevision:  acquired.Version,
-		})
-	}
-	if opts.CacheEventRecorder == nil {
-		return
-	}
-	input := cacheevent.AcquisitionEventInput{
-		Source:            cacheevent.SourceChart,
-		Target:            request.Repository,
-		RequestedRevision: request.Version,
-		Offline:           opts.OfflineCharts,
-		Refresh:           opts.RefreshCharts,
-		SensitiveValues:   chartSensitiveValues(opts.ChartCredentials),
-	}
-	if acquireErr != nil {
-		input.Err = acquireErr
-		opts.CacheEventRecorder.Record(cacheevent.NewAcquisitionError(input).Event)
-		return
-	}
-	input.Revision = acquired.Version
-	input.FromCache = acquired.FromCache
-	input.Network = !acquired.FromCache
-	opts.CacheEventRecorder.Record(cacheevent.NewAcquisitionEvent(input))
 }
 
 func redactKustomizeChartAcquireError(err error, repository string, credentials chart.ChartCredentials) string {

--- a/internal/render/kustomize_workspace.go
+++ b/internal/render/kustomize_workspace.go
@@ -42,7 +42,7 @@ func renderKustomizeWithPreparedWorkspace(ctx context.Context, source ResolvedSo
 	if err != nil {
 		return nil, nil, err
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	tempRepoRoot := filepath.Join(tempDir, "repo")
 	root, err := sourceRoot(source)

--- a/scripts/generate-homebrew-formula/main.go
+++ b/scripts/generate-homebrew-formula/main.go
@@ -93,7 +93,7 @@ func readChecksums(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read checksums: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	checksums := map[string]string{}
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
Addresses the production-code issues CodeFactor flags under its default analyzer set, which is holding the repo at an A grade:

- **Unchecked error returns (28 sites)** — cleanup `defer x.Close()` / `defer os.Remove*(...)` calls wrapped as `defer func() { _ = ... }()`, matching the discard idiom already used inline (e.g. `plugin_policy.go`). Test-server `fmt.Fprint*` writers get explicit `_, _ =` discards.
- **Duplicate code** —
  - `internal/app/discovery_merge.go`: the four per-type merge functions (Applications / ApplicationSets / Projects / SettingsCandidates) were identical except for key/kind/equality plumbing; collapsed into a generic `mergeDiscoveryItems` with thin typed wrappers.
  - `internal/render`: `recordHelmDependencyChartCacheEvent` and `recordKustomizeChartCacheEvent` were byte-identical; unified into `recordChartCacheEvent`.

Remaining CodeFactor duplication findings are table-test scaffolding in `*_test.go` files, intentionally left as-is (to be ignored in the CodeFactor UI rather than churned).

No behavior changes. `go test ./...` passes; `golangci-lint` clean under both the repo config and defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)