### PR TITLE
feat(plugin): pass the Argo CD build environment to exec and container plugins

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -288,6 +288,10 @@ Supported:
 - Trusted exec/container plugin policies that gate Application plugin
   parameters through `parameters.allow`, including string argv substitution and
   constrained path parameters.
+- The Argo CD build environment (`ARGOCD_APP_*`, `KUBE_VERSION`,
+  `KUBE_API_VERSIONS`) and an always-present `ARGOCD_APP_PARAMETERS` for
+  trusted exec/container plugins, in the repo-server's order. `env.allow`
+  entries naming those variables are ignored with a warning.
 - Config management plugin source detection with fail-closed diagnostics in
   the CLI and default Go client.
 - Injectable in-process plugin renderers, named plugin registry dispatch, and
@@ -309,7 +313,9 @@ Not supported:
 - Argo CD repo-server sidecar plugin discovery.
 - Ambient plugin configuration or environment loading.
 - Untrusted CMP descriptor execution, unallowlisted Application plugin
-  parameters, or Application plugin env for policy-backed native engines.
+  parameters, or Application plugin env (`spec.source.plugin.env`) for any
+  policy-backed engine; exec/container reject it with a message that names
+  the entries.
 - Plugin credential injection.
 
 See `site/content/docs/plugin-policy/` for trusted policy provenance, supported

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -950,8 +950,13 @@ func normalizeDiagnostics(diags []diagnostic.Diagnostic, strict, forceWarning bo
 // escalating it would convert exactly those working runs into hard failures.
 // Rendering stays unchanged when the hint fires (remote acquisition still
 // happens), so there is nothing for --strict to protect against.
+// The plugin-policy env-ignored warning has the same shape: the managed
+// env.allow entry is dropped whether or not the warning is shown, and the
+// policy is often read from the diff baseline or --plugin-policy-ref where the
+// PR branch cannot fix it, so diag/get --strict must accept the same policies
+// build/diff --strict accept.
 func strictExemptDiagnostic(diag diagnostic.Diagnostic) bool {
-	return diag.Code == selfRepoNearMissCode
+	return diag.Code == selfRepoNearMissCode || diag.Code == diagnostic.CodePluginPolicyEnvIgnored
 }
 
 func diagnosticFailure(diags []diagnostic.Diagnostic, strict bool) error {

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -846,6 +847,123 @@ data:
 	assertExecPolicyPluginExecution(t, result.PluginExecutions)
 }
 
+// argoBuildEnvForPluginFixture is the environment a repo-server would hand the
+// exec-renderer plugin for writePluginBuildApplication's fixture (name plugin,
+// namespace argocd == controller namespace, project default, destination
+// default, repo https://github.com/example/repo, path manifests/plugin,
+// targetRevision main) with --kube-version v1.30.2 and two API versions.
+func argoBuildEnvForPluginFixture() []string {
+	return []string{
+		"ARGOCD_APP_NAME=plugin",
+		"ARGOCD_APP_NAMESPACE=default",
+		"ARGOCD_APP_PROJECT_NAME=default",
+		"ARGOCD_APP_REVISION=main",
+		"ARGOCD_APP_REVISION_SHORT=main",
+		"ARGOCD_APP_REVISION_SHORT_8=main",
+		"ARGOCD_APP_SOURCE_REPO_URL=https://github.com/example/repo",
+		"ARGOCD_APP_SOURCE_PATH=manifests/plugin",
+		"ARGOCD_APP_SOURCE_TARGET_REVISION=main",
+		"KUBE_VERSION=1.30.2",
+		"KUBE_API_VERSIONS=apps/v1,monitoring.coreos.com/v1",
+		"ARGOCD_APP_PARAMETERS=null",
+	}
+}
+
+func TestOrchestratorBuildPassesArgoBuildEnvironmentToExecPolicyPlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "exec-renderer")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	policy, fingerprint := testExecPluginPolicy(t, "exec-renderer", []string{"renderer"})
+	runner := &recordingExecRunner{result: pluginexec.Result{Stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: injected\n")}}
+
+	for _, offline := range []bool{false, true} {
+		_, err := (Orchestrator{PluginExecRunner: runner}).Build(context.Background(), BuildRequest{
+			Path:                    root,
+			EnablePlugins:           true,
+			Offline:                 offline,
+			KubeVersion:             "v1.30.2",
+			APIVersions:             []string{"monitoring.coreos.com/v1", "apps/v1", "apps/v1"},
+			pluginPolicyLoaded:      true,
+			pluginPolicy:            policy,
+			pluginPolicyFingerprint: fingerprint,
+			pluginPolicyExecTrusted: true,
+		})
+		if err != nil {
+			t.Fatalf("Build(offline=%v) error = %v", offline, err)
+		}
+		want := argoBuildEnvForPluginFixture()
+		if offline {
+			want = append(want, "DRYDOCK_OFFLINE=true")
+		}
+		if got := runner.lastRequest.ExtraEnv; !reflect.DeepEqual(got, want) {
+			t.Fatalf("exec ExtraEnv (offline=%v) = %#v, want %#v", offline, got, want)
+		}
+	}
+}
+
+func TestOrchestratorBuildPassesArgoBuildEnvironmentToContainerPolicyPlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "container-renderer")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	policy, fingerprint := testContainerPluginPolicy(t, "container-renderer")
+	runner := &recordingContainerRunner{result: pluginexec.Result{Stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: injected\n")}}
+
+	_, err := (Orchestrator{PluginContainerRunner: runner}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		PluginCacheDir:          filepath.Join(t.TempDir(), "plugin-cache"),
+		KubeVersion:             "v1.30.2",
+		APIVersions:             []string{"monitoring.coreos.com/v1", "apps/v1"},
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if got, want := runner.lastRequest.ExtraEnv, argoBuildEnvForPluginFixture(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("container ExtraEnv = %#v, want %#v", got, want)
+	}
+}
+
+// End to end through a real subprocess: the helper prints what it observes.
+func TestOrchestratorBuildExecPolicyPluginObservesArgoBuildEnvironment(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplication(t, root, "plugin", "exec-renderer")
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	policy, fingerprint := testExecPluginPolicy(t, "exec-renderer", appExecCommand(t, "build-env"))
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		KubeVersion:             "v1.30.2",
+		APIVersions:             []string{"apps/v1"},
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	manifest, ok := manifestByName(result.Manifests, "exec-build-env")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want exec-build-env", result.Manifests)
+	}
+	data := configMapData(t, manifest)
+	want := map[string]string{
+		"name": "plugin", "namespace": "default", "project": "default",
+		"sourcePath": "manifests/plugin", "kube": "1.30.2", "api": "apps/v1", "params": "null", "offline": "",
+	}
+	for key, value := range want {
+		if data[key] != value {
+			t.Fatalf("data[%q] = %#v, want %q (data = %#v)", key, data[key], value, data)
+		}
+	}
+}
+
 func TestOrchestratorBuildRendersTrustedContainerPolicyPlugin(t *testing.T) {
 	root := t.TempDir()
 	pluginCacheDir := filepath.Join(t.TempDir(), "plugin-cache")
@@ -1561,13 +1679,15 @@ func assertExecPolicyPluginExecution(t *testing.T, executions []PluginExecution)
 }
 
 type recordingExecRunner struct {
-	calls  int
-	result pluginexec.Result
-	err    error
+	calls       int
+	lastRequest pluginexec.Request
+	result      pluginexec.Result
+	err         error
 }
 
-func (r *recordingExecRunner) Run(context.Context, pluginexec.Request) (pluginexec.Result, error) {
+func (r *recordingExecRunner) Run(_ context.Context, request pluginexec.Request) (pluginexec.Result, error) {
 	r.calls++
+	r.lastRequest = request
 	return r.result, r.err
 }
 
@@ -2837,6 +2957,9 @@ func TestAppExecPluginHelperProcess(t *testing.T) {
 	case "params":
 		appExecPluginHelperParams(args)
 		os.Exit(0)
+	case "build-env":
+		appExecPluginHelperBuildEnv()
+		os.Exit(0)
 	case "repo-param":
 		if err := appExecPluginHelperRepoParam(args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -2893,6 +3016,22 @@ func appExecPluginHelperParams(args []string) {
 	fmt.Printf("  arg: %q\n", paramArg)
 	fmt.Printf("  param: %q\n", os.Getenv("PARAM_PATH"))
 	fmt.Printf("  json: %q\n", os.Getenv("ARGOCD_APP_PARAMETERS"))
+}
+
+func appExecPluginHelperBuildEnv() {
+	fmt.Println("apiVersion: v1")
+	fmt.Println("kind: ConfigMap")
+	fmt.Println("metadata:")
+	fmt.Println("  name: exec-build-env")
+	fmt.Println("data:")
+	fmt.Printf("  name: %q\n", os.Getenv("ARGOCD_APP_NAME"))
+	fmt.Printf("  namespace: %q\n", os.Getenv("ARGOCD_APP_NAMESPACE"))
+	fmt.Printf("  project: %q\n", os.Getenv("ARGOCD_APP_PROJECT_NAME"))
+	fmt.Printf("  sourcePath: %q\n", os.Getenv("ARGOCD_APP_SOURCE_PATH"))
+	fmt.Printf("  kube: %q\n", os.Getenv("KUBE_VERSION"))
+	fmt.Printf("  api: %q\n", os.Getenv("KUBE_API_VERSIONS"))
+	fmt.Printf("  params: %q\n", os.Getenv("ARGOCD_APP_PARAMETERS"))
+	fmt.Printf("  offline: %q\n", os.Getenv("DRYDOCK_OFFLINE"))
 }
 
 func appExecPluginHelperRepoParam(args []string) error {

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -701,7 +701,7 @@ metadata:
 	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) {
 		t.Fatalf("Diagnostics = %#v, want plugin.unsupported", result.Diagnostics)
 	}
-	if !hasDiagnosticMessage(result.Diagnostics, "env or parameters") {
+	if !hasDiagnosticMessage(result.Diagnostics, "Application plugin env") {
 		t.Fatalf("Diagnostics = %#v, want env/parameters rejection", result.Diagnostics)
 	}
 }

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -3154,4 +3155,102 @@ func TestOrchestratorInjectedPluginRendererErrorPreservesDiagnostics(t *testing.
 	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginFailed) {
 		t.Fatalf("Diagnostics = %#v, want plugin.failed", result.Diagnostics)
 	}
+}
+
+func TestOrchestratorDiffAppsWarnsWhenPolicyEnvAllowListsManagedName(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left")
+	right := filepath.Join(root, "right")
+	writePluginBuildApplication(t, left, "plugin", "exec-renderer")
+	writePluginBuildApplication(t, right, "plugin", "exec-renderer")
+	writeTestFile(t, filepath.Join(left, "manifests", "plugin", "marker.txt"), "left")
+	writeTestFile(t, filepath.Join(right, "manifests", "plugin", "marker.txt"), "right")
+	// The policy is read from the diff baseline (LeftPath) through the real
+	// loader and is exec-trusted because LeftPath != RightPath.
+	writeTestFile(t, filepath.Join(left, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  exec-renderer:
+    engine: exec
+    generate:
+      command: ["renderer"]
+    env:
+      allow: ["KUBE_VERSION"]
+`)
+	t.Setenv("KUBE_VERSION", "from-host-shell")
+	runner := &recordingExecRunner{result: pluginexec.Result{Stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: injected\n")}}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).DiffApps(context.Background(), DiffRequest{
+		LeftPath:      left,
+		RightPath:     right,
+		ChangedOnly:   false,
+		Unified:       3,
+		EnablePlugins: true,
+		KubeVersion:   "v1.30.2",
+	})
+	if err != nil {
+		t.Fatalf("DiffApps() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginPolicyEnvIgnored) {
+		t.Fatalf("Diagnostics = %#v, want %s warning", result.Diagnostics, diagnostic.CodePluginPolicyEnvIgnored)
+	}
+	if runner.calls != 2 {
+		t.Fatalf("runner calls = %d, want both diff sides", runner.calls)
+	}
+	if got := runner.lastRequest.Config.Env.Allow; len(got) != 0 {
+		t.Fatalf("policy env.allow reaching the runner = %#v, want the managed name dropped", got)
+	}
+	if !slices.Contains(runner.lastRequest.ExtraEnv, "KUBE_VERSION=1.30.2") {
+		t.Fatalf("ExtraEnv = %#v, want drydock's KUBE_VERSION, not the host shell's", runner.lastRequest.ExtraEnv)
+	}
+}
+
+func TestOrchestratorStrictKeepsPolicyEnvIgnoredAsWarning(t *testing.T) {
+	root := t.TempDir()
+	writeBuildApplication(t, root, "plain", "plain-config")
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  exec-renderer:
+    engine: exec
+    generate:
+      command: ["renderer"]
+    env:
+      allow: ["KUBE_VERSION"]
+`)
+	request := BuildRequest{Path: root, Strict: true}
+	assertWarning := func(t *testing.T, diags []diagnostic.Diagnostic) {
+		t.Helper()
+		found := false
+		for _, diag := range diags {
+			if diag.Code != diagnostic.CodePluginPolicyEnvIgnored {
+				continue
+			}
+			found = true
+			if diag.Severity != diagnostic.SeverityWarning {
+				t.Fatalf("%s severity = %q, want warning under --strict", diag.Code, diag.Severity)
+			}
+		}
+		if !found {
+			t.Fatalf("Diagnostics = %#v, want %s", diags, diagnostic.CodePluginPolicyEnvIgnored)
+		}
+	}
+
+	// ListApplications and Diag both run diagnosticFailure over the policy
+	// diagnostics; Build and DiffApps do not, so a non-exempt warning would
+	// make get/diag --strict reject a policy build/diff --strict accept.
+	t.Run("ListApplications", func(t *testing.T) {
+		result, err := (Orchestrator{}).ListApplications(context.Background(), request)
+		if err != nil {
+			t.Fatalf("ListApplications() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+		}
+		assertWarning(t, result.Diagnostics)
+	})
+	t.Run("Diag", func(t *testing.T) {
+		result, err := (Orchestrator{}).Diag(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Diag() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+		}
+		assertWarning(t, result.Diagnostics)
+	})
 }

--- a/internal/app/plugin_parameters.go
+++ b/internal/app/plugin_parameters.go
@@ -119,9 +119,15 @@ func requireApplicationPluginParameters(name string, allowed []pluginpolicy.Exec
 	return ""
 }
 
+// recordApplicationPluginParameterEnv always records ARGOCD_APP_PARAMETERS
+// (null when the Application declares no parameters), matching the
+// repo-server.
 func recordApplicationPluginParameterEnv(name string, params argoappv1.ApplicationSourcePluginParameters, out *validatedPluginParameters) string {
 	if len(params) == 0 {
-		return ""
+		// Environ marshals nil as null, matching the repo-server for
+		// Applications without parameters; an explicit empty list and the
+		// bootstrap-entrypoint synthetic Application would otherwise yield [].
+		params = nil
 	}
 	extraEnv, err := params.Environ()
 	if err != nil {

--- a/internal/app/plugin_policy.go
+++ b/internal/app/plugin_policy.go
@@ -122,7 +122,20 @@ func loadPluginPolicyFromRoot(request BuildRequest, root string, requirePolicy b
 		request.pluginPolicyFingerprint = pluginpolicy.NoPolicyFingerprint
 		request.pluginPolicyExecTrusted = false
 	}
-	return request, nil, cleanup, nil
+	return request, pluginPolicyWarningDiagnostics(policy.Warnings), cleanup, nil
+}
+
+func pluginPolicyWarningDiagnostics(warnings []string) []diagnostic.Diagnostic {
+	out := make([]diagnostic.Diagnostic, 0, len(warnings))
+	for _, warning := range warnings {
+		out = append(out, diagnostic.Diagnostic{
+			Code:     diagnostic.CodePluginPolicyEnvIgnored,
+			Severity: diagnostic.SeverityWarning,
+			Category: "plugin",
+			Message:  "plugin policy: " + warning,
+		})
+	}
+	return out
 }
 
 func diffPluginPolicyExecTrusted(request DiffRequest) bool {

--- a/internal/app/plugin_render_container.go
+++ b/internal/app/plugin_render_container.go
@@ -44,10 +44,7 @@ func (p localProvider) renderContainerPolicyPluginSource(ctx context.Context, so
 	}
 	containerConfig := *policyPlugin.Container
 	containerConfig.Lifecycle = lifecycle
-	extraEnv := append([]string(nil), params.extraEnv...)
-	if p.offline {
-		extraEnv = append(extraEnv, "DRYDOCK_OFFLINE=true")
-	}
+	extraEnv := composePolicyPluginExtraEnv(opts, params, p.offline)
 	result, err := p.pluginContainerRunner.Run(ctx, plugincontainer.Request{
 		SourceDir:         sourceDir,
 		RepositoryDir:     source.RepoRoot,

--- a/internal/app/plugin_render_env.go
+++ b/internal/app/plugin_render_env.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/sholdee/drydock/internal/render"
+)
+
+// policyPluginBuildEnv returns the Argo CD build environment a repo-server
+// hands a config management plugin, in the repo-server's order: the nine
+// ARGOCD_APP_* entries, then KUBE_VERSION and KUBE_API_VERSIONS
+// (reposerver/repository/repository.go getPluginEnvs). Both KUBE_* keys are
+// always present and empty when drydock has no --kube-version or
+// --api-versions input, matching Argo CD's key presence so plugins that test
+// for the variable behave the same way. opts.KubeVersion and opts.APIVersions
+// here can only be the --kube-version/--api-versions capability values (a
+// plugin source cannot carry spec.helm/kustomize.kubeVersion: multi-type
+// sources are rejected at plan time), which matches the repo-server sending
+// the cluster version to plugins. KUBE_API_VERSIONS is sorted and
+// deduplicated, whereas a repo-server sends discovery order.
+func policyPluginBuildEnv(opts render.RenderOptions) []string {
+	env := append([]string(nil), opts.ArgoEnv.Environ()...)
+	env = append(env, "KUBE_VERSION="+opts.KubeVersion)
+	return append(env, "KUBE_API_VERSIONS="+strings.Join(opts.APIVersions, ","))
+}
+
+// composePolicyPluginExtraEnv orders everything drydock itself provides to a
+// command-backed plugin: the build environment, the Application parameter
+// environment (ARGOCD_APP_PARAMETERS then PARAM_*), then drydock extras.
+// pluginexec.BuildEnv places these after the policy env.allow copies.
+func composePolicyPluginExtraEnv(opts render.RenderOptions, params validatedPluginParameters, offline bool) []string {
+	env := policyPluginBuildEnv(opts)
+	env = append(env, params.extraEnv...)
+	if offline {
+		env = append(env, "DRYDOCK_OFFLINE=true")
+	}
+	return env
+}

--- a/internal/app/plugin_render_env.go
+++ b/internal/app/plugin_render_env.go
@@ -3,6 +3,7 @@ package app
 import (
 	"strings"
 
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sholdee/drydock/internal/render"
 )
 
@@ -35,4 +36,17 @@ func composePolicyPluginExtraEnv(opts render.RenderOptions, params validatedPlug
 		env = append(env, "DRYDOCK_OFFLINE=true")
 	}
 	return env
+}
+
+// applicationPluginEnvNames lists the names in spec.source.plugin.env for
+// diagnostics. Values are never included: Application env may carry secrets.
+func applicationPluginEnvNames(env argoappv1.Env) []string {
+	names := make([]string, 0, len(env))
+	for _, entry := range env {
+		if entry == nil || strings.TrimSpace(entry.Name) == "" {
+			continue
+		}
+		names = append(names, entry.Name)
+	}
+	return names
 }

--- a/internal/app/plugin_render_env_test.go
+++ b/internal/app/plugin_render_env_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+func TestPolicyPluginBuildEnvMirrorsRepoServerOrder(t *testing.T) {
+	opts := render.RenderOptions{
+		ArgoEnv: argoappv1.Env{
+			{Name: "ARGOCD_APP_NAME", Value: "demo"},
+			{Name: "ARGOCD_APP_NAMESPACE", Value: ""},
+		},
+		KubeVersion: "1.30.2",
+		APIVersions: []string{"apps/v1", "monitoring.coreos.com/v1"},
+	}
+	got := policyPluginBuildEnv(opts)
+	want := []string{
+		"ARGOCD_APP_NAME=demo",
+		"ARGOCD_APP_NAMESPACE=",
+		"KUBE_VERSION=1.30.2",
+		"KUBE_API_VERSIONS=apps/v1,monitoring.coreos.com/v1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("policyPluginBuildEnv() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPolicyPluginBuildEnvKeepsKubeKeysWhenUnset(t *testing.T) {
+	got := policyPluginBuildEnv(render.RenderOptions{})
+	want := []string{"KUBE_VERSION=", "KUBE_API_VERSIONS="}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("policyPluginBuildEnv() with no kube inputs = %#v, want key-present empty values like Argo CD", got)
+	}
+}
+
+func TestRecordApplicationPluginParameterEnvEmitsNullWithoutParameters(t *testing.T) {
+	for _, params := range []argoappv1.ApplicationSourcePluginParameters{nil, {}} {
+		out := newValidatedPluginParameters()
+		if msg := recordApplicationPluginParameterEnv("p", params, &out); msg != "" {
+			t.Fatal(msg)
+		}
+		if want := []string{"ARGOCD_APP_PARAMETERS=null"}; !reflect.DeepEqual(out.extraEnv, want) {
+			t.Fatalf("extraEnv for %#v = %#v, want %#v", params, out.extraEnv, want)
+		}
+	}
+}
+
+func TestComposePolicyPluginExtraEnvOrdersBuildEnvParametersThenExtras(t *testing.T) {
+	opts := render.RenderOptions{ArgoEnv: argoappv1.Env{{Name: "ARGOCD_APP_NAME", Value: "demo"}}}
+	params := validatedPluginParameters{extraEnv: []string{"ARGOCD_APP_PARAMETERS=null"}}
+	got := composePolicyPluginExtraEnv(opts, params, true)
+	want := []string{
+		"ARGOCD_APP_NAME=demo",
+		"KUBE_VERSION=",
+		"KUBE_API_VERSIONS=",
+		"ARGOCD_APP_PARAMETERS=null",
+		"DRYDOCK_OFFLINE=true",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composePolicyPluginExtraEnv() = %#v, want %#v", got, want)
+	}
+	if got := composePolicyPluginExtraEnv(opts, params, false); got[len(got)-1] != "ARGOCD_APP_PARAMETERS=null" {
+		t.Fatalf("composePolicyPluginExtraEnv(offline=false) = %#v, want no DRYDOCK_OFFLINE entry", got)
+	}
+}

--- a/internal/app/plugin_render_exec.go
+++ b/internal/app/plugin_render_exec.go
@@ -43,10 +43,7 @@ func (p localProvider) renderExecPolicyPluginSource(ctx context.Context, source 
 	if message != "" {
 		return nil, unsupportedPluginDiagnostic(fmt.Sprintf("config management plugin %s %s", pluginDisplayName(name), message)), true, unsupportedPolicyPluginError(message)
 	}
-	extraEnv := append([]string(nil), params.extraEnv...)
-	if p.offline {
-		extraEnv = append(extraEnv, "DRYDOCK_OFFLINE=true")
-	}
+	extraEnv := composePolicyPluginExtraEnv(opts, params, p.offline)
 	result, err := p.pluginExecRunner.Run(ctx, pluginexec.Request{
 		SourceDir:       sourceDir,
 		RepositoryDir:   source.RepoRoot,

--- a/internal/app/plugin_render_plan.go
+++ b/internal/app/plugin_render_plan.go
@@ -93,10 +93,13 @@ func (p localProvider) renderPolicyPluginPlan(ctx context.Context, source render
 
 func validatePolicyPluginSource(name string, source render.ResolvedSource, opts render.RenderOptions, policyPlugin pluginpolicy.Plugin) string {
 	if len(opts.Plugin.Env) > 0 {
-		return fmt.Sprintf("config management plugin %s uses env or parameters, which are unsupported by trusted native plugin policy", pluginDisplayName(name))
+		if policyPlugin.Engine == pluginpolicy.EngineExec || policyPlugin.Engine == pluginpolicy.EngineContainer {
+			return fmt.Sprintf("config management plugin %s uses Application plugin env (%s), which drydock does not forward to %s plugins yet; pass per-Application values through parameters allowlisted by parameters.allow", pluginDisplayName(name), strings.Join(applicationPluginEnvNames(opts.Plugin.Env), ", "), policyPlugin.Engine)
+		}
+		return fmt.Sprintf("config management plugin %s uses Application plugin env, which is unsupported by trusted native plugin policy", pluginDisplayName(name))
 	}
 	if len(opts.Plugin.Parameters) > 0 && policyPlugin.Engine != pluginpolicy.EngineExec && policyPlugin.Engine != pluginpolicy.EngineContainer {
-		return fmt.Sprintf("config management plugin %s uses env or parameters, which are unsupported by trusted native plugin policy", pluginDisplayName(name))
+		return fmt.Sprintf("config management plugin %s uses Application plugin parameters, which are unsupported by trusted native plugin policy", pluginDisplayName(name))
 	}
 	if source.Path == "" && source.Chart == "" {
 		return fmt.Sprintf("config management plugin %s must define path or chart for trusted native plugin policy", pluginDisplayName(name))

--- a/internal/app/plugin_render_plan_test.go
+++ b/internal/app/plugin_render_plan_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
+	"github.com/sholdee/drydock/internal/render"
+)
+
+func TestValidatePolicyPluginSourceMessages(t *testing.T) {
+	source := render.ResolvedSource{Path: "apps/demo"}
+	value := "prod"
+	env := argoappv1.Env{{Name: "MODE", Value: "secret-value"}, {Name: "SUFFIX", Value: "x"}, nil}
+	params := argoappv1.ApplicationSourcePluginParameters{{Name: "values", String_: &value}}
+	testCases := []struct {
+		name     string
+		engine   pluginpolicy.Engine
+		plugin   render.PluginConfig
+		wantSubs []string
+		wantNot  []string
+	}{
+		{name: "env on exec", engine: pluginpolicy.EngineExec, plugin: render.PluginConfig{Name: "pkl", Env: env}, wantSubs: []string{"Application plugin env (MODE, SUFFIX)", "does not forward", "exec", "parameters.allow"}, wantNot: []string{"native", "secret-value"}},
+		{name: "env on container", engine: pluginpolicy.EngineContainer, plugin: render.PluginConfig{Name: "pkl", Env: env}, wantSubs: []string{"Application plugin env (MODE, SUFFIX)", "container", "parameters.allow"}, wantNot: []string{"native", "secret-value"}},
+		{name: "env on native engine", engine: pluginpolicy.EngineAVPCompat, plugin: render.PluginConfig{Name: "avp", Env: env}, wantSubs: []string{"Application plugin env", "trusted native plugin policy"}, wantNot: []string{"parameters.allow", "secret-value"}},
+		{name: "parameters on native engine", engine: pluginpolicy.EngineNativeKustomize, plugin: render.PluginConfig{Name: "k", Parameters: params}, wantSubs: []string{"Application plugin parameters", "trusted native plugin policy"}},
+		{name: "parameters on exec are fine here", engine: pluginpolicy.EngineExec, plugin: render.PluginConfig{Name: "pkl", Parameters: params}},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			plugin := testCase.plugin
+			got := validatePolicyPluginSource(plugin.Name, source, render.RenderOptions{Plugin: &plugin}, pluginpolicy.Plugin{Engine: testCase.engine})
+			if len(testCase.wantSubs) == 0 {
+				if got != "" {
+					t.Fatalf("message = %q, want empty", got)
+				}
+				return
+			}
+			for _, sub := range testCase.wantSubs {
+				if !strings.Contains(got, sub) {
+					t.Fatalf("message = %q, want substring %q", got, sub)
+				}
+			}
+			for _, sub := range testCase.wantNot {
+				if strings.Contains(got, sub) {
+					t.Fatalf("message = %q, must not contain %q", got, sub)
+				}
+			}
+		})
+	}
+}

--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -10,11 +10,12 @@ const (
 )
 
 const (
-	CodePluginUnsupported   = "plugin.unsupported"
-	CodePluginFailed        = "plugin.failed"
-	CodePluginUnspecified   = "plugin.unspecified"
-	CodePluginPolicyInvalid = "plugin.policy.invalid"
-	CodePluginAutoDiscovery = "plugin.auto-discovery-deferred"
+	CodePluginUnsupported      = "plugin.unsupported"
+	CodePluginFailed           = "plugin.failed"
+	CodePluginUnspecified      = "plugin.unspecified"
+	CodePluginPolicyInvalid    = "plugin.policy.invalid"
+	CodePluginPolicyEnvIgnored = "plugin.policy.env-ignored"
+	CodePluginAutoDiscovery    = "plugin.auto-discovery-deferred"
 )
 
 type Provenance struct {

--- a/internal/pluginexec/pluginexec.go
+++ b/internal/pluginexec/pluginexec.go
@@ -483,30 +483,56 @@ func hasParentComponent(rel string) bool {
 	return slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), "..")
 }
 
+// BuildEnv composes the environment for a command-backed plugin run in this
+// order: drydock's controlled PATH, caller-environment values for the names in
+// policy env.allow, then extraEnv, which the caller has already ordered (Argo
+// CD build environment, ARGOCD_APP_PARAMETERS and PARAM_*, drydock extras).
+// Every name must be an identifier and unique across the whole environment;
+// policy parsing already drops the names drydock manages, so a duplicate here
+// is a composition bug and fails loudly rather than relying on os/exec or
+// docker --env-file precedence. Names are compared exact-case (Windows, where
+// the OS folds case, is unsupported). Values must not contain NUL and are
+// capped at MaxEnvValueBytes.
 func BuildEnv(policy pluginpolicy.ExecEnv, lookup func(string) (string, bool), extraEnv []string) ([]string, error) {
 	if lookup == nil {
 		lookup = os.LookupEnv
 	}
 	env := []string{"PATH=" + ControlledPath}
+	seen := map[string]struct{}{"PATH": {}}
+	add := func(name, value string) error {
+		if !pluginpolicy.IsValidEnvName(name) {
+			return fmt.Errorf("env name %q is invalid", name)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("env name %s is set twice", name)
+		}
+		if strings.ContainsRune(value, 0) {
+			return fmt.Errorf("env value %s contains a NUL byte", name)
+		}
+		if len(value) > MaxEnvValueBytes {
+			return fmt.Errorf("env value %s exceeds %d bytes", name, MaxEnvValueBytes)
+		}
+		seen[name] = struct{}{}
+		env = append(env, name+"="+value)
+		return nil
+	}
 	for _, name := range policy.Allow {
 		value, ok := lookup(name)
 		if !ok {
 			continue
 		}
-		if len(value) > MaxEnvValueBytes {
-			return nil, fmt.Errorf("env value %s exceeds %d bytes", name, MaxEnvValueBytes)
+		if err := add(name, value); err != nil {
+			return nil, err
 		}
-		env = append(env, name+"="+value)
 	}
 	for _, entry := range extraEnv {
 		name, value, ok := strings.Cut(entry, "=")
 		if !ok || name == "" {
 			return nil, fmt.Errorf("extra env entry is invalid")
 		}
-		if len(value) > MaxEnvValueBytes {
-			return nil, fmt.Errorf("env value %s exceeds %d bytes", name, MaxEnvValueBytes)
+		if err := add(name, value); err != nil {
+			return nil, err
 		}
-		env = append(env, entry)
 	}
 	return env, nil
 }

--- a/internal/pluginexec/pluginexec_test.go
+++ b/internal/pluginexec/pluginexec_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -778,4 +779,41 @@ func repositoryCopyTestConfig(t *testing.T, include []string, readPath string) p
 		Include: include,
 	}
 	return config
+}
+
+func TestBuildEnvRejectsDuplicateNames(t *testing.T) {
+	lookup := func(name string) (string, bool) { return "host", true }
+	_, err := BuildEnv(pluginpolicy.ExecEnv{Allow: []string{"REGION"}}, lookup, []string{"REGION=extra"})
+	if err == nil || !strings.Contains(err.Error(), "REGION") || !strings.Contains(err.Error(), "twice") {
+		t.Fatalf("BuildEnv() error = %v, want duplicate REGION error", err)
+	}
+	if _, err := BuildEnv(pluginpolicy.ExecEnv{}, lookup, []string{"PATH=/evil"}); err == nil {
+		t.Fatal("BuildEnv() error = nil, want PATH duplicate rejected")
+	}
+}
+
+func TestBuildEnvRejectsNULAndInvalidExtraNames(t *testing.T) {
+	lookup := func(string) (string, bool) { return "", false }
+	if _, err := BuildEnv(pluginpolicy.ExecEnv{}, lookup, []string{"ARGOCD_APP_NAME=a\x00b"}); err == nil || !strings.Contains(err.Error(), "ARGOCD_APP_NAME") || !strings.Contains(err.Error(), "NUL") {
+		t.Fatalf("BuildEnv() error = %v, want NUL rejection naming the variable", err)
+	}
+	if _, err := BuildEnv(pluginpolicy.ExecEnv{}, lookup, []string{"BAD-NAME=x"}); err == nil || !strings.Contains(err.Error(), "BAD-NAME") {
+		t.Fatalf("BuildEnv() error = %v, want invalid name rejection", err)
+	}
+	hostNUL := func(string) (string, bool) { return "x\x00y", true }
+	if _, err := BuildEnv(pluginpolicy.ExecEnv{Allow: []string{"REGION"}}, hostNUL, nil); err == nil || !strings.Contains(err.Error(), "REGION") {
+		t.Fatalf("BuildEnv() error = %v, want NUL rejection for allow-listed host value", err)
+	}
+}
+
+func TestBuildEnvOrdersPathAllowThenExtra(t *testing.T) {
+	lookup := func(name string) (string, bool) { return "host-" + name, true }
+	got, err := BuildEnv(pluginpolicy.ExecEnv{Allow: []string{"REGION"}}, lookup, []string{"ARGOCD_APP_NAME=demo", "KUBE_VERSION="})
+	if err != nil {
+		t.Fatalf("BuildEnv() error = %v", err)
+	}
+	want := []string{"PATH=" + ControlledPath, "REGION=host-REGION", "ARGOCD_APP_NAME=demo", "KUBE_VERSION="}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildEnv() = %#v, want %#v", got, want)
+	}
 }

--- a/internal/pluginonboarding/generate.go
+++ b/internal/pluginonboarding/generate.go
@@ -321,18 +321,8 @@ func commandAccepted(command []string) bool {
 	return !isDeniedCommand(argv0)
 }
 
-var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
 func envNameAccepted(name string) bool {
-	if !envNamePattern.MatchString(name) {
-		return false
-	}
-	upper := strings.ToUpper(name)
-	switch upper {
-	case "PATH", "ARGOCD_APP_PARAMETERS", "BASH_ENV", "ENV", "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "RUBYOPT", "RUBYLIB", "NODE_OPTIONS", "NODE_PATH", "PERL5LIB", "PERL5OPT", "PSMODULEPATH", "POWERSHELL_TELEMETRY_OPTOUT":
-		return false
-	}
-	return !strings.HasPrefix(upper, "LD_") && !strings.HasPrefix(upper, "DYLD_") && !strings.HasPrefix(upper, "PARAM_")
+	return pluginpolicy.ValidateEnvName(name) == nil && !pluginpolicy.IsManagedEnvName(name)
 }
 
 var parameterNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)

--- a/internal/pluginonboarding/onboarding_test.go
+++ b/internal/pluginonboarding/onboarding_test.go
@@ -764,3 +764,22 @@ func hasIssue(issues []ReadinessIssue, code string) bool {
 	}
 	return false
 }
+
+func TestGenerateSkipsDrydockManagedEnvNames(t *testing.T) {
+	root := t.TempDir()
+	app := pluginApp("argocd", "demo", "apps/demo", "pkl")
+	app.Spec.Source.Plugin.Env = argoappv1.Env{{Name: "KUBE_VERSION", Value: "1.30.0"}, {Name: "ARGOCD_APP_NAME", Value: "x"}, {Name: "PKL_ENV", Value: "prod"}}
+	settings := settingsWithCMP("pkl", config.ConfigManagementPlugin{Name: "pkl", GenerateCommand: []string{"pkl"}, Discover: config.ConfigManagementPluginDiscovery{FileName: "PklProject"}})
+	report, err := Analyze(root, []ApplicationInput{{Application: app}}, settings, nil, AnalyzeOptions{})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	data, err := Generate(report, GenerateOptions{})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `- "PKL_ENV"`) || strings.Contains(text, "KUBE_VERSION") || strings.Contains(text, "ARGOCD_APP_NAME") {
+		t.Fatalf("generated policy = \n%s\nwant PKL_ENV only (managed names skipped)", text)
+	}
+}

--- a/internal/pluginpolicy/exec_parse.go
+++ b/internal/pluginpolicy/exec_parse.go
@@ -276,7 +276,7 @@ func parseExecEnv(node *yaml.Node, path, pointer string) (ExecEnv, error) {
 		if name == "" {
 			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must not be empty", path, pointer, index)
 		}
-		if err := validateEnvName(name); err != nil {
+		if err := ValidateEnvName(name); err != nil {
 			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow: %w", path, pointer, err)
 		}
 		if _, ok := seen[name]; ok {
@@ -631,7 +631,11 @@ var reservedExecEnvNames = map[string]struct{}{
 
 var reservedExecEnvPrefixes = []string{"LD_", "DYLD_", "PARAM_"}
 
-func validateEnvName(name string) error {
+// ValidateEnvName returns an error if name may not appear in policy
+// env.allow: it must be an identifier and must not be a reserved
+// loader/interpreter variable or a name the Application parameter environment
+// owns (PATH, ARGOCD_APP_PARAMETERS, PARAM_*, LD_*, DYLD_*, ...).
+func ValidateEnvName(name string) error {
 	if !envNamePattern.MatchString(name) {
 		return fmt.Errorf("env name %q is invalid", name)
 	}
@@ -645,6 +649,37 @@ func validateEnvName(name string) error {
 		}
 	}
 	return nil
+}
+
+// IsValidEnvName reports whether name is a POSIX environment identifier.
+func IsValidEnvName(name string) bool { return envNamePattern.MatchString(name) }
+
+// managedEnvNames and managedEnvPrefixes are set by drydock itself for every
+// command-backed plugin run (the Argo CD build environment and drydock
+// extras). Listing them in env.allow is redundant and would let a
+// caller-environment value stand in for the value drydock computes, so Parse
+// drops them with a warning instead of forwarding them.
+var managedEnvNames = map[string]struct{}{
+	"KUBE_VERSION":      {},
+	"KUBE_API_VERSIONS": {},
+	"DRYDOCK_OFFLINE":   {},
+}
+
+var managedEnvPrefixes = []string{"ARGOCD_APP_"}
+
+// IsManagedEnvName reports whether drydock sets name itself for command-backed
+// plugins (case-insensitive, like the reserved-name check).
+func IsManagedEnvName(name string) bool {
+	upper := strings.ToUpper(name)
+	if _, ok := managedEnvNames[upper]; ok {
+		return true
+	}
+	for _, prefix := range managedEnvPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func parameterEnvName(name string) string {

--- a/internal/pluginpolicy/policy.go
+++ b/internal/pluginpolicy/policy.go
@@ -52,6 +52,9 @@ const (
 type Policy struct {
 	Bootstrap Bootstrap
 	Plugins   map[string]Plugin
+	// Warnings are non-fatal findings from Parse, such as env.allow entries
+	// drydock manages itself; callers surface them as warning diagnostics.
+	Warnings []string
 }
 
 type Bootstrap struct {
@@ -212,7 +215,47 @@ func Parse(path string, data []byte) (Policy, error) {
 	if err := validateYAMLTree(root, "$"); err != nil {
 		return Policy{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
 	}
-	return parsePolicy(root, path)
+	policy, err := parsePolicy(root, path)
+	if err != nil {
+		return Policy{}, err
+	}
+	policy.Warnings = dropManagedEnvNames(&policy)
+	return policy, nil
+}
+
+// dropManagedEnvNames removes env.allow entries drydock sets itself from every
+// exec and container lifecycle and returns one warning per dropped entry, in
+// plugin-name order so output is deterministic. Exec and Container are
+// pointers on Plugin, so the trimmed list is written in place.
+func dropManagedEnvNames(policy *Policy) []string {
+	names := make([]string, 0, len(policy.Plugins))
+	for name := range policy.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var warnings []string
+	for _, name := range names {
+		plugin := policy.Plugins[name]
+		var env *ExecEnv
+		switch {
+		case plugin.Exec != nil:
+			env = &plugin.Exec.Env
+		case plugin.Container != nil:
+			env = &plugin.Container.Lifecycle.Env
+		default:
+			continue
+		}
+		kept := env.Allow[:0:0]
+		for _, entry := range env.Allow {
+			if IsManagedEnvName(entry) {
+				warnings = append(warnings, fmt.Sprintf("plugins.%s.env.allow entry %q is ignored: drydock sets it for every command-backed plugin", name, entry))
+				continue
+			}
+			kept = append(kept, entry)
+		}
+		env.Allow = kept
+	}
+	return warnings
 }
 
 func (p Policy) Plugin(name string) (Plugin, bool) {

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -4,8 +4,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -2004,6 +2006,16 @@ func TestParseExecPolicyRejectsUnsafeFields(t *testing.T) {
 			want: "reserved",
 		},
 		{
+			name: "reserved parameter env takes precedence over managed drop",
+			body: `    engine: exec
+    generate:
+      command: ["argocd-vault-plugin"]
+    env:
+      allow: ["ARGOCD_APP_PARAMETERS"]
+`,
+			want: "reserved",
+		},
+		{
 			name: "duplicate env after trim",
 			body: `    engine: exec
     generate:
@@ -3168,4 +3180,128 @@ func mustPolicyFingerprint(t *testing.T, data string) string {
 		t.Fatalf("Fingerprint() error = %v", err)
 	}
 	return fingerprint
+}
+
+func TestParseDropsDrydockManagedEnvNamesWithWarning(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  render:
+    engine: exec
+    generate:
+      command: ["/usr/local/bin/render"]
+    env:
+      allow: ["CLUSTER_NAME", "KUBE_VERSION", "ARGOCD_APP_NAME", "kube_api_versions", "DRYDOCK_OFFLINE"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	got := policy.Plugins["render"].Exec.Env.Allow
+	if len(got) != 1 || got[0] != "CLUSTER_NAME" {
+		t.Fatalf("env.allow = %#v, want only CLUSTER_NAME", got)
+	}
+	want := []string{
+		`plugins.render.env.allow entry "ARGOCD_APP_NAME" is ignored: drydock sets it for every command-backed plugin`,
+		`plugins.render.env.allow entry "DRYDOCK_OFFLINE" is ignored: drydock sets it for every command-backed plugin`,
+		`plugins.render.env.allow entry "KUBE_VERSION" is ignored: drydock sets it for every command-backed plugin`,
+		`plugins.render.env.allow entry "kube_api_versions" is ignored: drydock sets it for every command-backed plugin`,
+	}
+	if !reflect.DeepEqual(policy.Warnings, want) {
+		t.Fatalf("Warnings = %#v, want %#v", policy.Warnings, want)
+	}
+}
+
+func TestParseDropsManagedEnvNamesForContainerLifecycle(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  render:
+    engine: container
+    image: registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    generate:
+      command: ["render"]
+    env:
+      allow: ["ARGOCD_APP_NAMESPACE", "REGION"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := policy.Plugins["render"].Container.Lifecycle.Env.Allow; len(got) != 1 || got[0] != "REGION" {
+		t.Fatalf("container env.allow = %#v, want only REGION", got)
+	}
+	if len(policy.Warnings) != 1 || !strings.Contains(policy.Warnings[0], `"ARGOCD_APP_NAMESPACE" is ignored`) {
+		t.Fatalf("Warnings = %#v, want one ARGOCD_APP_NAMESPACE warning", policy.Warnings)
+	}
+}
+
+func TestFingerprintIgnoresDroppedManagedEnvNames(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  render:
+    engine: exec
+    generate:
+      command: ["/usr/local/bin/render"]
+`
+	withEnv := base + `    env:
+      allow: [%s]
+`
+	fingerprint := func(t *testing.T, text string) string {
+		t.Helper()
+		policy, err := Parse("policy.yaml", []byte(text))
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		got, err := Fingerprint(policy)
+		if err != nil {
+			t.Fatalf("Fingerprint() error = %v", err)
+		}
+		return got
+	}
+	if a, b := fingerprint(t, fmt.Sprintf(withEnv, `"CLUSTER_NAME", "KUBE_VERSION"`)), fingerprint(t, fmt.Sprintf(withEnv, `"CLUSTER_NAME"`)); a != b {
+		t.Fatalf("fingerprints differ (%s vs %s); a dropped managed name must not change the fingerprint", a, b)
+	}
+	// A list made only of managed names fingerprints like a policy without an env block.
+	if a, b := fingerprint(t, fmt.Sprintf(withEnv, `"KUBE_VERSION"`)), fingerprint(t, base); a != b {
+		t.Fatalf("fingerprints differ (%s vs %s); an all-managed env.allow must fingerprint like no env block", a, b)
+	}
+}
+
+func TestManagedAndReservedEnvNames(t *testing.T) {
+	for _, name := range []string{"KUBE_VERSION", "KUBE_API_VERSIONS", "DRYDOCK_OFFLINE", "ARGOCD_APP_NAME", "argocd_app_source_path"} {
+		t.Run("managed "+name, func(t *testing.T) {
+			if !IsManagedEnvName(name) {
+				t.Errorf("IsManagedEnvName(%q) = false, want true", name)
+			}
+		})
+	}
+	for _, name := range []string{"CLUSTER_NAME", "DRYDOCK_APP_EXEC_HELPER", "ARGOCD_ENV_MODE", "KUBECONFIG"} {
+		t.Run("unmanaged "+name, func(t *testing.T) {
+			if IsManagedEnvName(name) {
+				t.Errorf("IsManagedEnvName(%q) = true, want false", name)
+			}
+		})
+	}
+	// Hard reservations stay parse errors and take precedence over the managed drop.
+	for _, name := range []string{"PATH", "ARGOCD_APP_PARAMETERS", "PARAM_X", "LD_PRELOAD"} {
+		t.Run("reserved "+name, func(t *testing.T) {
+			if err := ValidateEnvName(name); err == nil {
+				t.Errorf("ValidateEnvName(%q) = nil, want reserved error", name)
+			}
+		})
+	}
+	for _, tt := range []struct {
+		name string
+		want bool
+	}{
+		{name: "A_b9", want: true},
+		{name: "9A", want: false},
+		{name: "A-B", want: false},
+	} {
+		t.Run("identifier "+tt.name, func(t *testing.T) {
+			if got := IsValidEnvName(tt.name); got != tt.want {
+				t.Errorf("IsValidEnvName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
 }

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -257,7 +257,7 @@
           }
         },
         "env": {
-          "description": "Caller environment variables the plugin may receive.",
+          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
           "$ref": "#/$defs/env"
         },
         "parameters": {
@@ -345,7 +345,7 @@
           }
         },
         "env": {
-          "description": "Caller environment variables the plugin may receive.",
+          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
           "$ref": "#/$defs/env"
         },
         "parameters": {
@@ -611,7 +611,7 @@
     },
     "env": {
       "type": "object",
-      "description": "Environment variables allowed from the caller environment.",
+      "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
       "additionalProperties": false,
       "properties": {
         "allow": {

--- a/site/content/docs/plugin-policy/bootstrap.md
+++ b/site/content/docs/plugin-policy/bootstrap.md
@@ -24,7 +24,13 @@ Each bootstrap entrypoint creates an internal, hidden synthetic Application
 with namespace `argocd`, project `default`, destination name `in-cluster`, and
 destination namespace `argocd`. The synthetic Application is used only to
 render and scan the entrypoint output; it is not returned as a discovered
-Application.
+Application. Command-backed plugins therefore observe
+`ARGOCD_APP_NAME=<entrypoint name>`, `ARGOCD_APP_NAMESPACE=argocd`,
+`ARGOCD_APP_PROJECT_NAME=default`, empty `ARGOCD_APP_SOURCE_REPO_URL`,
+`ARGOCD_APP_REVISION*` and `ARGOCD_APP_SOURCE_TARGET_REVISION`, and
+`ARGOCD_APP_PARAMETERS` reflecting the entrypoint's declared parameters
+(`null` when none) during bootstrap discovery, which has no live Argo CD
+counterpart.
 
 Bootstrap entrypoints fail closed. The `sourcePath` must be repository-local,
 exist, be a directory, avoid symlink components, and match the referenced

--- a/site/content/docs/plugin-policy/examples.md
+++ b/site/content/docs/plugin-policy/examples.md
@@ -185,6 +185,7 @@ plugins:
     postRenderers:
       - command: ["/usr/local/bin/kbld", "-f", "-"]
         timeout: 15s
+    # env.allow copies drydock's own process variables; ARGOCD_APP_* and KUBE_* are set automatically.
     env:
       allow: ["CLUSTER_NAME", "ENVIRONMENT"]
     output:

--- a/site/content/docs/plugin-policy/schema.md
+++ b/site/content/docs/plugin-policy/schema.md
@@ -70,7 +70,7 @@ and optional `configManagementPlugin`.
 | `init` | No | None | Optional command run before `generate`. |
 | `generate` | Yes | None | Command that writes Kubernetes manifests to stdout. |
 | `postRenderers` | No | None | Non-empty list when present. Chains stdout through stdin. |
-| `env.allow` | No | `[]` | Up to 64 environment variable names copied from the caller environment. |
+| `env.allow` | No | `[]` | Up to 64 names of variables copied from drydock's own process environment (CI or shell), not from the Application. Names drydock sets itself (`ARGOCD_APP_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`, `DRYDOCK_OFFLINE`, matched case-insensitively) are ignored with a warning. |
 | `parameters.allow` | No | `[]` | Application plugin parameter allowlist for `engine: exec` and `engine: container`. |
 | `output.maxStdoutBytes` | No | `10485760` | Per-command stdout limit. |
 | `output.maxStderrBytes` | No | `65536` | Per-command stderr limit. Stderr is not printed in failure messages. |

--- a/site/content/docs/plugin-policy/trust.md
+++ b/site/content/docs/plugin-policy/trust.md
@@ -188,17 +188,36 @@ and rejects caller-provided remote Docker client configuration such as
 non-local `DOCKER_HOST`, `DOCKER_CONTEXT`, `DOCKER_CONFIG`,
 `DOCKER_TLS_VERIFY`, or `DOCKER_CERT_PATH`.
 
-For `engine: exec`, the command environment starts with only drydock's
-controlled `PATH`. For `engine: container`, the Docker client process uses a
-minimal controlled environment, while the process inside the image keeps the
-image-defined environment and receives policy-allowed environment values,
-Argo-style plugin parameter values, and drydock extras through `--env-file`.
+For both command-backed engines drydock composes the plugin environment in
+this order: the Argo CD build environment (`ARGOCD_APP_NAME`,
+`ARGOCD_APP_NAMESPACE`, `ARGOCD_APP_PROJECT_NAME`, `ARGOCD_APP_REVISION`,
+`ARGOCD_APP_REVISION_SHORT`, `ARGOCD_APP_REVISION_SHORT_8`,
+`ARGOCD_APP_SOURCE_REPO_URL`, `ARGOCD_APP_SOURCE_PATH`,
+`ARGOCD_APP_SOURCE_TARGET_REVISION`, then `KUBE_VERSION` and
+`KUBE_API_VERSIONS`, always present and empty without `--kube-version` /
+`--api-versions`), the Argo-style parameter environment
+(`ARGOCD_APP_PARAMETERS`, `null` when the Application declares none, then
+`PARAM_*`), and `DRYDOCK_OFFLINE=true` when offline. `ARGOCD_APP_REVISION*`
+carry the spec `targetRevision`, not a resolved commit SHA, and
+`KUBE_API_VERSIONS` is sorted and deduplicated where a repo-server sends
+discovery order. For `engine: exec` the process environment is exactly
+drydock's controlled `PATH`, then the `env.allow` copies from drydock's own
+process environment, then the drydock-composed values above. For
+`engine: container` the Docker client uses a minimal controlled environment,
+while the process inside the image keeps the image-defined environment and
+receives the `env.allow` copies and the same drydock-composed values through
+`--env-file` (the image `PATH` is kept).
 
-For both command-backed engines, allowed environment names must be valid
-environment identifiers, cannot be duplicated, and cannot be reserved
-loader/interpreter variables such as `PATH`, `LD_*`, `DYLD_*`, `PYTHONPATH`, or
-`NODE_OPTIONS`. Each copied value is capped at 16 KiB. Application-authored
-plugin env is rejected for policy-backed plugin sources.
+`env.allow` names must be valid environment identifiers, cannot be
+duplicated, and cannot be reserved loader/interpreter variables such as
+`PATH`, `LD_*`, `DYLD_*`, `PYTHONPATH`, or `NODE_OPTIONS`. Names drydock sets
+itself (`ARGOCD_APP_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`,
+`DRYDOCK_OFFLINE`, matched case-insensitively) are ignored with a
+`plugin.policy.env-ignored` warning. Names are otherwise compared exact-case;
+Windows, where the OS folds case, is unsupported. Each copied value is capped
+at 16 KiB. Application-authored plugin env (`spec.source.plugin.env`) is not
+forwarded yet for any engine; pass per-Application values through parameters
+allowlisted by `parameters.allow`.
 
 ### Application Parameters
 

--- a/site/content/reference/go-api.md
+++ b/site/content/reference/go-api.md
@@ -61,7 +61,13 @@ source.
 
 Exec and container policy require trusted provenance and `--enable-plugins`.
 Application plugin parameters for command-backed engines must be allowlisted by
-policy. Native policy engines such as `avp-compat` and `native-kustomize` do
+policy. Trusted `engine: exec` and `engine: container` policy plugins receive
+the Argo CD build environment (`ARGOCD_APP_*`, `KUBE_VERSION`,
+`KUBE_API_VERSIONS`) as environment variables, like a repo-server sidecar;
+Application plugin env (`spec.source.plugin.env`) is not forwarded to them
+yet. Injected `PluginRenderer` implementations are unaffected and keep
+receiving the full `PluginRequest` in process. Native policy engines such as
+`avp-compat` and `native-kustomize` do
 not execute plugin commands and reject Application plugin env and parameters.
 Explicit `argocd-vault-plugin` sources and discovered simple AVP CMP aliases
 use native AVP compatibility by default. `Config.EnableAVPCompat` forces the


### PR DESCRIPTION
Closes #297. Stacked on #312 (which fixes the `ARGOCD_APP_NAME`/`ARGOCD_APP_NAMESPACE` values themselves).

Trusted `engine: exec` and `engine: container` plugins now receive what a repo-server hands a config management plugin, in its order (`reposerver/repository/repository.go` `getPluginEnvs`): the nine `ARGOCD_APP_*` entries, `KUBE_VERSION`, `KUBE_API_VERSIONS` (always present, empty without `--kube-version` / `--api-versions`), then `ARGOCD_APP_PARAMETERS` (`null` for parameterless Applications, as Argo CD emits) and `PARAM_*`, then `DRYDOCK_OFFLINE`. Values come from the same `ArgoEnv` the native Helm/Kustomize/Jsonnet substitution uses. For `engine: exec` the process environment is exactly drydock's controlled `PATH`, then the `env.allow` copies, then these values; for `engine: container` the same list reaches the image through `--env-file` (image `PATH` kept).

- `env.allow` keeps its meaning (names copied from drydock's own process environment, never from the Application). Entries naming a variable drydock now sets (`ARGOCD_APP_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`, `DRYDOCK_OFFLINE`, matched case-insensitively) are dropped at parse with a `plugin.policy.env-ignored` warning rather than a parse error, so existing policies keep loading through the diff baseline (where the policy is read from the base tree or `--plugin-policy-ref` and cannot be fixed from the PR branch). The warning is advisory: `strictExemptDiagnostic` in `internal/app/orchestrator.go` keeps it a warning under `--strict`, so `get`/`diag --strict` accept the same policies `build`/`diff --strict` accept. The policy fingerprint uses the post-drop list (an all-managed `env.allow` fingerprints like no env block). The `DRYDOCK_` prefix is deliberately not reserved (only `DRYDOCK_OFFLINE`). `PATH`, `ARGOCD_APP_PARAMETERS`, `PARAM_*`, `LD_*`, `DYLD_*` and the interpreter variables stay hard parse errors and take precedence over the drop.
- The parser's name rules are exported (`pluginpolicy.ValidateEnvName`, `IsValidEnvName`, `IsManagedEnvName`) and `plugin-policy init` uses them instead of a hand-copied reserved list. `plugin-policy doctor` does not print the warning yet and still reports `env.missing_allow` for managed names an Application sets in `spec.source.plugin.env`; both belong to the init/doctor realignment follow-up.
- `pluginexec.BuildEnv` rejects duplicate names (exact-case; Windows, where the OS folds env keys, is unsupported), invalid names and NUL bytes, naming only the variable, instead of relying on `os/exec` versus `--env-file` precedence.
- `spec.source.plugin.env` is still rejected for every engine (a follow-up adds `applicationEnv.allow` with `ARGOCD_ENV_*` delivery); exec/container now get a message that names the entries (never values) and points at `parameters.allow` instead of the misleading "native" wording. Native engines get separate env and parameters messages.
- `ARGOCD_APP_SOURCE_REPO_URL` is passed verbatim like a repo-server. drydock's own runner never prints plugin output in failure messages, so a credential-bearing `repoURL` cannot surface through the CLI; redaction for injected Go-API runners is a follow-up.
- Docs: plugin-policy trust/schema/examples/bootstrap pages, Go API reference, compatibility notes, JSON schema descriptions.

Known gaps after this PR: `ARGOCD_APP_REVISION*` carry the spec `targetRevision`, not a resolved SHA; `KUBE_VERSION` is empty unless `--kube-version` is set (a repo-server always has a cluster version); `KUBE_API_VERSIONS` is sorted and deduplicated where a repo-server sends discovery order; bootstrap-entrypoint renders use the synthetic Application's name/namespace/project (`<entrypoint name>`, `argocd`, `default`, empty repo URL and revisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt
