### PR TITLE
ci: run the Argo CD parity smoke for any drydock source change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             changed_files="$(git diff --name-only "${BASE_SHA}...HEAD")"
 
-            if grep -Eq '^(\.github/workflows/argocd-parity-smoke\.yml|internal/app/|internal/diagnostic/|internal/paritycompare/|internal/project/|scripts/argocd-parity-compare/|scripts/argocd-project-policy-smoke/|scripts/argocd-parity-smoke\.sh|testdata/argocd-parity/|testdata/argocd-project-policy/)' <<<"${changed_files}"; then
+            if grep -Eq '^(\.github/workflows/argocd-parity-smoke\.yml|cmd/drydock/|internal/|scripts/argocd-parity-compare/|scripts/argocd-project-policy-smoke/|scripts/argocd-parity-smoke\.sh|testdata/argocd-parity/|testdata/argocd-project-policy/)' <<<"${changed_files}"; then
               run_smoke="true"
-              reason="render parity, project policy, or diagnostic files changed"
+              reason="drydock source, parity harness, or parity fixture files changed"
             elif grep -qx 'go.mod' <<<"${changed_files}"; then
               go_mod_diff="$(git diff --unified=0 "${BASE_SHA}...HEAD" -- go.mod)"
               semantic_modules='(github\.com/argoproj/argo-cd/v3|github\.com/argoproj/argo-cd/gitops-engine|github\.com/google/go-jsonnet|helm\.sh/helm/|k8s\.io/|sigs\.k8s\.io/controller-runtime|sigs\.k8s\.io/json|sigs\.k8s\.io/kustomize/|sigs\.k8s\.io/structured-merge-diff/|sigs\.k8s\.io/yaml)'


### PR DESCRIPTION
The live Argo CD parity smoke now runs for any pull request that changes code under `internal/` or `cmd/drydock/`, instead of only four `internal/` packages.

**Why.** The old rule covered `internal/app`, `internal/diagnostic`, `internal/paritycompare`, `internal/project`, the smoke's own scripts and fixtures, and rendering modules in `go.mod`. The rest of the render path was outside it: the Helm and Kustomize renderers, source acquisition, charts, manifests, discovery, and, since #324, the exec plugin engine and policy parser whose output the CMP fixture compares. Since the rule was added in May, 12 of 240 merged changes touched that code without running the smoke on their PR, and two of them could affect rendered output (#205 in the renderers, #281 in the plugin packages). Nothing broken could ship, because the release workflow runs the smoke before publishing, but a regression would surface at release time instead of on the PR that caused it.

**Scope.** `internal/` as a whole rather than a list, so new packages are covered automatically. The CLI the smoke runs is built only from `cmd/drydock` and `internal/`; `pkg/drydock` is not compiled into it and stays out. The `go.mod` rendering-module clause is unchanged. This PR only touches `ci.yml`, so it does not trigger the smoke itself.

**Cost.** The smoke takes about six and a half minutes in CI (6m05s on #321, 6m39s on #324). It now also runs on PRs that only change non-render packages such as the report renderer, or only tests. Skipping `_test.go`-only changes would trim that, but I left it out to keep the rule obvious.

**Verified.** Ran the real detect step, extracted from the old and new `ci.yml`, against synthetic pull requests:

| Changed path | Before | After |
| --- | --- | --- |
| `internal/render/helm.go` | skip | run |
| `internal/pluginexec/pluginexec.go` | skip | run |
| `internal/pluginpolicy/policy.go` | skip | run |
| `internal/source/resolver.go` | skip | run |
| `cmd/drydock/main.go` | skip | run |
| `internal/report/markdown.go` | skip | run |
| `internal/app/render.go` | run | run |
| `testdata/argocd-parity/repo/x.yaml` | run | run |
| `scripts/argocd-parity-smoke.sh` | run | run |
| `go.mod`, `k8s.io/api` bump | run | run |
| `go.mod`, `golang.org/x/net` bump | skip | skip |
| `pkg/drydock/client.go` | skip | skip |
| `site/content/docs/x.md` | skip | skip |
| `pr-action/run.sh` | skip | skip |
| `.github/workflows/ci.yml` | skip | skip |
| `internal-docs/notes.md` | skip | skip |

`actionlint` 1.7.12, `zizmor`, and `git diff --check` are clean. Kept separate from app changes per the repo's app/CI split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F33BPR6KxU789gkzFMmoAt
