### PR TITLE
feat(report): collapse markdown warnings, aggregate repeated codes, add --markdown-diagnostics

### DIFF
--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -342,7 +342,11 @@ and omits unchanged images by default. `diff images -o name` prints current-only
 added image references, one per line. Removed-only image changes print no names
 but still count as a diff for exit-code semantics unless `--exit-code=false`.
 Diagnostics stay on stderr for structured/name/unified diff output. Markdown
-diff output embeds successful diagnostics in the markdown document. `-o name`
+diff output embeds successful diagnostics in the markdown document: errors are
+listed openly, warnings collapse inside a `<details>` block, and repeated
+diagnostic codes aggregate with counts. `--markdown-diagnostics all|errors|none`
+narrows or drops the embedded list without touching summary counts or
+non-markdown diagnostics surfaces. `-o name`
 remains unsupported for `diff apps` and `diff app`.
 
 Application-local and global ignore rules support `jsonPointers`,

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -343,7 +343,8 @@ added image references, one per line. Removed-only image changes print no names
 but still count as a diff for exit-code semantics unless `--exit-code=false`.
 Diagnostics stay on stderr for structured/name/unified diff output. Markdown
 diff output embeds successful diagnostics in the markdown document: errors are
-listed openly, warnings collapse inside a `<details>` block, and repeated
+listed openly above the diffs, warnings collapse inside a `<details>` block
+rendered below the diffs, and repeated
 diagnostic codes aggregate with counts. `--markdown-diagnostics all|errors|none`
 narrows or drops the embedded list without touching summary counts or
 non-markdown diagnostics surfaces. `-o name`

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -47,7 +47,7 @@ func TestRepresentativeCommandsExposeFocusedFlagGroups(t *testing.T) {
 		{
 			name:    "diff apps common specialized diff flags",
 			command: []string{"diff", "apps"},
-			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "project-diagnostics", "ref-orig", "show-ignored-fields"},
+			flags:   []string{"offline", "repo-map", "plugin-cache-dir", "appset-provider-fixture", "skip-kind", "project-diagnostics", "ref-orig", "show-ignored-fields", "markdown-diagnostics"},
 		},
 		{
 			name:    "test apps common specialized lua flag",

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -41,6 +41,7 @@ func newDiffAppsCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appsColor := diffColorAuto
 	appsMarkdownMaxBytes := report.DefaultMaxBytes
+	appsMarkdownDiagnostics := string(report.DiagnosticsModeAll)
 	appsRawOutputFile := ""
 	appsHTMLOutputFile := ""
 	apps := &cobra.Command{
@@ -52,7 +53,8 @@ func newDiffAppsCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateDiffMarkdownFlags(output, appsMarkdownMaxBytes); err != nil {
+			markdownDiagnostics, err := parseDiffMarkdownFlags(output, appsMarkdownMaxBytes, appsMarkdownDiagnostics)
+			if err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(appsColor)
@@ -72,7 +74,7 @@ func newDiffAppsCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor, appsRawOutputFile, appsHTMLOutputFile, appsMarkdownMaxBytes)
+			return renderDiffResult(cmd, result, !appsFlags.exitCode, output, diffColor, diagnosticColor, appsRawOutputFile, appsHTMLOutputFile, appsMarkdownMaxBytes, markdownDiagnostics)
 		},
 	}
 	bindCommonFlags(apps, &appsFlags)
@@ -84,7 +86,7 @@ func newDiffAppsCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	bindChangedOnlyPathFilterFlags(apps, &appsFlags)
 	bindShowIgnoredFieldsFlag(apps, &appsFlags)
 	bindDiffColorFlag(apps, &appsColor)
-	bindDiffReportFileFlags(apps, &appsMarkdownMaxBytes, &appsRawOutputFile, &appsHTMLOutputFile)
+	bindDiffReportFileFlags(apps, &appsMarkdownMaxBytes, &appsMarkdownDiagnostics, &appsRawOutputFile, &appsHTMLOutputFile)
 
 	return apps
 }
@@ -95,6 +97,7 @@ func newDiffAppCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	appFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appColor := diffColorAuto
 	appMarkdownMaxBytes := report.DefaultMaxBytes
+	appMarkdownDiagnostics := string(report.DiagnosticsModeAll)
 	appRawOutputFile := ""
 	appHTMLOutputFile := ""
 	appCmd := &cobra.Command{
@@ -106,7 +109,8 @@ func newDiffAppCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateDiffMarkdownFlags(output, appMarkdownMaxBytes); err != nil {
+			markdownDiagnostics, err := parseDiffMarkdownFlags(output, appMarkdownMaxBytes, appMarkdownDiagnostics)
+			if err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(appColor)
@@ -129,7 +133,7 @@ func newDiffAppCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor, appRawOutputFile, appHTMLOutputFile, appMarkdownMaxBytes)
+			return renderDiffResult(cmd, result, !appFlags.exitCode, output, diffColor, diagnosticColor, appRawOutputFile, appHTMLOutputFile, appMarkdownMaxBytes, markdownDiagnostics)
 		},
 	}
 	bindCommonFlags(appCmd, &appFlags)
@@ -140,7 +144,7 @@ func newDiffAppCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	bindDiffRefFlags(appCmd, &appFlags)
 	bindShowIgnoredFieldsFlag(appCmd, &appFlags)
 	bindDiffColorFlag(appCmd, &appColor)
-	bindDiffReportFileFlags(appCmd, &appMarkdownMaxBytes, &appRawOutputFile, &appHTMLOutputFile)
+	bindDiffReportFileFlags(appCmd, &appMarkdownMaxBytes, &appMarkdownDiagnostics, &appRawOutputFile, &appHTMLOutputFile)
 
 	return appCmd
 }
@@ -151,6 +155,7 @@ func newDiffImagesCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	imagesFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	imagesColor := diffColorAuto
 	imagesMarkdownMaxBytes := report.DefaultMaxBytes
+	imagesMarkdownDiagnostics := string(report.DiagnosticsModeAll)
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "Diff rendered image references",
@@ -160,7 +165,8 @@ func newDiffImagesCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateDiffMarkdownFlags(output, imagesMarkdownMaxBytes); err != nil {
+			markdownDiagnostics, err := parseDiffMarkdownFlags(output, imagesMarkdownMaxBytes, imagesMarkdownDiagnostics)
+			if err != nil {
 				return err
 			}
 			colorMode, err := parseDiffColorMode(imagesColor)
@@ -180,7 +186,7 @@ func newDiffImagesCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 				return err
 			}
 			diffColor := output == diffOutputUnified && shouldColorDiffOutput(colorMode, deps, cmd.OutOrStdout())
-			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output, diffColor, diagnosticColor, imagesMarkdownMaxBytes)
+			return renderImageDiffResult(cmd, result, !imagesFlags.exitCode, output, diffColor, diagnosticColor, imagesMarkdownMaxBytes, markdownDiagnostics)
 		},
 	}
 	bindCommonFlags(images, &imagesFlags)
@@ -192,6 +198,7 @@ func newDiffImagesCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	bindChangedOnlyPathFilterFlags(images, &imagesFlags)
 	bindDiffColorFlag(images, &imagesColor)
 	bindDiffMarkdownMaxBytesFlag(images, &imagesMarkdownMaxBytes)
+	bindDiffMarkdownDiagnosticsFlag(images, &imagesMarkdownDiagnostics)
 
 	return images
 }
@@ -210,8 +217,9 @@ func bindDiffColorFlag(cmd *cobra.Command, colorMode *string) {
 	cmd.Flags().StringVar(colorMode, "color", *colorMode, "color diff output: auto, always, or never")
 }
 
-func bindDiffReportFileFlags(cmd *cobra.Command, markdownMaxBytes *int, rawOutputFile, htmlOutputFile *string) {
+func bindDiffReportFileFlags(cmd *cobra.Command, markdownMaxBytes *int, markdownDiagnostics *string, rawOutputFile, htmlOutputFile *string) {
 	bindDiffMarkdownMaxBytesFlag(cmd, markdownMaxBytes)
+	bindDiffMarkdownDiagnosticsFlag(cmd, markdownDiagnostics)
 	cmd.Flags().StringVar(rawOutputFile, "raw-output-file", *rawOutputFile, "write full uncolored unified diff output to this file")
 	cmd.Flags().StringVar(htmlOutputFile, "html-output-file", *htmlOutputFile, "write full static HTML diff report to this file")
 }
@@ -221,17 +229,25 @@ func bindDiffMarkdownMaxBytesFlag(cmd *cobra.Command, markdownMaxBytes *int) {
 		fmt.Sprintf("maximum markdown output bytes; 0 disables the limit, positive values must be at least %d", report.MinPositiveMaxByte))
 }
 
-func validateDiffMarkdownFlags(output string, markdownMaxBytes int) error {
+func bindDiffMarkdownDiagnosticsFlag(cmd *cobra.Command, markdownDiagnostics *string) {
+	cmd.Flags().StringVar(markdownDiagnostics, "markdown-diagnostics", *markdownDiagnostics,
+		"markdown report diagnostics detail: all (errors open, warnings collapsed), errors, or none")
+}
+
+// parseDiffMarkdownFlags validates the markdown-only flags and returns the
+// parsed diagnostics mode; non-markdown outputs skip validation and get the
+// default mode because the report is never rendered.
+func parseDiffMarkdownFlags(output string, markdownMaxBytes int, markdownDiagnostics string) (report.DiagnosticsMode, error) {
 	if output != diffOutputMarkdown {
-		return nil
+		return report.DiagnosticsModeAll, nil
 	}
 	if markdownMaxBytes < 0 {
-		return fmt.Errorf("markdown max bytes must be greater than or equal to zero")
+		return "", fmt.Errorf("markdown max bytes must be greater than or equal to zero")
 	}
 	if markdownMaxBytes > 0 && markdownMaxBytes < report.MinPositiveMaxByte {
-		return fmt.Errorf("markdown max bytes must be zero or at least %d", report.MinPositiveMaxByte)
+		return "", fmt.Errorf("markdown max bytes must be zero or at least %d", report.MinPositiveMaxByte)
 	}
-	return nil
+	return report.ParseDiagnosticsMode(markdownDiagnostics)
 }
 
 func parseDiffColorMode(value string) (string, error) {
@@ -258,11 +274,11 @@ func shouldColorDiffOutput(mode string, deps Dependencies, w io.Writer) bool {
 	}
 }
 
-func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile, htmlOutputFile string, markdownMaxBytes int) error {
+func renderDiffResult(cmd *cobra.Command, result app.DiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, rawOutputFile, htmlOutputFile string, markdownMaxBytes int, markdownDiagnostics report.DiagnosticsMode) error {
 	if err := writeDiffSideOutputs(cmd.ErrOrStderr(), result, output, diagnosticColor, rawOutputFile, htmlOutputFile); err != nil {
 		return err
 	}
-	if err := writeDiffCommandOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes); err != nil {
+	if err := writeDiffCommandOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes, markdownDiagnostics); err != nil {
 		return err
 	}
 	return diffResultExitError(result, disableDiffExitCode)
@@ -287,12 +303,12 @@ func writeDiffSideOutputs(stderr io.Writer, result app.DiffResult, output string
 	return nil
 }
 
-func writeDiffCommandOutput(w io.Writer, result app.DiffResult, output string, diffColor bool, markdownMaxBytes int) error {
+func writeDiffCommandOutput(w io.Writer, result app.DiffResult, output string, diffColor bool, markdownMaxBytes int, markdownDiagnostics report.DiagnosticsMode) error {
 	switch output {
 	case diffOutputUnified:
 		return writeUnifiedDiffOutput(w, result, diffColor)
 	case diffOutputMarkdown:
-		_, err := report.WriteDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes})
+		_, err := report.WriteDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes, Diagnostics: markdownDiagnostics})
 		return err
 	case string(cliformat.OutputJSON), string(cliformat.OutputYAML):
 		return writeStructuredOutput(w, output, result.Results)
@@ -333,13 +349,13 @@ func writeHTMLDiffOutput(path string, result app.DiffResult) error {
 	return nil
 }
 
-func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, markdownMaxBytes int) error {
+func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disableDiffExitCode bool, output string, diffColor, diagnosticColor bool, markdownMaxBytes int, markdownDiagnostics report.DiagnosticsMode) error {
 	if output != diffOutputMarkdown {
 		if err := renderDiagnosticsWithColor(cmd.ErrOrStderr(), result.Diagnostics, diagnosticColor); err != nil {
 			return err
 		}
 	}
-	if err := writeImageDiffOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes); err != nil {
+	if err := writeImageDiffOutput(cmd.OutOrStdout(), result, output, diffColor, markdownMaxBytes, markdownDiagnostics); err != nil {
 		return err
 	}
 	code := exitCode(nil, disableDiffExitCode, len(result.Added) > 0 || len(result.Removed) > 0)
@@ -349,7 +365,7 @@ func renderImageDiffResult(cmd *cobra.Command, result app.ImageDiffResult, disab
 	return nil
 }
 
-func writeImageDiffOutput(w io.Writer, result app.ImageDiffResult, output string, diffColor bool, markdownMaxBytes int) error {
+func writeImageDiffOutput(w io.Writer, result app.ImageDiffResult, output string, diffColor bool, markdownMaxBytes int, markdownDiagnostics report.DiagnosticsMode) error {
 	switch output {
 	case diffOutputUnified:
 		return writeUnifiedImageDiff(w, result, diffColor)
@@ -363,7 +379,7 @@ func writeImageDiffOutput(w io.Writer, result app.ImageDiffResult, output string
 	case string(cliformat.OutputName):
 		return cliformat.Name(w, result.Added)
 	case diffOutputMarkdown:
-		_, err := report.WriteImageDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes})
+		_, err := report.WriteImageDiffMarkdown(w, result, report.MarkdownOptions{MaxBytes: markdownMaxBytes, Diagnostics: markdownDiagnostics})
 		return err
 	default:
 		return fmt.Errorf("unsupported output %q for diff images", output)

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -164,7 +164,7 @@ func TestDiffAppsMarkdownOutput(t *testing.T) {
 	assertStdoutContainsAll(t, result,
 		"## drydock diff",
 		"**Summary:** 1 app, 1 resource, +1/-1, 1 warning.",
-		"Diagnostics:",
+		"<summary>Diagnostics (1 warning)</summary>",
 		"&lt;tag&gt;",
 		"<details open>",
 		"<summary>argocd/demo",
@@ -320,6 +320,80 @@ func TestDiffAppsMarkdownRejectsInvalidMaxBytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDiffAppsMarkdownDiagnosticsModeNone(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffAppsResult: app.DiffResult{
+			Results: []diff.Result{{
+				Parent: diff.Parent{Namespace: "argocd", Name: "demo"},
+				Diff:   sampleUnifiedDiffForCLI(),
+			}},
+			Diagnostics: []diagnostic.Diagnostic{{
+				Severity: diagnostic.SeverityWarning,
+				Category: "render",
+				Message:  "noisy placeholder warning",
+			}},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--markdown-diagnostics", "none", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"## drydock diff",
+		"**Summary:** 1 app, 1 resource, +1/-1, 1 warning.",
+	)
+	assertStdoutExcludesAll(t, result, "noisy placeholder warning", "<summary>Diagnostics")
+}
+
+func TestDiffAppsMarkdownRejectsInvalidDiagnosticsMode(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{}
+	cmd := NewRootCommandWithDependencies(VersionInfo{}, Dependencies{
+		Orchestrator: recorder,
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"diff", "apps", "--path-orig", "left", "--path", "right", "-o", "markdown", "--markdown-diagnostics", "verbose", "--exit-code=false"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want invalid markdown diagnostics error")
+	}
+	if !strings.Contains(err.Error(), "markdown diagnostics must be all, errors, or none") {
+		t.Fatalf("Execute() error = %v, want markdown diagnostics mode error", err)
+	}
+	if len(recorder.diffAppsRequests) != 0 {
+		t.Fatalf("DiffApps requests = %#v, want none before invalid markdown diagnostics error", recorder.diffAppsRequests)
+	}
+}
+
+func TestDiffImagesMarkdownDiagnosticsModeErrors(t *testing.T) {
+	recorder := &recordingCLIOrchestrator{
+		diffImagesResult: app.ImageDiffResult{
+			Added: []string{"example/app:v2"},
+			Diagnostics: []diagnostic.Diagnostic{
+				{
+					Severity: diagnostic.SeverityWarning,
+					Category: "render",
+					Message:  "noisy placeholder warning",
+				},
+				{
+					Severity: diagnostic.SeverityError,
+					Category: "render",
+					Message:  "render exploded",
+				},
+			},
+		},
+	}
+
+	result := runCLIWithDependencies(t, Dependencies{Orchestrator: recorder}, "diff", "images", "--path-orig", "left", "--path", "right", "-o", "markdown", "--markdown-diagnostics", "errors", "--exit-code=false")
+
+	assertStdoutContainsAll(t, result,
+		"## drydock image diff",
+		"render exploded",
+	)
+	assertStdoutExcludesAll(t, result, "noisy placeholder warning")
 }
 
 func TestDiffAppsColorNeverKeepsTTYOutputPlain(t *testing.T) {
@@ -971,7 +1045,7 @@ func TestDiffImagesMarkdownOutput(t *testing.T) {
 	assertStdoutContainsAll(t, result,
 		"## drydock image diff",
 		"**Summary:** 1 added, 1 removed, 1 warning.",
-		"Diagnostics:",
+		"<summary>Diagnostics (1 warning)</summary>",
 		"&lt;tag&gt;",
 		"| Change | Image |",
 		"| added | `example/app:v2` |",

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -49,6 +49,7 @@ func TestNonDiffLeafHelpOmitsDiffOnlyFlags(t *testing.T) {
 			"--show-ignored-fields",
 			"--color",
 			"--markdown-max-bytes",
+			"--markdown-diagnostics",
 			"--raw-output-file",
 			"--ref-orig",
 		)
@@ -79,6 +80,7 @@ func TestDiffAppsHelpIncludesDiffFlags(t *testing.T) {
 		"--show-ignored-fields",
 		"--color",
 		"--markdown-max-bytes",
+		"--markdown-diagnostics",
 		"--raw-output-file",
 		"--ref-orig",
 	)

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -25,6 +25,45 @@ type MarkdownOptions struct {
 	MaxBytes        int
 	DiagnosticLimit int
 	Title           string
+	Diagnostics     DiagnosticsMode
+}
+
+// DiagnosticsMode controls how much of the diagnostics list the markdown
+// report embeds. Summary warning/error counts are always kept.
+type DiagnosticsMode string
+
+const (
+	// DiagnosticsModeAll lists errors openly and collapses warnings inside a
+	// <details> block.
+	DiagnosticsModeAll DiagnosticsMode = "all"
+	// DiagnosticsModeErrors lists errors openly and omits warnings entirely.
+	DiagnosticsModeErrors DiagnosticsMode = "errors"
+	// DiagnosticsModeNone omits the diagnostics section entirely.
+	DiagnosticsModeNone DiagnosticsMode = "none"
+)
+
+func ParseDiagnosticsMode(value string) (DiagnosticsMode, error) {
+	mode := DiagnosticsMode(strings.ToLower(strings.TrimSpace(value))).Normalize()
+	if err := mode.Validate(); err != nil {
+		return "", err
+	}
+	return mode, nil
+}
+
+func (mode DiagnosticsMode) Normalize() DiagnosticsMode {
+	if mode == "" {
+		return DiagnosticsModeAll
+	}
+	return mode
+}
+
+func (mode DiagnosticsMode) Validate() error {
+	switch mode.Normalize() {
+	case DiagnosticsModeAll, DiagnosticsModeErrors, DiagnosticsModeNone:
+		return nil
+	default:
+		return fmt.Errorf("markdown diagnostics must be all, errors, or none, got %q", string(mode))
+	}
 }
 
 type MarkdownResult struct {
@@ -78,13 +117,20 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 	if strings.TrimSpace(options.Title) == "" {
 		options.Title = "drydock diff"
 	}
+	diagnosticsMode := options.Diagnostics.Normalize()
+	if err := diagnosticsMode.Validate(); err != nil {
+		return nil, MarkdownResult{}, err
+	}
 
 	groups := groupedDiffs(result.Results)
 	totalAdded, totalRemoved := totalLineChanges(groups)
 	state := markdownState{maxBytes: options.MaxBytes}
 	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
 	state.appendRequired(summaryMarkdown(len(result.Results), len(groups), totalAdded, totalRemoved, result.Diagnostics))
-	state.appendBounded(diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit))
+	errorsPart, warningsPart := diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit, diagnosticsMode)
+	if state.appendBounded(errorsPart) {
+		state.appendBounded(warningsPart)
+	}
 	if len(groups) == 0 {
 		state.appendBounded(noDiffMarkdown())
 	} else {
@@ -115,12 +161,19 @@ func ImageDiffMarkdown(result app.ImageDiffResult, options MarkdownOptions) ([]b
 	if strings.TrimSpace(options.Title) == "" {
 		options.Title = "drydock image diff"
 	}
+	diagnosticsMode := options.Diagnostics.Normalize()
+	if err := diagnosticsMode.Validate(); err != nil {
+		return nil, MarkdownResult{}, err
+	}
 
 	rows := imageDiffRows(result)
 	state := markdownState{maxBytes: options.MaxBytes}
 	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
 	state.appendRequired(imageSummaryMarkdown(len(result.Added), len(result.Removed), result.Diagnostics))
-	state.appendBounded(diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit))
+	errorsPart, warningsPart := diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit, diagnosticsMode)
+	if state.appendBounded(errorsPart) {
+		state.appendBounded(warningsPart)
+	}
 	if len(rows) == 0 {
 		state.appendBounded(noImageDiffMarkdown())
 	} else {
@@ -157,15 +210,16 @@ func (s *markdownState) appendRequired(text string) {
 	s.truncated = true
 }
 
-func (s *markdownState) appendBounded(text string) {
+func (s *markdownState) appendBounded(text string) bool {
 	if text == "" {
-		return
+		return true
 	}
 	if s.maxBytes == 0 || s.buffer.Len()+len(text) <= s.maxBytes {
 		s.buffer.WriteString(text)
-		return
+		return true
 	}
 	s.truncated = true
+	return false
 }
 
 func (s *markdownState) appendAppDetails(groups []appGroup, openDetails bool) {
@@ -373,38 +427,161 @@ func diagnosticCounts(diagnostics []diagnostic.Diagnostic) (int, int) {
 	return warnings, errors
 }
 
-func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int) string {
-	if len(diagnostics) == 0 {
-		return ""
+// diagnosticEntry is one distinct rendered diagnostic line; count carries how
+// many identical diagnostics it represents.
+type diagnosticEntry struct {
+	body  string
+	count int
+}
+
+// diagnosticGroup collects diagnostics sharing one stable code so repeated
+// codes render as a single aggregated bullet.
+type diagnosticGroup struct {
+	code     string
+	category string
+	severity diagnostic.Severity
+	entries  []diagnosticEntry
+	total    int
+}
+
+// diagnosticsMarkdown renders the diagnostics section as two independently
+// appendable parts: errors stay openly listed, warnings collapse inside a
+// <details> block so PR comments lead with the diffs.
+func diagnosticsMarkdown(diagnostics []diagnostic.Diagnostic, limit int, mode DiagnosticsMode) (string, string) {
+	if len(diagnostics) == 0 || mode == DiagnosticsModeNone {
+		return "", ""
 	}
-	var builder strings.Builder
-	builder.WriteString("Diagnostics:\n")
-	shown := min(limit, len(diagnostics))
-	for _, diag := range diagnostics[:shown] {
-		builder.WriteString("- ")
-		builder.WriteString(escapeMarkdownText(string(diag.Severity)))
-		builder.WriteString(" ")
-		if diag.Category != "" {
-			builder.WriteString("`")
-			builder.WriteString(escapeCodeSpan(diag.Category))
-			builder.WriteString("` ")
+	var errors, warnings []diagnostic.Diagnostic
+	for _, diag := range diagnostics {
+		if diag.Severity == diagnostic.SeverityError {
+			errors = append(errors, diag)
+		} else {
+			warnings = append(warnings, diag)
 		}
-		builder.WriteString(escapeMarkdownText(singleLine(diag.Message)))
-		if diag.Provenance.Path != "" {
-			builder.WriteString(" (")
-			builder.WriteString(escapeMarkdownText(diag.Provenance.Path))
-			if diag.Provenance.Pointer != "" {
-				builder.WriteString(" ")
-				builder.WriteString(escapeMarkdownText(diag.Provenance.Pointer))
-			}
-			builder.WriteString(")")
-		}
+	}
+
+	remaining := limit
+	var errorsPart string
+	if len(errors) > 0 {
+		var builder strings.Builder
+		builder.WriteString("Diagnostics:\n")
+		remaining = writeDiagnosticList(&builder, groupDiagnostics(errors), remaining)
 		builder.WriteByte('\n')
+		errorsPart = builder.String()
 	}
-	if omitted := len(diagnostics) - shown; omitted > 0 {
-		fmt.Fprintf(&builder, "_... and %d more diagnostics omitted._\n", omitted)
+	if mode == DiagnosticsModeErrors || len(warnings) == 0 {
+		return errorsPart, ""
 	}
+
+	var builder strings.Builder
+	summary := plural(len(warnings), "warning", "warnings")
+	if len(errors) == 0 {
+		summary = "Diagnostics (" + summary + ")"
+	}
+	fmt.Fprintf(&builder, "<details>\n<summary>%s</summary>\n\n", summary)
+	writeDiagnosticList(&builder, groupDiagnostics(warnings), remaining)
+	builder.WriteString("\n</details>\n\n")
+	return errorsPart, builder.String()
+}
+
+// groupDiagnostics buckets diagnostics by stable code in first-seen order and
+// dedupes identical rendered bodies within each bucket.
+func groupDiagnostics(diagnostics []diagnostic.Diagnostic) []diagnosticGroup {
+	groups := make([]diagnosticGroup, 0, len(diagnostics))
+	index := make(map[string]int, len(diagnostics))
+	for _, diag := range diagnostics {
+		code := diag.Code
+		if code == "" {
+			code = diagnostic.StableCode(diag)
+		}
+		at, ok := index[code]
+		if !ok {
+			at = len(groups)
+			index[code] = at
+			groups = append(groups, diagnosticGroup{code: code, category: diag.Category, severity: diag.Severity})
+		}
+		group := &groups[at]
+		group.total++
+		body := diagnosticBodyMarkdown(diag)
+		deduped := false
+		for i := range group.entries {
+			if group.entries[i].body == body {
+				group.entries[i].count++
+				deduped = true
+				break
+			}
+		}
+		if !deduped {
+			group.entries = append(group.entries, diagnosticEntry{body: body, count: 1})
+		}
+	}
+	return groups
+}
+
+// writeDiagnosticList renders grouped diagnostics as at most limit markdown
+// bullet lines (aggregated group headers included) and returns the unused
+// line budget. Diagnostic instances whose bodies never render are counted
+// into a trailing omitted note.
+func writeDiagnosticList(builder *strings.Builder, groups []diagnosticGroup, limit int) int {
+	remaining := limit
+	omitted := 0
+	for _, group := range groups {
+		if remaining <= 0 {
+			omitted += group.total
+			continue
+		}
+		if group.total == 1 {
+			writeDiagnosticBullet(builder, group)
+			remaining--
+			continue
+		}
+		fmt.Fprintf(builder, "- %s %s × %d\n", escapeMarkdownText(string(group.severity)), markdownCodeSpan(group.code), group.total)
+		remaining--
+		for _, entry := range group.entries {
+			if remaining <= 0 {
+				omitted += entry.count
+				continue
+			}
+			builder.WriteString("  - ")
+			builder.WriteString(entry.body)
+			if entry.count > 1 {
+				fmt.Fprintf(builder, " × %d", entry.count)
+			}
+			builder.WriteByte('\n')
+			remaining--
+		}
+	}
+	if omitted > 0 {
+		fmt.Fprintf(builder, "\n_... and %d more diagnostics omitted._\n", omitted)
+	}
+	return remaining
+}
+
+func writeDiagnosticBullet(builder *strings.Builder, group diagnosticGroup) {
+	builder.WriteString("- ")
+	builder.WriteString(escapeMarkdownText(string(group.severity)))
+	builder.WriteString(" ")
+	if group.category != "" {
+		builder.WriteString("`")
+		builder.WriteString(escapeCodeSpan(group.category))
+		builder.WriteString("` ")
+	}
+	builder.WriteString(group.entries[0].body)
 	builder.WriteByte('\n')
+}
+
+func diagnosticBodyMarkdown(diag diagnostic.Diagnostic) string {
+	var builder strings.Builder
+	builder.WriteString(escapeMarkdownText(singleLine(diag.Message)))
+	if diag.Provenance.Path != "" {
+		builder.WriteString(" (")
+		builder.WriteString(escapeMarkdownText(diag.Provenance.Path))
+		if diag.Provenance.Pointer != "" {
+			builder.WriteString(" ")
+			builder.WriteString(escapeMarkdownText(diag.Provenance.Pointer))
+		}
+		builder.WriteString(")")
+	}
 	return builder.String()
 }
 

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -128,15 +128,16 @@ func DiffMarkdown(result app.DiffResult, options MarkdownOptions) ([]byte, Markd
 	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
 	state.appendRequired(summaryMarkdown(len(result.Results), len(groups), totalAdded, totalRemoved, result.Diagnostics))
 	errorsPart, warningsPart := diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit, diagnosticsMode)
-	if state.appendBounded(errorsPart) {
-		state.appendBounded(warningsPart)
-	}
+	errorsFit := state.appendBounded(errorsPart)
 	if len(groups) == 0 {
 		state.appendBounded(noDiffMarkdown())
 	} else {
 		state.appendAppDetails(groups, len(groups) == 1)
 	}
 	state.appendBounded(omittedMarkdown(groups[state.shownApps:]))
+	if errorsFit {
+		state.appendBounded(warningsPart)
+	}
 	state.appendBounded(statsMarkdown(state.truncated, state.shownApps, len(groups)))
 
 	out := state.bytes()
@@ -171,13 +172,14 @@ func ImageDiffMarkdown(result app.ImageDiffResult, options MarkdownOptions) ([]b
 	state.appendRequired(fmt.Sprintf("## %s\n\n", escapeMarkdownText(options.Title)))
 	state.appendRequired(imageSummaryMarkdown(len(result.Added), len(result.Removed), result.Diagnostics))
 	errorsPart, warningsPart := diagnosticsMarkdown(result.Diagnostics, options.DiagnosticLimit, diagnosticsMode)
-	if state.appendBounded(errorsPart) {
-		state.appendBounded(warningsPart)
-	}
+	errorsFit := state.appendBounded(errorsPart)
 	if len(rows) == 0 {
 		state.appendBounded(noImageDiffMarkdown())
 	} else {
 		state.appendImageRows(rows)
+	}
+	if errorsFit {
+		state.appendBounded(warningsPart)
 	}
 
 	out := state.bytes()

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -340,3 +340,437 @@ func diffResult(namespace, appName, resourceName, body string) diff.Result {
 		Diff:   "@@ Application modified: " + appName + " @@\n" + body,
 	}
 }
+
+func TestDiffMarkdownCollapsesWarningsInDetails(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "first warning",
+			},
+			{
+				Code:     "source.self-repo-near-miss",
+				Severity: diagnostic.SeverityWarning,
+				Category: "source",
+				Message:  "second warning",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"<details>\n<summary>Diagnostics (2 warnings)</summary>\n\n",
+		"- warning `kustomize` first warning\n",
+		"- warning `source` second warning\n",
+		"\n</details>\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "Diagnostics:") {
+		t.Fatalf("warnings-only report should not render the open Diagnostics list:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownKeepsErrorsVisibleAndCollapsesWarnings(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "placeholder warning",
+			},
+			{
+				Code:     "render.failed",
+				Severity: diagnostic.SeverityError,
+				Category: "render",
+				Message:  "render exploded",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"Diagnostics:\n- error `render` render exploded\n",
+		"<details>\n<summary>1 warning</summary>\n\n",
+		"- warning `kustomize` placeholder warning\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	errorAt := strings.Index(text, "render exploded")
+	detailsAt := strings.Index(text, "<details>")
+	if errorAt == -1 || detailsAt == -1 || errorAt > detailsAt {
+		t.Fatalf("error bullet should render before the collapsed warnings block:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownErrorsOnlyRendersOpenList(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{{
+			Code:     "render.failed",
+			Severity: diagnostic.SeverityError,
+			Category: "render",
+			Message:  "render exploded",
+		}},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "Diagnostics:\n- error `render` render exploded\n") {
+		t.Fatalf("markdown missing open error list:\n%s", text)
+	}
+	if strings.Contains(text, "<details>\n<summary>") && strings.Contains(text, "warning") {
+		t.Fatalf("errors-only report should not render a warnings block:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownAggregatesRepeatedDiagnosticCodes(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "substituted 2 sops files",
+			},
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "substituted 2 sops files",
+			},
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "substituted 5 sops files",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"- warning `kustomize.ksops-compat-substituted` × 3\n",
+		"  - substituted 2 sops files × 2\n",
+		"  - substituted 5 sops files\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestDiffMarkdownAggregatesEmptyCodeViaStableCode(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Severity:   diagnostic.SeverityWarning,
+				Category:   "appset",
+				Message:    "generator one skipped",
+				Provenance: diagnostic.Provenance{Path: "apps/one.yaml", Pointer: "spec.generators"},
+			},
+			{
+				Severity:   diagnostic.SeverityWarning,
+				Category:   "appset",
+				Message:    "generator two skipped",
+				Provenance: diagnostic.Provenance{Path: "apps/two.yaml", Pointer: "spec.generators"},
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "× 2") {
+		t.Fatalf("empty-code diagnostics with a shared stable code should aggregate:\n%s", text)
+	}
+	for _, want := range []string{"generator one skipped", "generator two skipped"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing aggregated instance %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestDiffMarkdownDiagnosticsModeErrors(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "placeholder warning",
+			},
+			{
+				Code:     "render.failed",
+				Severity: diagnostic.SeverityError,
+				Category: "render",
+				Message:  "render exploded",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes, Diagnostics: DiagnosticsModeErrors})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "- error `render` render exploded\n") {
+		t.Fatalf("errors mode should keep the error bullet:\n%s", text)
+	}
+	if strings.Contains(text, "placeholder warning") || strings.Contains(text, "<details>\n<summary>1 warning") {
+		t.Fatalf("errors mode should omit warnings entirely:\n%s", text)
+	}
+	if !strings.Contains(text, "**Summary:** 0 apps, 0 resources, +0/-0, 1 warning, 1 error.") {
+		t.Fatalf("summary counts should be unaffected by the diagnostics mode:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownDiagnosticsModeNone(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{
+				Code:     "kustomize.ksops-compat-substituted",
+				Severity: diagnostic.SeverityWarning,
+				Category: "kustomize",
+				Message:  "placeholder warning",
+			},
+			{
+				Code:     "render.failed",
+				Severity: diagnostic.SeverityError,
+				Category: "render",
+				Message:  "render exploded",
+			},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes, Diagnostics: DiagnosticsModeNone})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, unwanted := range []string{"Diagnostics:", "placeholder warning", "render exploded", "<summary>"} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("none mode should omit the diagnostics section, found %q:\n%s", unwanted, text)
+		}
+	}
+	if !strings.Contains(text, "**Summary:** 0 apps, 0 resources, +0/-0, 1 warning, 1 error.") {
+		t.Fatalf("summary counts should be unaffected by the diagnostics mode:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownRejectsInvalidDiagnosticsMode(t *testing.T) {
+	_, _, err := DiffMarkdown(app.DiffResult{}, MarkdownOptions{MaxBytes: DefaultMaxBytes, Diagnostics: DiagnosticsMode("verbose")})
+	if err == nil {
+		t.Fatal("DiffMarkdown(Diagnostics=verbose) error = nil, want error")
+	}
+	_, _, err = ImageDiffMarkdown(app.ImageDiffResult{}, MarkdownOptions{MaxBytes: DefaultMaxBytes, Diagnostics: DiagnosticsMode("verbose")})
+	if err == nil {
+		t.Fatal("ImageDiffMarkdown(Diagnostics=verbose) error = nil, want error")
+	}
+}
+
+func TestDiffMarkdownDiagnosticLimitCountsOmittedInstances(t *testing.T) {
+	diags := make([]diagnostic.Diagnostic, 0, 6)
+	for i := range 6 {
+		diags = append(diags, diagnostic.Diagnostic{
+			Code:     fmt.Sprintf("discovery.duplicate-%d", i),
+			Severity: diagnostic.SeverityWarning,
+			Category: "discovery",
+			Message:  fmt.Sprintf("duplicate resource %d", i),
+		})
+	}
+	out, _, err := DiffMarkdown(app.DiffResult{Diagnostics: diags},
+		MarkdownOptions{MaxBytes: DefaultMaxBytes, DiagnosticLimit: 4})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "_... and 2 more diagnostics omitted._") {
+		t.Fatalf("omitted trailer missing or wrong:\n%s", text)
+	}
+	if !strings.Contains(text, "duplicate resource 3") || strings.Contains(text, "duplicate resource 4") {
+		t.Fatalf("limit should render the first 4 warnings only:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownDiagnosticLimitSpansErrorsThenWarnings(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Diagnostics: []diagnostic.Diagnostic{
+			{Code: "render.failed-a", Severity: diagnostic.SeverityError, Category: "render", Message: "error one"},
+			{Code: "render.failed-b", Severity: diagnostic.SeverityError, Category: "render", Message: "error two"},
+			{Code: "discovery.duplicate-a", Severity: diagnostic.SeverityWarning, Category: "discovery", Message: "warning one"},
+			{Code: "discovery.duplicate-b", Severity: diagnostic.SeverityWarning, Category: "discovery", Message: "warning two"},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes, DiagnosticLimit: 3})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{"error one", "error two", "warning one"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "warning two") {
+		t.Fatalf("limit of 3 should omit the fourth diagnostic:\n%s", text)
+	}
+	if !strings.Contains(text, "_... and 1 more diagnostics omitted._") {
+		t.Fatalf("omitted trailer missing:\n%s", text)
+	}
+}
+
+func TestImageDiffMarkdownCollapsesWarningsInDetails(t *testing.T) {
+	out, _, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Added: []string{"registry.example.com/app:v2"},
+		Diagnostics: []diagnostic.Diagnostic{{
+			Code:     "kustomize.ksops-compat-substituted",
+			Severity: diagnostic.SeverityWarning,
+			Category: "kustomize",
+			Message:  "placeholder warning",
+		}},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"<details>\n<summary>Diagnostics (1 warning)</summary>\n\n",
+		"- warning `kustomize` placeholder warning\n",
+		"\n</details>\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestImageDiffMarkdownDiagnosticsModeNone(t *testing.T) {
+	out, _, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Diagnostics: []diagnostic.Diagnostic{{
+			Severity: diagnostic.SeverityWarning,
+			Category: "render",
+			Message:  "placeholder warning",
+		}},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes, Diagnostics: DiagnosticsModeNone})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	if strings.Contains(string(out), "placeholder warning") {
+		t.Fatalf("none mode should omit diagnostics:\n%s", string(out))
+	}
+}
+
+func TestParseDiagnosticsMode(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  DiagnosticsMode
+	}{
+		{value: "", want: DiagnosticsModeAll},
+		{value: "all", want: DiagnosticsModeAll},
+		{value: " Errors", want: DiagnosticsModeErrors},
+		{value: "NONE", want: DiagnosticsModeNone},
+	} {
+		got, err := ParseDiagnosticsMode(tc.value)
+		if err != nil {
+			t.Fatalf("ParseDiagnosticsMode(%q) error = %v", tc.value, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseDiagnosticsMode(%q) = %q, want %q", tc.value, got, tc.want)
+		}
+	}
+	if _, err := ParseDiagnosticsMode("verbose"); err == nil {
+		t.Fatal("ParseDiagnosticsMode(verbose) error = nil, want error")
+	}
+}
+
+func TestDiffMarkdownAggregatedParentLinesCountAgainstLimit(t *testing.T) {
+	diags := make([]diagnostic.Diagnostic, 0, 3)
+	for _, message := range []string{"first body", "second body", "third body"} {
+		diags = append(diags, diagnostic.Diagnostic{
+			Code:     "discovery.duplicate",
+			Severity: diagnostic.SeverityWarning,
+			Category: "discovery",
+			Message:  message,
+		})
+	}
+	out, _, err := DiffMarkdown(app.DiffResult{Diagnostics: diags},
+		MarkdownOptions{MaxBytes: DefaultMaxBytes, DiagnosticLimit: 2})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"- warning `discovery.duplicate` × 3\n",
+		"  - first body\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "second body") || strings.Contains(text, "third body") {
+		t.Fatalf("parent line should consume one unit of the limit, leaving room for one entry only:\n%s", text)
+	}
+	if !strings.Contains(text, "_... and 2 more diagnostics omitted._") {
+		t.Fatalf("omitted trailer missing or wrong:\n%s", text)
+	}
+}
+
+func TestDiffMarkdownOmittedTrailerIsAStandaloneParagraph(t *testing.T) {
+	diags := make([]diagnostic.Diagnostic, 0, 3)
+	for i := range 3 {
+		diags = append(diags, diagnostic.Diagnostic{
+			Code:     fmt.Sprintf("discovery.duplicate-%d", i),
+			Severity: diagnostic.SeverityWarning,
+			Category: "discovery",
+			Message:  fmt.Sprintf("duplicate %d", i),
+		})
+	}
+	out, _, err := DiffMarkdown(app.DiffResult{Diagnostics: diags},
+		MarkdownOptions{MaxBytes: DefaultMaxBytes, DiagnosticLimit: 2})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	if !strings.Contains(string(out), "\n\n_... and 1 more diagnostics omitted._\n") {
+		t.Fatalf("omitted trailer should be separated from the list by a blank line:\n%s", string(out))
+	}
+}
+
+func TestDiffMarkdownDropsWarningsWhenErrorsDoNotFit(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	diags := make([]diagnostic.Diagnostic, 0, 9)
+	for i := range 8 {
+		diags = append(diags, diagnostic.Diagnostic{
+			Code:     fmt.Sprintf("render.failed-%d", i),
+			Severity: diagnostic.SeverityError,
+			Category: "render",
+			Message:  fmt.Sprintf("error %d %s", i, long),
+		})
+	}
+	diags = append(diags, diagnostic.Diagnostic{
+		Code:     "kustomize.ksops-compat-substituted",
+		Severity: diagnostic.SeverityWarning,
+		Category: "kustomize",
+		Message:  "short warning",
+	})
+	out, meta, err := DiffMarkdown(app.DiffResult{Diagnostics: diags},
+		MarkdownOptions{MaxBytes: MinPositiveMaxByte})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, "short warning") || strings.Contains(text, "<summary>1 warning</summary>") {
+		t.Fatalf("collapsed warnings must not render when the open errors list was dropped:\n%s", text)
+	}
+	if !meta.Truncated {
+		t.Fatal("meta.Truncated = false, want true when the errors block is dropped")
+	}
+}

--- a/internal/report/markdown_test.go
+++ b/internal/report/markdown_test.go
@@ -774,3 +774,50 @@ func TestDiffMarkdownDropsWarningsWhenErrorsDoNotFit(t *testing.T) {
 		t.Fatal("meta.Truncated = false, want true when the errors block is dropped")
 	}
 }
+
+func TestDiffMarkdownRendersWarningsBelowAppDetails(t *testing.T) {
+	out, _, err := DiffMarkdown(app.DiffResult{
+		Results: []diff.Result{diffResult("argocd", "demo", "cm", "-  value: old\n+  value: new\n")},
+		Diagnostics: []diagnostic.Diagnostic{
+			{Code: "render.failed", Severity: diagnostic.SeverityError, Category: "render", Message: "render exploded"},
+			{Code: "kustomize.ksops-compat-substituted", Severity: diagnostic.SeverityWarning, Category: "kustomize", Message: "placeholder warning"},
+		},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("DiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	errorAt := strings.Index(text, "render exploded")
+	appAt := strings.Index(text, "<summary>argocd/demo")
+	warningsAt := strings.Index(text, "<summary>1 warning</summary>")
+	if errorAt == -1 || appAt == -1 || warningsAt == -1 {
+		t.Fatalf("expected error, app details, and warnings sections:\n%s", text)
+	}
+	if errorAt >= appAt || appAt >= warningsAt {
+		t.Fatalf("order = error@%d app@%d warnings@%d, want errors above diffs and warnings below:\n%s", errorAt, appAt, warningsAt, text)
+	}
+}
+
+func TestImageDiffMarkdownRendersWarningsBelowRows(t *testing.T) {
+	out, _, err := ImageDiffMarkdown(app.ImageDiffResult{
+		Added: []string{"registry.example.com/app:v2"},
+		Diagnostics: []diagnostic.Diagnostic{{
+			Code:     "kustomize.ksops-compat-substituted",
+			Severity: diagnostic.SeverityWarning,
+			Category: "kustomize",
+			Message:  "placeholder warning",
+		}},
+	}, MarkdownOptions{MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("ImageDiffMarkdown() error = %v", err)
+	}
+	text := string(out)
+	rowsAt := strings.Index(text, "| Change | Image |")
+	warningsAt := strings.Index(text, "<summary>Diagnostics (1 warning)</summary>")
+	if rowsAt == -1 || warningsAt == -1 {
+		t.Fatalf("expected image table and warnings sections:\n%s", text)
+	}
+	if rowsAt > warningsAt {
+		t.Fatalf("order = rows@%d warnings@%d, want image rows above collapsed warnings:\n%s", rowsAt, warningsAt, text)
+	}
+}

--- a/pr-action/action.yml
+++ b/pr-action/action.yml
@@ -224,6 +224,9 @@ inputs:
     description: Maximum rendered diff comment bytes. Values above 60000 are clamped to GitHub's comment budget.
     required: false
     default: "60000"
+  markdown-diagnostics:
+    description: Diagnostics detail embedded in PR comments with all, errors, or none. Leave empty for drydock defaults.
+    required: false
   upload-artifacts:
     description: Upload full diff and image report artifacts when they are non-empty.
     required: false
@@ -460,6 +463,7 @@ runs:
         DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR: ${{ inputs.fail-on-render-error }}
         DRYDOCK_INPUT_HEAD_REF: ${{ inputs.head-ref }}
         DRYDOCK_INPUT_KUBE_VERSION: ${{ inputs.kube-version }}
+        DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS: ${{ inputs.markdown-diagnostics }}
         DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH: ${{ inputs.max-discovery-depth }}
         DRYDOCK_INPUT_OFFLINE: ${{ inputs.offline }}
         DRYDOCK_INPUT_PARALLELISM: ${{ inputs.parallelism }}

--- a/pr-action/action_yml_test.go
+++ b/pr-action/action_yml_test.go
@@ -207,6 +207,29 @@ func TestActionKSOPSCompatInputDeclaredAndWiredToRunStep(t *testing.T) {
 	}
 }
 
+func TestActionMarkdownDiagnosticsInputDeclaredAndWiredToRunStep(t *testing.T) {
+	actionYAML := loadActionYAML(t)
+
+	if !strings.Contains(actionYAML, "markdown-diagnostics:") {
+		t.Fatalf("action.yml missing markdown-diagnostics input declaration")
+	}
+
+	runIdx := strings.Index(actionYAML, "- name: Run drydock\n")
+	if runIdx == -1 {
+		t.Fatalf("action.yml missing 'Run drydock' step")
+	}
+	nextStep := strings.Index(actionYAML[runIdx+1:], "\n    - name: ")
+	var runBlock string
+	if nextStep == -1 {
+		runBlock = actionYAML[runIdx:]
+	} else {
+		runBlock = actionYAML[runIdx : runIdx+1+nextStep]
+	}
+	if !strings.Contains(runBlock, "DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS: ${{ inputs.markdown-diagnostics }}") {
+		t.Fatalf("Run step env block missing DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS wiring:\n%s", runBlock)
+	}
+}
+
 func TestActionDiscoverIgnoreInputDeclaredAndWiredToRunStep(t *testing.T) {
 	actionYAML := loadActionYAML(t)
 

--- a/pr-action/run.sh
+++ b/pr-action/run.sh
@@ -270,6 +270,13 @@ case "${DRYDOCK_INPUT_CHANGED_ONLY}" in
     exit 1
     ;;
 esac
+case "${DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS}" in
+  '' | all | errors | none) ;;
+  *)
+    echo "markdown-diagnostics must be empty, all, errors, or none, got '${DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS}'." >&2
+    exit 1
+    ;;
+esac
 
 work_dir="${DRYDOCK_ACTION_WORK_DIR}"
 mkdir -p "${work_dir}"
@@ -401,6 +408,7 @@ if [[ "${DRYDOCK_INPUT_RUN_DIFF}" == "true" ]]; then
     --html-output-file "${diff_html_path}"
     --exit-code=false
   )
+  append_value_flag diff_args "${DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS}" "--markdown-diagnostics"
   if ! capture_command "${diff_comment_path}" "${diff_stderr}" "${diff_args[@]}"; then
     failed="true"
   fi
@@ -507,6 +515,7 @@ if [[ "${images_comment}" == "true" ]]; then
       --markdown-max-bytes "$(diff_comment_budget "${DRYDOCK_INPUT_DIFF_MAX_BYTES}")"
       --exit-code=false
     )
+    append_value_flag image_comment_args "${DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS}" "--markdown-diagnostics"
     if ! capture_command_quiet "${images_comment_path}" "${images_comment_stderr}" "${image_comment_args[@]}"; then
       if grep -Eq 'unsupported output "markdown" for diff images|markdown output is not supported for diff images' "${images_comment_stderr}"; then
         if [[ "${image_diff_details_complete}" != "true" ]]; then

--- a/pr-action/run_test.go
+++ b/pr-action/run_test.go
@@ -388,6 +388,81 @@ func TestRunPassesDiscoverIgnoreToAllCommands(t *testing.T) {
 	}
 }
 
+func TestRunPassesMarkdownDiagnosticsOnlyToMarkdownInvocations(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode:         "both",
+		diffOutput:          true,
+		imageOutput:         true,
+		runTest:             true,
+		markdownDiagnostics: "errors",
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	lines := strings.Split(strings.TrimSpace(args), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("drydock invocations = %q, want test, diff apps, diff images name, diff images markdown", args)
+	}
+	for _, line := range lines {
+		hasFlag := strings.Contains(line, "--markdown-diagnostics errors")
+		isMarkdown := strings.Contains(line, "-o markdown")
+		if isMarkdown && !hasFlag {
+			t.Fatalf("markdown invocation missing --markdown-diagnostics:\n%s", line)
+		}
+		if !isMarkdown && hasFlag {
+			t.Fatalf("non-markdown invocation received --markdown-diagnostics:\n%s", line)
+		}
+	}
+}
+
+func TestRunOmitsMarkdownDiagnosticsWhenInputUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	workDir := runCommentScenario(t, commentScenario{
+		commentMode: "both",
+		diffOutput:  true,
+		imageOutput: true,
+		runTest:     true,
+	})
+
+	args := readFile(t, filepath.Join(workDir, "drydock-args.txt"))
+	if strings.Contains(args, "--markdown-diagnostics") {
+		t.Fatalf("drydock invocations = %q, want no --markdown-diagnostics flag when input unset", args)
+	}
+}
+
+func TestRunRejectsInvalidMarkdownDiagnosticsValue(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell action tests require bash")
+	}
+
+	tmp := t.TempDir()
+	workDir := filepath.Join(tmp, "work")
+	outputPath := filepath.Join(tmp, "github-output")
+	writeExecutable(t, filepath.Join(tmp, "drydock"), `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "${DRYDOCK_ACTION_WORK_DIR}"
+printf '%s\n' "$*" >> "${DRYDOCK_ACTION_WORK_DIR}/drydock-args.txt"
+`)
+	cmd := exec.Command("bash", "run.sh")
+	cmd.Dir = "."
+	cmd.Env = append(defaultRunEnv(tmp, workDir, outputPath),
+		"DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS=verbose",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("run.sh error = nil, want invalid markdown-diagnostics failure\n%s", out)
+	}
+	if !strings.Contains(string(out), "markdown-diagnostics must be empty, all, errors, or none") {
+		t.Fatalf("run.sh output = %q, want markdown-diagnostics validation message", out)
+	}
+}
+
 func TestRunOmitsDiscoverIgnoreWhenInputUnset(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell action tests require bash")
@@ -730,6 +805,7 @@ type commentScenario struct {
 	changedOnlyInclude              string
 	changedOnlyIgnore               string
 	discoverIgnore                  string
+	markdownDiagnostics             string
 	omitDiffHTMLArtifactNameFromEnv bool
 	cachePath                       string
 }
@@ -753,6 +829,7 @@ func runCommentScenario(t *testing.T, scenario commentScenario) string {
 		"DRYDOCK_INPUT_CHANGED_ONLY_INCLUDE="+scenario.changedOnlyInclude,
 		"DRYDOCK_INPUT_CHANGED_ONLY_IGNORE="+scenario.changedOnlyIgnore,
 		"DRYDOCK_INPUT_DISCOVER_IGNORE="+scenario.discoverIgnore,
+		"DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS="+scenario.markdownDiagnostics,
 		"DRYDOCK_INPUT_RUN_DIFF=true",
 		"DRYDOCK_INPUT_RUN_IMAGE_DIFF="+boolString(!scenario.skipImageDiff),
 		"DRYDOCK_INPUT_RUN_TEST="+boolString(scenario.runTest),
@@ -1104,6 +1181,7 @@ func defaultRunEnv(tmp, workDir, outputPath string) []string {
 		"DRYDOCK_INPUT_FAIL_ON_RENDER_ERROR=true",
 		"DRYDOCK_INPUT_HEAD_REF=",
 		"DRYDOCK_INPUT_KUBE_VERSION=",
+		"DRYDOCK_INPUT_MARKDOWN_DIAGNOSTICS=",
 		"DRYDOCK_INPUT_MAX_DISCOVERY_DEPTH=",
 		"DRYDOCK_INPUT_OFFLINE=false",
 		"DRYDOCK_INPUT_PARALLELISM=",

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -529,7 +529,7 @@ rotation audit rather than relying on drydock diff for this class of change.
 | `comment-empty` | `false` | Comment even when the corresponding diff is empty. |
 | `comment-continue-on-error` | `true` | Do not fail the workflow when pull request commenting fails. |
 | `diff-max-bytes` | `60000` | Maximum rendered diff comment bytes; larger values are clamped to GitHub's comment budget. |
-| `markdown-diagnostics` | unset | Diagnostics detail embedded in PR comments: `all` (errors open, warnings collapsed), `errors`, or `none`. Unset omits the flag and uses the drydock default (`all`). |
+| `markdown-diagnostics` | unset | Diagnostics detail embedded in PR comments: `all` (errors open above the diffs, warnings collapsed below), `errors`, or `none`. Unset omits the flag and uses the drydock default (`all`). |
 | `upload-artifacts` | `true` | Upload full diff and image report artifacts when they are non-empty. |
 | `artifact-retention-days` | `30` | Retention days for uploaded artifacts. |
 | `diff-artifact-name` | generated | Artifact name override for rendered manifest diffs. |

--- a/site/content/workflows/github-actions.md
+++ b/site/content/workflows/github-actions.md
@@ -529,6 +529,7 @@ rotation audit rather than relying on drydock diff for this class of change.
 | `comment-empty` | `false` | Comment even when the corresponding diff is empty. |
 | `comment-continue-on-error` | `true` | Do not fail the workflow when pull request commenting fails. |
 | `diff-max-bytes` | `60000` | Maximum rendered diff comment bytes; larger values are clamped to GitHub's comment budget. |
+| `markdown-diagnostics` | unset | Diagnostics detail embedded in PR comments: `all` (errors open, warnings collapsed), `errors`, or `none`. Unset omits the flag and uses the drydock default (`all`). |
 | `upload-artifacts` | `true` | Upload full diff and image report artifacts when they are non-empty. |
 | `artifact-retention-days` | `30` | Retention days for uploaded artifacts. |
 | `diff-artifact-name` | generated | Artifact name override for rendered manifest diffs. |

--- a/site/content/workflows/output.md
+++ b/site/content/workflows/output.md
@@ -24,8 +24,9 @@ diff for exit-code behavior.
 Diagnostics remain on stderr for unified, JSON, YAML, and name output so stdout
 stays parseable. Markdown diff output embeds successful diagnostics in the
 generated report because the markdown document is the review surface: errors
-are listed openly, warnings collapse inside an expandable block so the diffs
-lead, and repeated diagnostic codes aggregate into one entry with a count.
+are listed openly above the diffs, warnings collapse inside an expandable
+block rendered below the diffs, and repeated diagnostic codes aggregate into
+one entry with a count.
 
 `test apps` text output prints `PASS`, `FAIL`, or `SKIPPED` status lines. When
 stdout and stderr are terminals, status lines stream as Applications complete
@@ -46,8 +47,9 @@ drydock diff images --repo . --ref HEAD --ref-orig origin/main -o markdown
 ```
 
 `--markdown-diagnostics` controls how much of the diagnostics list the
-markdown report embeds. The default `all` lists errors openly and collapses
-warnings inside an expandable block; `errors` omits warnings entirely; `none`
+markdown report embeds. The default `all` lists errors openly above the diffs
+and collapses warnings inside an expandable block below them; `errors` omits
+warnings entirely; `none`
 omits the whole diagnostics section. Summary warning and error counts stay in
 the report in every mode, and the flag never changes stderr, JSON, or YAML
 diagnostics:

--- a/site/content/workflows/output.md
+++ b/site/content/workflows/output.md
@@ -22,8 +22,10 @@ diffs, and removed-only image changes print no names while still counting as a
 diff for exit-code behavior.
 
 Diagnostics remain on stderr for unified, JSON, YAML, and name output so stdout
-stays parseable. Markdown manifest diff output embeds successful diagnostics in
-the generated report because the markdown document is the review surface.
+stays parseable. Markdown diff output embeds successful diagnostics in the
+generated report because the markdown document is the review surface: errors
+are listed openly, warnings collapse inside an expandable block so the diffs
+lead, and repeated diagnostic codes aggregate into one entry with a count.
 
 `test apps` text output prints `PASS`, `FAIL`, or `SKIPPED` status lines. When
 stdout and stderr are terminals, status lines stream as Applications complete
@@ -41,6 +43,17 @@ Use markdown output when the result will be read in a pull request comment:
 ```bash
 drydock diff apps --repo . --ref HEAD --ref-orig origin/main -o markdown
 drydock diff images --repo . --ref HEAD --ref-orig origin/main -o markdown
+```
+
+`--markdown-diagnostics` controls how much of the diagnostics list the
+markdown report embeds. The default `all` lists errors openly and collapses
+warnings inside an expandable block; `errors` omits warnings entirely; `none`
+omits the whole diagnostics section. Summary warning and error counts stay in
+the report in every mode, and the flag never changes stderr, JSON, or YAML
+diagnostics:
+
+```bash
+drydock diff apps --repo . --ref HEAD --ref-orig origin/main -o markdown --markdown-diagnostics errors
 ```
 
 For local browser review, manifest diff commands can also write the standalone


### PR DESCRIPTION
Closes #231.

PR comments led with a flat `Diagnostics:` list rendered above the diffs, so fleets with expected-state warnings (the issue's KSOPS case: one warning per app per render) buried the content reviewers came for. Three layers, defense in depth:

## 1. Warnings collapse below the diffs, errors stay open above

The markdown diagnostics section now renders in two parts: error-severity diagnostics keep the existing open `Diagnostics:` list **above the diffs** (a failed render means the report below may be incomplete, so reviewers see it first), and warnings collapse inside `<details>` rendered **below the diffs** — the diffs lead, and warnings become the footnote they are. Placement also gives diffs byte-budget priority over warnings, so tight comments degrade in severity order. Summary-line warning/error counts are untouched, so nothing is silently hidden.

## 2. `--markdown-diagnostics all|errors|none` (default `all`)

On `diff apps`, `diff app`, and `diff images`; validated like `--markdown-max-bytes` (markdown output only, fails before the orchestrator runs). `errors` omits warnings entirely; `none` omits the whole section. Neither mode changes summary counts, stderr, JSON, or YAML diagnostics. The pr-action grows a matching optional `markdown-diagnostics` input passed through **only when set**, so users pinned to released drydock binaries are unaffected.

## 3. Repeated codes aggregate

Same-code diagnostics group into one parent bullet — `` warning `kustomize.ksops-compat-substituted` × 12 `` — with deduplicated instance lines nested (identical bodies collapse to `× k`). Codes missing at emission (appset/provider paths) resolve via `diagnostic.StableCode`. The issue's 12-app KSOPS wall becomes one line inside a collapsed block.

Sample warnings-only output:

```markdown
**Summary:** 12 apps, 40 resources, +120/-80, 12 warnings.

<details>
<summary>Diagnostics (12 warnings)</summary>

- warning `kustomize.ksops-compat-substituted` × 12
  - KSOPS generators were rendered as deterministic placeholder manifests without decryption (2 sops files substituted) × 8
  - KSOPS generators were rendered as deterministic placeholder manifests without decryption (5 sops files substituted) × 4

</details>
```

## Correctness details (from adversarial review)

- `DiagnosticLimit` bounds rendered bullet lines *including* aggregate headers; instances whose bodies never render are counted in the omitted trailer, which is now a standalone paragraph (previously it rendered inside the last `<li>` via GFM lazy continuation).
- The two diagnostics parts append to the byte budget as a prioritized pair: if the open errors list does not fit, the collapsed warnings block is dropped with it rather than surviving alone (severity-priority inversion caught in review, with a regression test).
- Aggregate code spans use the delimiter-widening `markdownCodeSpan` rather than backslash escaping (inert inside code spans).

## Verification

`go test ./...` clean including 18 new/updated report tests, 5 CLI tests, 4 pr-action tests (input wiring, passthrough to exactly the two `-o markdown` invocations, unset-omission, invalid-value rejection). `golangci-lint`, `gofmt`, `shellcheck`, `actionlint`, `docs-check`, and `whitespace` gates all pass. Docs updated: `site/content/workflows/output.md`, `site/content/workflows/github-actions.md`, `docs/agent-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
