### PR TITLE
fix(cli): build honors -o, text diagnostics print codes, doctor INFO for opted-in mutable tags, full env fail-closed message

### DIFF
--- a/internal/app/plugin_render_env.go
+++ b/internal/app/plugin_render_env.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	argoappv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -71,9 +72,10 @@ const maxApplicationPluginEnvValueBytes = pluginexec.MaxEnvValueBytes
 // policy's applicationEnv.allow and drydock's env rules, then returns the
 // ARGOCD_ENV_<name>=<value> entries in spec order with each value expanded
 // against buildEnv (Argo CD's Envsubst: $VAR/${VAR}, $$ -> $, unknown ->
-// empty). It fails closed with a message that names the entry but never its
-// value: Application env may carry secrets. Values are not added to the
-// redaction set because a repo-server treats them as non-secret too.
+// empty). It fails closed with a message that names every entry missing from
+// the allowlist but never a value: Application env may carry secrets. Values
+// are not added to the redaction set because a repo-server treats them as
+// non-secret too.
 func validateApplicationPluginEnv(name string, allow []string, env argoappv1.Env, buildEnv argoappv1.Env) ([]string, string) {
 	if len(env) == 0 {
 		return nil, ""
@@ -83,6 +85,7 @@ func validateApplicationPluginEnv(name string, allow []string, env argoappv1.Env
 		allowed[entry] = struct{}{}
 	}
 	seen := make(map[string]struct{}, len(env))
+	var notAllowed []string
 	out := make([]string, 0, len(env))
 	for _, entry := range env {
 		if entry == nil || strings.TrimSpace(entry.Name) == "" {
@@ -91,13 +94,16 @@ func validateApplicationPluginEnv(name string, allow []string, env argoappv1.Env
 		if !pluginpolicy.IsValidEnvName(entry.Name) {
 			return nil, fmt.Sprintf("config management plugin %s has invalid Application plugin env name %q", pluginDisplayName(name), entry.Name)
 		}
-		if _, ok := allowed[entry.Name]; !ok {
-			return nil, fmt.Sprintf("config management plugin %s uses Application plugin env %q, which is not allowed by policy applicationEnv.allow", pluginDisplayName(name), entry.Name)
-		}
 		if _, ok := seen[entry.Name]; ok {
 			return nil, fmt.Sprintf("config management plugin %s has duplicate Application plugin env %q", pluginDisplayName(name), entry.Name)
 		}
 		seen[entry.Name] = struct{}{}
+		if _, ok := allowed[entry.Name]; !ok {
+			// Keep going: one message that names every missing entry saves a
+			// policy edit per name.
+			notAllowed = append(notAllowed, entry.Name)
+			continue
+		}
 		if len(entry.Value) > maxApplicationPluginEnvValueBytes {
 			return nil, fmt.Sprintf("config management plugin %s Application plugin env %q value is too large", pluginDisplayName(name), entry.Name)
 		}
@@ -110,5 +116,21 @@ func validateApplicationPluginEnv(name string, allow []string, env argoappv1.Env
 		}
 		out = append(out, pluginpolicy.ApplicationEnvPrefix+entry.Name+"="+expanded)
 	}
+	if len(notAllowed) == 1 {
+		return nil, fmt.Sprintf("config management plugin %s uses Application plugin env %q, which is not allowed by policy applicationEnv.allow", pluginDisplayName(name), notAllowed[0])
+	}
+	if len(notAllowed) > 1 {
+		return nil, fmt.Sprintf("config management plugin %s uses Application plugin env %s, which are not allowed by policy applicationEnv.allow", pluginDisplayName(name), quotedEnvNames(notAllowed))
+	}
 	return out, ""
+}
+
+// quotedEnvNames renders names as `"A", "B"` so the plural fail-closed message
+// reads like the single-entry one.
+func quotedEnvNames(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, strconv.Quote(name))
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/internal/app/plugin_render_env_test.go
+++ b/internal/app/plugin_render_env_test.go
@@ -121,6 +121,9 @@ func TestValidateApplicationPluginEnvFailsClosed(t *testing.T) {
 		want  string
 	}{
 		{name: "not allowlisted", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "SECRET", Value: sentinel}}, want: `Application plugin env "SECRET", which is not allowed by policy applicationEnv.allow`},
+		{name: "several not allowlisted are all named", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "SECRET", Value: sentinel}, {Name: "MODE", Value: sentinel}, {Name: "TOKEN", Value: sentinel}}, want: `Application plugin env "SECRET", "TOKEN", which are not allowed by policy applicationEnv.allow`},
+		{name: "no allowlist names every entry once", allow: nil, env: argoappv1.Env{{Name: "MODE", Value: sentinel}, {Name: "SUFFIX", Value: sentinel}, {Name: "USE_TELEMETRY", Value: sentinel}}, want: `Application plugin env "MODE", "SUFFIX", "USE_TELEMETRY", which are not allowed by policy applicationEnv.allow`},
+		{name: "duplicate of a non-allowlisted name is a duplicate", allow: nil, env: argoappv1.Env{{Name: "MODE", Value: sentinel}, {Name: "MODE", Value: sentinel}}, want: `duplicate Application plugin env "MODE"`},
 		{name: "no allowlist at all", allow: nil, env: argoappv1.Env{{Name: "MODE", Value: sentinel}}, want: "applicationEnv.allow"},
 		{name: "invalid name", allow: []string{"MODE"}, env: argoappv1.Env{{Name: "9MODE", Value: sentinel}}, want: "invalid Application plugin env name"},
 		{name: "nil entry", allow: []string{"MODE"}, env: argoappv1.Env{nil}, want: "unnamed Application plugin env entry"},

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sholdee/drydock/internal/app"
+	cliformat "github.com/sholdee/drydock/internal/format"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v3"
 )
@@ -20,6 +21,7 @@ func newBuildCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	}
 
 	appsFlags := defaultCommonFlags()
+	appsFlags.output = string(cliformat.OutputYAML)
 	appsFlags.parallelism = defaultRenderAppsParallelism()
 	appsFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	apps := &cobra.Command{
@@ -33,6 +35,7 @@ func newBuildCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 	bindCommonFlags(apps, &appsFlags)
 
 	appFlags := defaultCommonFlags()
+	appFlags.output = string(cliformat.OutputYAML)
 	appFlags.parallelism = defaultRenderAppsParallelism()
 	appFlags.engineFingerprint = engineFingerprintFromVersionInfo(info)
 	appCmd := &cobra.Command{
@@ -50,6 +53,10 @@ func newBuildCommand(info VersionInfo, deps Dependencies) *cobra.Command {
 }
 
 func runBuildApps(cmd *cobra.Command, deps Dependencies, flags commonFlags) error {
+	output, err := parseBuildOutput(flags.output)
+	if err != nil {
+		return err
+	}
 	repoMaps, err := parseRepoMaps(flags.repoMaps)
 	if err != nil {
 		return err
@@ -66,7 +73,7 @@ func runBuildApps(cmd *cobra.Command, deps Dependencies, flags commonFlags) erro
 		}
 		return err
 	}
-	if err := renderBuildResult(cmd, result); err != nil {
+	if err := renderBuildResult(cmd, output, result); err != nil {
 		return err
 	}
 	if flags.cacheEvents {
@@ -76,6 +83,10 @@ func runBuildApps(cmd *cobra.Command, deps Dependencies, flags commonFlags) erro
 }
 
 func runBuildApp(cmd *cobra.Command, deps Dependencies, flags commonFlags, name string) error {
+	output, err := parseBuildOutput(flags.output)
+	if err != nil {
+		return err
+	}
 	repoMaps, err := parseRepoMaps(flags.repoMaps)
 	if err != nil {
 		return err
@@ -95,7 +106,7 @@ func runBuildApp(cmd *cobra.Command, deps Dependencies, flags commonFlags, name 
 		}
 		return err
 	}
-	if err := renderBuildResult(cmd, result); err != nil {
+	if err := renderBuildResult(cmd, output, result); err != nil {
 		return err
 	}
 	if flags.cacheEvents {
@@ -104,21 +115,41 @@ func runBuildApp(cmd *cobra.Command, deps Dependencies, flags commonFlags, name 
 	return nil
 }
 
-func renderBuildResult(cmd *cobra.Command, result app.BuildResult) error {
+// manifestList is the v1 List envelope kubectl prints for multiple objects;
+// one JSON document lets kubectl, kubeconform, and jq consume build output
+// without splitting a stream.
+type manifestList struct {
+	APIVersion string           `json:"apiVersion"`
+	Kind       string           `json:"kind"`
+	Items      []map[string]any `json:"items"`
+}
+
+func renderBuildResult(cmd *cobra.Command, output string, result app.BuildResult) error {
 	if err := renderDiagnostics(cmd.ErrOrStderr(), result.Diagnostics); err != nil {
 		return err
 	}
-	for _, manifest := range result.Manifests {
-		data, err := yaml.Marshal(manifest.Object.Object)
-		if err != nil {
-			return err
+	switch output {
+	case string(cliformat.OutputJSON):
+		list := manifestList{APIVersion: "v1", Kind: "List", Items: make([]map[string]any, 0, len(result.Manifests))}
+		for _, manifest := range result.Manifests {
+			list.Items = append(list.Items, manifest.Object.Object)
 		}
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "---"); err != nil {
-			return err
+		return cliformat.JSON(cmd.OutOrStdout(), list)
+	case string(cliformat.OutputYAML):
+		for _, manifest := range result.Manifests {
+			data, err := yaml.Marshal(manifest.Object.Object)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "---"); err != nil {
+				return err
+			}
+			if _, err := cmd.OutOrStdout().Write(data); err != nil {
+				return err
+			}
 		}
-		if _, err := cmd.OutOrStdout().Write(data); err != nil {
-			return err
-		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output %q for build", output)
 	}
-	return nil
 }

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -100,7 +100,7 @@ data:
 			t.Fatalf("output leaked placeholder material %q\nstdout:\n%s\nstderr:\n%s", forbidden, stdout.String(), stderr.String())
 		}
 	}
-	for _, want := range []string{"warning plugin:", "argocd-vault-plugin placeholders were replaced with deterministic redacted values"} {
+	for _, want := range []string{"warning plugin.avp-compat-substituted:", "argocd-vault-plugin placeholders were replaced with deterministic redacted values"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want AVP compatibility diagnostic fragment %q", stderr.String(), want)
 		}
@@ -170,7 +170,7 @@ spec:
 			t.Fatalf("build apps stdout missing %q:\n%s", want, got)
 		}
 	}
-	wantStderr := "warning appset: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
+	wantStderr := "warning appset.unsupported-generator: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
 	if got := stderr.String(); got != wantStderr {
 		t.Fatalf("build apps stderr = %q, want %q", got, wantStderr)
 	}
@@ -245,7 +245,7 @@ func TestBuildAppsSuppressesPartialStdoutWhenOutputWouldBeInvalid(t *testing.T) 
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want empty partial output on build error", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "error render:") {
+	if !strings.Contains(stderr.String(), "error render.failed:") {
 		t.Fatalf("stderr = %q, want render diagnostic", stderr.String())
 	}
 }
@@ -271,7 +271,7 @@ func TestBuildAppsFailsClosedForPluginSource(t *testing.T) {
 				t.Fatalf("stdout = %q, want empty partial output", stdout.String())
 			}
 			for _, want := range []string{
-				"error plugin:",
+				"error plugin.unsupported:",
 				"config management plugin cue is not supported by the default renderer",
 				"no compatible native renderer",
 			} {

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -661,4 +663,126 @@ func writeCLIFile(path, body string) error {
 		return err
 	}
 	return os.WriteFile(path, []byte(body), 0o600)
+}
+
+func TestBuildJSONOutputIsAV1List(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "one")
+	for _, args := range [][]string{
+		{"build", "apps", "--path", root, "-o", "json"},
+		{"build", "app", "demo", "--path", root, "--output", "json"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			result := runCLI(t, args...)
+			var list struct {
+				APIVersion string           `json:"apiVersion"`
+				Kind       string           `json:"kind"`
+				Items      []map[string]any `json:"items"`
+			}
+			if err := json.Unmarshal([]byte(result.Stdout), &list); err != nil {
+				t.Fatalf("stdout is not one JSON document: %v\n%s", err, result.Stdout)
+			}
+			if list.APIVersion != "v1" || list.Kind != "List" || len(list.Items) != 1 {
+				t.Fatalf("stdout = %s, want a v1 List with one item", result.Stdout)
+			}
+			if kind := list.Items[0]["kind"]; kind != "ConfigMap" {
+				t.Fatalf("items[0].kind = %v, want ConfigMap", kind)
+			}
+			if strings.Contains(result.Stdout, "---") {
+				t.Fatalf("json output must not carry YAML document markers:\n%s", result.Stdout)
+			}
+			if result.Stderr != "" {
+				t.Fatalf("stderr = %q, want empty", result.Stderr)
+			}
+		})
+	}
+}
+
+func TestBuildJSONOutputListsItemsEvenWhenEmpty(t *testing.T) {
+	root := t.TempDir()
+	writeCLITestFile(t, filepath.Join(root, "apps", "demo.yaml"), `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/example/repo
+    path: manifests/demo
+    targetRevision: main
+  destination:
+    name: in-cluster
+    namespace: demo
+`)
+	writeCLITestFile(t, filepath.Join(root, "manifests", "demo", ".keep"), "")
+	result := runCLI(t, "build", "apps", "--path", root, "-o", "json")
+	if !strings.Contains(result.Stdout, `"items": []`) {
+		t.Fatalf("stdout = %s, want an empty items array, never null", result.Stdout)
+	}
+}
+
+func TestBuildDefaultOutputIsTheYAMLStream(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "one")
+	// The exact bytes build printed before -o was honored: the default stream
+	// is a documented pipeline input, so the flag must not change it.
+	want := "---\napiVersion: v1\ndata:\n    value: one\nkind: ConfigMap\nmetadata:\n    annotations:\n        argocd.argoproj.io/tracking-id: demo:/ConfigMap:demo/demo\n    name: demo\n    namespace: demo\n"
+	if got := runCLI(t, "build", "apps", "--path", root).Stdout; got != want {
+		t.Fatalf("default stdout = %q, want the pre-change YAML stream %q", got, want)
+	}
+	if got := runCLI(t, "build", "apps", "--path", root, "-o", "yaml").Stdout; got != want {
+		t.Fatalf("-o yaml stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBuildRejectsUnsupportedOutputBeforeRendering(t *testing.T) {
+	root := t.TempDir()
+	writeFailingCLIApplication(t, root, "broken")
+	for _, args := range [][]string{
+		{"build", "apps", "--path", root, "-o", "table"},
+		{"build", "app", "broken", "--path", root, "-o", "name"},
+		{"build", "apps", "--path", root, "-o", "diff"},
+	} {
+		t.Run(strings.Join(args[len(args)-2:], " "), func(t *testing.T) {
+			cmd := NewRootCommand(VersionInfo{})
+			cmd.SetArgs(args)
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			err := cmd.Execute()
+			want := fmt.Sprintf("unsupported output %q for build", args[len(args)-1])
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %v, want %q", err, want)
+			}
+			if stdout.String() != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			// The broken Application would print a render diagnostic if
+			// rendering had started; the flag is rejected before that.
+			if strings.Contains(stderr.String(), "render") {
+				t.Fatalf("stderr = %q, want no render diagnostics for a rejected flag", stderr.String())
+			}
+		})
+	}
+}
+
+func TestBuildAppsJSONOutputStaysEmptyOnRenderFailure(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleAppForCLI(t, root, "ok")
+	writeFailingCLIApplication(t, root, "broken")
+	cmd := NewRootCommand(VersionInfo{})
+	cmd.SetArgs([]string{"build", "apps", "--path", root, "-o", "json"})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	if code := commandErrorCode(err); code != 2 {
+		t.Fatalf("error code = %d, want 2; err = %v", code, err)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty: a partial List would read as the whole desired state", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "error render") {
+		t.Fatalf("stderr = %q, want render diagnostic", stderr.String())
+	}
 }

--- a/internal/cli/diag.go
+++ b/internal/cli/diag.go
@@ -270,7 +270,12 @@ func renderDiagnosticsWithColor(w io.Writer, diags []diagnostic.Diagnostic, colo
 		if color {
 			severity = colorizeDiagnosticSeverity(diag.Severity)
 		}
-		if _, err := fmt.Fprintf(w, "%s %s: %s%s\n", severity, diag.Category, diag.Message, formatDiagnosticProvenance(diag.Provenance)); err != nil {
+		// The stable code (always set by WithStableCodes) is what -o json, the
+		// markdown report, and the docs use to identify a diagnostic, so it
+		// replaces the category label. Codes are <category>.<detail> except
+		// changed-only (diff.changed-only-incomplete), repeated-resource
+		// (render.repeated-resource), and crd-scope (build.crd-scope-collision).
+		if _, err := fmt.Fprintf(w, "%s %s: %s%s\n", severity, diag.Code, diag.Message, formatDiagnosticProvenance(diag.Provenance)); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/diag_test.go
+++ b/internal/cli/diag_test.go
@@ -208,7 +208,7 @@ func TestDiagPrintsUnsupportedApplicationSetWarning(t *testing.T) {
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
-	want := "warning appset: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
+	want := "warning appset.unsupported-generator: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
 	if stderr.String() != want {
 		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
 	}
@@ -233,7 +233,7 @@ func TestDiagReportsPluginSourceFailure(t *testing.T) {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 	for _, want := range []string{
-		"error plugin:",
+		"error plugin.unsupported:",
 		"config management plugin cue is not supported by the default renderer",
 		"no compatible native renderer",
 	} {
@@ -276,8 +276,8 @@ func TestRenderDiagnosticsWithColorColorsWarningAndErrorLabels(t *testing.T) {
 		t.Fatalf("renderDiagnosticsWithColor() error = %v", err)
 	}
 
-	want := "\x1b[33mwarning\x1b[0m settings: metadata only\n" +
-		"\x1b[31merror\x1b[0m render: decode failed\n"
+	want := "\x1b[33mwarning\x1b[0m settings.unspecified: metadata only\n" +
+		"\x1b[31merror\x1b[0m render.failed: decode failed\n"
 	if stderr.String() != want {
 		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
 	}
@@ -293,7 +293,7 @@ func TestRenderDiagnosticsWithoutColorKeepsPlainOutput(t *testing.T) {
 		t.Fatalf("renderDiagnosticsWithColor() error = %v", err)
 	}
 
-	if got, want := stderr.String(), "warning settings: metadata only\n"; got != want {
+	if got, want := stderr.String(), "warning settings.unspecified: metadata only\n"; got != want {
 		t.Fatalf("stderr = %q, want %q", got, want)
 	}
 }
@@ -834,7 +834,7 @@ func TestDiagStrictUnsupportedApplicationSetErrors(t *testing.T) {
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "error appset:") {
+	if !strings.Contains(stderr.String(), "error appset.unsupported-generator:") {
 		t.Fatalf("stderr = %q, want error appset diagnostic", stderr.String())
 	}
 }
@@ -946,4 +946,44 @@ func (acquirer *recordingDiagChartAcquirer) Acquire(_ context.Context, request c
 		Kind:       request.Kind,
 		FromCache:  acquirer.fromCache,
 	}, nil
+}
+
+func TestRenderDiagnosticsTextPrintsTheStableCode(t *testing.T) {
+	testCases := []struct {
+		name string
+		diag diagnostic.Diagnostic
+		want string
+	}{
+		{
+			name: "explicit code replaces the category label",
+			diag: diagnostic.Diagnostic{Code: diagnostic.CodePluginUnsupported, Severity: diagnostic.SeverityError, Category: "plugin", Message: "config management plugin cue is not supported"},
+			want: "error plugin.unsupported: config management plugin cue is not supported\n",
+		},
+		{
+			name: "derived code keeps provenance",
+			diag: diagnostic.Diagnostic{Severity: diagnostic.SeverityWarning, Category: "settings", Message: "argocd-cm parsed as metadata only", Provenance: diagnostic.Provenance{Path: "argocd/argocd-cm.yaml"}},
+			want: "warning settings.metadata-only: argocd-cm parsed as metadata only (path: argocd/argocd-cm.yaml)\n",
+		},
+		{
+			name: "category whose code has a different prefix",
+			diag: diagnostic.Diagnostic{Severity: diagnostic.SeverityWarning, Category: "changed-only", Message: "unowned input"},
+			want: "warning diff.changed-only-incomplete: unowned input\n",
+		},
+		{
+			name: "uncategorized diagnostics still get a code",
+			diag: diagnostic.Diagnostic{Severity: diagnostic.SeverityWarning, Category: "profile", Message: "unknown profile key"},
+			want: "warning profile.unspecified: unknown profile key\n",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if err := renderDiagnosticsWithColor(&stderr, []diagnostic.Diagnostic{testCase.diag}, false); err != nil {
+				t.Fatalf("renderDiagnosticsWithColor() error = %v", err)
+			}
+			if got := stderr.String(); got != testCase.want {
+				t.Fatalf("stderr = %q, want %q", got, testCase.want)
+			}
+		})
+	}
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -700,7 +700,7 @@ func TestDiffAppsFailsClosedForPluginSource(t *testing.T) {
 				t.Fatalf("stdout = %q, want empty diff output", stdout.String())
 			}
 			for _, want := range []string{
-				"error plugin:",
+				"error plugin.unsupported:",
 				"config management plugin cue is not supported by the default renderer",
 				"no compatible native renderer",
 			} {
@@ -896,7 +896,7 @@ func TestDiffAppsStructuredOutputKeepsDiagnosticsOnStderr(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("len(results) = %d, want 1", len(results))
 	}
-	for _, want := range []string{"warning changed-only:", "README.md"} {
+	for _, want := range []string{"warning diff.changed-only-incomplete:", "README.md"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\nstdout:\n%s\nstderr:\n%s", want, stdout.String(), stderr.String())
 		}
@@ -1071,7 +1071,7 @@ func TestDiffColorNeverLeavesDiagnosticsColorIndependent(t *testing.T) {
 		},
 	}, "diff", "apps", "--path-orig", "left", "--path", "right", "--color=never", "--exit-code=false")
 
-	if !strings.Contains(result.Stderr, "\x1b[33mwarning\x1b[0m changed-only: unowned input") {
+	if !strings.Contains(result.Stderr, "\x1b[33mwarning\x1b[0m diff.changed-only-incomplete: unowned input") {
 		t.Fatalf("stderr = %q, want colored warning diagnostic", result.Stderr)
 	}
 }
@@ -1231,7 +1231,7 @@ func TestDiffAppsPrintsDiagnosticsOnStrictChangedOnlyError(t *testing.T) {
 		t.Fatal("Execute() error = nil, want strict changed-only error")
 	}
 
-	for _, want := range []string{"error changed-only:", "README.md"} {
+	for _, want := range []string{"error diff.changed-only-incomplete:", "README.md"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\nstdout:\n%s\nstderr:\n%s", want, stdout.String(), stderr.String())
 		}
@@ -1262,7 +1262,7 @@ func TestDiffImagesPrintsDiagnosticsOnStrictChangedOnlyError(t *testing.T) {
 		t.Fatal("Execute() error = nil, want strict changed-only error")
 	}
 
-	for _, want := range []string{"error changed-only:", "README.md"} {
+	for _, want := range []string{"error diff.changed-only-incomplete:", "README.md"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\nstdout:\n%s\nstderr:\n%s", want, stdout.String(), stderr.String())
 		}

--- a/internal/cli/discovery_flags_test.go
+++ b/internal/cli/discovery_flags_test.go
@@ -103,7 +103,7 @@ func TestDiffAppsDiscoverIgnoreKeepsStrictChangedOnlyIndependent(t *testing.T) {
 	// path under --strict-changed-only; the flag families are independent.
 	_, stderr, _ := executeCLIExpectingError(t, "diff", "apps", "--path-orig", left, "--path", right,
 		"--strict-changed-only", "--discover-ignore", "templates/**")
-	for _, want := range []string{"error changed-only:", "templates/scaffold.yaml"} {
+	for _, want := range []string{"error diff.changed-only-incomplete:", "templates/scaffold.yaml"} {
 		if !strings.Contains(stderr, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr)
 		}

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -187,7 +187,7 @@ spec:
 		t.Fatalf("Execute() error = %v", err)
 	}
 	assertTableContainsApp(t, out.String(), "NAMESPACE", "NAME", "direct")
-	wantStderr := "warning appset: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
+	wantStderr := "warning appset.unsupported-generator: unsupported ApplicationSet generator; supported generators are git directories, git files, list, matrix, and merge (path: unsupported-appset.yaml, pointer: spec.generators)\n"
 	if got := stderr.String(); got != wantStderr {
 		t.Fatalf("get apps stderr = %q, want %q", got, wantStderr)
 	}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -72,3 +72,17 @@ func writeStructuredOutput(w io.Writer, output string, value any) error {
 		return fmt.Errorf("unsupported structured output %q", output)
 	}
 }
+
+// parseBuildOutput accepts the manifest formats build can print. The YAML
+// stream is the default so existing `drydock build apps > out.yaml` pipelines
+// keep working byte for byte; JSON wraps the objects in one v1 List document.
+func parseBuildOutput(value string) (string, error) {
+	switch output := strings.TrimSpace(value); output {
+	case "", string(cliformat.OutputYAML):
+		return string(cliformat.OutputYAML), nil
+	case string(cliformat.OutputJSON):
+		return output, nil
+	default:
+		return "", fmt.Errorf("unsupported output %q for build", value)
+	}
+}

--- a/internal/cli/test_test.go
+++ b/internal/cli/test_test.go
@@ -123,7 +123,7 @@ func TestTestAppsReportsPluginSourceFailure(t *testing.T) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
 	}
-	if !strings.Contains(stderr.String(), "error plugin:") {
+	if !strings.Contains(stderr.String(), "error plugin.unsupported:") {
 		t.Fatalf("stderr = %q, want plugin diagnostic", stderr.String())
 	}
 }
@@ -152,7 +152,7 @@ func TestTestAppReportsPluginSourceFailure(t *testing.T) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
 	}
-	if !strings.Contains(stderr.String(), "error plugin:") {
+	if !strings.Contains(stderr.String(), "error plugin.unsupported:") {
 		t.Fatalf("stderr = %q, want plugin diagnostic", stderr.String())
 	}
 }

--- a/internal/pluginonboarding/onboarding_test.go
+++ b/internal/pluginonboarding/onboarding_test.go
@@ -656,12 +656,15 @@ func TestReadinessDetectsPlaceholdersAndMutableImages(t *testing.T) {
 		t.Fatalf("Parse mutable() error = %v", err)
 	}
 	readiness = Readiness(report, &policy, DoctorOptions{EnablePlugins: true, TrustedPolicy: true})
-	if readiness.Status != StatusWarn || !hasIssue(readiness.Plugins[0].Issues, IssueImageMutable) {
-		t.Fatalf("Readiness = %#v, want mutable warning", readiness)
+	if readiness.Status != StatusPass || readiness.Plugins[0].Status != StatusPass {
+		t.Fatalf("Readiness = %#v, want PASS: allowMutableImageTag is the policy author's acknowledgment", readiness)
+	}
+	if status := issueStatus(readiness.Plugins[0].Issues, IssueImageMutable); status != StatusInfo {
+		t.Fatalf("image.mutable status = %q, want INFO", status)
 	}
 	readiness = Readiness(report, &policy, DoctorOptions{EnablePlugins: true, TrustedPolicy: true, Strict: true})
-	if readiness.Status != StatusFail || !hasIssue(readiness.Plugins[0].Issues, IssueImageMutable) {
-		t.Fatalf("Strict readiness = %#v, want mutable failure", readiness)
+	if readiness.Status != StatusPass || issueStatus(readiness.Plugins[0].Issues, IssueImageMutable) != StatusInfo {
+		t.Fatalf("Strict readiness = %#v, want PASS with image.mutable at INFO: strict does not override a reviewed opt-in", readiness)
 	}
 }
 
@@ -921,5 +924,29 @@ func TestGenerateWritesApplicationEnvAllowFromObservedNames(t *testing.T) {
 	}
 	if _, err := pluginpolicy.Parse("generated.yaml", data); err != nil {
 		t.Fatalf("generated policy does not parse: %v", err)
+	}
+}
+
+func TestCombineStatusesNeverRaisesReadinessForInfo(t *testing.T) {
+	testCases := []struct {
+		left, right, want string
+	}{
+		{StatusPass, StatusInfo, StatusPass},
+		{StatusInfo, StatusPass, StatusPass},
+		{"", StatusInfo, StatusPass},
+		{StatusInfo, StatusInfo, StatusPass},
+		{StatusInfo, StatusWarn, StatusWarn},
+		{StatusWarn, StatusInfo, StatusWarn},
+		{StatusInfo, StatusFail, StatusFail},
+		{"", StatusWarn, StatusWarn},
+		{StatusPass, StatusPass, StatusPass},
+		{"", "", ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.left+"+"+testCase.right, func(t *testing.T) {
+			if got := combineStatuses(testCase.left, testCase.right); got != testCase.want {
+				t.Fatalf("combineStatuses(%q, %q) = %q, want %q", testCase.left, testCase.right, got, testCase.want)
+			}
+		})
 	}
 }

--- a/internal/pluginonboarding/readiness.go
+++ b/internal/pluginonboarding/readiness.go
@@ -111,11 +111,9 @@ func policyGateIssues(report PluginReport, plugin pluginpolicy.Plugin, opts Doct
 			issues = append(issues, issue(IssueImagePlaceholder, StatusFail, name, fmt.Sprintf("plugin %q image is still a placeholder", name)))
 		}
 		if plugin.Container.AllowMutableImageTag {
-			status := StatusWarn
-			if opts.Strict {
-				status = StatusFail
-			}
-			issues = append(issues, issue(IssueImageMutable, status, name, fmt.Sprintf("plugin %q uses a mutable image tag; digest pinning is recommended", name)))
+			// The parser refuses a tag-only image without this opt-in, so the
+			// policy already records the decision; report it, never gate on it.
+			issues = append(issues, issue(IssueImageMutable, StatusInfo, name, fmt.Sprintf("plugin %q uses a mutable image tag allowed by allowMutableImageTag; pin a digest for reproducible renders", name)))
 		}
 		if commandHasPlaceholder(plugin.Container.Lifecycle.Generate.Command) {
 			issues = append(issues, issue(IssueCommandPlaceholder, StatusFail, name, fmt.Sprintf("plugin %q generate command is still a placeholder", name)))
@@ -231,6 +229,9 @@ func applicationReadinessStatus(items []ApplicationReadiness) string {
 	return status
 }
 
+// combineStatuses ranks FAIL over WARN over PASS. INFO issues stay in the
+// report but never change readiness: an informational issue on a PASS plugin
+// leaves the plugin, and the report, at PASS.
 func combineStatuses(left, right string) string {
 	if left == StatusFail || right == StatusFail {
 		return StatusFail
@@ -238,8 +239,11 @@ func combineStatuses(left, right string) string {
 	if left == StatusWarn || right == StatusWarn {
 		return StatusWarn
 	}
-	if left == StatusInfo || right == StatusInfo {
-		return StatusInfo
+	if left == StatusInfo {
+		left = StatusPass
+	}
+	if right == StatusInfo {
+		right = StatusPass
 	}
 	if left == "" {
 		return right

--- a/internal/pluginonboarding/types.go
+++ b/internal/pluginonboarding/types.go
@@ -20,6 +20,7 @@ const (
 	StatusPass = "PASS"
 	StatusWarn = "WARN"
 	StatusFail = "FAIL"
+	// StatusInfo is issue-only: reported, never changes readiness.
 	StatusInfo = "INFO"
 )
 

--- a/site/content/docs/plugin-policy/schema.md
+++ b/site/content/docs/plugin-policy/schema.md
@@ -82,7 +82,7 @@ and optional `configManagementPlugin`.
 | --- | --- | --- | --- |
 | `runtime` | No | `docker` | Only Docker is supported. |
 | `image` | Yes | None | Fully qualified image reference. Digest required unless `allowMutableImageTag: true`. |
-| `allowMutableImageTag` | No | `false` | Allows tag-only image references for local/trusted workflows. |
+| `allowMutableImageTag` | No | `false` | Allows tag-only image references for local/trusted workflows. `plugin-policy doctor` reports the opt-in as `image.mutable` at `INFO`, which never changes readiness. |
 | `network` | No | `none` | `none` or `default`. `default` is rejected when `--offline` is set. |
 | `cacheMounts` | No | `[]` | Policy-managed durable cache mounts under reserved container paths below `/drydock-cache`. |
 

--- a/site/content/docs/plugin-policy/trust.md
+++ b/site/content/docs/plugin-policy/trust.md
@@ -255,8 +255,8 @@ it; host `env.allow` values and other Application entries are not
 substitutable. Names must be identifiers, duplicates are rejected, values are
 capped at 16 KiB and may not contain NUL (`engine: container` also rejects CR
 or LF, which cannot pass through `--env-file`). An entry that is not
-allowlisted fails the source before the plugin runs, naming the entry but
-never its value. The 16 KiB cap applies after substitution. Without
+allowlisted fails the source before the plugin runs, naming every such entry
+but never a value. The 16 KiB cap applies after substitution. Without
 `--kube-version` / `--api-versions`, `$KUBE_VERSION` and
 `$KUBE_API_VERSIONS` expand to empty strings. Application env values are not
 redacted from diagnostics; like a repo-server, drydock treats them as

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -337,6 +337,11 @@ and settings metadata without rendering Applications. It prints diagnostics to
 stderr and returns an error when runtime failures or error-severity diagnostics
 are found. Use `--strict` to promote warnings to errors.
 
+Text diagnostics are printed as `<severity> <code>: <message>`, followed by
+the source path and pointer when known, for example
+`warning appset.unsupported-generator: …`. The code is the same stable `code`
+that `-o json`, `-o yaml`, and markdown reports carry.
+
 `diag` refuses broad roots such as the filesystem root or the current user's
 home directory. Run it from the GitOps repository root or pass `--path` to that
 repository.

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -261,6 +261,10 @@ explicit missing `--plugin-policy-path` is a command error. `-o json` provides
 deterministic `status` and issue `code` fields. `--strict` exits nonzero on
 readiness `FAIL` after rendering the report.
 
+Readiness statuses are `PASS`, `WARN`, and `FAIL`. Issues can also carry
+`INFO`, which is reported but never changes readiness; an explicit
+`allowMutableImageTag: true` is reported that way.
+
 ## Render Tests
 
 Test every discovered Application without printing manifest bodies:

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -124,6 +124,11 @@ drydock build app argocd/my-app --path .
 `build app` errors when no discovered Application matches. The unqualified
 `NAME` form must identify exactly one Application.
 
+`build` prints a `---` separated YAML document stream by default. Use `-o json`
+for one `v1` `List` document whose `items` hold the rendered objects; both
+formats keep diagnostics on stderr, and any other format is rejected before an
+Application renders.
+
 When one selected Application fails to render, embedding callers receive
 partial results containing successful manifests, diagnostics, and
 per-Application statuses. CLI `build` commands keep stdout parseable:

--- a/site/content/workflows/output.md
+++ b/site/content/workflows/output.md
@@ -27,7 +27,9 @@ stays parseable. Markdown diff output embeds successful diagnostics in the
 generated report because the markdown document is the review surface: errors
 are listed openly above the diffs, warnings collapse inside an expandable
 block rendered below the diffs, and repeated diagnostic codes aggregate into
-one entry with a count.
+one entry with a count. Text diagnostics carry their stable code
+(`error plugin.unsupported: …`) so the same identifier appears in text, JSON,
+YAML, and markdown output.
 
 `test apps` text output prints `PASS`, `FAIL`, or `SKIPPED` status lines. When
 stdout and stderr are terminals, status lines stream as Applications complete

--- a/site/content/workflows/output.md
+++ b/site/content/workflows/output.md
@@ -11,6 +11,7 @@ Use `-o` or `--output` to select the format supported by each command:
 
 | Command area | Output formats |
 | --- | --- |
+| `build apps`, `build app` | `yaml`, `json` |
 | `get apps`, `get images` | `table`, `name`, `json`, `yaml` |
 | `test apps`, `test app` | `text`, `json`, `yaml` |
 | `diff apps`, `diff app` | `unified`, `markdown`, `json`, `yaml` |


### PR DESCRIPTION
Four rough edges found while validating #317 against a real pkl repository (the Discord report behind #297). Independent commits, one per edge.

- **`build apps` / `build app` honor `-o`.** The flag was bound but never read, so `-o json` silently printed YAML. Default stays the `---` separated stream, byte for byte (`--help` now shows `(default "yaml")`). `-o json` prints one `v1` `List` with the rendered objects in `items` (`[]` when nothing rendered), directly consumable by kubectl, kubeconform, and jq. Any other format, including the shared `diff` default the other render commands use, is rejected before any Application renders. A render failure still leaves stdout empty in both formats (the documented "no partial desired state" contract is unchanged).
- **Text diagnostics print the stable code.** `warning plugin: …` becomes `warning plugin.policy.env-ignored: …`, matching `-o json`, `-o yaml`, and the markdown report; the `(path: …, pointer: …)` suffix is unchanged. Codes are `<category>.<detail>`, so `grep "error plugin"` still matches, except three categories whose code has a different prefix: `changed-only` now prints as `diff.changed-only-incomplete`, `repeated-resource` as `render.repeated-resource`, `crd-scope` as `build.crd-scope-collision`. Anyone matching the exact old `severity category:` text on stderr needs to update; no in-repo consumer did (the GitHub Action reads markdown/JSON). The profile-stop warning is a plain stderr line, not a diagnostic, and is unchanged.
- **`plugin-policy doctor` reports an opted-in mutable image tag as `INFO`.** `allowMutableImageTag: true` is the only way a tag-only image passes the parser, so the policy already records the decision; doctor no longer warns (or fails under `--strict`) about it. `INFO` never changes readiness, so a plugin whose only issue is informational stays `PASS`; the text report lists the issue under the `PASS` plugin, and `-o json`/`-o yaml` carry `"status": "INFO"` on it. If a strict CI should still refuse mutable tags regardless of the policy opt-in, say so and it is a one-line change back to `FAIL` under `--strict`.
- **Fail-closed Application env message names every missing entry.** `uses Application plugin env "MODE", "SUFFIX", "USE_TELEMETRY", which are not allowed by policy applicationEnv.allow` instead of one name per render attempt. Single-entry wording is byte-identical; values are never echoed. Duplicate names are now checked before the allowlist, so a repeated non-allowlisted name reports as `duplicate Application plugin env` rather than being listed twice.

Deliberately not changed: `build` printing successfully rendered manifests when another Application fails. That is the documented stdout contract (`cli.md` Build Commands) and pinned by `TestBuildAppsSuppressesPartialStdoutWhenOutputWouldBeInvalid`; `test apps` gives per-Application status and the Go API returns partial results.

Verified against scratch repositories: default and `-o yaml` output are byte-identical; `-o json` is consumed by `jq`, `kubeconform -strict` (2 valid), and `kubectl create --dry-run=client -f -`; `-o table`/`-o diff` exit 2 with no render diagnostics; a failing Application leaves `-o json` stdout empty; doctor on a policy with `allowMutableImageTag: true` reports `PASS` with `image.mutable` at `INFO` in normal and `--strict` mode; the three-entry env message prints exactly as quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt