### PR TITLE
chore(ci): ignore zizmor's self-repository audit on in-repo reusable workflows

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# zizmor configuration. The self-repository audit (zizmor >= 1.30.0) asks for
+# GitHub's `$/` self-repository syntax on in-repo reusable-workflow calls, but
+# actionlint (1.7.12) rejects that form, so the `./` form stays until
+# actionlint supports it.
+rules:
+  self-repository:
+    ignore:
+      - ci.yml
+      - release.yml


### PR DESCRIPTION
Unblocks the zizmor 1.30.0 renovate bump (#296), whose `workflow-lint` job fails on the new `self-repository` audit.

zizmor 1.30.0 flags the two in-repo reusable-workflow calls (`uses: ./.github/workflows/argocd-parity-smoke.yml` in `ci.yml` and `release.yml`) and asks for GitHub's `$/` self-repository syntax. actionlint 1.7.12 rejects that form (`reusable workflow call "$/..." is not following the format "owner/repo/path/to/workflow.yml@ref" nor "./path/to/workflow.yml"`), so switching the syntax just moves the failure to the actionlint step. This adds `.github/zizmor.yml` ignoring the audit for those two files, with a comment saying why, until actionlint supports the shorthand.

Verified locally: `zizmor` 1.29.0 (pinned) and 1.30.0 both report no findings (1.30.0: `2 ignored`), and `mise run actionlint` passes. After this merges, #296 can be rebased; #306 and #288 only need a rebase to pick up main's earlier lint fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt
