### PR TITLE
fix(render): resolve .argocd-source-<app>.yaml by Application instance name, live-pinned by a tenant-namespace parity fixture

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -210,6 +210,10 @@ Supported:
   (`<namespace>_<name>` for Applications outside the controller namespace;
   drydock assumes the Argo CD controller namespace is `argocd`) and
   `ARGOCD_APP_NAMESPACE` is `spec.destination.namespace`.
+- `.argocd-source.yaml` and `.argocd-source-<app>.yaml` overrides, where
+  `<app>` is the Application instance name like the repo-server's lookup: an
+  Application outside the controller namespace reads
+  `.argocd-source-<namespace>_<name>.yaml`, and a bare-name file is ignored.
 - Recorded divergence from strict Argo CD v3.5.2: `ARGOCD_APP_REVISION`,
   `ARGOCD_APP_REVISION_SHORT`, and `ARGOCD_APP_REVISION_SHORT_8` carry the spec
   `targetRevision` string; a repo-server reports the resolved revision

--- a/internal/app/local_provider.go
+++ b/internal/app/local_provider.go
@@ -20,7 +20,12 @@ import (
 )
 
 type localProvider struct {
-	repoRoot                     string
+	repoRoot string
+	// controllerNamespace is the Argo CD controller namespace that decides an
+	// Application's instance name (<namespace>_<name> outside it); empty means
+	// the drydock default. It must match the tracking options the render path
+	// uses so override files, ARGOCD_APP_NAME, and tracking metadata agree.
+	controllerNamespace          string
 	sourceResolver               *sourcepkg.Resolver
 	chartAcquirer                chart.Acquirer
 	gitAcquirer                  sourcepkg.GitAcquirer

--- a/internal/app/local_provider_builder.go
+++ b/internal/app/local_provider_builder.go
@@ -42,6 +42,7 @@ func newLocalProvider(ctx context.Context, orchestrator Orchestrator, root strin
 	forbiddenRoots := requestForbiddenRoots(root, request.AcquisitionOptions)
 	provider := localProvider{
 		repoRoot:                     root,
+		controllerNamespace:          trackingOptionsFromSettings(settings).ControllerNamespace,
 		sourceResolver:               sourcepkg.NewResolver(sourcepkg.Options{RepoMaps: request.RepoMaps, Offline: request.Offline}),
 		chartAcquirer:                acquirer,
 		gitAcquirer:                  gitAcquirer,

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -89,6 +89,21 @@ resources:
 	}
 }
 
+func TestNewLocalProviderCarriesControllerNamespace(t *testing.T) {
+	settings := config.DefaultSettings()
+	provider, cleanup, err := newLocalProvider(context.Background(), Orchestrator{}, t.TempDir(), settings, BuildRequest{}, nil, "drydock-test-*")
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("newLocalProvider() error = %v", err)
+	}
+	// The override-file lookup must agree with the render path's tracking
+	// options, or ARGOCD_APP_NAME and .argocd-source-<app>.yaml would name
+	// different Applications.
+	if want := trackingOptionsFromSettings(settings).ControllerNamespace; provider.controllerNamespace != want || want == "" {
+		t.Fatalf("controllerNamespace = %q, want %q (non-empty)", provider.controllerNamespace, want)
+	}
+}
+
 func TestNewLocalProviderCarriesHelmValuesFileSchemes(t *testing.T) {
 	settings := config.DefaultSettings()
 	settings.HelmValuesFileSchemes = []config.Value[string]{

--- a/internal/app/render_cache_persistent.go
+++ b/internal/app/render_cache_persistent.go
@@ -541,7 +541,7 @@ func localInputSourceIdentity(ctx context.Context, handle *persistentRenderCache
 	// Clean mode: globs are safe because Helm expansion happens against
 	// committed-equal content and any expansion change rotates the path set
 	// (and therefore the cache key) via the committed digest.
-	paths, _, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider.repoRoot)
+	paths, _, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider)
 	if err != nil {
 		return SourceIdentity{}, renderCacheReasonInputGraph, false
 	}
@@ -567,7 +567,7 @@ func committedSourceIdentityForPaths(ctx context.Context, handle *persistentRend
 }
 
 func worktreeInputSourceIdentity(ctx context.Context, handle *persistentRenderCache, provider localProvider, plan PlanResult, sourcePlan SourcePlan) (SourceIdentity, string, bool) {
-	paths, helmGlobs, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider.repoRoot)
+	paths, helmGlobs, err := localInputDigestPathsForSource(ctx, plan, sourcePlan, provider)
 	if err != nil {
 		return SourceIdentity{}, renderCacheReasonInputGraph, false
 	}
@@ -749,7 +749,7 @@ func strictPathInsideRoot(root, candidate string) bool {
 	return rel != "." && !pathsafety.RelEscapes(rel) && !filepath.IsAbs(rel)
 }
 
-func localInputDigestPathsForSource(ctx context.Context, plan PlanResult, sourcePlan SourcePlan, repoRoot string) ([]gitref.PathDigestPath, bool, error) {
+func localInputDigestPathsForSource(ctx context.Context, plan PlanResult, sourcePlan SourcePlan, provider localProvider) ([]gitref.PathDigestPath, bool, error) {
 	sourcePath := strings.TrimSpace(sourcePlan.Source.Path)
 	if sourcePath == "" {
 		return nil, false, fmt.Errorf("local source path is empty")
@@ -758,15 +758,17 @@ func localInputDigestPathsForSource(ctx context.Context, plan PlanResult, source
 	if err != nil {
 		return nil, false, err
 	}
-	paths, helmGlobs, err := localToolInputDigestPaths(ctx, plan, sourcePlan, repoRoot, clean)
+	paths, helmGlobs, err := localToolInputDigestPaths(ctx, plan, sourcePlan, provider.repoRoot, clean)
 	if err != nil {
 		return nil, false, err
 	}
 	// PrepareSource merges these override files into the source spec before
 	// rendering, so their content is a render input for every tool. Optional:
 	// absence is itself a digest record, so adding or deleting one rotates
-	// the key.
-	return append(paths, argocdSourceOverrideDigestPaths(clean, plan.Application.Name)...), helmGlobs, nil
+	// the key. The per-Application file name follows the instance name, so a
+	// tenant Application's digest tracks .argocd-source-<namespace>_<name>.yaml
+	// and never the bare-name file the repo-server would not read.
+	return append(paths, argocdSourceOverrideDigestPaths(clean, provider.overrideInstanceName(plan.Application))...), helmGlobs, nil
 }
 
 func argocdSourceOverrideDigestPaths(sourcePath, appName string) []gitref.PathDigestPath {

--- a/internal/app/render_cache_persistent_test.go
+++ b/internal/app/render_cache_persistent_test.go
@@ -1584,7 +1584,7 @@ func TestLocalInputDigestPathsIncludeArgocdSourceOverrides(t *testing.T) {
 	}
 	plan := mustPlan(t, application)
 
-	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], localProvider{repoRoot: repoRoot})
 	if err != nil {
 		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
 	}
@@ -1602,6 +1602,33 @@ func TestLocalInputDigestPathsIncludeArgocdSourceOverrides(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Fatalf("digest paths missing override files %v; got %#v", want, paths)
+	}
+}
+
+func TestLocalInputDigestPathsResolveApplicationOverrideByInstanceName(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTestFile(t, repoRoot+"/manifests/demo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n")
+	application := argoappv1.Application{
+		Name: "demo-app", Namespace: "tenant",
+		Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{
+			RepoURL: "https://git.example.test/org/repo.git", Path: "manifests/demo", TargetRevision: "main",
+		}},
+	}
+	plan := mustPlan(t, application)
+
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], localProvider{repoRoot: repoRoot})
+	if err != nil {
+		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
+	}
+	seen := map[string]bool{}
+	for _, item := range paths {
+		seen[item.Path] = true
+	}
+	if !seen["manifests/demo/.argocd-source-tenant_demo-app.yaml"] {
+		t.Fatalf("digest paths missing the instance-name override file; got %#v", paths)
+	}
+	if seen["manifests/demo/.argocd-source-demo-app.yaml"] {
+		t.Fatalf("digest paths must not track the bare-name file for a tenant Application; got %#v", paths)
 	}
 }
 
@@ -1645,7 +1672,7 @@ func TestLocalToolInputDigestPathsMatchSelectLocalRendererPrecedence(t *testing.
 	}}}
 	plan := mustPlan(t, application)
 
-	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], localProvider{repoRoot: repoRoot})
 	if err != nil {
 		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
 	}
@@ -1773,7 +1800,7 @@ func TestKustomizeDigestPathsIncludeFilenameVariants(t *testing.T) {
 		RepoURL: "https://git.example.test/org/repo.git", Path: "apps/alpha", TargetRevision: "main",
 	}}}
 	plan := mustPlan(t, application)
-	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], repoRoot)
+	paths, _, err := localInputDigestPathsForSource(context.Background(), plan, plan.Sources[0], localProvider{repoRoot: repoRoot})
 	if err != nil {
 		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
 	}

--- a/internal/app/render_input_coverage_test.go
+++ b/internal/app/render_input_coverage_test.go
@@ -89,7 +89,7 @@ func assertRenderInputCoverage(t *testing.T, repoRoot string, application argoap
 		t.Fatalf("preparePlanSourcesForRender() error = %v", prepErr)
 	}
 
-	digestPaths, _, err := localInputDigestPathsForSource(context.Background(), preparedPlan, preparedPlan.Sources[0], repoRoot)
+	digestPaths, _, err := localInputDigestPathsForSource(context.Background(), preparedPlan, preparedPlan.Sources[0], provider)
 	if err != nil {
 		t.Fatalf("localInputDigestPathsForSource() error = %v", err)
 	}

--- a/internal/app/render_test.go
+++ b/internal/app/render_test.go
@@ -1013,6 +1013,52 @@ helm:
 	}
 }
 
+func TestRenderApplicationResolvesArgocdSourceOverrideByInstanceName(t *testing.T) {
+	root := t.TempDir()
+	writeSourceOverrideChart(t, filepath.Join(root, "apps", "demo"), "demo")
+	// The repo-server names the per-Application file after the instance name,
+	// so for an Application outside the controller namespace the bare-name
+	// file is not an override at all.
+	writeAppTestFile(t, filepath.Join(root, "apps", "demo", ".argocd-source-demo.yaml"), `
+helm:
+  values: |
+    message: bare-name-file-must-be-ignored
+`)
+	writeAppTestFile(t, filepath.Join(root, "apps", "demo", ".argocd-source-tenant_demo.yaml"), `
+helm:
+  values: |
+    message: instance-name-file
+`)
+	testCases := []struct {
+		name                 string
+		provider             localProvider
+		applicationNamespace string
+		want                 string
+	}{
+		{name: "tenant namespace, default controller namespace", provider: localProvider{repoRoot: root}, applicationNamespace: "tenant", want: "instance-name-file"},
+		{name: "tenant namespace, explicit controller namespace", provider: localProvider{repoRoot: root, controllerNamespace: "argocd"}, applicationNamespace: "tenant", want: "instance-name-file"},
+		{name: "controller namespace keeps the bare name", provider: localProvider{repoRoot: root, controllerNamespace: "tenant"}, applicationNamespace: "tenant", want: "bare-name-file-must-be-ignored"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			application := rendererSelectionApplication("demo", argoappv1.ApplicationSource{
+				RepoURL: "https://repo.example.invalid/repo.git",
+				Path:    "apps/demo",
+			})
+			application.Namespace = testCase.applicationNamespace
+			result, err := RenderApplication(context.Background(), application, testCase.provider)
+			if err != nil {
+				t.Fatalf("RenderApplication() error = %v", err)
+			}
+			manifest := assertManifestNamed(t, result.Manifests, "demo")
+			message, _, _ := unstructured.NestedString(manifest.Object.Object, "data", "message")
+			if message != testCase.want {
+				t.Fatalf("data.message = %q, want %q", message, testCase.want)
+			}
+		})
+	}
+}
+
 func TestRenderApplicationRejectsArgocdSourceOverrideExplicitTypeConflict(t *testing.T) {
 	root := t.TempDir()
 	writeDirectorySelectionFixture(t, filepath.Join(root, "apps", "demo"))

--- a/internal/app/source_overrides.go
+++ b/internal/app/source_overrides.go
@@ -40,7 +40,7 @@ func (p localProvider) PrepareSource(ctx context.Context, application argoappv1.
 		return sourcePlan, err
 	}
 	sourceDir := filepath.Join(sourceRoot, sourcePath)
-	merged, err := mergeArgocdSourceOverrides(sourcePlan.Source, sourceDir, application.Name)
+	merged, err := mergeArgocdSourceOverrides(sourcePlan.Source, sourceDir, p.overrideInstanceName(application))
 	if err != nil {
 		return sourcePlan, err
 	}
@@ -104,4 +104,16 @@ func mergeArgocdSourceOverrides(source argoappv1.ApplicationSource, sourceDir, a
 	merged.Ref = source.Ref
 	merged.Name = source.Name
 	return merged, nil
+}
+
+// overrideInstanceName is the name the Argo CD repo-server uses for the
+// per-Application override file: the Application instance name, so an
+// Application outside the controller namespace reads
+// .argocd-source-<namespace>_<name>.yaml and a bare-name file is ignored.
+func (p localProvider) overrideInstanceName(application argoappv1.Application) string {
+	controllerNamespace := p.controllerNamespace
+	if controllerNamespace == "" {
+		controllerNamespace = defaultArgoCDControllerNamespace
+	}
+	return application.InstanceName(controllerNamespace)
 }

--- a/scripts/argocd-parity-smoke.sh
+++ b/scripts/argocd-parity-smoke.sh
@@ -101,6 +101,16 @@ TRACKING_APPLICATIONS=(
   parity-tracking
   parity-helm-crds-default
   parity-oci-config
+  parity-tenant-overrides
+)
+
+# Applications outside the Argo CD controller namespace. They pin instance-name
+# semantics: ARGOCD_APP_NAME is <namespace>_<name>, the per-Application source
+# override file is .argocd-source-<namespace>_<name>.yaml (the bare-name file is
+# ignored), and tracking metadata carries the same instance name.
+TENANT_NAMESPACE="parity-tenant"
+TENANT_APPLICATIONS=(
+  parity-tenant-overrides
 )
 
 PROJECT_POLICY_CASES=(
@@ -599,27 +609,58 @@ login_argocd() {
 }
 
 apply_fixture_apps() {
+  ensure_namespace "${TENANT_NAMESPACE}"
+  kubectl -n argocd apply -f "${FIXTURE_REPO_PATH}/projects" >/dev/null
   kubectl -n argocd apply -f "${FIXTURE_REPO_PATH}/applications" >/dev/null
   kubectl -n argocd apply -f "${FIXTURE_REPO_PATH}/applicationsets" >/dev/null
+  kubectl -n "${TENANT_NAMESPACE}" apply -f "${FIXTURE_REPO_PATH}/tenant-applications" >/dev/null
+}
+
+wait_for_application() {
+  local namespace="$1"
+  local app="$2"
+  local reconciled_at
+  for _ in {1..120}; do
+    if kubectl -n "${namespace}" get application "${app}" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  kubectl -n "${namespace}" get application "${app}" >/dev/null
+  # `argocd app manifests` serves the controller's cached comparison, so an
+  # Application the controller never reconciled returns exit 0 with empty
+  # output. Gate on reconciledAt so that failure surfaces here instead of as a
+  # misleading "did not generate manifests" after the capture retry loop.
+  for _ in {1..120}; do
+    reconciled_at="$(kubectl -n "${namespace}" get application "${app}" -o jsonpath='{.status.reconciledAt}' 2>/dev/null || true)"
+    if [[ -n "${reconciled_at}" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+  local dump
+  dump="$(artifact_dir logs)/unreconciled-${namespace}-${app}.yaml"
+  kubectl -n "${namespace}" get application "${app}" -o yaml > "${dump}" 2>&1 || true
+  fail "Argo CD did not reconcile Application ${namespace}/${app}; see ${dump}"
 }
 
 wait_for_applications() {
   local app
   for app in "${APPLICATIONS[@]}"; do
-    for _ in {1..120}; do
-      if kubectl -n argocd get application "${app}" >/dev/null 2>&1; then
-        break
-      fi
-      sleep 1
-    done
-    kubectl -n argocd get application "${app}" >/dev/null
+    wait_for_application argocd "${app}"
+  done
+  for app in "${TENANT_APPLICATIONS[@]}"; do
+    wait_for_application "${TENANT_NAMESPACE}" "${app}"
   done
 }
 
-assert_application_inventory() {
+assert_namespace_inventory() {
+  local namespace="$1"
+  local diff_file="$2"
+  shift 2
   local expected actual
-  expected="$(printf '%s\n' "${APPLICATIONS[@]}" | sort)"
-  actual="$(kubectl -n argocd get applications.argoproj.io -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
+  expected="$(printf '%s\n' "$@" | sort)"
+  actual="$(kubectl -n "${namespace}" get applications.argoproj.io -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
   if [[ "${actual}" != "${expected}" ]]; then
     {
       echo "expected Applications:"
@@ -627,8 +668,29 @@ assert_application_inventory() {
       echo
       echo "actual Applications:"
       printf '%s\n' "${actual}"
-    } > "${OUT_DIR}/application-inventory.diff"
-    fail "Argo CD Application inventory did not match expected list; see ${OUT_DIR}/application-inventory.diff"
+    } > "${OUT_DIR}/${diff_file}"
+    fail "Argo CD Application inventory in ${namespace} did not match expected list; see ${OUT_DIR}/${diff_file}"
+  fi
+}
+
+assert_application_inventory() {
+  assert_namespace_inventory argocd application-inventory.diff "${APPLICATIONS[@]}"
+  assert_namespace_inventory "${TENANT_NAMESPACE}" tenant-application-inventory.diff "${TENANT_APPLICATIONS[@]}"
+}
+
+capture_argocd_manifest() {
+  local app_ref="$1"
+  local stem="$2"
+  local output_dir="$3"
+  for _ in {1..120}; do
+    if argocd app manifests "${app_ref}" > "${output_dir}/${stem}.yaml" 2> "${OUT_DIR}/argocd-${stem}.stderr"; then
+      rm -f "${OUT_DIR}/argocd-${stem}.stderr"
+      break
+    fi
+    sleep 2
+  done
+  if [[ ! -s "${output_dir}/${stem}.yaml" ]]; then
+    fail "Argo CD did not generate manifests for ${app_ref}; see ${OUT_DIR}/argocd-${stem}.stderr"
   fi
 }
 
@@ -636,31 +698,35 @@ capture_argocd_manifests() {
   local app output_dir
   output_dir="$(artifact_dir argocd-manifests)"
   for app in "${APPLICATIONS[@]}"; do
-    for _ in {1..120}; do
-      if argocd app manifests "${app}" > "${output_dir}/${app}.yaml" 2> "${OUT_DIR}/argocd-${app}.stderr"; then
-        rm -f "${OUT_DIR}/argocd-${app}.stderr"
-        break
-      fi
-      sleep 2
-    done
-    if [[ ! -s "${output_dir}/${app}.yaml" ]]; then
-      fail "Argo CD did not generate manifests for ${app}; see ${OUT_DIR}/argocd-${app}.stderr"
-    fi
+    capture_argocd_manifest "${app}" "${app}" "${output_dir}"
   done
+  for app in "${TENANT_APPLICATIONS[@]}"; do
+    capture_argocd_manifest "${TENANT_NAMESPACE}/${app}" "${app}" "${output_dir}"
+  done
+}
+
+capture_drydock_manifest() {
+  local app_ref="$1"
+  local stem="$2"
+  local output_dir="$3"
+  (cd "${REPO_ROOT}" && "${DRYDOCK_CMD[@]}" build app "${app_ref}" \
+    --path "${FIXTURE_REPO_PATH}" \
+    --repo-map "${FIXTURE_REPO_URL}=${FIXTURE_REPO_PATH}" \
+    --oci-cache-dir "${OCI_CACHE_DIR}" \
+    --oci-ca-file "${OCI_CA_FILE}" \
+    --render-cache-dir "${OCI_OFFLINE_RENDER_CACHE_DIR}" \
+    --offline > "${output_dir}/${stem}.yaml" 2> "${OUT_DIR}/drydock-${stem}.stderr")
+  rm -f "${OUT_DIR}/drydock-${stem}.stderr"
 }
 
 capture_drydock_manifests() {
   local app output_dir
   output_dir="$(artifact_dir drydock-manifests)"
   for app in "${APPLICATIONS[@]}"; do
-    (cd "${REPO_ROOT}" && "${DRYDOCK_CMD[@]}" build app "argocd/${app}" \
-      --path "${FIXTURE_REPO_PATH}" \
-      --repo-map "${FIXTURE_REPO_URL}=${FIXTURE_REPO_PATH}" \
-      --oci-cache-dir "${OCI_CACHE_DIR}" \
-      --oci-ca-file "${OCI_CA_FILE}" \
-      --render-cache-dir "${OCI_OFFLINE_RENDER_CACHE_DIR}" \
-      --offline > "${output_dir}/${app}.yaml" 2> "${OUT_DIR}/drydock-${app}.stderr")
-    rm -f "${OUT_DIR}/drydock-${app}.stderr"
+    capture_drydock_manifest "argocd/${app}" "${app}" "${output_dir}"
+  done
+  for app in "${TENANT_APPLICATIONS[@]}"; do
+    capture_drydock_manifest "${TENANT_NAMESPACE}/${app}" "${app}" "${output_dir}"
   done
 }
 
@@ -693,9 +759,9 @@ ensure_namespace() {
   kubectl get namespace "${namespace}" >/dev/null 2>&1 || kubectl create namespace "${namespace}" >/dev/null
 }
 
-configure_project_policy_application_namespaces() {
+configure_application_namespaces() {
   kubectl -n argocd patch configmap argocd-cmd-params-cm --type merge \
-    -p '{"data":{"application.namespaces":"project-policy-tenant"}}' >/dev/null
+    -p "{\"data\":{\"application.namespaces\":\"${TENANT_NAMESPACE},project-policy-tenant\"}}" >/dev/null
   kubectl -n argocd rollout restart deployment/argocd-server >/dev/null
   kubectl -n argocd rollout restart statefulset/argocd-application-controller >/dev/null
   kubectl -n argocd rollout status deployment/argocd-server --timeout=300s
@@ -825,8 +891,6 @@ compare_project_policy_smoke() {
 }
 
 run_project_policy_smoke() {
-  log_step "Configuring Argo CD project-policy Application namespaces"
-  configure_project_policy_application_namespaces
   log_step "Preparing project-policy namespaces"
   prepare_project_policy_namespaces
   log_step "Applying project-policy AppProjects and Applications"
@@ -871,6 +935,10 @@ main() {
   verify_oci_artifact_manifest
   log_step "Installing Argo CD ${argocd_version}"
   install_argocd "${argocd_version}"
+  # Restarting argocd-server must happen before login_argocd starts the
+  # port-forward it binds to a single server pod.
+  log_step "Enabling Applications in tenant namespaces"
+  configure_application_namespaces
   log_step "Logging in to Argo CD"
   login_argocd
   log_step "Applying parity fixture Applications"

--- a/site/content/concepts/argocd-render-parity.md
+++ b/site/content/concepts/argocd-render-parity.md
@@ -53,6 +53,7 @@ treated as a rendering regression for the covered fixture set.
 | Jsonnet | ext vars, top-level arguments, code mode, libraries |
 | Multi-source | `$ref` values, ref-only sources, source precedence, last-wins resources |
 | ApplicationSet | git directories, git files, list, matrix, merge, Go templates, `missingkey=error`, selectors, generator template overrides, `templatePatch`, fasttemplate (default) mode with `path`/`path.basename`/`path[N]`/`values.*` params, `elementsYaml` generator input, `normalize` and `upper` template functions, template render error scoping (comment-only git files match under `missingkey=error` contributes zero Applications) |
+| Apps in any namespace | Application outside the controller namespace: instance-name `ARGOCD_APP_NAME` (`<namespace>_<name>`), destination `ARGOCD_APP_NAMESPACE`, `.argocd-source-<namespace>_<name>.yaml` override with the bare-name file ignored, AppProject `sourceNamespaces`, tracking metadata compared without ignore rules |
 | Tracking and resources | Argo CD tracking metadata, repeated-resource last-wins behavior, CRDs excluded from tracking metadata, hook-annotated resources excluded from the manifests view across all source types (helm test hooks, Argo CD sync hooks; `crd-install` kept) |
 
 The source of truth for the active fixture inventory is the parity smoke script;

--- a/site/content/concepts/source-acquisition.md
+++ b/site/content/concepts/source-acquisition.md
@@ -409,9 +409,10 @@ generated Application input invalidates that Application while unchanged
 Applications can still hit the render cache. Generated inputs include static
 Application YAML, ApplicationSet generator files, and rendered bootstrap
 Application parents when discovery records those paths. Local source override
-files (`.argocd-source.yaml` and `.argocd-source-<app>.yaml`) are also part
-of every Application's input digest; adding, editing, or deleting an override
-file invalidates that Application's cached entry.
+files (`.argocd-source.yaml` and `.argocd-source-<app>.yaml`, `<app>` being
+the Application instance name) are also part of every Application's input
+digest; adding, editing, or deleting an override file invalidates that
+Application's cached entry.
 
 Local dirty worktrees can also use the render output cache for Applications
 whose proven render inputs are unchanged. In dirty Git-backed roots, drydock

--- a/testdata/argocd-parity/README.md
+++ b/testdata/argocd-parity/README.md
@@ -12,6 +12,62 @@ URL:
 The smoke harness maps that URL back to this local fixture repository with
 `--repo-map` so drydock and Argo CD render the same source tree.
 
+## Tenant namespace fixture
+
+`projects/parity-tenant.yaml` and `tenant-applications/` cover Applications
+that live outside the Argo CD controller namespace, which is where the
+instance-name rules become visible.
+
+The smoke enables the `parity-tenant` namespace by patching
+`application.namespaces` in `argocd-cmd-params-cm` and restarting the server
+and controller *before* it logs in to Argo CD and applies fixtures, because
+`login_argocd` starts a port-forward bound to a single `argocd-server` pod
+that a later restart would kill.
+
+`tenant-applications/parity-tenant-overrides.yaml` is a Helm Application in
+the `parity-tenant` namespace whose parameters substitute `$ARGOCD_APP_NAME`
+and `$ARGOCD_APP_NAMESPACE`. Its chart `charts/tenant-overrides` carries three
+override files:
+
+- `.argocd-source.yaml` — the path-level override, read for every
+  Application that renders this source path.
+- `.argocd-source-parity-tenant_parity-tenant-overrides.yaml` — the
+  per-Application override, named by the Application *instance name*
+  (`<namespace>_<name>`) because the Application is outside the controller
+  namespace.
+- `.argocd-source-parity-tenant-overrides.yaml` — a deliberate decoy named by
+  the bare Application name. The repo-server never reads it for this
+  Application; it exists so a regression that resolves the override file by
+  `metadata.name` flips the comparison instead of passing silently.
+
+The override files use `helm.valuesObject` maps rather than `helm.parameters`
+lists: override merging is an RFC 7386 JSON merge patch, which replaces arrays
+wholesale, so a `parameters` list in an override would erase the Application's
+own `appName`/`appNamespace` parameters. Maps merge key by key, later files win
+per key, and Helm applies `parameters` over `valuesObject`, so the six keys
+stay independent.
+
+Both Argo CD and drydock must render this `data`:
+
+| key | value |
+| --- | --- |
+| `fromRepoOverride` | `from-argocd-source` |
+| `fromAppOverride` | `from-instance-override` |
+| `both` | `from-instance-override` |
+| `decoy` | `from-default` |
+| `appName` | `parity-tenant_parity-tenant-overrides` |
+| `appNamespace` | `parity-tenant-workloads` |
+
+The `sourceNamespaces: [parity-tenant]` entry on the `parity-tenant`
+AppProject is what lets live Argo CD reconcile the Application at all; without
+it the controller refuses it and `argocd app manifests` returns nothing.
+drydock reports a missing `sourceNamespaces` entry only as a warning
+diagnostic, so this half of the rule is enforced by live Argo CD.
+
+`parity-tenant-overrides` is also in the tracking comparison, which runs
+without ignore rules, so the instance name in the tracking annotation is
+compared too.
+
 ## OCI artifact fixture
 
 `oci-artifact/` is the content directory for the one first-class OCI

--- a/testdata/argocd-parity/repo/applications/helm-params-edge.yaml
+++ b/testdata/argocd-parity/repo/applications/helm-params-edge.yaml
@@ -19,6 +19,8 @@ spec:
           value: alpha,beta
         - name: appName
           value: $ARGOCD_APP_NAME
+        - name: appNamespace
+          value: $ARGOCD_APP_NAMESPACE
       fileParameters:
         - name: fileMessage
           path: ../../shared-files/params-edge-message.txt

--- a/testdata/argocd-parity/repo/charts/params-edge/values.yaml
+++ b/testdata/argocd-parity/repo/charts/params-edge/values.yaml
@@ -1,5 +1,6 @@
 commaValue: from-default
 appName: from-default
+appNamespace: from-default
 envFile: from-default
 shared: from-default
 fileMessage: from-default

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source-parity-tenant-overrides.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source-parity-tenant-overrides.yaml
@@ -1,0 +1,4 @@
+helm:
+  valuesObject:
+    decoy: bare-name-file-must-be-ignored
+    both: from-bare-name-file

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source-parity-tenant_parity-tenant-overrides.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source-parity-tenant_parity-tenant-overrides.yaml
@@ -1,0 +1,4 @@
+helm:
+  valuesObject:
+    fromAppOverride: from-instance-override
+    both: from-instance-override

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/.argocd-source.yaml
@@ -1,0 +1,4 @@
+helm:
+  valuesObject:
+    fromRepoOverride: from-argocd-source
+    both: from-argocd-source

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/Chart.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: tenant-overrides
+version: 0.1.0

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/templates/configmap.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/templates/configmap.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 data:
-  commaValue: {{ .Values.commaValue }}
+  fromRepoOverride: {{ .Values.fromRepoOverride }}
+  fromAppOverride: {{ .Values.fromAppOverride }}
+  both: {{ .Values.both }}
+  decoy: {{ .Values.decoy }}
   appName: {{ .Values.appName }}
   appNamespace: {{ .Values.appNamespace }}
-  envFile: {{ .Values.envFile }}
-  shared: {{ .Values.shared }}
-  fileMessage: {{ .Values.fileMessage | quote }}

--- a/testdata/argocd-parity/repo/charts/tenant-overrides/values.yaml
+++ b/testdata/argocd-parity/repo/charts/tenant-overrides/values.yaml
@@ -1,0 +1,6 @@
+fromRepoOverride: from-default
+fromAppOverride: from-default
+both: from-default
+decoy: from-default
+appName: from-default
+appNamespace: from-default

--- a/testdata/argocd-parity/repo/projects/parity-tenant.yaml
+++ b/testdata/argocd-parity/repo/projects/parity-tenant.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: parity-tenant
+  namespace: argocd
+spec:
+  sourceRepos:
+    - git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: parity-tenant-workloads
+  sourceNamespaces:
+    - parity-tenant

--- a/testdata/argocd-parity/repo/tenant-applications/parity-tenant-overrides.yaml
+++ b/testdata/argocd-parity/repo/tenant-applications/parity-tenant-overrides.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: parity-tenant-overrides
+  namespace: parity-tenant
+spec:
+  project: parity-tenant
+  source:
+    repoURL: git://argocd-parity-git.argocd-parity.svc.cluster.local/repo.git
+    targetRevision: HEAD
+    path: charts/tenant-overrides
+    helm:
+      releaseName: parity-tenant-overrides
+      parameters:
+        - name: appName
+          value: $ARGOCD_APP_NAME
+        - name: appNamespace
+          value: $ARGOCD_APP_NAMESPACE
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: parity-tenant-workloads


### PR DESCRIPTION
Third leg of the instance-name rule that #312 introduced for `ARGOCD_APP_NAME` and tracking metadata. The Argo CD repo-server names the per-Application source override file after the Application *instance name* (`controller/state.go:357` passes `app.InstanceName(controllerNamespace)` as `ManifestRequest.AppName`, which `reposerver/repository/repository.go:1866-1871` formats into `.argocd-source-<appName>.yaml`), so an Application outside the controller namespace reads `.argocd-source-<namespace>_<name>.yaml` and a bare-name file is ignored. drydock used `metadata.name` in both places that name the file: the override merge in `PrepareSource` and the persistent render cache's input digest. Both now go through one `localProvider.overrideInstanceName`, so the file the renderer reads and the file the cache key digests cannot drift apart. The controller namespace is taken from the same `trackingOptionsFromSettings(settings)` expression the render path already uses, and falls back to drydock's `argocd` default when empty. Applications in the `argocd` namespace are unchanged.

The parity smoke gains its first Application outside the controller namespace. `parity-tenant` is enabled through `application.namespaces` before `login_argocd` binds its port-forward (a later restart would kill it), an AppProject grants `sourceNamespaces: [parity-tenant]`, and one Helm Application there carries `.argocd-source.yaml`, the instance-name override, and a decoy bare-name override that must be ignored, with `$ARGOCD_APP_NAME` and `$ARGOCD_APP_NAMESPACE` in its parameters. Override files use `helm.valuesObject` rather than `helm.parameters`, because override merging is an RFC 7386 merge patch and a `parameters` array would replace the Application's own parameters wholesale. The fixture is compared with and without the tracking ignore rules, so `ARGOCD_APP_NAME` as `<namespace>_<name>`, the destination-namespace `ARGOCD_APP_NAMESPACE`, the override lookup, `sourceNamespaces` validation, and instance-name tracking metadata are all pinned against live Argo CD v3.5.2 rather than by source reading alone. `parity-helm-params-edge` also substitutes `$ARGOCD_APP_NAMESPACE` now, which pins #312's namespace value for a controller-namespace Application. The smoke additionally gates every fixture Application on `status.reconciledAt` before capture, because `argocd app manifests` returns exit 0 with empty output for an Application the controller never reconciled.

Verified locally on kind against Argo CD v3.5.2 — `scripts/argocd-parity-smoke.sh` exit code **0**:

- General comparison: Applications 56, Resources 71, **Differences 0**
- Tracking comparison, no ignore rules: Applications 4, Resources 5, **Differences 0**
- Project-policy comparison: Cases 6, **Failures 0** (including `project-policy-tenant/project-policy-source-namespace-allowed` and `...-denied`)

`parity-tenant/parity-tenant-overrides` as rendered by live Argo CD (drydock's render matches after canonicalization):

```yaml
apiVersion: v1
data:
  appName: parity-tenant_parity-tenant-overrides
  appNamespace: parity-tenant-workloads
  both: from-instance-override
  decoy: from-default
  fromAppOverride: from-instance-override
  fromRepoOverride: from-argocd-source
kind: ConfigMap
metadata:
  annotations:
    argocd.argoproj.io/tracking-id: parity-tenant_parity-tenant-overrides:/ConfigMap:parity-tenant-workloads/parity-tenant-overrides
  name: parity-tenant-overrides
  namespace: parity-tenant-workloads
```

`decoy: from-default` is the load-bearing value: the chart also ships `.argocd-source-parity-tenant-overrides.yaml` (bare name) setting `decoy: bare-name-file-must-be-ignored` and `both: from-bare-name-file`, and live Argo CD never reads it. A regression back to `metadata.name` flips `decoy`, `both` and `fromAppOverride` and fails both comparisons instead of passing silently.

`parity-helm-params-edge` now renders `appNamespace: parity-helm-params-edge` — its destination namespace, not its metadata namespace `argocd` — pinning #312's `ARGOCD_APP_NAMESPACE` value for a controller-namespace Application.

Integration-review nits folded in after the run: a unit guard for the `controllerNamespace` wiring in `newLocalProvider`, the render test renamed so the semantic registry's `-run ArgocdSource` scope covers it, and the unreconciled-Application dump written under the uploaded `logs/` artifact.

Gates: `go build ./...`, `go vet ./...`, `go test ./internal/app/ -count=1` (ok, 28.9s), `mise run lint` (0 issues), `mise run shellcheck` (clean), gomarklint on the four touched docs (no issues).

Intended for 0.3.0 alongside #312/#316/#317; the footer below asks release-please for that version (precedent: #146).

Release-As: 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt