### PR TITLE
refactor: replace errors.As with errors.AsType

### DIFF
--- a/cmd/drydock/main.go
+++ b/cmd/drydock/main.go
@@ -35,8 +35,7 @@ func main() {
 		KubernetesModule:   moduleLabel(rendercache.KubernetesModulePath),
 	})
 	if err := cmd.Execute(); err != nil {
-		var exitErr cli.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[cli.ExitError](err); ok {
 			os.Exit(exitErr.Code)
 		}
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -460,8 +460,7 @@ func commandErrorCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	var exitErr ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[ExitError](err); ok {
 		return exitErr.Code
 	}
 	return 2

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -64,8 +64,7 @@ func newTestCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 				result, err = deps.Orchestrator.Build(context.Background(), buildRequest)
 			}
 			if liveReporter != nil {
-				var liveErr liveTestOutputError
-				if errors.As(err, &liveErr) {
+				if _, ok := errors.AsType[liveTestOutputError](err); ok {
 					return err
 				}
 				if renderErr := liveReporter.Clear(); renderErr != nil {

--- a/internal/cli/test_test.go
+++ b/internal/cli/test_test.go
@@ -665,8 +665,7 @@ func TestTestAppsTTYSetsLiveOutputWriteErrorApartFromTestFailure(t *testing.T) {
 	if err == nil || !errors.Is(err, writeErr) {
 		t.Fatalf("Execute() error = %v, want write error", err)
 	}
-	var exitErr ExitError
-	if errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[ExitError](err); ok {
 		t.Fatalf("Execute() error = %v, must not be converted to ExitError", err)
 	}
 }

--- a/internal/plugincontainer/plugincontainer.go
+++ b/internal/plugincontainer/plugincontainer.go
@@ -228,8 +228,7 @@ func runConfiguredContainerCommand(
 			_ = cleanupContainer(ctx, processRunner, docker, dockerEnv, cidFile)
 			return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "command timed out"}
 		}
-		var exitErr exitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[exitError](err); ok {
 			code := exitErr.Code
 			return commandResult{}, &pluginexec.Error{Phase: phase, Command: execution.Command, Reason: "container command failed; stderr omitted to avoid leaking secrets", ExitCode: &code}
 		}

--- a/internal/pluginexec/pluginexec.go
+++ b/internal/pluginexec/pluginexec.go
@@ -182,8 +182,7 @@ func runConfiguredCommand(ctx context.Context, phase string, command pluginpolic
 		if errors.Is(err, context.DeadlineExceeded) {
 			return commandResult{}, &Error{Phase: phase, Command: safeCommandName(resolved), Reason: "command timed out"}
 		}
-		var exitErr exitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[exitError](err); ok {
 			code := exitErr.Code
 			return commandResult{}, &Error{Phase: phase, Command: safeCommandName(resolved), Reason: "command failed; stderr omitted to avoid leaking secrets", ExitCode: &code}
 		}

--- a/internal/pluginexec/process.go
+++ b/internal/pluginexec/process.go
@@ -30,8 +30,7 @@ func processWaitError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var exit *exec.ExitError
-	if errors.As(err, &exit) {
+	if exit, ok := errors.AsType[*exec.ExitError](err); ok {
 		return exitError{Code: exit.ExitCode()}
 	}
 	return err


### PR DESCRIPTION
## Root cause

golangci-lint v2.13 (via x/tools 0.49.0) added the `errorsastype` modernize check, which flags the pre-Go-1.26 `var t T; errors.As(err, &t)` pattern. Renovate PR #276 (golangci-lint 2.12.2 -> 2.13.1) is red because seven existing sites on `main` trip the new check — failing run: https://github.com/sholdee/drydock/actions/runs/32798261670 — and #274/#271 (Go 1.27) are queued behind it.

## What this change does

Rewrites the seven flagged sites to the `errors.AsType[T]` form using golangci-lint v2.13.1's own auto-fix (no hand edits):

- `cmd/drydock/main.go`
- `internal/cli/get_test.go`
- `internal/cli/test.go`
- `internal/cli/test_test.go`
- `internal/plugincontainer/plugincontainer.go`
- `internal/pluginexec/pluginexec.go`
- `internal/pluginexec/process.go`

`errors.AsType` is available since Go 1.26, so this is valid under the current `go 1.26.6` directive, and the pinned linter (2.12.2) has no objection — the rewrite can land on `main` first. Renovate then rebases #276 green, unblocking #274 and #271. `mise.toml`/`mise.lock` are untouched; the linter bump stays in #276.

## Validation

- `gofmt -l` on changed files: clean
- `go build ./...` and full `go test ./...` (go 1.26.7): pass
- golangci-lint v2.13.1 `run` (no `--fix`): 0 issues
- `mise run lint` (pinned 2.12.2): 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)