### PR TITLE
chore(renovate): keep structured-merge-diff on the major line argo-cd pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,6 +107,13 @@
       enabled: false,
     },
     {
+      description: 'structured-merge-diff major line is pinned by argo-cd (util/argo/managedfields.Normalize takes its typed.ParseableType); migrate only inside an argo-cd upgrade that moves it',
+      matchManagers: ['gomod'],
+      matchPackageNames: ['/^sigs\\.k8s\\.io\\/structured-merge-diff\\//'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+    },
+    {
       description: 'Do not automerge high-risk GitOps renderer module updates',
       matchManagers: ['gomod'],
       matchPackageNames: [


### PR DESCRIPTION
Resolves the `go mod tidy` failure on #306 by not proposing it again.

Renovate wants `sigs.k8s.io/structured-merge-diff/v6` → `v7`, but nothing in this module can import v7 yet: the only user is `internal/diff/managed_fields.go`, which passes a `typed.ParseableType` to argo-cd's `util/argo/managedfields.Normalize`, and that signature is the **v6** type. So the v7 `require` is unused, `go mod tidy` removes it, and the tidiness check fails (switching the import to v7 does not compile). argo-cd `master` is still on v6.4.2.

This adds a `packageRules` entry that disables **major** updates for the module (minor/patch keep flowing). The migration happens inside the argo-cd upgrade that moves it, the same way `argoproj/pkg` is already handled in this config. `renovate-config-validator --strict` (43.150.0, the version CI runs) passes.

#306 can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt
