### PR TITLE
feat(plugin-policy): applicationEnv.allow delivers Application plugin env to exec/container plugins as ARGOCD_ENV_*

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -203,8 +203,9 @@ Supported:
   annotation-based tracking, and CRDs are not stamped.
 - Argo CD build-environment substitution (`$ARGOCD_APP_NAME`,
   `$ARGOCD_APP_NAMESPACE`, `$ARGOCD_APP_PROJECT_NAME`, `$ARGOCD_APP_SOURCE_*`)
-  in Helm parameters and value-file names, Kustomize images, labels, and
-  `commonAnnotationsEnvsubst` annotations, and Jsonnet ext vars and TLAs, with
+  in Helm parameters, value-file names, and `fileParameters` paths, Kustomize
+  images, labels, and `commonAnnotationsEnvsubst` annotations, and Jsonnet ext
+  vars and TLAs, with
   the repo-server's values: `ARGOCD_APP_NAME` is the Application instance name
   (`<namespace>_<name>` for Applications outside the controller namespace;
   drydock assumes the Argo CD controller namespace is `argocd`) and
@@ -292,6 +293,10 @@ Supported:
   `KUBE_API_VERSIONS`) and an always-present `ARGOCD_APP_PARAMETERS` for
   trusted exec/container plugins, in the repo-server's order. `env.allow`
   entries naming those variables are ignored with a warning.
+- Application `spec.source.plugin.env` for trusted exec/container plugins when
+  allowlisted by `applicationEnv.allow`, delivered as `ARGOCD_ENV_<name>` after
+  build-environment substitution in the repo-server's order and position. Host
+  `env.allow` entries naming `ARGOCD_ENV_*` are ignored with a warning.
 - Config management plugin source detection with fail-closed diagnostics in
   the CLI and default Go client.
 - Injectable in-process plugin renderers, named plugin registry dispatch, and
@@ -313,9 +318,8 @@ Not supported:
 - Argo CD repo-server sidecar plugin discovery.
 - Ambient plugin configuration or environment loading.
 - Untrusted CMP descriptor execution, unallowlisted Application plugin
-  parameters, or Application plugin env (`spec.source.plugin.env`) for any
-  policy-backed engine; exec/container reject it with a message that names
-  the entries.
+  parameters or env (`parameters.allow` / `applicationEnv.allow`), or
+  Application plugin env for policy-backed native engines.
 - Plugin credential injection.
 
 See `site/content/docs/plugin-policy/` for trusted policy provenance, supported

--- a/internal/app/orchestrator_plugins_test.go
+++ b/internal/app/orchestrator_plugins_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -3033,6 +3035,8 @@ func appExecPluginHelperBuildEnv() {
 	fmt.Printf("  api: %q\n", os.Getenv("KUBE_API_VERSIONS"))
 	fmt.Printf("  params: %q\n", os.Getenv("ARGOCD_APP_PARAMETERS"))
 	fmt.Printf("  offline: %q\n", os.Getenv("DRYDOCK_OFFLINE"))
+	fmt.Printf("  appEnvMode: %q\n", os.Getenv("ARGOCD_ENV_MODE"))
+	fmt.Printf("  bareMode: %q\n", os.Getenv("MODE"))
 }
 
 func appExecPluginHelperRepoParam(args []string) error {
@@ -3253,4 +3257,198 @@ plugins:
 		}
 		assertWarning(t, result.Diagnostics)
 	})
+}
+
+// writePluginBuildApplicationWithEnv is writePluginBuildApplication plus a
+// spec.source.plugin.env block.
+func writePluginBuildApplicationWithEnv(t *testing.T, root, appName, pluginName string, env map[string]string) {
+	t.Helper()
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var block strings.Builder
+	if len(names) > 0 {
+		block.WriteString("      env:\n")
+	}
+	for _, name := range names {
+		fmt.Fprintf(&block, "        - name: %s\n          value: %s\n", name, yamlSingleQuoted(env[name]))
+	}
+	writeTestFile(t, filepath.Join(root, "apps", appName+".yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: `+appName+`
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/`+appName+`
+    targetRevision: main
+    plugin:
+      name: `+pluginName+`
+`+block.String()+`  destination:
+    name: in-cluster
+    namespace: default
+`)
+	writeTestFile(t, filepath.Join(root, "manifests", appName, ".keep"), "")
+}
+
+func writeExecPluginPolicyWithApplicationEnv(t *testing.T, root, name string, command []string, allow []string) {
+	t.Helper()
+	quoted := yamlSingleQuotedList(command)
+	allowed := make([]string, 0, len(allow))
+	for _, entry := range allow {
+		allowed = append(allowed, strconv.Quote(entry))
+	}
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  `+name+`:
+    engine: exec
+    generate:
+      command: [`+strings.Join(quoted, ", ")+`]
+      timeout: `+testExecPolicyCommandTimeout+`
+    env:
+      allow: ["DRYDOCK_APP_EXEC_HELPER", "DRYDOCK_APP_EXEC_VALUE"]
+    applicationEnv:
+      allow: [`+strings.Join(allowed, ", ")+`]
+`)
+}
+
+func TestOrchestratorBuildDeliversAllowlistedApplicationEnvToExecPlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplicationWithEnv(t, root, "plugin", "exec-renderer", map[string]string{
+		"MODE":   "prod",
+		"SUFFIX": "$ARGOCD_APP_NAME-$KUBE_VERSION-$$-$MODE", // $MODE: earlier entries are not substitutable
+	})
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	writeExecPluginPolicyWithApplicationEnv(t, root, "exec-renderer", []string{"renderer"}, []string{"MODE", "SUFFIX"})
+	policy, fingerprint := readTestPluginPolicy(t, root)
+	runner := &recordingExecRunner{result: pluginexec.Result{Stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: injected\n")}}
+
+	_, err := (Orchestrator{PluginExecRunner: runner}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		KubeVersion:             "v1.30.2",
+		APIVersions:             []string{"monitoring.coreos.com/v1", "apps/v1"},
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	base := argoBuildEnvForPluginFixture()
+	want := append(append([]string(nil), base[:11]...), "ARGOCD_ENV_MODE=prod", "ARGOCD_ENV_SUFFIX=plugin-1.30.2-$-", base[11])
+	if got := runner.lastRequest.ExtraEnv; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtraEnv = %#v, want %#v", got, want)
+	}
+	if slices.Contains(runner.lastRequest.ExtraEnv, "MODE=prod") {
+		t.Fatalf("ExtraEnv = %#v must not contain a bare MODE", runner.lastRequest.ExtraEnv)
+	}
+}
+
+func TestOrchestratorBuildRejectsApplicationEnvNotAllowlisted(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplicationWithEnv(t, root, "plugin", "exec-renderer", map[string]string{"MODE": "prod", "SECRET": "hunter2"})
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	writeExecPluginPolicyWithApplicationEnv(t, root, "exec-renderer", []string{"renderer"}, []string{"MODE"})
+	policy, fingerprint := readTestPluginPolicy(t, root)
+	runner := &recordingExecRunner{}
+
+	result, err := (Orchestrator{PluginExecRunner: runner}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err == nil {
+		t.Fatal("Build() error = nil, want rejection")
+	}
+	if runner.calls != 0 {
+		t.Fatalf("runner calls = %d, want 0 (fail closed before execution)", runner.calls)
+	}
+	if !hasDiagnosticCode(result.Diagnostics, diagnostic.CodePluginUnsupported) || !hasDiagnosticMessage(result.Diagnostics, `Application plugin env "SECRET", which is not allowed by policy applicationEnv.allow`) {
+		t.Fatalf("Diagnostics = %#v, want plugin.unsupported naming SECRET and applicationEnv.allow", result.Diagnostics)
+	}
+	if hasDiagnosticMessage(result.Diagnostics, "hunter2") {
+		t.Fatalf("Diagnostics = %#v leak the env value", result.Diagnostics)
+	}
+}
+
+func TestOrchestratorBuildDeliversAllowlistedApplicationEnvToContainerPlugin(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplicationWithEnv(t, root, "plugin", "container-renderer", map[string]string{"REGION": "eu"})
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	writeTestFile(t, filepath.Join(root, ".drydock", "plugins.yaml"), `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  container-renderer:
+    engine: container
+    image: registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    configManagementPlugin:
+      discover:
+        fileName: marker.txt
+    generate:
+      command: ["pkl", "eval", "index.pkl"]
+    applicationEnv:
+      allow: ["REGION"]
+`)
+	policy, fingerprint := readTestPluginPolicy(t, root)
+	runner := &recordingContainerRunner{result: pluginexec.Result{Stdout: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: injected\n")}}
+
+	_, err := (Orchestrator{PluginContainerRunner: runner}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		PluginCacheDir:          filepath.Join(t.TempDir(), "plugin-cache"),
+		KubeVersion:             "v1.30.2",
+		APIVersions:             []string{"monitoring.coreos.com/v1", "apps/v1"},
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	base := argoBuildEnvForPluginFixture()
+	want := append(append([]string(nil), base[:11]...), "ARGOCD_ENV_REGION=eu", base[11])
+	if got := runner.lastRequest.ExtraEnv; !reflect.DeepEqual(got, want) {
+		t.Fatalf("container ExtraEnv = %#v, want %#v", got, want)
+	}
+}
+
+// End to end through a real subprocess.
+func TestOrchestratorBuildExecPolicyPluginObservesApplicationEnv(t *testing.T) {
+	root := t.TempDir()
+	writePluginBuildApplicationWithEnv(t, root, "plugin", "exec-renderer", map[string]string{"MODE": "prod"})
+	writeTestFile(t, filepath.Join(root, "manifests", "plugin", "marker.txt"), "from-source")
+	t.Setenv("DRYDOCK_APP_EXEC_HELPER", "1")
+	writeExecPluginPolicyWithApplicationEnv(t, root, "exec-renderer", appExecCommand(t, "build-env"), []string{"MODE"})
+	policy, fingerprint := readTestPluginPolicy(t, root)
+
+	result, err := (Orchestrator{}).Build(context.Background(), BuildRequest{
+		Path:                    root,
+		EnablePlugins:           true,
+		pluginPolicyLoaded:      true,
+		pluginPolicy:            policy,
+		pluginPolicyFingerprint: fingerprint,
+		pluginPolicyExecTrusted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v\nDiagnostics: %#v", err, result.Diagnostics)
+	}
+	manifest, ok := manifestByName(result.Manifests, "exec-build-env")
+	if !ok {
+		t.Fatalf("Manifests = %#v, want exec-build-env", result.Manifests)
+	}
+	data := configMapData(t, manifest)
+	if data["appEnvMode"] != "prod" || data["bareMode"] != "" {
+		t.Fatalf("data = %#v, want ARGOCD_ENV_MODE=prod and no bare MODE", data)
+	}
 }

--- a/internal/app/orchestrator_test_helpers_test.go
+++ b/internal/app/orchestrator_test_helpers_test.go
@@ -309,24 +309,7 @@ data:
 }
 func writePluginBuildApplication(t *testing.T, root, appName, pluginName string) {
 	t.Helper()
-	writeTestFile(t, filepath.Join(root, "apps", appName+".yaml"), `apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: `+appName+`
-  namespace: argocd
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/example/repo
-    path: manifests/`+appName+`
-    targetRevision: main
-    plugin:
-      name: `+pluginName+`
-  destination:
-    name: in-cluster
-    namespace: default
-`)
-	writeTestFile(t, filepath.Join(root, "manifests", appName, ".keep"), "")
+	writePluginBuildApplicationWithEnv(t, root, appName, pluginName, nil)
 }
 func writeBuildApplicationWithProject(t *testing.T, root, appName, configMapName, projectName, repoURL, destinationNamespace string) {
 	t.Helper()

--- a/internal/app/plugin_render_container.go
+++ b/internal/app/plugin_render_container.go
@@ -38,13 +38,17 @@ func (p localProvider) renderContainerPolicyPluginSource(ctx context.Context, so
 	if message != "" {
 		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
 	}
+	applicationEnv, message := validateApplicationPluginEnv(name, policyPlugin.Container.Lifecycle.ApplicationEnv.Allow, opts.Plugin.Env, policyPluginBuildEnvEntries(opts))
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
 	lifecycle, sensitive, message := expandExecPluginCommandTemplates(policyPlugin.Container.Lifecycle, params)
 	if message != "" {
 		return nil, unsupportedPluginDiagnostic(fmt.Sprintf("config management plugin %s %s", pluginDisplayName(name), message)), true, unsupportedPolicyPluginError(message)
 	}
 	containerConfig := *policyPlugin.Container
 	containerConfig.Lifecycle = lifecycle
-	extraEnv := composePolicyPluginExtraEnv(opts, params, p.offline)
+	extraEnv := composePolicyPluginExtraEnv(opts, applicationEnv, params, p.offline)
 	result, err := p.pluginContainerRunner.Run(ctx, plugincontainer.Request{
 		SourceDir:         sourceDir,
 		RepositoryDir:     source.RepoRoot,

--- a/internal/app/plugin_render_env.go
+++ b/internal/app/plugin_render_env.go
@@ -1,11 +1,35 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/pluginexec"
+	"github.com/sholdee/drydock/internal/pluginpolicy"
 	"github.com/sholdee/drydock/internal/render"
 )
+
+// policyPluginBuildEnvEntries returns the eleven build-environment entries
+// (opts.ArgoEnv then KUBE_VERSION and KUBE_API_VERSIONS) as an Env, the exact
+// substitution scope a repo-server applies to spec.source.plugin.env values
+// (reposerver/repository/repository.go getPluginParamEnvs): host env.allow
+// values and earlier ARGOCD_ENV_* entries are deliberately not substitutable.
+func policyPluginBuildEnvEntries(opts render.RenderOptions) argoappv1.Env {
+	// Envsubst dereferences every entry, so nil entries (legal in the public
+	// RenderOptions.ArgoEnv) are dropped rather than passed through.
+	entries := make(argoappv1.Env, 0, len(opts.ArgoEnv)+2)
+	for _, entry := range opts.ArgoEnv {
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	entries = append(entries,
+		&argoappv1.EnvEntry{Name: "KUBE_VERSION", Value: opts.KubeVersion},
+		&argoappv1.EnvEntry{Name: "KUBE_API_VERSIONS", Value: strings.Join(opts.APIVersions, ",")},
+	)
+	return entries
+}
 
 // policyPluginBuildEnv returns the Argo CD build environment a repo-server
 // hands a config management plugin, in the repo-server's order: the nine
@@ -20,17 +44,17 @@ import (
 // the cluster version to plugins. KUBE_API_VERSIONS is sorted and
 // deduplicated, whereas a repo-server sends discovery order.
 func policyPluginBuildEnv(opts render.RenderOptions) []string {
-	env := append([]string(nil), opts.ArgoEnv.Environ()...)
-	env = append(env, "KUBE_VERSION="+opts.KubeVersion)
-	return append(env, "KUBE_API_VERSIONS="+strings.Join(opts.APIVersions, ","))
+	return policyPluginBuildEnvEntries(opts).Environ()
 }
 
 // composePolicyPluginExtraEnv orders everything drydock itself provides to a
-// command-backed plugin: the build environment, the Application parameter
+// command-backed plugin, in the repo-server's order: the build environment,
+// the Application env delivered as ARGOCD_ENV_*, the Application parameter
 // environment (ARGOCD_APP_PARAMETERS then PARAM_*), then drydock extras.
 // pluginexec.BuildEnv places these after the policy env.allow copies.
-func composePolicyPluginExtraEnv(opts render.RenderOptions, params validatedPluginParameters, offline bool) []string {
+func composePolicyPluginExtraEnv(opts render.RenderOptions, applicationEnv []string, params validatedPluginParameters, offline bool) []string {
 	env := policyPluginBuildEnv(opts)
+	env = append(env, applicationEnv...)
 	env = append(env, params.extraEnv...)
 	if offline {
 		env = append(env, "DRYDOCK_OFFLINE=true")
@@ -38,15 +62,53 @@ func composePolicyPluginExtraEnv(opts render.RenderOptions, params validatedPlug
 	return env
 }
 
-// applicationPluginEnvNames lists the names in spec.source.plugin.env for
-// diagnostics. Values are never included: Application env may carry secrets.
-func applicationPluginEnvNames(env argoappv1.Env) []string {
-	names := make([]string, 0, len(env))
+// maxApplicationPluginEnvValueBytes is the runner's env value cap. Checking it
+// here, before pluginexec.BuildEnv does, yields a value-free diagnostic that
+// names the Application env entry instead of the runner's generic error.
+const maxApplicationPluginEnvValueBytes = pluginexec.MaxEnvValueBytes
+
+// validateApplicationPluginEnv checks spec.source.plugin.env against the
+// policy's applicationEnv.allow and drydock's env rules, then returns the
+// ARGOCD_ENV_<name>=<value> entries in spec order with each value expanded
+// against buildEnv (Argo CD's Envsubst: $VAR/${VAR}, $$ -> $, unknown ->
+// empty). It fails closed with a message that names the entry but never its
+// value: Application env may carry secrets. Values are not added to the
+// redaction set because a repo-server treats them as non-secret too.
+func validateApplicationPluginEnv(name string, allow []string, env argoappv1.Env, buildEnv argoappv1.Env) ([]string, string) {
+	if len(env) == 0 {
+		return nil, ""
+	}
+	allowed := make(map[string]struct{}, len(allow))
+	for _, entry := range allow {
+		allowed[entry] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(env))
+	out := make([]string, 0, len(env))
 	for _, entry := range env {
 		if entry == nil || strings.TrimSpace(entry.Name) == "" {
-			continue
+			return nil, fmt.Sprintf("config management plugin %s has an unnamed Application plugin env entry", pluginDisplayName(name))
 		}
-		names = append(names, entry.Name)
+		if !pluginpolicy.IsValidEnvName(entry.Name) {
+			return nil, fmt.Sprintf("config management plugin %s has invalid Application plugin env name %q", pluginDisplayName(name), entry.Name)
+		}
+		if _, ok := allowed[entry.Name]; !ok {
+			return nil, fmt.Sprintf("config management plugin %s uses Application plugin env %q, which is not allowed by policy applicationEnv.allow", pluginDisplayName(name), entry.Name)
+		}
+		if _, ok := seen[entry.Name]; ok {
+			return nil, fmt.Sprintf("config management plugin %s has duplicate Application plugin env %q", pluginDisplayName(name), entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+		if len(entry.Value) > maxApplicationPluginEnvValueBytes {
+			return nil, fmt.Sprintf("config management plugin %s Application plugin env %q value is too large", pluginDisplayName(name), entry.Name)
+		}
+		if strings.ContainsRune(entry.Value, 0) {
+			return nil, fmt.Sprintf("config management plugin %s Application plugin env %q value contains a NUL byte", pluginDisplayName(name), entry.Name)
+		}
+		expanded := buildEnv.Envsubst(entry.Value)
+		if len(expanded) > maxApplicationPluginEnvValueBytes {
+			return nil, fmt.Sprintf("config management plugin %s Application plugin env %q value is too large after build-environment substitution", pluginDisplayName(name), entry.Name)
+		}
+		out = append(out, pluginpolicy.ApplicationEnvPrefix+entry.Name+"="+expanded)
 	}
-	return names
+	return out, ""
 }

--- a/internal/app/plugin_render_env_test.go
+++ b/internal/app/plugin_render_env_test.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sholdee/drydock/internal/pluginexec"
 	"github.com/sholdee/drydock/internal/render"
 )
 
@@ -52,18 +54,117 @@ func TestRecordApplicationPluginParameterEnvEmitsNullWithoutParameters(t *testin
 func TestComposePolicyPluginExtraEnvOrdersBuildEnvParametersThenExtras(t *testing.T) {
 	opts := render.RenderOptions{ArgoEnv: argoappv1.Env{{Name: "ARGOCD_APP_NAME", Value: "demo"}}}
 	params := validatedPluginParameters{extraEnv: []string{"ARGOCD_APP_PARAMETERS=null"}}
-	got := composePolicyPluginExtraEnv(opts, params, true)
+	applicationEnv := []string{"ARGOCD_ENV_MODE=prod"}
+	got := composePolicyPluginExtraEnv(opts, applicationEnv, params, true)
 	want := []string{
+		"ARGOCD_APP_NAME=demo",
+		"KUBE_VERSION=",
+		"KUBE_API_VERSIONS=",
+		"ARGOCD_ENV_MODE=prod",
+		"ARGOCD_APP_PARAMETERS=null",
+		"DRYDOCK_OFFLINE=true",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composePolicyPluginExtraEnv() = %#v, want %#v (build env, ARGOCD_ENV_*, parameters, extras)", got, want)
+	}
+	if got := composePolicyPluginExtraEnv(opts, applicationEnv, params, false); got[len(got)-1] != "ARGOCD_APP_PARAMETERS=null" {
+		t.Fatalf("composePolicyPluginExtraEnv(offline=false) = %#v, want no DRYDOCK_OFFLINE entry", got)
+	}
+	withoutApplicationEnv := []string{
 		"ARGOCD_APP_NAME=demo",
 		"KUBE_VERSION=",
 		"KUBE_API_VERSIONS=",
 		"ARGOCD_APP_PARAMETERS=null",
 		"DRYDOCK_OFFLINE=true",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("composePolicyPluginExtraEnv() = %#v, want %#v", got, want)
+	if got := composePolicyPluginExtraEnv(opts, nil, params, true); !reflect.DeepEqual(got, withoutApplicationEnv) {
+		t.Fatalf("composePolicyPluginExtraEnv(nil application env) = %#v, want %#v (no ARGOCD_ENV_* entry)", got, withoutApplicationEnv)
 	}
-	if got := composePolicyPluginExtraEnv(opts, params, false); got[len(got)-1] != "ARGOCD_APP_PARAMETERS=null" {
-		t.Fatalf("composePolicyPluginExtraEnv(offline=false) = %#v, want no DRYDOCK_OFFLINE entry", got)
+}
+
+func TestValidateApplicationPluginEnvDeliversArgoEnvWithBuildEnvSubstitution(t *testing.T) {
+	build := argoappv1.Env{
+		{Name: "ARGOCD_APP_NAME", Value: "demo"},
+		{Name: "KUBE_VERSION", Value: "1.30.2"},
+	}
+	env := argoappv1.Env{
+		{Name: "MODE", Value: "prod"},
+		// MODE precedes SUFFIX, so $MODE and $ARGOCD_ENV_MODE prove that earlier
+		// Application env entries are not in the substitution scope.
+		{Name: "SUFFIX", Value: "$ARGOCD_APP_NAME-$KUBE_VERSION-$$-$UNKNOWN-$CLUSTER_NAME-$MODE-$ARGOCD_ENV_MODE"},
+		{Name: "EMPTY", Value: ""},
+	}
+	got, message := validateApplicationPluginEnv("pkl", []string{"EMPTY", "MODE", "SUFFIX"}, env, build)
+	if message != "" {
+		t.Fatalf("message = %q, want empty", message)
+	}
+	want := []string{
+		"ARGOCD_ENV_MODE=prod",
+		"ARGOCD_ENV_SUFFIX=demo-1.30.2-$----", // $$ -> $; unknown, host, and earlier Application env names expand to empty
+		"ARGOCD_ENV_EMPTY=",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validateApplicationPluginEnv() = %#v, want %#v (spec order, build-env substitution only)", got, want)
+	}
+}
+
+func TestValidateApplicationPluginEnvFailsClosed(t *testing.T) {
+	build := argoappv1.Env{{Name: "ARGOCD_APP_NAME", Value: "demo"}}
+	// Every value carries the sentinel so any message shape that echoes a
+	// value is caught; the oversized value is additionally a run of one byte.
+	const sentinel = "sentinel-value"
+	big := sentinel + strings.Repeat("x", pluginexec.MaxEnvValueBytes)
+	testCases := []struct {
+		name  string
+		allow []string
+		env   argoappv1.Env
+		want  string
+	}{
+		{name: "not allowlisted", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "SECRET", Value: sentinel}}, want: `Application plugin env "SECRET", which is not allowed by policy applicationEnv.allow`},
+		{name: "no allowlist at all", allow: nil, env: argoappv1.Env{{Name: "MODE", Value: sentinel}}, want: "applicationEnv.allow"},
+		{name: "invalid name", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "9MODE", Value: sentinel}}, want: "invalid Application plugin env name"},
+		{name: "nil entry", allow: []string{"MODE"}, env: argoappv1.Env{nil}, want: "unnamed Application plugin env entry"},
+		{name: "blank name", allow: []string{"MODE"}, env: argoappv1.Env{{Name: " ", Value: sentinel}}, want: "unnamed Application plugin env entry"},
+		{name: "duplicate", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "MODE", Value: sentinel + "-a"}, {Name: "MODE", Value: sentinel + "-b"}}, want: `duplicate Application plugin env "MODE"`},
+		{name: "too large", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "MODE", Value: big}}, want: `Application plugin env "MODE" value is too large`},
+		{name: "NUL byte", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "MODE", Value: sentinel + "\x00" + sentinel}}, want: `Application plugin env "MODE" value contains a NUL byte`},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, message := validateApplicationPluginEnv("pkl", testCase.allow, testCase.env, build)
+			if got != nil {
+				t.Fatalf("entries = %#v, want none on failure", got)
+			}
+			if !strings.Contains(message, testCase.want) {
+				t.Fatalf("message = %q, want substring %q", message, testCase.want)
+			}
+			if strings.Contains(message, sentinel) || strings.Contains(message, "xxxx") {
+				t.Fatalf("message = %q leaks a value", message)
+			}
+		})
+	}
+	if got, message := validateApplicationPluginEnv("pkl", nil, nil, build); message != "" || got != nil {
+		t.Fatalf("no env, no allowlist: got %#v / %q, want nil / empty", got, message)
+	}
+}
+
+func TestPolicyPluginBuildEnvEntriesMatchEnviron(t *testing.T) {
+	opts := render.RenderOptions{
+		// A nil element is legal in the public RenderOptions.ArgoEnv and must be
+		// dropped: Env.Envsubst dereferences every entry.
+		ArgoEnv:     argoappv1.Env{{Name: "ARGOCD_APP_NAME", Value: "demo"}, nil},
+		KubeVersion: "1.30.2",
+		APIVersions: []string{"apps/v1"},
+	}
+	entries := policyPluginBuildEnvEntries(opts)
+	want := []string{"ARGOCD_APP_NAME=demo", "KUBE_VERSION=1.30.2", "KUBE_API_VERSIONS=apps/v1"}
+	if got := entries.Environ(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Environ() = %#v, want %#v", got, want)
+	}
+	if got := policyPluginBuildEnv(opts); !reflect.DeepEqual(got, want) {
+		t.Fatalf("policyPluginBuildEnv() = %#v, want %#v", got, want)
+	}
+	if got := entries.Envsubst("$KUBE_VERSION/$KUBE_API_VERSIONS"); got != "1.30.2/apps/v1" {
+		t.Fatalf("Envsubst = %q", got)
 	}
 }

--- a/internal/app/plugin_render_exec.go
+++ b/internal/app/plugin_render_exec.go
@@ -39,11 +39,15 @@ func (p localProvider) renderExecPolicyPluginSource(ctx context.Context, source 
 	if message != "" {
 		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
 	}
+	applicationEnv, message := validateApplicationPluginEnv(name, policyPlugin.Exec.ApplicationEnv.Allow, opts.Plugin.Env, policyPluginBuildEnvEntries(opts))
+	if message != "" {
+		return nil, unsupportedPluginDiagnostic(message), true, unsupportedPolicyPluginError(message)
+	}
 	execConfig, sensitive, message := expandExecPluginCommandTemplates(*policyPlugin.Exec, params)
 	if message != "" {
 		return nil, unsupportedPluginDiagnostic(fmt.Sprintf("config management plugin %s %s", pluginDisplayName(name), message)), true, unsupportedPolicyPluginError(message)
 	}
-	extraEnv := composePolicyPluginExtraEnv(opts, params, p.offline)
+	extraEnv := composePolicyPluginExtraEnv(opts, applicationEnv, params, p.offline)
 	result, err := p.pluginExecRunner.Run(ctx, pluginexec.Request{
 		SourceDir:       sourceDir,
 		RepositoryDir:   source.RepoRoot,

--- a/internal/app/plugin_render_plan.go
+++ b/internal/app/plugin_render_plan.go
@@ -92,10 +92,7 @@ func (p localProvider) renderPolicyPluginPlan(ctx context.Context, source render
 }
 
 func validatePolicyPluginSource(name string, source render.ResolvedSource, opts render.RenderOptions, policyPlugin pluginpolicy.Plugin) string {
-	if len(opts.Plugin.Env) > 0 {
-		if policyPlugin.Engine == pluginpolicy.EngineExec || policyPlugin.Engine == pluginpolicy.EngineContainer {
-			return fmt.Sprintf("config management plugin %s uses Application plugin env (%s), which drydock does not forward to %s plugins yet; pass per-Application values through parameters allowlisted by parameters.allow", pluginDisplayName(name), strings.Join(applicationPluginEnvNames(opts.Plugin.Env), ", "), policyPlugin.Engine)
-		}
+	if len(opts.Plugin.Env) > 0 && policyPlugin.Engine != pluginpolicy.EngineExec && policyPlugin.Engine != pluginpolicy.EngineContainer {
 		return fmt.Sprintf("config management plugin %s uses Application plugin env, which is unsupported by trusted native plugin policy", pluginDisplayName(name))
 	}
 	if len(opts.Plugin.Parameters) > 0 && policyPlugin.Engine != pluginpolicy.EngineExec && policyPlugin.Engine != pluginpolicy.EngineContainer {

--- a/internal/app/plugin_render_plan_test.go
+++ b/internal/app/plugin_render_plan_test.go
@@ -21,8 +21,8 @@ func TestValidatePolicyPluginSourceMessages(t *testing.T) {
 		wantSubs []string
 		wantNot  []string
 	}{
-		{name: "env on exec", engine: pluginpolicy.EngineExec, plugin: render.PluginConfig{Name: "pkl", Env: env}, wantSubs: []string{"Application plugin env (MODE, SUFFIX)", "does not forward", "exec", "parameters.allow"}, wantNot: []string{"native", "secret-value"}},
-		{name: "env on container", engine: pluginpolicy.EngineContainer, plugin: render.PluginConfig{Name: "pkl", Env: env}, wantSubs: []string{"Application plugin env (MODE, SUFFIX)", "container", "parameters.allow"}, wantNot: []string{"native", "secret-value"}},
+		{name: "env on exec is validated later", engine: pluginpolicy.EngineExec, plugin: render.PluginConfig{Name: "pkl", Env: env}},
+		{name: "env on container is validated later", engine: pluginpolicy.EngineContainer, plugin: render.PluginConfig{Name: "pkl", Env: env}},
 		{name: "env on native engine", engine: pluginpolicy.EngineAVPCompat, plugin: render.PluginConfig{Name: "avp", Env: env}, wantSubs: []string{"Application plugin env", "trusted native plugin policy"}, wantNot: []string{"parameters.allow", "secret-value"}},
 		{name: "parameters on native engine", engine: pluginpolicy.EngineNativeKustomize, plugin: render.PluginConfig{Name: "k", Parameters: params}, wantSubs: []string{"Application plugin parameters", "trusted native plugin policy"}},
 		{name: "parameters on exec are fine here", engine: pluginpolicy.EngineExec, plugin: render.PluginConfig{Name: "pkl", Parameters: params}},

--- a/internal/cli/plugin_policy_test.go
+++ b/internal/cli/plugin_policy_test.go
@@ -195,6 +195,11 @@ plugins:
 		t.Fatal(err)
 	}
 	result := pluginPolicyCLIListResult(root)
+	// avp-compat policy accepts neither Application parameters nor env, and
+	// doctor fails them like build does; this test is about unused
+	// descriptors, so serve a plain plugin source.
+	result.Applications[0].Spec.Source.Plugin = &argoappv1.ApplicationSourcePlugin{Name: "pkl"}
+	result.ApplicationInputs[0].Application.Spec.Source.Plugin = &argoappv1.ApplicationSourcePlugin{Name: "pkl"}
 	result.Settings.ConfigManagementPlugins["unused-ytt"] = config.ConfigManagementPlugin{
 		Name:            "unused-ytt",
 		GenerateCommand: []string{"ytt"},
@@ -323,4 +328,64 @@ func executeCLIForPluginPolicyTest(cmd *cobra.Command, args ...string) (string, 
 	cmd.SetErr(&stderr)
 	err := cmd.Execute()
 	return stdout.String(), stderr.String(), err
+}
+
+func TestPluginPolicyInitAndDoctorRoundTripApplicationEnv(t *testing.T) {
+	root := t.TempDir()
+	// pluginPolicyCLIDependencies serves the pkl fixture whose Application sets
+	// spec.source.plugin.env PKL_ENV (plugin_policy_test.go:~299).
+	runCLIWithDependencies(t, pluginPolicyCLIDependencies(root), "plugin-policy", "init", "--path", root, "--write")
+	written, err := os.ReadFile(filepath.Join(root, ".drydock", "plugins.yaml"))
+	if err != nil {
+		t.Fatalf("read generated policy: %v", err)
+	}
+	if !strings.Contains(string(written), "applicationEnv:") || strings.Contains(string(written), "\n    env:\n") {
+		t.Fatalf("generated policy = \n%s\nwant applicationEnv.allow and no host env.allow", written)
+	}
+	result := runCLIWithDependencies(t, pluginPolicyCLIDependencies(root), "plugin-policy", "doctor", "--path", root, "-o", "json")
+	var readiness pluginonboarding.ReadinessReport
+	if err := json.Unmarshal([]byte(result.Stdout), &readiness); err != nil {
+		t.Fatalf("json unmarshal error = %v\n%s", err, result.Stdout)
+	}
+	for _, plugin := range readiness.Plugins {
+		for _, issue := range plugin.Issues {
+			if issue.Code == pluginonboarding.IssueEnvMissingAllow || issue.Code == pluginonboarding.IssueEnvMisdirected {
+				t.Fatalf("doctor reported %s on init's own output: %#v", issue.Code, plugin.Issues)
+			}
+		}
+	}
+}
+
+func TestPluginPolicyDoctorReportsIgnoredHostEnvAllowEntries(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, ".drydock", "plugins.yaml")
+	if err := os.MkdirAll(filepath.Dir(policyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(policyPath, []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+    env:
+      allow: ["KUBE_VERSION"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := runCLIWithDependencies(t, pluginPolicyCLIDependencies(root), "plugin-policy", "doctor", "--path", root, "-o", "json")
+	var readiness pluginonboarding.ReadinessReport
+	if err := json.Unmarshal([]byte(result.Stdout), &readiness); err != nil {
+		t.Fatalf("json unmarshal error = %v\n%s", err, result.Stdout)
+	}
+	found := false
+	for _, rec := range readiness.Recommendations {
+		if rec.Code == pluginonboarding.IssuePolicyEnvIgnored {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Recommendations = %#v, want %s", readiness.Recommendations, pluginonboarding.IssuePolicyEnvIgnored)
+	}
 }

--- a/internal/pluginonboarding/generate.go
+++ b/internal/pluginonboarding/generate.go
@@ -125,7 +125,7 @@ func writePlugin(b *strings.Builder, plugin PluginReport, opts GenerateOptions) 
 	b.WriteString("    copy:\n")
 	b.WriteString("      scope: source\n")
 	writeLifecycle(b, plugin, opts)
-	writeEnv(b, plugin)
+	writeApplicationEnv(b, plugin, opts)
 	writeParameters(b, plugin)
 }
 
@@ -253,24 +253,28 @@ func writeLifecycle(b *strings.Builder, plugin PluginReport, opts GenerateOption
 	b.WriteString("      command: " + yamlStringSequence(command) + "\n")
 }
 
-func writeEnv(b *strings.Builder, plugin PluginReport) {
-	if len(plugin.Env) == 0 {
-		return
-	}
-	var env []string
+// writeApplicationEnv emits applicationEnv.allow from the Application env
+// names observed on plugin sources. Host env.allow is never generated from
+// Application evidence: it copies drydock's own process environment.
+func writeApplicationEnv(b *strings.Builder, plugin PluginReport, opts GenerateOptions) {
+	var names []string
 	for _, name := range plugin.Env {
 		name = strings.TrimSpace(name)
-		if envNameAccepted(name) {
-			env = append(env, name)
+		if pluginpolicy.IsValidEnvName(name) {
+			names = append(names, name)
 		}
 	}
-	if len(env) == 0 {
+	if len(names) == 0 {
 		return
 	}
-	sort.Strings(env)
-	b.WriteString("    env:\n")
+	sort.Strings(names)
+	if opts.Comments {
+		b.WriteString("    # applicationEnv.allow admits Application spec.source.plugin.env names, delivered as ARGOCD_ENV_<name>.\n")
+		b.WriteString("    # env.allow (not generated) copies variables from drydock's own process environment instead.\n")
+	}
+	b.WriteString("    applicationEnv:\n")
 	b.WriteString("      allow:\n")
-	for _, name := range env {
+	for _, name := range names {
 		b.WriteString("        - " + quote(name) + "\n")
 	}
 }
@@ -319,10 +323,6 @@ func commandAccepted(command []string) bool {
 		return false
 	}
 	return !isDeniedCommand(argv0)
-}
-
-func envNameAccepted(name string) bool {
-	return pluginpolicy.ValidateEnvName(name) == nil && !pluginpolicy.IsManagedEnvName(name)
 }
 
 var parameterNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)

--- a/internal/pluginonboarding/onboarding_test.go
+++ b/internal/pluginonboarding/onboarding_test.go
@@ -162,11 +162,15 @@ func TestGenerateAllowsObservedParametersAndEnv(t *testing.T) {
 		`type: array`,
 		`name: "values-file"`,
 		`type: string`,
+		`applicationEnv:`,
 		`- "PKL_ENV"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("generated policy missing %q:\n%s", want, text)
 		}
+	}
+	if strings.Contains(text, "\n    env:\n") {
+		t.Fatalf("generated policy must not emit host env.allow from Application evidence:\n%s", text)
 	}
 }
 
@@ -690,6 +694,134 @@ plugins:
 	}
 }
 
+func TestReadinessAcceptsApplicationEnvAllowAndWarnsOnMisdirectedHostEnv(t *testing.T) {
+	root := t.TempDir()
+	app := pluginApp("argocd", "demo", "apps/demo", "pkl")
+	app.Spec.Source.Plugin.Env = argoappv1.Env{{Name: "PKL_ENV", Value: "prod"}}
+	settings := settingsWithCMP("pkl", config.ConfigManagementPlugin{Name: "pkl", GenerateCommand: []string{"pkl"}})
+	report, err := Analyze(root, []ApplicationInput{{Application: app}}, settings, nil, AnalyzeOptions{})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	parse := func(body string) *pluginpolicy.Policy {
+		policy, err := pluginpolicy.Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+`+body))
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		return &policy
+	}
+	opts := DoctorOptions{EnablePlugins: true, TrustedPolicy: true}
+
+	good := Readiness(report, parse("    applicationEnv:\n      allow: [\"PKL_ENV\"]\n"), opts)
+	if hasIssue(good.Plugins[0].Issues, IssueEnvMissingAllow) || hasIssue(good.Plugins[0].Issues, IssueEnvMisdirected) || good.Status != StatusPass {
+		t.Fatalf("Readiness with applicationEnv.allow = %#v, want PASS without env issues", good)
+	}
+
+	misdirected := Readiness(report, parse("    env:\n      allow: [\"PKL_ENV\"]\n"), opts)
+	if !hasIssue(misdirected.Plugins[0].Issues, IssueEnvMissingAllow) || !hasIssue(misdirected.Plugins[0].Issues, IssueEnvMisdirected) {
+		t.Fatalf("Readiness with host env.allow = %#v, want env.missing_allow and env.misdirected", misdirected.Plugins[0].Issues)
+	}
+	if status := issueStatus(misdirected.Plugins[0].Issues, IssueEnvMisdirected); status != StatusWarn {
+		t.Fatalf("env.misdirected status = %q, want WARN", status)
+	}
+	strict := Readiness(report, parse("    env:\n      allow: [\"PKL_ENV\"]\n"), DoctorOptions{EnablePlugins: true, TrustedPolicy: true, Strict: true})
+	if status := issueStatus(strict.Plugins[0].Issues, IssueEnvMisdirected); status != StatusFail {
+		t.Fatalf("env.misdirected status under --strict = %q, want FAIL", status)
+	}
+
+	// A host variable that legitimately shares a name with an allowlisted
+	// Application env entry is not misdirected.
+	both := Readiness(report, parse("    applicationEnv:\n      allow: [\"PKL_ENV\"]\n    env:\n      allow: [\"PKL_ENV\"]\n"), opts)
+	if hasIssue(both.Plugins[0].Issues, IssueEnvMisdirected) || both.Status != StatusPass {
+		t.Fatalf("Readiness with both lists = %#v, want PASS without env.misdirected", both)
+	}
+}
+
+func TestReadinessRejectsInvalidApplicationEnvNamesAndNativeEngineEnv(t *testing.T) {
+	root := t.TempDir()
+	app := pluginApp("argocd", "demo", "apps/demo", "pkl")
+	app.Spec.Source.Plugin.Env = argoappv1.Env{{Name: "my-var", Value: "x"}}
+	settings := settingsWithCMP("pkl", config.ConfigManagementPlugin{Name: "pkl", GenerateCommand: []string{"pkl"}})
+	report, err := Analyze(root, []ApplicationInput{{Application: app}}, settings, nil, AnalyzeOptions{})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	execPolicy, err := pluginpolicy.Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	opts := DoctorOptions{EnablePlugins: true, TrustedPolicy: true}
+	invalid := Readiness(report, &execPolicy, opts)
+	if !hasIssue(invalid.Plugins[0].Issues, IssueEnvMissingAllow) {
+		t.Fatalf("Readiness = %#v, want env.missing_allow for an invalid identifier", invalid.Plugins[0].Issues)
+	}
+	for _, item := range invalid.Plugins[0].Issues {
+		if item.Code == IssueEnvMissingAllow && !strings.Contains(item.Message, "not a valid environment identifier") {
+			t.Fatalf("message = %q, want the invalid-identifier explanation", item.Message)
+		}
+	}
+
+	nativePolicy, err := pluginpolicy.Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: avp-compat
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	native := Readiness(report, &nativePolicy, opts)
+	if !hasIssue(native.Plugins[0].Issues, IssueEnvMissingAllow) || native.Status != StatusFail {
+		t.Fatalf("Readiness for a native engine with Application env = %#v, want FAIL env.missing_allow", native)
+	}
+}
+
+func TestReadinessSurfacesPolicyWarnings(t *testing.T) {
+	policy, err := pluginpolicy.Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+    env:
+      allow: ["KUBE_VERSION"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	readiness := Readiness(Report{}, &policy, DoctorOptions{EnablePlugins: true, TrustedPolicy: true})
+	if !hasIssue(readiness.Recommendations, IssuePolicyEnvIgnored) {
+		t.Fatalf("Recommendations = %#v, want %s", readiness.Recommendations, IssuePolicyEnvIgnored)
+	}
+	if readiness.Status != StatusWarn {
+		t.Fatalf("Status = %q, want WARN", readiness.Status)
+	}
+}
+
+func issueStatus(issues []ReadinessIssue, code string) string {
+	for _, item := range issues {
+		if item.Code == code {
+			return item.Status
+		}
+	}
+	return ""
+}
+
 func pluginApp(namespace, name, sourcePath, plugin string) argoappv1.Application {
 	app := sourceApp(namespace, name, sourcePath)
 	app.Spec.Source.Plugin = &argoappv1.ApplicationSourcePlugin{Name: plugin}
@@ -765,21 +897,29 @@ func hasIssue(issues []ReadinessIssue, code string) bool {
 	return false
 }
 
-func TestGenerateSkipsDrydockManagedEnvNames(t *testing.T) {
+func TestGenerateWritesApplicationEnvAllowFromObservedNames(t *testing.T) {
 	root := t.TempDir()
 	app := pluginApp("argocd", "demo", "apps/demo", "pkl")
-	app.Spec.Source.Plugin.Env = argoappv1.Env{{Name: "KUBE_VERSION", Value: "1.30.0"}, {Name: "ARGOCD_APP_NAME", Value: "x"}, {Name: "PKL_ENV", Value: "prod"}}
+	app.Spec.Source.Plugin.Env = argoappv1.Env{{Name: "KUBE_VERSION", Value: "1.30.0"}, {Name: "9BAD", Value: "x"}, {Name: "PKL_ENV", Value: "prod"}}
 	settings := settingsWithCMP("pkl", config.ConfigManagementPlugin{Name: "pkl", GenerateCommand: []string{"pkl"}, Discover: config.ConfigManagementPluginDiscovery{FileName: "PklProject"}})
 	report, err := Analyze(root, []ApplicationInput{{Application: app}}, settings, nil, AnalyzeOptions{})
 	if err != nil {
 		t.Fatalf("Analyze() error = %v", err)
 	}
-	data, err := Generate(report, GenerateOptions{})
+	data, err := Generate(report, GenerateOptions{Comments: true})
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
 	text := string(data)
-	if !strings.Contains(text, `- "PKL_ENV"`) || strings.Contains(text, "KUBE_VERSION") || strings.Contains(text, "ARGOCD_APP_NAME") {
-		t.Fatalf("generated policy = \n%s\nwant PKL_ENV only (managed names skipped)", text)
+	for _, want := range []string{"    applicationEnv:\n      allow:\n", `- "KUBE_VERSION"`, `- "PKL_ENV"`, "env.allow"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated policy missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "9BAD") || strings.Contains(text, "\n    env:\n") {
+		t.Fatalf("generated policy must skip invalid names and never emit host env.allow:\n%s", text)
+	}
+	if _, err := pluginpolicy.Parse("generated.yaml", data); err != nil {
+		t.Fatalf("generated policy does not parse: %v", err)
 	}
 }

--- a/internal/pluginonboarding/readiness.go
+++ b/internal/pluginonboarding/readiness.go
@@ -16,6 +16,13 @@ func Readiness(report Report, policy *pluginpolicy.Policy, opts DoctorOptions) R
 		out.Recommendations = append(out.Recommendations, issue(IssuePolicyMissing, StatusFail, "", "plugin policy is missing"))
 		return out
 	}
+	// Never FAIL under --strict: build and diff --strict exempt
+	// plugin.policy.env-ignored for the same policies (orchestrator.go
+	// strictExemptDiagnostic), because the entry is dropped either way and the
+	// policy often comes from a baseline the PR branch cannot fix.
+	for _, warning := range policy.Warnings {
+		out.Recommendations = append(out.Recommendations, issue(IssuePolicyEnvIgnored, StatusWarn, "", "plugin policy: "+warning))
+	}
 
 	for _, plugin := range report.Plugins {
 		pluginReadiness := PluginReadiness{Name: plugin.Name, Status: StatusPass}
@@ -93,7 +100,7 @@ func policyGateIssues(report PluginReport, plugin pluginpolicy.Plugin, opts Doct
 		if commandHasPlaceholder(plugin.Exec.Generate.Command) {
 			issues = append(issues, issue(IssueCommandPlaceholder, StatusFail, name, fmt.Sprintf("plugin %q generate command is still a placeholder", name)))
 		}
-		issues = append(issues, allowlistIssues(report, plugin.Exec.Parameters.Allow, plugin.Exec.Env.Allow)...)
+		issues = append(issues, allowlistIssues(report, plugin.Exec.Parameters.Allow, plugin.Exec.ApplicationEnv.Allow, plugin.Exec.Env.Allow, opts)...)
 	case pluginpolicy.EngineContainer:
 		issues = append(issues, commandBackedGateIssues(name, opts)...)
 		if plugin.Container == nil {
@@ -113,8 +120,14 @@ func policyGateIssues(report PluginReport, plugin pluginpolicy.Plugin, opts Doct
 		if commandHasPlaceholder(plugin.Container.Lifecycle.Generate.Command) {
 			issues = append(issues, issue(IssueCommandPlaceholder, StatusFail, name, fmt.Sprintf("plugin %q generate command is still a placeholder", name)))
 		}
-		issues = append(issues, allowlistIssues(report, plugin.Container.Lifecycle.Parameters.Allow, plugin.Container.Lifecycle.Env.Allow)...)
+		issues = append(issues, allowlistIssues(report, plugin.Container.Lifecycle.Parameters.Allow, plugin.Container.Lifecycle.ApplicationEnv.Allow, plugin.Container.Lifecycle.Env.Allow, opts)...)
 	case pluginpolicy.EngineAVPCompat, pluginpolicy.EngineNativeKustomize:
+		if len(report.Env) > 0 {
+			issues = append(issues, issue(IssueEnvMissingAllow, StatusFail, name, fmt.Sprintf("plugin %q observes Application env, which %s policy does not accept", name, plugin.Engine)))
+		}
+		if len(report.Parameters) > 0 {
+			issues = append(issues, issue(IssueParamsMissingAllow, StatusFail, name, fmt.Sprintf("plugin %q observes Application parameters, which %s policy does not accept", name, plugin.Engine)))
+		}
 	default:
 	}
 	return issues
@@ -131,7 +144,7 @@ func commandBackedGateIssues(name string, opts DoctorOptions) []ReadinessIssue {
 	return issues
 }
 
-func allowlistIssues(report PluginReport, allowedParams []pluginpolicy.ExecParameter, allowedEnv []string) []ReadinessIssue {
+func allowlistIssues(report PluginReport, allowedParams []pluginpolicy.ExecParameter, applicationEnv []string, hostEnv []string, opts DoctorOptions) []ReadinessIssue {
 	var issues []ReadinessIssue
 	params := map[string]struct{}{}
 	for _, allowed := range allowedParams {
@@ -142,13 +155,29 @@ func allowlistIssues(report PluginReport, allowedParams []pluginpolicy.ExecParam
 			issues = append(issues, issue(IssueParamsMissingAllow, StatusFail, report.Name, fmt.Sprintf("plugin %q observes Application parameter %q that is not allowed by policy", report.Name, observed.Name)))
 		}
 	}
-	env := map[string]struct{}{}
-	for _, allowed := range allowedEnv {
-		env[allowed] = struct{}{}
+	allowedEnv := map[string]struct{}{}
+	for _, allowed := range applicationEnv {
+		allowedEnv[allowed] = struct{}{}
+	}
+	misdirected := map[string]struct{}{}
+	for _, allowed := range hostEnv {
+		misdirected[allowed] = struct{}{}
 	}
 	for _, observed := range report.Env {
-		if _, ok := env[observed]; !ok {
-			issues = append(issues, issue(IssueEnvMissingAllow, StatusFail, report.Name, fmt.Sprintf("plugin %q observes Application env %q that is not allowed by policy", report.Name, observed)))
+		if !pluginpolicy.IsValidEnvName(observed) {
+			issues = append(issues, issue(IssueEnvMissingAllow, StatusFail, report.Name, fmt.Sprintf("plugin %q observes Application env %q, which is not a valid environment identifier and cannot be delivered as ARGOCD_ENV_*; rename it in the Application", report.Name, observed)))
+			continue
+		}
+		if _, ok := allowedEnv[observed]; ok {
+			continue
+		}
+		issues = append(issues, issue(IssueEnvMissingAllow, StatusFail, report.Name, fmt.Sprintf("plugin %q observes Application env %q that is not allowed by policy applicationEnv.allow", report.Name, observed)))
+		if _, ok := misdirected[observed]; ok {
+			status := StatusWarn
+			if opts.Strict {
+				status = StatusFail
+			}
+			issues = append(issues, issue(IssueEnvMisdirected, status, report.Name, fmt.Sprintf("plugin %q lists Application env %q under env.allow, which copies drydock's own process environment; move it to applicationEnv.allow", report.Name, observed)))
 		}
 	}
 	return issues

--- a/internal/pluginonboarding/types.go
+++ b/internal/pluginonboarding/types.go
@@ -34,6 +34,8 @@ const (
 	IssueBootstrapMissing   = "bootstrap.missing"
 	IssueParamsMissingAllow = "params.missing_allow"
 	IssueEnvMissingAllow    = "env.missing_allow"
+	IssueEnvMisdirected     = "env.misdirected"
+	IssuePolicyEnvIgnored   = "policy.env_ignored"
 )
 
 type ApplicationInput struct {
@@ -82,8 +84,9 @@ type PluginReport struct {
 	GenerateSafe    bool
 	SuggestedEngine pluginpolicy.Engine
 	Parameters      []ParameterEvidence
-	Env             []string
-	Sidecar         SidecarMatch
+	// Env lists spec.source.plugin.env NAMES observed on Applications; init emits them under applicationEnv.allow.
+	Env     []string
+	Sidecar SidecarMatch
 }
 
 type PluginUse struct {

--- a/internal/pluginpolicy/exec_parse.go
+++ b/internal/pluginpolicy/exec_parse.go
@@ -48,6 +48,10 @@ func parseExecLifecycleConfig(fields map[string]*yaml.Node, path, pointer string
 	if err != nil {
 		return ExecConfig{}, err
 	}
+	applicationEnv, err := parseApplicationEnv(fields["applicationEnv"], path, pointer+".applicationEnv")
+	if err != nil {
+		return ExecConfig{}, err
+	}
 	parameters, err := parseExecParameters(fields["parameters"], copyConfig.Scope, path, pointer+".parameters")
 	if err != nil {
 		return ExecConfig{}, err
@@ -57,14 +61,15 @@ func parseExecLifecycleConfig(fields map[string]*yaml.Node, path, pointer string
 		return ExecConfig{}, err
 	}
 	return ExecConfig{
-		Workdir:       workdir,
-		Copy:          copyConfig,
-		Init:          init,
-		Generate:      generate,
-		PostRenderers: postRenderers,
-		Env:           env,
-		Parameters:    parameters,
-		Output:        output,
+		Workdir:        workdir,
+		Copy:           copyConfig,
+		Init:           init,
+		Generate:       generate,
+		PostRenderers:  postRenderers,
+		Env:            env,
+		ApplicationEnv: applicationEnv,
+		Parameters:     parameters,
+		Output:         output,
 	}, nil
 }
 
@@ -241,52 +246,85 @@ func parseExecCommand(node *yaml.Node, path, pointer string, defaultTimeout time
 	return ExecCommand{Command: command, Timeout: timeout}, nil
 }
 
-func parseExecEnv(node *yaml.Node, path, pointer string) (ExecEnv, error) {
+// parseEnvAllowList parses the {allow: [...]} block shared by env and
+// applicationEnv: entries are trimmed, none may be empty, each must pass
+// validate, exact-case duplicates are rejected, the result is sorted and
+// capped at maxEnvAllowCount. It returns nil when the block or its allow key
+// is absent and an empty non-nil list for allow: []; callers decide what an
+// empty list means.
+func parseEnvAllowList(node *yaml.Node, path, pointer string, validate func(string) error) ([]string, error) {
 	if node == nil || isNullNode(node) {
-		return ExecEnv{}, nil
+		return nil, nil
 	}
 	if node.Kind != yaml.MappingNode {
-		return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
+		return nil, fmt.Errorf("parse plugin policy %s: %s must be a mapping", path, pointer)
 	}
-	fields := map[string]*yaml.Node{}
-	for i := 0; i < len(node.Content); i += 2 {
-		name, err := stringKey(node.Content[i], pointer)
-		if err != nil {
-			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
-		}
-		fields[name] = node.Content[i+1]
+	fields, err := mappingFields(node, pointer)
+	if err != nil {
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
 	}
 	if err := rejectUnknownFields(fields, map[string]bool{"allow": true}, pointer); err != nil {
-		return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
+	}
+	if fields["allow"] == nil {
+		return nil, nil
 	}
 	allow, err := stringSequence(fields["allow"], pointer+".allow")
-	if fields["allow"] == nil {
-		return ExecEnv{}, nil
-	}
 	if err != nil {
-		return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %w", path, err)
+		return nil, fmt.Errorf("parse plugin policy %s: %w", path, err)
 	}
 	if len(allow) > maxEnvAllowCount {
-		return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow has %d entries, maximum is %d", path, pointer, len(allow), maxEnvAllowCount)
+		return nil, fmt.Errorf("parse plugin policy %s: %s.allow has %d entries, maximum is %d", path, pointer, len(allow), maxEnvAllowCount)
 	}
 	seen := map[string]struct{}{}
 	normalized := make([]string, 0, len(allow))
 	for index, rawName := range allow {
 		name := strings.TrimSpace(rawName)
 		if name == "" {
-			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must not be empty", path, pointer, index)
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow[%d] must not be empty", path, pointer, index)
 		}
-		if err := ValidateEnvName(name); err != nil {
-			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow: %w", path, pointer, err)
+		if err := validate(name); err != nil {
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow: %w", path, pointer, err)
 		}
 		if _, ok := seen[name]; ok {
-			return ExecEnv{}, fmt.Errorf("parse plugin policy %s: %s.allow contains duplicate env name %q", path, pointer, name)
+			return nil, fmt.Errorf("parse plugin policy %s: %s.allow contains duplicate env name %q", path, pointer, name)
 		}
 		seen[name] = struct{}{}
 		normalized = append(normalized, name)
 	}
 	sort.Strings(normalized)
-	return ExecEnv{Allow: normalized}, nil
+	return normalized, nil
+}
+
+// parseExecEnv parses env.allow: names forwarded from drydock's own process
+// environment, subject to the reserved-name rules.
+func parseExecEnv(node *yaml.Node, path, pointer string) (ExecEnv, error) {
+	allow, err := parseEnvAllowList(node, path, pointer, ValidateEnvName)
+	if err != nil {
+		return ExecEnv{}, err
+	}
+	return ExecEnv{Allow: allow}, nil
+}
+
+// parseApplicationEnv parses applicationEnv.allow: identifier names only, no
+// reserved-name rules (delivery is always ApplicationEnvPrefix-prefixed). An
+// empty list parses to nil so consumers see nil, not an empty slice.
+func parseApplicationEnv(node *yaml.Node, path, pointer string) (ApplicationEnv, error) {
+	allow, err := parseEnvAllowList(node, path, pointer, validateApplicationEnvName)
+	if err != nil {
+		return ApplicationEnv{}, err
+	}
+	if len(allow) == 0 {
+		return ApplicationEnv{}, nil
+	}
+	return ApplicationEnv{Allow: allow}, nil
+}
+
+func validateApplicationEnvName(name string) error {
+	if !IsValidEnvName(name) {
+		return fmt.Errorf("env name %q is invalid", name)
+	}
+	return nil
 }
 
 func parseExecParameters(node *yaml.Node, copyScope string, path, pointer string) (ExecParameters, error) {
@@ -658,14 +696,21 @@ func IsValidEnvName(name string) bool { return envNamePattern.MatchString(name) 
 // command-backed plugin run (the Argo CD build environment and drydock
 // extras). Listing them in env.allow is redundant and would let a
 // caller-environment value stand in for the value drydock computes, so Parse
-// drops them with a warning instead of forwarding them.
+// drops them with a warning instead of forwarding them. ARGOCD_ENV_* is the
+// delivery channel for applicationEnv.allow.
 var managedEnvNames = map[string]struct{}{
 	"KUBE_VERSION":      {},
 	"KUBE_API_VERSIONS": {},
 	"DRYDOCK_OFFLINE":   {},
 }
 
-var managedEnvPrefixes = []string{"ARGOCD_APP_"}
+var managedEnvPrefixes = []string{"ARGOCD_APP_", ApplicationEnvPrefix}
+
+// ApplicationEnvPrefix prefixes every Application env name on delivery: an
+// applicationEnv.allow entry NAME reaches the plugin as ARGOCD_ENV_NAME, the
+// way an Argo CD repo-server delivers spec.source.plugin.env. IsManagedEnvName,
+// managedEnvNameWarning, and the delivery code must agree on this prefix.
+const ApplicationEnvPrefix = "ARGOCD_ENV_"
 
 // IsManagedEnvName reports whether drydock sets name itself for command-backed
 // plugins (case-insensitive, like the reserved-name check).

--- a/internal/pluginpolicy/fingerprint.go
+++ b/internal/pluginpolicy/fingerprint.go
@@ -78,8 +78,11 @@ type fingerprintLifecycleConfig struct {
 	Generate      fingerprintCommand   `json:"generate"`
 	PostRenderers []fingerprintCommand `json:"postRenderers,omitempty"`
 	Env           ExecEnv              `json:"env"`
-	Parameters    ExecParameters       `json:"parameters"`
-	Output        ExecOutput           `json:"output"`
+	// ApplicationEnv is a bare list rather than a struct so omitempty can drop
+	// it and pre-existing policies keep their fingerprint.
+	ApplicationEnv []string       `json:"applicationEnv,omitempty"`
+	Parameters     ExecParameters `json:"parameters"`
+	Output         ExecOutput     `json:"output"`
 }
 
 type fingerprintCommand struct {
@@ -164,8 +167,9 @@ func newFingerprintLifecycleConfig(config *ExecConfig) *fingerprintLifecycleConf
 		Env: ExecEnv{
 			Allow: append([]string(nil), config.Env.Allow...),
 		},
-		Parameters: cloneExecParameters(config.Parameters),
-		Output:     config.Output,
+		ApplicationEnv: append([]string(nil), config.ApplicationEnv.Allow...),
+		Parameters:     cloneExecParameters(config.Parameters),
+		Output:         config.Output,
 	}
 	if config.Init != nil {
 		out.Init = &fingerprintCommand{

--- a/internal/pluginpolicy/policy.go
+++ b/internal/pluginpolicy/policy.go
@@ -111,14 +111,24 @@ type ConfigManagementPluginGenerate struct {
 }
 
 type ExecConfig struct {
-	Workdir       string
-	Copy          ExecCopy
-	Init          *ExecCommand
-	Generate      ExecCommand
-	PostRenderers []ExecCommand
-	Env           ExecEnv
-	Parameters    ExecParameters
-	Output        ExecOutput
+	Workdir        string
+	Copy           ExecCopy
+	Init           *ExecCommand
+	Generate       ExecCommand
+	PostRenderers  []ExecCommand
+	Env            ExecEnv
+	ApplicationEnv ApplicationEnv
+	Parameters     ExecParameters
+	Output         ExecOutput
+}
+
+// ApplicationEnv allowlists Application-authored spec.source.plugin.env NAMES
+// for command-backed engines. Allowed entries reach the plugin as
+// ARGOCD_ENV_<name> after substitution against the Argo CD build environment,
+// exactly as a repo-server delivers them; the prefix keeps them apart from
+// env.allow (drydock's own process environment) and from every reserved name.
+type ApplicationEnv struct {
+	Allow []string
 }
 
 type ExecCopy struct {
@@ -248,7 +258,7 @@ func dropManagedEnvNames(policy *Policy) []string {
 		kept := env.Allow[:0:0]
 		for _, entry := range env.Allow {
 			if IsManagedEnvName(entry) {
-				warnings = append(warnings, fmt.Sprintf("plugins.%s.env.allow entry %q is ignored: drydock sets it for every command-backed plugin", name, entry))
+				warnings = append(warnings, managedEnvNameWarning(name, entry))
 				continue
 			}
 			kept = append(kept, entry)
@@ -256,6 +266,16 @@ func dropManagedEnvNames(policy *Policy) []string {
 		env.Allow = kept
 	}
 	return warnings
+}
+
+// managedEnvNameWarning explains why an env.allow entry is dropped. The
+// ApplicationEnvPrefix names are not set by drydock itself: they are delivered
+// from spec.source.plugin.env for the names listed in applicationEnv.allow.
+func managedEnvNameWarning(plugin, entry string) string {
+	if strings.HasPrefix(strings.ToUpper(entry), ApplicationEnvPrefix) {
+		return fmt.Sprintf("plugins.%s.env.allow entry %q is ignored: %s* is delivered from spec.source.plugin.env for names listed in applicationEnv.allow", plugin, entry, ApplicationEnvPrefix)
+	}
+	return fmt.Sprintf("plugins.%s.env.allow entry %q is ignored: drydock sets it for every command-backed plugin", plugin, entry)
 }
 
 func (p Policy) Plugin(name string) (Plugin, bool) {
@@ -777,14 +797,15 @@ func execPluginAllowedFields() map[string]bool {
 
 func execLifecycleAllowedFields() map[string]bool {
 	return map[string]bool{
-		"workdir":       true,
-		"copy":          true,
-		"init":          true,
-		"generate":      true,
-		"postRenderers": true,
-		"env":           true,
-		"parameters":    true,
-		"output":        true,
+		"workdir":        true,
+		"copy":           true,
+		"init":           true,
+		"generate":       true,
+		"postRenderers":  true,
+		"env":            true,
+		"applicationEnv": true,
+		"parameters":     true,
+		"output":         true,
 	}
 }
 

--- a/internal/pluginpolicy/policy_test.go
+++ b/internal/pluginpolicy/policy_test.go
@@ -120,6 +120,7 @@ func assertExecPluginSchema(t *testing.T, defs map[string]any) {
 	if ref, ok := parametersProp["$ref"].(string); !ok || ref != "#/$defs/parameters" {
 		t.Fatalf("exec parameters schema ref = %#v, want #/$defs/parameters", parametersProp["$ref"])
 	}
+	assertSchemaRef(t, schemaObject(t, execProps, "applicationEnv"), "#/$defs/applicationEnv")
 }
 
 func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
@@ -144,6 +145,7 @@ func assertContainerPluginSchema(t *testing.T, defs map[string]any) {
 	assertSchemaRef(t, schemaObject(t, containerProps, "cacheMounts"), "#/$defs/containerCacheMounts")
 	assertSchemaRef(t, schemaObject(t, containerProps, "generate"), "#/$defs/command")
 	assertSchemaRef(t, schemaObject(t, containerProps, "parameters"), "#/$defs/parameters")
+	assertSchemaRef(t, schemaObject(t, containerProps, "applicationEnv"), "#/$defs/applicationEnv")
 	assertContainerCacheMountSchema(t, defs)
 }
 
@@ -3268,14 +3270,14 @@ plugins:
 }
 
 func TestManagedAndReservedEnvNames(t *testing.T) {
-	for _, name := range []string{"KUBE_VERSION", "KUBE_API_VERSIONS", "DRYDOCK_OFFLINE", "ARGOCD_APP_NAME", "argocd_app_source_path"} {
+	for _, name := range []string{"KUBE_VERSION", "KUBE_API_VERSIONS", "DRYDOCK_OFFLINE", "ARGOCD_APP_NAME", "argocd_app_source_path", "ARGOCD_ENV_MODE", "argocd_env_x"} {
 		t.Run("managed "+name, func(t *testing.T) {
 			if !IsManagedEnvName(name) {
 				t.Errorf("IsManagedEnvName(%q) = false, want true", name)
 			}
 		})
 	}
-	for _, name := range []string{"CLUSTER_NAME", "DRYDOCK_APP_EXEC_HELPER", "ARGOCD_ENV_MODE", "KUBECONFIG"} {
+	for _, name := range []string{"CLUSTER_NAME", "DRYDOCK_APP_EXEC_HELPER", "ARGOCD_ENVX", "KUBECONFIG"} {
 		t.Run("unmanaged "+name, func(t *testing.T) {
 			if IsManagedEnvName(name) {
 				t.Errorf("IsManagedEnvName(%q) = true, want false", name)
@@ -3303,5 +3305,164 @@ func TestManagedAndReservedEnvNames(t *testing.T) {
 				t.Errorf("IsValidEnvName(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseApplicationEnvAllow(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+    applicationEnv:
+      allow: ["SUFFIX", "MODE", " USE_TELEMETRY "]
+  render:
+    engine: container
+    image: registry.example.test/plugins/render@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    generate:
+      command: ["render"]
+    applicationEnv:
+      allow: ["REGION"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := policy.Plugins["pkl"].Exec.ApplicationEnv.Allow; !reflect.DeepEqual(got, []string{"MODE", "SUFFIX", "USE_TELEMETRY"}) {
+		t.Fatalf("exec applicationEnv.allow = %#v, want trimmed and sorted", got)
+	}
+	if got := policy.Plugins["render"].Container.Lifecycle.ApplicationEnv.Allow; !reflect.DeepEqual(got, []string{"REGION"}) {
+		t.Fatalf("container applicationEnv.allow = %#v, want [REGION]", got)
+	}
+	if len(policy.Warnings) != 0 {
+		t.Fatalf("Warnings = %#v, want none", policy.Warnings)
+	}
+}
+
+func TestParseApplicationEnvRejectsInvalidEntries(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+    applicationEnv:
+%s
+`
+	testCases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid identifier", body: `      allow: ["9MODE"]`, want: "invalid"},
+		{name: "duplicate", body: `      allow: ["MODE", " MODE "]`, want: "duplicate"},
+		{name: "empty entry", body: `      allow: ["MODE", ""]`, want: "must not be empty"},
+		{name: "unknown field", body: `      deny: ["MODE"]`, want: "unknown"},
+		{name: "not a mapping", body: `      - MODE`, want: "must be a mapping"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, testCase.body)))
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+	tooMany := make([]string, 0, maxEnvAllowCount+1)
+	for i := 0; i <= maxEnvAllowCount; i++ {
+		tooMany = append(tooMany, fmt.Sprintf(`"V%d"`, i))
+	}
+	if _, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, "      allow: ["+strings.Join(tooMany, ", ")+"]"))); err == nil || !strings.Contains(err.Error(), "maximum") {
+		t.Fatalf("Parse() error = %v, want maximum-entries error", err)
+	}
+	// Managed and reserved host names are legal Application env names: the
+	// prefix keeps them from colliding with anything drydock sets.
+	if _, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, `      allow: ["KUBE_VERSION", "PATH", "ARGOCD_APP_NAME"]`))); err != nil {
+		t.Fatalf("Parse() error = %v, want managed/reserved host names accepted under applicationEnv", err)
+	}
+}
+
+func TestParseApplicationEnvRejectedForNativeEngines(t *testing.T) {
+	for _, engine := range []Engine{EngineAVPCompat, EngineNativeKustomize} {
+		_, err := Parse("policy.yaml", []byte(fmt.Sprintf(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  native:
+    engine: %s
+    applicationEnv:
+      allow: ["MODE"]
+`, engine)))
+		if err == nil || !strings.Contains(err.Error(), "applicationEnv") {
+			t.Fatalf("Parse(engine=%s) error = %v, want unknown-field error naming applicationEnv", engine, err)
+		}
+	}
+}
+
+func TestFingerprintChangesOnlyWhenApplicationEnvPresent(t *testing.T) {
+	base := `apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+%s
+`
+	without, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, "")))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	emptyList, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, "    applicationEnv:\n      allow: []")))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	withEnv, err := Parse("policy.yaml", []byte(fmt.Sprintf(base, "    applicationEnv:\n      allow: [\"MODE\"]")))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	a, _ := Fingerprint(without)
+	b, _ := Fingerprint(emptyList)
+	c, _ := Fingerprint(withEnv)
+	if a != b {
+		t.Fatalf("empty applicationEnv.allow must fingerprint like an absent block (%s vs %s)", a, b)
+	}
+	if a == c {
+		t.Fatalf("applicationEnv.allow entries must change the fingerprint")
+	}
+	// wantJSON is the canonical fingerprint input this policy produced before
+	// applicationEnv existed. It carries no applicationEnv key at all, and it
+	// must keep hashing identically: the fingerprint gates exec/container
+	// trust, so a mismatch here means every existing exec/container policy's
+	// recorded trust fingerprint would be invalidated.
+	wantJSON := `{"apiVersion":"drydock.sholdee.dev/v1alpha1","kind":"PluginPolicy","plugins":{"pkl":{"engine":"exec","exec":{"workdir":"source","copy":{"Scope":"source","Include":null},"generate":{"command":["pkl"],"timeout":"1m0s"},"env":{"Allow":null},"parameters":{"Allow":[]},"output":{"MaxStdoutBytes":10485760,"MaxStderrBytes":65536}}}}}`
+	if strings.Contains(wantJSON, "applicationEnv") {
+		t.Fatalf("wantJSON must be the pre-applicationEnv canonical form; it must not mention applicationEnv")
+	}
+	if want := sha256Hex(wantJSON); a != want {
+		t.Fatalf("Fingerprint(without applicationEnv) = %s, want %s: an absent applicationEnv block changed a pre-existing policy's fingerprint", a, want)
+	}
+}
+
+func TestParseDropsArgoEnvPrefixedNamesFromHostEnvAllow(t *testing.T) {
+	policy, err := Parse("policy.yaml", []byte(`apiVersion: drydock.sholdee.dev/v1alpha1
+kind: PluginPolicy
+plugins:
+  pkl:
+    engine: exec
+    generate:
+      command: ["pkl"]
+    env:
+      allow: ["ARGOCD_ENV_MODE", "CLUSTER_NAME"]
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := policy.Plugins["pkl"].Exec.Env.Allow; !reflect.DeepEqual(got, []string{"CLUSTER_NAME"}) {
+		t.Fatalf("env.allow = %#v, want ARGOCD_ENV_MODE dropped", got)
+	}
+	if len(policy.Warnings) != 1 || !strings.Contains(policy.Warnings[0], `"ARGOCD_ENV_MODE" is ignored`) || !strings.Contains(policy.Warnings[0], "applicationEnv.allow") {
+		t.Fatalf("Warnings = %#v, want one ARGOCD_ENV_MODE warning that points at applicationEnv.allow", policy.Warnings)
 	}
 }

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -257,8 +257,12 @@
           }
         },
         "env": {
-          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
+          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here; ARGOCD_ENV_* is reserved for applicationEnv.allow delivery and ignored here too.",
           "$ref": "#/$defs/env"
+        },
+        "applicationEnv": {
+          "description": "Application-authored spec.source.plugin.env names accepted by this policy; delivered to the plugin as ARGOCD_ENV_<name> after Argo CD build-environment substitution.",
+          "$ref": "#/$defs/applicationEnv"
         },
         "parameters": {
           "description": "Application-authored plugin parameters accepted by this policy.",
@@ -345,8 +349,12 @@
           }
         },
         "env": {
-          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
+          "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here; ARGOCD_ENV_* is reserved for applicationEnv.allow delivery and ignored here too.",
           "$ref": "#/$defs/env"
+        },
+        "applicationEnv": {
+          "description": "Application-authored spec.source.plugin.env names accepted by this policy; delivered to the plugin as ARGOCD_ENV_<name> after Argo CD build-environment substitution.",
+          "$ref": "#/$defs/applicationEnv"
         },
         "parameters": {
           "description": "Application-authored plugin parameters accepted by this policy.",
@@ -611,12 +619,29 @@
     },
     "env": {
       "type": "object",
-      "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here.",
+      "description": "Names of drydock's own process environment variables copied into the plugin (not Application env). ARGOCD_APP_*, KUBE_VERSION, KUBE_API_VERSIONS and DRYDOCK_OFFLINE are set automatically and ignored here; ARGOCD_ENV_* is reserved for applicationEnv.allow delivery and ignored here too.",
       "additionalProperties": false,
       "properties": {
         "allow": {
           "type": "array",
           "description": "Variable names the plugin may receive from the caller environment.",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          }
+        }
+      }
+    },
+    "applicationEnv": {
+      "type": "object",
+      "description": "Allowlist of Application spec.source.plugin.env names for exec and container engines.",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Application env names the plugin may receive as ARGOCD_ENV_<name>.",
           "maxItems": 64,
           "uniqueItems": true,
           "items": {

--- a/schemas/plugin-policy.schema.json
+++ b/schemas/plugin-policy.schema.json
@@ -624,7 +624,7 @@
       "properties": {
         "allow": {
           "type": "array",
-          "description": "Variable names the plugin may receive from the caller environment.",
+          "description": "Names of drydock's own process environment variables to copy into the plugin.",
           "maxItems": 64,
           "uniqueItems": true,
           "items": {

--- a/site/content/docs/plugin-policy/examples.md
+++ b/site/content/docs/plugin-policy/examples.md
@@ -161,12 +161,30 @@ plugins:
             base: repository
             allow:
               - personal-cluster/**/*.pkl
+    applicationEnv:
+      allow: ["MODE", "SUFFIX"]
 ```
 
 This replaces sidecar patterns such as `/tmp/pkl-cache`, `sh -c`, or Docker
 execution with trusted argv. `configManagementPlugin.generate`, if copied into
 the policy for compatibility metadata, still remains metadata only. The
 top-level exec `generate.command` is the command that runs.
+
+An Application that uses it:
+
+```yaml
+spec:
+  source:
+    plugin:
+      name: pkl
+      env:
+        - name: MODE
+          value: prod
+        - name: SUFFIX
+          value: $ARGOCD_APP_NAME
+```
+
+The plugin observes `ARGOCD_ENV_MODE=prod` and `ARGOCD_ENV_SUFFIX=<instance name>`.
 
 When an Application already supplies source-relative `path` values, use
 `path.base: source` with source-relative `path.allow` patterns instead.
@@ -185,7 +203,7 @@ plugins:
     postRenderers:
       - command: ["/usr/local/bin/kbld", "-f", "-"]
         timeout: 15s
-    # env.allow copies drydock's own process variables; ARGOCD_APP_* and KUBE_* are set automatically.
+    # env.allow copies drydock's own process variables; ARGOCD_APP_* and KUBE_* are set automatically, ARGOCD_ENV_* is reserved for applicationEnv.allow.
     env:
       allow: ["CLUSTER_NAME", "ENVIRONMENT"]
     output:
@@ -221,9 +239,10 @@ drydock plugin-policy doctor --path . --plugin-policy-ref main --enable-plugins 
 ```
 
 `doctor` reports readiness for policy presence, trust provenance,
-`--enable-plugins`, image placeholders, mutable image tags, parameters, env,
-and bootstrap hints. A missing default policy is a readiness failure; an
-explicit missing `--plugin-policy-path` is a command error.
+`--enable-plugins`, image placeholders, mutable image tags, parameters,
+Application env (`applicationEnv.allow`), misdirected host `env.allow`
+entries, and bootstrap hints. A missing default policy is a readiness
+failure; an explicit missing `--plugin-policy-path` is a command error.
 
 For a single-tree command, run command-backed plugins from an explicit trusted
 ref:

--- a/site/content/docs/plugin-policy/schema.md
+++ b/site/content/docs/plugin-policy/schema.md
@@ -70,8 +70,9 @@ and optional `configManagementPlugin`.
 | `init` | No | None | Optional command run before `generate`. |
 | `generate` | Yes | None | Command that writes Kubernetes manifests to stdout. |
 | `postRenderers` | No | None | Non-empty list when present. Chains stdout through stdin. |
-| `env.allow` | No | `[]` | Up to 64 names of variables copied from drydock's own process environment (CI or shell), not from the Application. Names drydock sets itself (`ARGOCD_APP_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`, `DRYDOCK_OFFLINE`, matched case-insensitively) are ignored with a warning. |
+| `env.allow` | No | `[]` | Up to 64 names of variables copied from drydock's own process environment (CI or shell), not from the Application. Names drydock sets itself (`ARGOCD_APP_*`, `ARGOCD_ENV_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`, `DRYDOCK_OFFLINE`, matched case-insensitively) are ignored with a warning. |
 | `parameters.allow` | No | `[]` | Application plugin parameter allowlist for `engine: exec` and `engine: container`. |
+| `applicationEnv.allow` | No | `[]` | Application `spec.source.plugin.env` names accepted for `engine: exec` and `engine: container`; delivered as `ARGOCD_ENV_<name>`. Identifier names only, up to 64. |
 | `output.maxStdoutBytes` | No | `10485760` | Per-command stdout limit. |
 | `output.maxStderrBytes` | No | `65536` | Per-command stderr limit. Stderr is not printed in failure messages. |
 

--- a/site/content/docs/plugin-policy/trust.md
+++ b/site/content/docs/plugin-policy/trust.md
@@ -195,7 +195,8 @@ this order: the Argo CD build environment (`ARGOCD_APP_NAME`,
 `ARGOCD_APP_SOURCE_REPO_URL`, `ARGOCD_APP_SOURCE_PATH`,
 `ARGOCD_APP_SOURCE_TARGET_REVISION`, then `KUBE_VERSION` and
 `KUBE_API_VERSIONS`, always present and empty without `--kube-version` /
-`--api-versions`), the Argo-style parameter environment
+`--api-versions`), the Application env as `ARGOCD_ENV_<name>` entries in spec
+order, the Argo-style parameter environment
 (`ARGOCD_APP_PARAMETERS`, `null` when the Application declares none, then
 `PARAM_*`), and `DRYDOCK_OFFLINE=true` when offline. `ARGOCD_APP_REVISION*`
 carry the spec `targetRevision`, not a resolved commit SHA, and
@@ -212,14 +213,14 @@ receives the `env.allow` copies and the same drydock-composed values through
 duplicated, and cannot be reserved loader/interpreter variables such as
 `PATH`, `LD_*`, `DYLD_*`, `PYTHONPATH`, or `NODE_OPTIONS`. Names drydock sets
 itself (`ARGOCD_APP_*`, `KUBE_VERSION`, `KUBE_API_VERSIONS`,
-`DRYDOCK_OFFLINE`, matched case-insensitively) are ignored with a
+`DRYDOCK_OFFLINE`) and the `ARGOCD_ENV_*` delivery channel of
+`applicationEnv.allow`, all matched case-insensitively, are ignored with a
 `plugin.policy.env-ignored` warning. Names are otherwise compared exact-case;
 Windows, where the OS folds case, is unsupported. Each copied value is capped
-at 16 KiB. Application-authored plugin env (`spec.source.plugin.env`) is not
-forwarded yet for any engine; pass per-Application values through parameters
-allowlisted by `parameters.allow`.
+at 16 KiB. Application-authored plugin env (`spec.source.plugin.env`) is
+delivered only when allowlisted by `applicationEnv.allow` (see below).
 
-### Application Parameters
+### Application Parameters And Env
 
 Application plugin parameters are accepted only for `engine: exec` and
 `engine: container`, and only when allowlisted by trusted policy. Native engines
@@ -244,6 +245,28 @@ Path parameters may be constrained to paths under the Application source or the
 repository. Repository-scoped path parameters require `copy.scope: repository`.
 Values under the Application source are copied by default; trusted sibling
 repository paths must also match `copy.include`.
+
+`applicationEnv.allow` lists the `spec.source.plugin.env` names a policy
+accepts. Each allowed entry reaches the plugin as `ARGOCD_ENV_<name>` with its
+value substituted against the eleven build-environment variables only
+(`$ARGOCD_APP_*`, `$KUBE_VERSION`, `$KUBE_API_VERSIONS`; `$$` yields a literal
+`$`, unknown references expand to empty), exactly as a repo-server delivers
+it; host `env.allow` values and other Application entries are not
+substitutable. Names must be identifiers, duplicates are rejected, values are
+capped at 16 KiB and may not contain NUL (`engine: container` also rejects CR
+or LF, which cannot pass through `--env-file`). An entry that is not
+allowlisted fails the source before the plugin runs, naming the entry but
+never its value. The 16 KiB cap applies after substitution. Without
+`--kube-version` / `--api-versions`, `$KUBE_VERSION` and
+`$KUBE_API_VERSIONS` expand to empty strings. Application env values are not
+redacted from diagnostics; like a repo-server, drydock treats them as
+non-secret. Bootstrap entrypoints render a synthetic Application without
+`spec.source.plugin.env`, so they receive no `ARGOCD_ENV_*` entries; use
+entrypoint `parameters` instead. `plugin-policy init` generates
+`applicationEnv.allow` from the Applications it sees, and `doctor` reports
+`env.missing_allow` for names outside it and `env.misdirected` for
+Application names placed under host `env.allow` instead of
+`applicationEnv.allow`.
 
 Command-backed runs keep structured execution metadata per phase: phase name,
 engine, sanitized command basename, elapsed duration, and for container policy

--- a/site/content/reference/go-api.md
+++ b/site/content/reference/go-api.md
@@ -64,11 +64,12 @@ Application plugin parameters for command-backed engines must be allowlisted by
 policy. Trusted `engine: exec` and `engine: container` policy plugins receive
 the Argo CD build environment (`ARGOCD_APP_*`, `KUBE_VERSION`,
 `KUBE_API_VERSIONS`) as environment variables, like a repo-server sidecar;
-Application plugin env (`spec.source.plugin.env`) is not forwarded to them
-yet. Injected `PluginRenderer` implementations are unaffected and keep
-receiving the full `PluginRequest` in process. Native policy engines such as
-`avp-compat` and `native-kustomize` do
-not execute plugin commands and reject Application plugin env and parameters.
+Application plugin env (`spec.source.plugin.env`) reaches them as
+`ARGOCD_ENV_<name>` when allowlisted by `applicationEnv.allow`. Injected
+`PluginRenderer` implementations are unaffected and keep receiving the full
+`PluginRequest` in process. Native policy engines such as `avp-compat` and
+`native-kustomize` do not execute plugin commands and reject Application
+plugin env and parameters.
 Explicit `argocd-vault-plugin` sources and discovered simple AVP CMP aliases
 use native AVP compatibility by default. `Config.EnableAVPCompat` forces the
 same placeholder redaction pass for ordinary native-rendered sources.


### PR DESCRIPTION
Stacked on #314 (build environment) and #312. Closes the gap behind the Discord report where a pkl plugin's Application was rejected for its `spec.source.plugin.env` block and `plugin-policy init` had written those names into `env.allow`, which never could have admitted them.

- New lifecycle field `applicationEnv.allow` (exec and container) lists the Application env names a policy accepts. Allowed entries reach the plugin as `ARGOCD_ENV_<name>=<value>` in spec order, between `KUBE_API_VERSIONS` and `ARGOCD_APP_PARAMETERS`, with values expanded against the eleven build-environment variables only (`$$` → `$`, unknown → empty; host `env.allow` values and earlier `ARGOCD_ENV_*` entries are not substitutable), matching `reposerver/repository/repository.go getPluginParamEnvs` in Argo CD v3.5.2. Anything not allowlisted fails closed before the plugin runs, naming the entry but never its value. Names are identifiers, duplicates are rejected, values are capped at 16 KiB (before and after substitution) with no NUL; empty values are still delivered. Native engines keep rejecting Application env. Bootstrap entrypoints render a synthetic Application without `spec.source.plugin.env`, so they receive no `ARGOCD_ENV_*` entries.
- `env.allow` is unchanged in meaning; `ARGOCD_ENV_*` joins the drydock-managed names it ignores, with a warning that points at `applicationEnv.allow`. The policy fingerprint carries `applicationEnv` only when present (an empty `allow: []` fingerprints like an absent block), so existing policies keep their fingerprint; a policy that adds `applicationEnv.allow` gets a new fingerprint, so its container cache mounts rotate once. An older drydock rejects a policy with `applicationEnv` as an unknown field (fail closed), as with any new policy field. The render cache key already hashes the full Application spec, so a changed `spec.source.plugin.env` value never serves a stale render.
- `plugin-policy init` now writes observed Application env names under `applicationEnv.allow` (with a comment explaining the two lists; invalid identifiers are skipped; names such as `KUBE_VERSION` are legal there because delivery is prefixed) and never generates host `env.allow` from Application evidence. `doctor` checks `applicationEnv.allow`, reports `env.misdirected` (WARN, FAIL under `--strict`) when an Application name sits in host `env.allow` instead of `applicationEnv.allow`, reports `env.missing_allow` for Application env names that are not valid identifiers (with a rename hint), fails native-engine policies whose Applications carry env or parameters, and surfaces the parser's `env.allow` warnings (build's `plugin.policy.env-ignored` diagnostic) as `policy.env_ignored` recommendations (WARN even under `--strict`, matching `build --strict`). For exec and container policies, init → doctor → build now agree.
- Application env values are not added to the diagnostics redaction set: a repo-server treats them as non-secret and the redactor is a substring replace.
- Docs: plugin-policy trust/schema/examples pages, Go API reference, compatibility notes, JSON schema. Also tidies doc nits left by the earlier PRs in this stack: the compatibility build-environment bullet now lists Helm `fileParameters` paths, the inner `env.allow` JSON-schema description matches its parent, and the Go API paragraph is reflowed.

Divergences from a repo-server: the allowlist itself (Argo forwards any entry), identifier-only names, duplicate rejection, the 16 KiB cap, and CR/LF rejection for `engine: container` (values cannot pass through `--env-file`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt